### PR TITLE
fix(#9): validate frontmatter before save

### DIFF
--- a/src/sw/handlers/content/update.ts
+++ b/src/sw/handlers/content/update.ts
@@ -1,6 +1,7 @@
-import { Effect, pipe } from 'effect'
+import { Effect, Either, pipe } from 'effect'
 import type { ContentType } from '@/types/content'
 import { isContentType } from '@/types/content'
+import { validateFrontmatter } from '@/validation/schemas/frontmatter'
 import { ValidationError } from '../../errors'
 import { writeAndStage } from '../../git/io/write-file'
 import { commitAndPush } from '../../git/remote/commit-and-push'
@@ -13,12 +14,26 @@ import { resolveContentPath } from './resolve-path'
 import type { UpdateBody } from './update-body'
 import { isValidUpdate } from './update-body'
 
+const validate = (
+  b: UpdateBody
+): Effect.Effect<void, ValidationError> => {
+  if (!isContentType(b.type)) return Effect.succeed(undefined)
+  const result = validateFrontmatter(b.type as ContentType, b.frontmatter)
+  if (Either.isLeft(result)) {
+    return Effect.fail(new ValidationError({ message: result.left }))
+  }
+  return Effect.succeed(undefined)
+}
+
 const checkAndWrite = (b: UpdateBody) =>
   pipe(
-    assertPermission(
-      'update',
-      isContentType(b.type) ? (b.type as ContentType) : 'blog',
-      String(b.frontmatter['author'] ?? '')
+    validate(b),
+    Effect.flatMap(() =>
+      assertPermission(
+        'update',
+        isContentType(b.type) ? (b.type as ContentType) : 'blog',
+        String(b.frontmatter['author'] ?? '')
+      )
     ),
     Effect.flatMap(() =>
       Effect.promise(() => resolveContentPath(b.type, b.slug, b.lang))

--- a/src/validation/schemas/frontmatter-blog.ts
+++ b/src/validation/schemas/frontmatter-blog.ts
@@ -1,0 +1,18 @@
+import { Schema } from 'effect'
+
+/**
+ * Shape a committed blog frontmatter must have before it hits git.
+ * Mirrors public-website src/content.config.ts blogCollection.
+ * Date values are accepted as ISO strings or Date (YAML parsers vary).
+ */
+export const BlogFrontmatterSchema = Schema.Struct({
+  title: Schema.String.pipe(Schema.nonEmptyString()),
+  description: Schema.String.pipe(Schema.nonEmptyString()),
+  category: Schema.String.pipe(Schema.nonEmptyString()),
+  lang: Schema.String.pipe(Schema.nonEmptyString()),
+  published: Schema.optional(Schema.Boolean),
+  publishDate: Schema.optional(
+    Schema.Union(Schema.String, Schema.DateFromSelf)
+  ),
+  image: Schema.optional(Schema.String),
+})

--- a/src/validation/schemas/frontmatter-newspaper.ts
+++ b/src/validation/schemas/frontmatter-newspaper.ts
@@ -1,0 +1,16 @@
+import { Schema } from 'effect'
+
+/**
+ * Shape a committed newspaper frontmatter must have before it hits git.
+ * Mirrors public-website newspaperCollection.
+ */
+export const NewspaperFrontmatterSchema = Schema.Struct({
+  title: Schema.String.pipe(Schema.nonEmptyString()),
+  description: Schema.String.pipe(Schema.nonEmptyString()),
+  lang: Schema.String.pipe(Schema.nonEmptyString()),
+  published: Schema.optional(Schema.Boolean),
+  publishDate: Schema.optional(
+    Schema.Union(Schema.String, Schema.DateFromSelf)
+  ),
+  image: Schema.optional(Schema.String),
+})

--- a/src/validation/schemas/frontmatter-pages.ts
+++ b/src/validation/schemas/frontmatter-pages.ts
@@ -1,0 +1,11 @@
+import { Schema } from 'effect'
+
+/**
+ * Shape a committed pages frontmatter must have before it hits git.
+ * Mirrors public-website pagesCollection — pages have no publish gate.
+ */
+export const PagesFrontmatterSchema = Schema.Struct({
+  title: Schema.String.pipe(Schema.nonEmptyString()),
+  lang: Schema.String.pipe(Schema.nonEmptyString()),
+  description: Schema.optional(Schema.String),
+})

--- a/src/validation/schemas/frontmatter-positions.ts
+++ b/src/validation/schemas/frontmatter-positions.ts
@@ -1,0 +1,15 @@
+import { Schema } from 'effect'
+
+/**
+ * Shape a committed positions frontmatter must have before it hits git.
+ * Mirrors public-website positionsCollection.
+ */
+export const PositionsFrontmatterSchema = Schema.Struct({
+  title: Schema.String.pipe(Schema.nonEmptyString()),
+  description: Schema.String.pipe(Schema.nonEmptyString()),
+  lang: Schema.String.pipe(Schema.nonEmptyString()),
+  published: Schema.optional(Schema.Boolean),
+  publishDate: Schema.optional(
+    Schema.Union(Schema.String, Schema.DateFromSelf)
+  ),
+})

--- a/src/validation/schemas/frontmatter.test.ts
+++ b/src/validation/schemas/frontmatter.test.ts
@@ -1,0 +1,63 @@
+import { Either } from 'effect'
+import { describe, expect, it } from 'vitest'
+import { validateFrontmatter } from './frontmatter'
+
+describe('validateFrontmatter', () => {
+  it('accepts a minimal blog frontmatter', () => {
+    const r = validateFrontmatter('blog', {
+      title: 'T',
+      description: 'D',
+      category: 'C',
+      lang: 'en',
+    })
+    expect(Either.isRight(r)).toBe(true)
+  })
+
+  it('rejects a blog with an empty title', () => {
+    const r = validateFrontmatter('blog', {
+      title: '',
+      description: 'D',
+      category: 'C',
+      lang: 'en',
+    })
+    expect(Either.isLeft(r)).toBe(true)
+  })
+
+  it('rejects a blog missing required fields', () => {
+    const r = validateFrontmatter('blog', { title: 'T', lang: 'en' })
+    expect(Either.isLeft(r)).toBe(true)
+  })
+
+  it('rejects a positions missing description', () => {
+    const r = validateFrontmatter('positions', {
+      title: 'T',
+      lang: 'en',
+    })
+    expect(Either.isLeft(r)).toBe(true)
+  })
+
+  it('accepts newspaper with optional publishDate', () => {
+    const r = validateFrontmatter('newspaper', {
+      title: 'T',
+      description: 'D',
+      lang: 'en',
+      publishDate: '2026-04-20',
+    })
+    expect(Either.isRight(r)).toBe(true)
+  })
+
+  it('accepts a pages with title + lang only', () => {
+    const r = validateFrontmatter('pages', { title: 'T', lang: 'en' })
+    expect(Either.isRight(r)).toBe(true)
+  })
+
+  it('rejects pages missing title', () => {
+    const r = validateFrontmatter('pages', { lang: 'en' })
+    expect(Either.isLeft(r)).toBe(true)
+  })
+
+  it('accepts unknown types (common) without opinion', () => {
+    const r = validateFrontmatter('common', { anything: 'goes' })
+    expect(Either.isRight(r)).toBe(true)
+  })
+})

--- a/src/validation/schemas/frontmatter.ts
+++ b/src/validation/schemas/frontmatter.ts
@@ -1,0 +1,34 @@
+import { Either, Schema } from 'effect'
+import type { ContentType } from '@/types/content'
+import { BlogFrontmatterSchema } from './frontmatter-blog'
+import { NewspaperFrontmatterSchema } from './frontmatter-newspaper'
+import { PagesFrontmatterSchema } from './frontmatter-pages'
+import { PositionsFrontmatterSchema } from './frontmatter-positions'
+
+type Result = Either.Either<void, string>
+
+const run = <A>(schema: Schema.Schema<A>, value: unknown): Result => {
+  const parsed = Schema.decodeUnknownEither(schema)(value)
+  return Either.mapBoth(parsed, {
+    onLeft: e => e.message,
+    onRight: () => undefined,
+  })
+}
+
+/**
+ * Validate the frontmatter for a given content type.
+ *
+ * @param type the content type whose schema should apply
+ * @param value the frontmatter object to validate
+ * @returns Right(void) when valid, Left(message) listing all errors
+ */
+export const validateFrontmatter = (
+  type: ContentType,
+  value: unknown
+): Result => {
+  if (type === 'blog') return run(BlogFrontmatterSchema, value)
+  if (type === 'positions') return run(PositionsFrontmatterSchema, value)
+  if (type === 'newspaper') return run(NewspaperFrontmatterSchema, value)
+  if (type === 'pages') return run(PagesFrontmatterSchema, value)
+  return Either.right(undefined)
+}

--- a/src/views/ContentEditView/build-raw-save.ts
+++ b/src/views/ContentEditView/build-raw-save.ts
@@ -29,6 +29,8 @@ export const buildRawSave = (
     saveCurrentLanguage: editor.saveCurrentLanguage,
     reloadContent: list.reloadContent,
     title,
+    contentType: page.contentType,
+    frontmatter: () => editor.frontmatterData.value,
     contentTypeName: page.contentType,
     track,
     onError: msg => globalThis.alert(`Save failed: ${msg}`),

--- a/src/views/ContentEditView/create-handle-save.ts
+++ b/src/views/ContentEditView/create-handle-save.ts
@@ -1,10 +1,12 @@
+import { Either } from 'effect'
 import type { ComputedRef, Ref } from 'vue'
 import type { TrackDeploy } from '@/composables/useDeployStatus/deploy-context'
 import {
   clearPendingDeploy,
   setPendingDeploy,
 } from '@/composables/useDeployStatus/pending-deploy'
-import type { Language } from '@/types/content'
+import type { ContentType, Language } from '@/types/content'
+import { validateFrontmatter } from '@/validation/schemas/frontmatter'
 
 interface HandleSaveDeps {
   readonly hasAssets: ComputedRef<boolean>
@@ -17,18 +19,33 @@ interface HandleSaveDeps {
   ) => Promise<void>
   readonly reloadContent: () => Promise<void>
   readonly title: ComputedRef<string>
+  readonly contentType: ComputedRef<ContentType>
+  readonly frontmatter: () => Record<string, unknown>
   readonly contentTypeName: ComputedRef<string>
   readonly track?: TrackDeploy
   readonly onError?: (msg: string) => void
 }
 
+const guard = (deps: HandleSaveDeps): string | undefined => {
+  const result = validateFrontmatter(
+    deps.contentType.value,
+    deps.frontmatter()
+  )
+  return Either.isLeft(result) ? result.left : undefined
+}
+
 /**
- * Create the save handler for edit page.
- * @param deps - Dependencies for saving
- * @returns Async save handler
+ * Create the save handler for the edit page.
+ *
+ * @param deps dependencies for saving
+ * @returns an async function to invoke on Save
  */
 export const createHandleSave = (deps: HandleSaveDeps) => async () => {
   const message = `updated ${deps.title.value} in ${deps.contentTypeName.value}`
+  const gate = guard(deps)
+  if (gate !== undefined) {
+    throw new Error(gate)
+  }
   setPendingDeploy(message)
   try {
     if (deps.hasAssets.value) await deps.blogSave(message)


### PR DESCRIPTION
## Summary
- Per-content-type Effect.Schema validators under \`src/validation/schemas/frontmatter-*.ts\`, mirroring the post-#12 Zod shapes.
- \`createHandleSave\` validates before any git operation; a validation error throws and the ErrorMessage banner surfaces the reason.
- \`sw/handlers/content/update.ts\` gets the same validator as an Effect step and returns 400 on failure.
- 8 unit tests covering positive + negative for blog / positions / newspaper / pages + passthrough for \`common\`.

Closes #9. Stacked on #17.

## Test plan
- [x] \`bun run type-check\` — clean.
- [x] \`bun run test:unit\` — 253/253 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)