### PR TITLE
feat(#12): consolidate publish flags; drop pubDate from admin UI

### DIFF
--- a/scripts/migrate-mocks.ts
+++ b/scripts/migrate-mocks.ts
@@ -1,0 +1,48 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+const ROOT = 'src/sw/mock'
+
+const walk = async (dir: string): Promise<readonly string[]> => {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const out: string[] = []
+  for (const entry of entries) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) out.push(...(await walk(full)))
+    else if (entry.name.endsWith('.ts')) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Rewrite `pubDate:` lines inside template-literal frontmatter to
+ * `publishDate:` and ensure a `published: true` line follows.
+ */
+const rewrite = (source: string): string => {
+  let changed = false
+  const next = source.replace(/^pubDate:\s*(.+)$/gm, (_, value: string) => {
+    changed = true
+    return `published: true\npublishDate: ${value.trim()}`
+  })
+  return changed ? next : source
+}
+
+const run = async (): Promise<void> => {
+  let count = 0
+  for (const file of await walk(ROOT)) {
+    const src = await readFile(file, 'utf8')
+    const out = rewrite(src)
+    if (out !== src) {
+      await writeFile(file, out, 'utf8')
+      count += 1
+    }
+  }
+  // eslint-disable-next-line no-console
+  console.log(`migrated ${count} mock file(s)`)
+}
+
+run().catch((err: unknown) => {
+  // eslint-disable-next-line no-console
+  console.error(err)
+  process.exit(1)
+})

--- a/src/components/ContentList/ContentListItem.vue
+++ b/src/components/ContentList/ContentListItem.vue
@@ -18,7 +18,7 @@ const fm = computed(() => props.item.frontmatter)
 const labelsStore = useLabelsStore()
 
 const formattedDate = computed(() => {
-  const date = fm.value.pubDate
+  const date = fm.value.publishDate
   if (!date) return undefined
   const d = date instanceof Date ? date : new Date(String(date))
   return new Intl.DateTimeFormat('en-US', {

--- a/src/components/MarkdownEditor/fields-blog.ts
+++ b/src/components/MarkdownEditor/fields-blog.ts
@@ -20,7 +20,6 @@ export const blogFields: readonly FieldDefinition[] = [
     type: 'text',
     required: true,
   },
-  { key: 'pubDate', label: 'Creation Date', type: 'date' },
   { key: 'published', label: 'Published', type: 'checkbox' },
   { key: 'publishDate', label: 'Publish Date', type: 'date' },
 ]

--- a/src/components/MarkdownEditor/fields-newspaper.ts
+++ b/src/components/MarkdownEditor/fields-newspaper.ts
@@ -14,7 +14,6 @@ export const newspaperFields: readonly FieldDefinition[] = [
     type: 'textarea',
     required: true,
   },
-  { key: 'pubDate', label: 'Publication Date', type: 'date' },
   { key: 'published', label: 'Published', type: 'checkbox' },
   { key: 'publishDate', label: 'Publish Date', type: 'date' },
 ]

--- a/src/components/MarkdownEditor/fields-positions.ts
+++ b/src/components/MarkdownEditor/fields-positions.ts
@@ -14,7 +14,6 @@ export const positionsFields: readonly FieldDefinition[] = [
     type: 'textarea',
     required: true,
   },
-  { key: 'pubDate', label: 'Creation Date', type: 'date' },
   { key: 'published', label: 'Published', type: 'checkbox' },
   { key: 'publishDate', label: 'Publish Date', type: 'date' },
 ]

--- a/src/components/MarkdownEditor/frontmatter-fields.test.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.test.ts
@@ -10,7 +10,6 @@ describe('getFields', () => {
         'title',
         'description',
         'category',
-        'pubDate',
         'published',
         'publishDate',
       ])
@@ -24,7 +23,6 @@ describe('getFields', () => {
       expect(keys).toEqual([
         'title',
         'description',
-        'pubDate',
         'published',
         'publishDate',
       ])

--- a/src/sw/mock/blog/astro-framework-translations.ts
+++ b/src/sw/mock/blog/astro-framework-translations.ts
@@ -8,7 +8,8 @@ export const astroTranslations: readonly MockEntry[] = [
 title: Perché Scegliere il Framework Astro
 description: Scopri l'approccio unico di Astro per siti web veloci.
 category: Tecnologia
-pubDate: 2024-01-25
+published: true
+publishDate: 2024-01-25
 lang: it
 ---
 
@@ -22,7 +23,8 @@ Astro è un framework web moderno con un approccio innovativo.`,
 title: Por Qué Elegir el Framework Astro
 description: Descubre el enfoque único de Astro para sitios web rápidos.
 category: Tecnología
-pubDate: 2024-01-25
+published: true
+publishDate: 2024-01-25
 lang: es
 ---
 

--- a/src/sw/mock/blog/astro-framework.ts
+++ b/src/sw/mock/blog/astro-framework.ts
@@ -9,7 +9,8 @@ export const astroFrameworkEntries: readonly MockEntry[] = [
 title: Why Choose Astro Framework
 description: Learn about Astro's unique approach to building fast websites.
 category: Technology
-pubDate: 2024-01-25
+published: true
+publishDate: 2024-01-25
 lang: en
 ---
 
@@ -23,7 +24,8 @@ Astro is a modern web framework with a fresh approach.`,
 title: Почему выбрать фреймворк Astro
 description: Узнайте об уникальном подходе Astro к созданию быстрых сайтов.
 category: Технологии
-pubDate: 2024-01-25
+published: true
+publishDate: 2024-01-25
 lang: ru
 ---
 

--- a/src/sw/mock/blog/media-showcase-translations.ts
+++ b/src/sw/mock/blog/media-showcase-translations.ts
@@ -8,7 +8,8 @@ export const mediaShowcaseTranslations: readonly MockEntry[] = [
 title: Мультимедиа в блоге
 description: Демонстрация типов медиаконтента в блоге Prometheus.
 category: Технология
-pubDate: 2024-02-10
+published: true
+publishDate: 2024-02-10
 image: ./assets/cover.jpg
 lang: ru
 ---
@@ -23,7 +24,8 @@ lang: ru
 title: Contenuti multimediali nel blog
 description: Una vetrina dei tipi di media supportati nel blog Prometheus.
 category: Tecnologia
-pubDate: 2024-02-10
+published: true
+publishDate: 2024-02-10
 image: ./assets/cover.jpg
 lang: it
 ---
@@ -38,7 +40,8 @@ Il blog Prometheus supporta un'ampia gamma di contenuti multimediali.`,
 title: Contenido multimedia en el blog
 description: Muestra de tipos de medios en el blog Prometheus.
 category: Tecnología
-pubDate: 2024-02-10
+published: true
+publishDate: 2024-02-10
 image: ./assets/cover.jpg
 lang: es
 ---

--- a/src/sw/mock/blog/media-showcase.ts
+++ b/src/sw/mock/blog/media-showcase.ts
@@ -10,7 +10,8 @@ export const mediaShowcaseEntries: readonly MockEntry[] = [
 title: Rich Media in Blog Posts
 description: A showcase of media types supported in Prometheus blog.
 category: Technology
-pubDate: 2024-02-10
+published: true
+publishDate: 2024-02-10
 image: ./assets/cover.jpg
 lang: en
 ---

--- a/src/sw/mock/blog/modern-web-translations.ts
+++ b/src/sw/mock/blog/modern-web-translations.ts
@@ -8,7 +8,8 @@ export const modernWebTranslations: readonly MockEntry[] = [
 title: Best Practice per lo Sviluppo Web Moderno
 description: Esplora le ultime best practice nello sviluppo web.
 category: Tecnologia
-pubDate: 2024-01-20
+published: true
+publishDate: 2024-01-20
 lang: it
 ---
 
@@ -22,7 +23,8 @@ Il panorama dello sviluppo web è in costante evoluzione.`,
 title: Mejores Prácticas de Desarrollo Web Moderno
 description: Explora las últimas mejores prácticas en desarrollo web.
 category: Tecnología
-pubDate: 2024-01-20
+published: true
+publishDate: 2024-01-20
 lang: es
 ---
 

--- a/src/sw/mock/blog/modern-web.ts
+++ b/src/sw/mock/blog/modern-web.ts
@@ -9,7 +9,8 @@ export const modernWebEntries: readonly MockEntry[] = [
 title: Modern Web Development Best Practices
 description: Explore the latest best practices in web development.
 category: Technology
-pubDate: 2024-01-20
+published: true
+publishDate: 2024-01-20
 lang: en
 ---
 
@@ -23,7 +24,8 @@ The web development landscape is constantly evolving.`,
 title: Лучшие практики современной веб-разработки
 description: Изучите новейшие практики веб-разработки.
 category: Технологии
-pubDate: 2024-01-20
+published: true
+publishDate: 2024-01-20
 lang: ru
 ---
 

--- a/src/sw/mock/blog/open-source-translations.ts
+++ b/src/sw/mock/blog/open-source-translations.ts
@@ -8,7 +8,8 @@ export const openSourceTranslations: readonly MockEntry[] = [
 title: Il potere della collaborazione open source
 description: Come le comunità open source guidano l'innovazione.
 category: Comunità
-pubDate: 2024-02-05
+published: true
+publishDate: 2024-02-05
 image: ./assets/cover.jpg
 lang: it
 ---
@@ -23,7 +24,8 @@ L'open source è più di un modello di sviluppo.`,
 title: El poder de la colaboración open source
 description: Cómo las comunidades de código abierto impulsan la innovación.
 category: Comunidad
-pubDate: 2024-02-05
+published: true
+publishDate: 2024-02-05
 image: ./assets/cover.jpg
 lang: es
 ---

--- a/src/sw/mock/blog/open-source.ts
+++ b/src/sw/mock/blog/open-source.ts
@@ -10,7 +10,8 @@ export const openSourceEntries: readonly MockEntry[] = [
 title: The Power of Open Source Collaboration
 description: How open source communities drive innovation.
 category: Community
-pubDate: 2024-02-05
+published: true
+publishDate: 2024-02-05
 image: ./assets/cover.jpg
 lang: en
 ---
@@ -25,7 +26,8 @@ Open source is more than a development model.`,
 title: Сила открытого сотрудничества
 description: Как сообщества открытого кода стимулируют инновации.
 category: Сообщество
-pubDate: 2024-02-05
+published: true
+publishDate: 2024-02-05
 image: ./assets/cover.jpg
 lang: ru
 ---

--- a/src/sw/mock/blog/welcome-translations.ts
+++ b/src/sw/mock/blog/welcome-translations.ts
@@ -8,7 +8,8 @@ export const welcomeTranslations: readonly MockEntry[] = [
 title: Benvenuti su Prometheus
 description: Scoprite la nostra visione per una piattaforma moderna.
 category: Annuncio
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 image: ./assets/hero.svg
 lang: it
 ---
@@ -23,7 +24,8 @@ Siamo entusiasti di presentare **Prometheus**.`,
 title: Bienvenidos a Prometheus
 description: Descubre nuestra visión para una plataforma moderna.
 category: Anuncio
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 image: ./assets/hero.svg
 lang: es
 ---

--- a/src/sw/mock/blog/welcome.ts
+++ b/src/sw/mock/blog/welcome.ts
@@ -10,7 +10,8 @@ export const welcomeEntries: readonly MockEntry[] = [
 title: Welcome to Prometheus
 description: Discover our vision for a modern knowledge sharing platform.
 category: Announcement
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 image: ./assets/hero.svg
 lang: en
 ---
@@ -27,7 +28,8 @@ We're excited to introduce **Prometheus** - a modern platform.`,
 title: Добро пожаловать в Prometheus
 description: Откройте для себя наше видение современной платформы.
 category: Объявление
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 image: ./assets/hero.svg
 lang: ru
 ---

--- a/src/sw/mock/positions/digital-sovereignty-translations.ts
+++ b/src/sw/mock/positions/digital-sovereignty-translations.ts
@@ -7,7 +7,8 @@ export const sovereigntyTranslations: readonly MockEntry[] = [
     content: `---
 title: Sovranità Digitale
 description: La tecnologia deve servire le persone, non le corporazioni.
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 lang: it
 ---
 
@@ -20,7 +21,8 @@ Sosteniamo l'infrastruttura open-source.`,
     content: `---
 title: Soberanía Digital
 description: La tecnología debe servir a las personas, no a las corporaciones.
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 lang: es
 ---
 

--- a/src/sw/mock/positions/digital-sovereignty.ts
+++ b/src/sw/mock/positions/digital-sovereignty.ts
@@ -8,7 +8,8 @@ export const digitalSovereigntyEntries: readonly MockEntry[] = [
     content: `---
 title: Digital Sovereignty
 description: Technology must serve the people, not corporations.
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 lang: en
 ---
 
@@ -21,7 +22,8 @@ We advocate for open-source infrastructure.`,
     content: `---
 title: Цифровой суверенитет
 description: Технологии должны служить людям, а не корпорациям.
-pubDate: 2024-01-15
+published: true
+publishDate: 2024-01-15
 lang: ru
 ---
 

--- a/src/sw/mock/positions/knowledge-access-translations.ts
+++ b/src/sw/mock/positions/knowledge-access-translations.ts
@@ -7,7 +7,8 @@ export const knowledgeTranslations: readonly MockEntry[] = [
     content: `---
 title: Accesso Universale alla Conoscenza
 description: L'istruzione e la conoscenza dovrebbero essere liberamente disponibili.
-pubDate: 2024-02-01
+published: true
+publishDate: 2024-02-01
 lang: it
 ---
 
@@ -20,7 +21,8 @@ L'apprendimento dovrebbe essere collaborativo.`,
     content: `---
 title: Acceso Universal al Conocimiento
 description: La educación y el conocimiento deben estar disponibles libremente.
-pubDate: 2024-02-01
+published: true
+publishDate: 2024-02-01
 lang: es
 ---
 

--- a/src/sw/mock/positions/knowledge-access.ts
+++ b/src/sw/mock/positions/knowledge-access.ts
@@ -8,7 +8,8 @@ export const knowledgeAccessEntries: readonly MockEntry[] = [
     content: `---
 title: Universal Knowledge Access
 description: Education and knowledge should be freely available to everyone.
-pubDate: 2024-02-01
+published: true
+publishDate: 2024-02-01
 lang: en
 ---
 
@@ -21,7 +22,8 @@ Everyone deserves equal access to knowledge.`,
     content: `---
 title: Всеобщий доступ к знаниям
 description: Образование и знания должны быть свободно доступны каждому.
-pubDate: 2024-02-01
+published: true
+publishDate: 2024-02-01
 lang: ru
 ---
 

--- a/src/types/frontmatter-blog.ts
+++ b/src/types/frontmatter-blog.ts
@@ -7,9 +7,10 @@ export interface BlogFrontmatter {
   readonly title: string
   readonly description: string
   readonly category: string
-  readonly pubDate: Date
   readonly lang: Language
   readonly image?: string
+  readonly published?: boolean
+  readonly publishDate?: Date
 }
 
 /**
@@ -18,6 +19,7 @@ export interface BlogFrontmatter {
 export interface PositionFrontmatter {
   readonly title: string
   readonly description: string
-  readonly pubDate: Date
   readonly lang: Language
+  readonly published?: boolean
+  readonly publishDate?: Date
 }

--- a/src/views/ContentEditView/useEditPageInit.ts
+++ b/src/views/ContentEditView/useEditPageInit.ts
@@ -41,7 +41,6 @@ export const createInitEditor =
         lang: draft.lang,
         ...(draft.description ? { description: draft.description } : {}),
         ...(draft.category ? { category: draft.category } : {}),
-        pubDate: new Date().toISOString().slice(0, 10),
       }
       deps.bodyContent.value = ''
       return


### PR DESCRIPTION
## Summary
- Drop the \`pubDate\` field from blog/positions/newspaper editors — one remaining date: \`publishDate\`.
- Auto-fill of \`publishDate\` when Published is toggled on remains the single allowed auto-write.
- Strip \`pubDate\` from the \`BlogFrontmatter\` / \`PositionFrontmatter\` type shapes.
- Drop the create→edit handover code that was also stamping \`pubDate\` (missed in #16).
- Migrate SW mock content to mirror the new public-website shape via \`scripts/migrate-mocks.ts\` (14 files rewritten).
- \`ContentListItem.vue\` now sorts/displays \`publishDate\`.

Stacked on admin PR #16 and public-website PRs #27/#28. Closes #12.

## Test plan
- [x] \`bun run type-check\` — clean.
- [x] \`bun run test:unit\` — 245/245 pass across 47 files.
- [x] \`bun run lint\` — 0 issues across 720 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)