### PR TITLE
feat(#13): add Import-from-Docs action to the editor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,14 @@
       "name": "admin-website",
       "dependencies": {
         "@isomorphic-git/lightning-fs": "^4.6.2",
+        "@types/turndown": "^5.0.6",
         "hono": "^4.12.8",
         "isomorphic-git": "^1.37.2",
+        "mammoth": "^1.12.0",
         "marked": "^17.0.4",
         "pinia": "^3.0.4",
+        "turndown": "^7.2.4",
+        "turndown-plugin-gfm": "^1.0.2",
         "vue": "beta",
         "vue-router": "^5.0.2",
       },
@@ -310,6 +314,8 @@
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
+    "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
@@ -544,6 +550,8 @@
 
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
+    "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
+
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -640,6 +648,8 @@
 
     "@vue/tsconfig": ["@vue/tsconfig@0.8.1", "", { "peerDependencies": { "typescript": "5.x", "vue": "^3.4.0" } }, "sha512-aK7feIWPXFSUhsCP9PFqPyFOcz4ENkb8hZ2pneL6m2UjCkccvaOhC/5KCKluuBufvp2KzkbdA2W2pk20vLzu3g=="],
 
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
+
     "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -668,7 +678,7 @@
 
     "are-docs-informative": ["are-docs-informative@0.0.2", "", {}, "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig=="],
 
-    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+    "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -713,6 +723,8 @@
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
+
+    "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
@@ -786,6 +798,8 @@
 
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
+    "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
+
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" } }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
@@ -834,6 +848,8 @@
 
     "diff3": ["diff3@0.0.3", "", {}, "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g=="],
 
+    "dingbat-to-unicode": ["dingbat-to-unicode@1.0.1", "", {}, "sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w=="],
+
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
@@ -845,6 +861,8 @@
     "dot-prop": ["dot-prop@9.0.0", "", { "dependencies": { "type-fest": "^4.18.2" } }, "sha512-1gxPBJpI/pcjQhKgIU91II6Wkay+dLcN3M6rf2uwP8hRur3HtQXjVrdAK3sjC0piaEuxzMwjXChcETiJl47lAQ=="],
 
     "dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
+
+    "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1050,6 +1068,8 @@
 
     "image-ssim": ["image-ssim@0.2.0", "", {}, "sha512-W7+sO6/yhxy83L0G7xR8YAc5Z5QFtYEXXRV6EaE8tuYBZJnA3gVgp3q7X7muhLZVodeb9UfvjSbwt9VJwjIYAg=="],
 
+    "immediate": ["immediate@3.0.6", "", {}, "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="],
+
     "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
@@ -1140,6 +1160,8 @@
 
     "jsx-ast-utils-x": ["jsx-ast-utils-x@0.1.0", "", {}, "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw=="],
 
+    "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
+
     "just-debounce-it": ["just-debounce-it@1.1.0", "", {}, "sha512-87Nnc0qZKgBZuhFZjYVjSraic0x7zwjhaTMrCKlj0QYKH6lh0KbFzVnfu6LHan03NO7J8ygjeBeD0epejn5Zcg=="],
 
     "just-once": ["just-once@1.1.0", "", {}, "sha512-+rZVpl+6VyTilK7vB/svlMPil4pxqIJZkbnN7DKZTOzyXfun6ZiFeq2Pk4EtCEHZ0VU4EkdFzG8ZK5F3PErcDw=="],
@@ -1153,6 +1175,8 @@
     "legacy-javascript": ["legacy-javascript@0.0.1", "", {}, "sha512-lPyntS4/aS7jpuvOlitZDFifBCb4W8L/3QU0PLbUTUj+zYah8rfVjYic88yG7ZKTxhS5h9iz7duT8oUXKszLhg=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
+    "lie": ["lie@3.3.0", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ=="],
 
     "lighthouse": ["lighthouse@13.1.0", "", { "dependencies": { "@paulirish/trace_engine": "0.0.61", "@sentry/node": "^9.28.1", "axe-core": "^4.11.2", "chrome-launcher": "^1.2.1", "configstore": "^7.0.0", "csp_evaluator": "1.1.5", "devtools-protocol": "0.0.1608973", "enquirer": "^2.3.6", "http-link-header": "^1.1.1", "intl-messageformat": "^10.5.3", "jpeg-js": "^0.4.4", "js-library-detector": "^6.7.0", "lighthouse-logger": "^2.0.2", "lighthouse-stack-packs": "1.12.3", "lodash-es": "^4.17.21", "lookup-closest-locale": "6.2.0", "open": "^8.4.0", "puppeteer-core": "^24.40.0", "robots-parser": "^3.0.1", "speedline-core": "^1.4.3", "third-party-web": "^0.29.0", "tldts-icann": "^7.0.27", "web-features": "^3.21.0", "ws": "^7.0.0", "yargs": "^17.3.1", "yargs-parser": "^21.0.0" }, "bin": { "chrome-debug": "core/scripts/manual-chrome-launcher.js", "lighthouse": "cli/index.js", "smokehouse": "cli/test/smokehouse/frontends/smokehouse-bin.js" } }, "sha512-H3Qi4fJBXbaCTdE3XzdONq6kH5wMoG4v5sv+1BgG4H+0nivSo35eTp/yryHEU7G4xepUJmmlvjS10OWGHFwU+Q=="],
 
@@ -1204,11 +1228,15 @@
 
     "lookup-closest-locale": ["lookup-closest-locale@6.2.0", "", {}, "sha512-/c2kL+Vnp1jnV6K6RpDTHK3dgg0Tu2VVp+elEiJpjfS1UyY7AjOYHohRug6wT0OpoX2qFgNORndE9RqesfVxWQ=="],
 
+    "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
+
     "lru-cache": ["lru-cache@11.3.3", "", {}, "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magic-string-ast": ["magic-string-ast@1.0.3", "", { "dependencies": { "magic-string": "^0.30.19" } }, "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA=="],
+
+    "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
 
     "marked": ["marked@17.0.6", "", { "bin": "bin/marked.js" }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
 
@@ -1282,6 +1310,8 @@
 
     "open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
+    "option": ["option@0.2.4", "", {}, "sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "oxlint": ["oxlint@1.48.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.48.0", "@oxlint/binding-android-arm64": "1.48.0", "@oxlint/binding-darwin-arm64": "1.48.0", "@oxlint/binding-darwin-x64": "1.48.0", "@oxlint/binding-freebsd-x64": "1.48.0", "@oxlint/binding-linux-arm-gnueabihf": "1.48.0", "@oxlint/binding-linux-arm-musleabihf": "1.48.0", "@oxlint/binding-linux-arm64-gnu": "1.48.0", "@oxlint/binding-linux-arm64-musl": "1.48.0", "@oxlint/binding-linux-ppc64-gnu": "1.48.0", "@oxlint/binding-linux-riscv64-gnu": "1.48.0", "@oxlint/binding-linux-riscv64-musl": "1.48.0", "@oxlint/binding-linux-s390x-gnu": "1.48.0", "@oxlint/binding-linux-x64-gnu": "1.48.0", "@oxlint/binding-linux-x64-musl": "1.48.0", "@oxlint/binding-openharmony-arm64": "1.48.0", "@oxlint/binding-win32-arm64-msvc": "1.48.0", "@oxlint/binding-win32-ia32-msvc": "1.48.0", "@oxlint/binding-win32-x64-msvc": "1.48.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.12.2" }, "optionalPeers": ["oxlint-tsgolint"], "bin": "bin/oxlint" }, "sha512-m5vyVBgPtPhVCJc3xI//8je9lRc8bYuYB4R/1PH3VPGOjA4vjVhkHtyJukdEjYEjwrw4Qf1eIf+pP9xvfhfMow=="],
@@ -1311,6 +1341,8 @@
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1371,6 +1403,8 @@
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
 
     "progress": ["progress@2.0.3", "", {}, "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="],
 
@@ -1486,6 +1520,8 @@
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
 
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
     "sha.js": ["sha.js@2.4.12", "", { "dependencies": { "inherits": "^2.0.4", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.0" }, "bin": "bin.js" }, "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
@@ -1529,6 +1565,8 @@
     "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
 
     "speedline-core": ["speedline-core@1.4.3", "", { "dependencies": { "@types/node": "*", "image-ssim": "^0.2.0", "jpeg-js": "^0.4.1" } }, "sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog=="],
+
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -1624,6 +1662,10 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
+    "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
+
+    "turndown-plugin-gfm": ["turndown-plugin-gfm@1.0.2", "", {}, "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg=="],
+
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
     "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
@@ -1637,6 +1679,8 @@
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": "script/cli.js" }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "underscore": ["underscore@1.13.8", "", {}, "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ=="],
 
     "undici": ["undici@7.24.7", "", {}, "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ=="],
 
@@ -1725,6 +1769,8 @@
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlbuilder": ["xmlbuilder@10.1.1", "", {}, "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="],
 
     "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
@@ -1820,9 +1866,13 @@
 
     "isomorphic-git/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
+    "js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
     "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
 
     "jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
     "lighthouse/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
@@ -1903,6 +1953,12 @@
     "global-prefix/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "jszip/readable-stream/isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
+
+    "jszip/readable-stream/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "jszip/readable-stream/string_decoder": ["string_decoder@1.1.1", "", { "dependencies": { "safe-buffer": "~5.1.0" } }, "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -38,10 +38,14 @@
   },
   "dependencies": {
     "@isomorphic-git/lightning-fs": "^4.6.2",
+    "@types/turndown": "^5.0.6",
     "hono": "^4.12.8",
     "isomorphic-git": "^1.37.2",
+    "mammoth": "^1.12.0",
     "marked": "^17.0.4",
     "pinia": "^3.0.4",
+    "turndown": "^7.2.4",
+    "turndown-plugin-gfm": "^1.0.2",
     "vue": "beta",
     "vue-router": "^5.0.2"
   },

--- a/src/components/MarkdownEditor/ImportDocs/ImportDocsButton.vue
+++ b/src/components/MarkdownEditor/ImportDocs/ImportDocsButton.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { importFile } from './import-file'
+
+const emit = defineEmits<{
+  imported: [markdown: string, images: readonly File[]]
+  error: [message: string]
+}>()
+
+const busy = ref(false)
+const input = ref<HTMLInputElement>()
+
+const handleChange = async (event: Event) => {
+  const el = event.target instanceof HTMLInputElement ? event.target : undefined
+  const file = el?.files?.[0]
+  if (!file) return
+  busy.value = true
+  try {
+    const result = await importFile(file)
+    emit('imported', result.markdown, result.images)
+  } catch (err) {
+    emit('error', err instanceof Error ? err.message : 'Import failed')
+  } finally {
+    busy.value = false
+    if (el) el.value = ''
+  }
+}
+</script>
+
+<template>
+  <label class="import-docs">
+    <input
+      ref="input"
+      type="file"
+      accept=".docx,.html,.htm,.md"
+      data-testid="import-docs-input"
+      :disabled="busy"
+      @change="handleChange"
+    >
+    <span data-testid="import-docs-button">
+      {{ busy ? 'Importing…' : 'Import from Docs' }}
+    </span>
+  </label>
+</template>
+
+<style scoped>
+.import-docs {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  cursor: pointer;
+  font-size: clamp(0.8125rem, 1.8vw, 0.9375rem);
+  user-select: none;
+}
+
+.import-docs:has(input:disabled) {
+  opacity: 50%;
+  cursor: wait;
+}
+
+input {
+  display: none;
+}
+</style>

--- a/src/components/MarkdownEditor/ImportDocs/convert-docx.ts
+++ b/src/components/MarkdownEditor/ImportDocs/convert-docx.ts
@@ -1,0 +1,15 @@
+import mammoth from 'mammoth'
+
+/**
+ * Convert a .docx ArrayBuffer to HTML via mammoth. Embedded images are
+ * emitted as inline base64 data URIs; callers extract those later.
+ *
+ * @param buffer raw .docx bytes
+ * @returns mammoth HTML string
+ */
+export const convertDocxToHtml = async (
+  buffer: ArrayBuffer
+): Promise<string> => {
+  const result = await mammoth.convertToHtml({ arrayBuffer: buffer })
+  return result.value
+}

--- a/src/components/MarkdownEditor/ImportDocs/extract-images.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/extract-images.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { extractImages } from './extract-images'
+
+const tiny =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII='
+
+describe('extractImages', () => {
+  it('extracts a single png data URI', () => {
+    const html = `<p>hi</p><img src="data:image/png;base64,${tiny}"/>`
+    const out = extractImages(html, 'docx-img')
+    expect(out).toHaveLength(1)
+    expect(out[0]?.filename).toBe('docx-img-1.png')
+    expect(out[0]?.file.type).toBe('image/png')
+  })
+
+  it('numbers multiple images', () => {
+    const html =
+      `<img src="data:image/jpeg;base64,${tiny}"/>` +
+      `<img src="data:image/gif;base64,${tiny}"/>`
+    const out = extractImages(html, 'p')
+    expect(out.map(o => o.filename)).toEqual(['p-1.jpg', 'p-2.gif'])
+  })
+
+  it('ignores http(s) image sources', () => {
+    const html = '<img src="https://example.com/a.png"/>'
+    expect(extractImages(html, 'p')).toHaveLength(0)
+  })
+
+  it('returns empty list for HTML with no images', () => {
+    expect(extractImages('<p>hi</p>', 'p')).toHaveLength(0)
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/extract-images.ts
+++ b/src/components/MarkdownEditor/ImportDocs/extract-images.ts
@@ -1,0 +1,54 @@
+const DATA_URI = /^data:(image\/[^;]+);base64,(.+)$/
+const MIME_EXT: Readonly<Record<string, string>> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/svg+xml': 'svg',
+}
+
+interface Extracted {
+  readonly file: File
+  readonly filename: string
+  readonly dataUri: string
+}
+
+const toBytes = (base64: string): ArrayBuffer => {
+  const binary = atob(base64)
+  const buffer = new ArrayBuffer(binary.length)
+  const bytes = new Uint8Array(buffer)
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+  return buffer
+}
+
+/**
+ * Extract `<img src="data:...">` images from an HTML string and
+ * return them as Files plus the original data URIs so callers can
+ * rewrite the HTML.
+ *
+ * @param html HTML string containing inline-image <img> tags
+ * @param prefix filename prefix, e.g. `docx`
+ * @returns list of extracted images ready for asset upload
+ */
+export const extractImages = (
+  html: string,
+  prefix: string
+): readonly Extracted[] => {
+  const out: Extracted[] = []
+  const re = /<img\s[^>]*src="([^"]+)"[^>]*>/gi
+  let match: RegExpExecArray | null = re.exec(html)
+  while (match !== null) {
+    const src = match[1] ?? ''
+    const m = DATA_URI.exec(src)
+    if (m) {
+      const ext = MIME_EXT[m[1] ?? ''] ?? 'png'
+      const filename = `${prefix}-${out.length + 1}.${ext}`
+      const file = new File([toBytes(m[2] ?? '')], filename, {
+        type: m[1],
+      })
+      out.push({ file, filename, dataUri: src })
+    }
+    match = re.exec(html)
+  }
+  return out
+}

--- a/src/components/MarkdownEditor/ImportDocs/html-to-markdown.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/html-to-markdown.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { htmlToMarkdown } from './html-to-markdown'
+
+describe('htmlToMarkdown', () => {
+  it('renders headings, bold, italic, and links', () => {
+    const html =
+      '<h1>Hi</h1><p><strong>bold</strong> <em>italic</em> ' +
+      '<a href="http://x">link</a></p>'
+    const md = htmlToMarkdown(html)
+    expect(md).toContain('# Hi')
+    expect(md).toContain('**bold**')
+    expect(md).toContain('_italic_')
+    expect(md).toContain('[link](http://x)')
+  })
+
+  it('renders unordered and ordered lists', () => {
+    const md = htmlToMarkdown(
+      '<ul><li>a</li><li>b</li></ul><ol><li>c</li></ol>'
+    )
+    expect(md).toMatch(/^-\s+a/m)
+    expect(md).toMatch(/^-\s+b/m)
+    expect(md).toMatch(/^1\.\s+c/m)
+  })
+
+  it('renders fenced code blocks', () => {
+    const md = htmlToMarkdown('<pre><code>hello</code></pre>')
+    expect(md).toContain('```')
+    expect(md).toContain('hello')
+  })
+
+  it('renders images with the expected markdown', () => {
+    const md = htmlToMarkdown('<img src="./assets/x.png" alt="alt"/>')
+    expect(md).toContain('![alt](./assets/x.png)')
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/html-to-markdown.ts
+++ b/src/components/MarkdownEditor/ImportDocs/html-to-markdown.ts
@@ -1,0 +1,25 @@
+import TurndownService from 'turndown'
+import { gfm } from 'turndown-plugin-gfm'
+
+let cached: TurndownService | undefined
+
+const build = (): TurndownService => {
+  const td = new TurndownService({
+    headingStyle: 'atx',
+    codeBlockStyle: 'fenced',
+    bulletListMarker: '-',
+  })
+  td.use(gfm)
+  return td
+}
+
+/**
+ * Convert HTML to GitHub-flavored Markdown.
+ *
+ * @param html source HTML
+ * @returns Markdown output
+ */
+export const htmlToMarkdown = (html: string): string => {
+  if (cached === undefined) cached = build()
+  return cached.turndown(html)
+}

--- a/src/components/MarkdownEditor/ImportDocs/import-file.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/import-file.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { importFile } from './import-file'
+
+describe('importFile', () => {
+  it('imports .md verbatim', async () => {
+    const file = new File(['# hi\n\nbody'], 'doc.md', {
+      type: 'text/markdown',
+    })
+    const out = await importFile(file)
+    expect(out.markdown).toBe('# hi\n\nbody')
+    expect(out.images).toHaveLength(0)
+  })
+
+  it('imports .html to markdown', async () => {
+    const file = new File(['<h1>T</h1>'], 'x.html', { type: 'text/html' })
+    const out = await importFile(file)
+    expect(out.markdown).toContain('# T')
+  })
+
+  it('rejects .pdf with a clear error', async () => {
+    const file = new File(['x'], 'x.pdf', { type: 'application/pdf' })
+    await expect(importFile(file)).rejects.toThrow(/unsupported/i)
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/import-file.ts
+++ b/src/components/MarkdownEditor/ImportDocs/import-file.ts
@@ -1,0 +1,45 @@
+import { convertDocxToHtml } from './convert-docx'
+import { extractImages } from './extract-images'
+import { htmlToMarkdown } from './html-to-markdown'
+import { rewriteImages } from './rewrite-images'
+
+/** Output of an import: converted markdown and accompanying images. */
+export interface ImportResult {
+  readonly markdown: string
+  readonly images: readonly File[]
+}
+
+const UNSUPPORTED = 'Unsupported file type. Pick a .docx, .html, or .md.'
+const EMPTY: ImportResult = { markdown: '', images: [] }
+
+const fromHtml = (html: string, prefix: string): ImportResult => {
+  const images = extractImages(html, prefix)
+  const clean = rewriteImages(html, images)
+  return { markdown: htmlToMarkdown(clean), images: images.map(i => i.file) }
+}
+
+const fromDocx = async (file: File): Promise<ImportResult> => {
+  const buffer = await file.arrayBuffer()
+  const html = await convertDocxToHtml(buffer)
+  return fromHtml(html, 'docx-img')
+}
+
+const ext = (file: File): string =>
+  file.name.toLowerCase().split('.').pop() ?? ''
+
+/**
+ * Parse a user-picked file and return clean Markdown plus any images
+ * that need to be uploaded as assets alongside.
+ *
+ * @param file picker file from the toolbar
+ * @returns markdown + image files; throws on unsupported type
+ */
+export const importFile = async (file: File): Promise<ImportResult> => {
+  const e = ext(file)
+  if (e === 'docx') return fromDocx(file)
+  if (e === 'html' || e === 'htm') {
+    return fromHtml(await file.text(), 'html-img')
+  }
+  if (e === 'md') return { ...EMPTY, markdown: await file.text() }
+  throw new Error(UNSUPPORTED)
+}

--- a/src/components/MarkdownEditor/ImportDocs/insert-imported.ts
+++ b/src/components/MarkdownEditor/ImportDocs/insert-imported.ts
@@ -1,0 +1,20 @@
+/**
+ * Insert imported markdown at the caret and return the images for
+ * upload through the caller's existing asset pipeline.
+ *
+ * @param el target textarea element (may be undefined mid-transition)
+ * @param markdown text to insert
+ * @param images image files that accompany the markdown
+ * @param upload callback invoked once per image
+ */
+export const insertImported = (
+  el: HTMLTextAreaElement | undefined,
+  markdown: string,
+  images: readonly File[],
+  upload: (file: File) => void
+): void => {
+  if (!el) return
+  el.focus()
+  document.execCommand('insertText', false, markdown)
+  for (const file of images) upload(file)
+}

--- a/src/components/MarkdownEditor/ImportDocs/rewrite-images.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/rewrite-images.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { rewriteImages } from './rewrite-images'
+
+describe('rewriteImages', () => {
+  it('replaces a data URI with the local asset path', () => {
+    const html = '<img src="data:image/png;base64,AA=="/>'
+    const out = rewriteImages(html, [
+      { dataUri: 'data:image/png;base64,AA==', filename: 'docx-img-1.png' },
+    ])
+    expect(out).toContain('./assets/docx-img-1.png')
+    expect(out).not.toContain('data:image/png')
+  })
+
+  it('returns the HTML unchanged when no images were extracted', () => {
+    const html = '<p>plain</p>'
+    expect(rewriteImages(html, [])).toBe(html)
+  })
+
+  it('replaces every occurrence of the same data URI', () => {
+    const dup = 'data:image/gif;base64,BB=='
+    const html = `<img src="${dup}"/><img src="${dup}"/>`
+    const out = rewriteImages(html, [{ dataUri: dup, filename: 'x.gif' }])
+    const matches = out.match(/\.\/assets\/x\.gif/g) ?? []
+    expect(matches).toHaveLength(2)
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/rewrite-images.ts
+++ b/src/components/MarkdownEditor/ImportDocs/rewrite-images.ts
@@ -1,0 +1,24 @@
+const escapeRe = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+/**
+ * Replace each `data:...` src with the local `./assets/<filename>`
+ * path so the subsequent HTML→Markdown conversion produces the right
+ * Markdown image reference.
+ *
+ * @param html original HTML string
+ * @param images extracted images with their source data URIs
+ * @returns HTML with data URIs replaced by local asset paths
+ */
+export const rewriteImages = (
+  html: string,
+  images: readonly { readonly dataUri: string; readonly filename: string }[]
+): string =>
+  images.reduce(
+    (acc, img) =>
+      acc.replace(
+        new RegExp(escapeRe(img.dataUri), 'g'),
+        `./assets/${img.filename}`
+      ),
+    html
+  )

--- a/src/components/MarkdownEditor/MarkdownEditorBody.vue
+++ b/src/components/MarkdownEditor/MarkdownEditorBody.vue
@@ -2,15 +2,16 @@
 import { ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import CommandPanel from './CommandPanel.vue'
-import { buildDropTag, extractDropFile } from './handle-drop'
+import { createPasteDrop } from './editor-paste-drop'
 import { handleKeyboard } from './handle-keyboard'
-import { buildPasteTag, extractMediaFile } from './handle-paste'
 import { insertUploadTag } from './handle-upload'
+import ImportDocsButton from './ImportDocs/ImportDocsButton.vue'
+import { insertImported } from './ImportDocs/insert-imported'
 import MarkdownPreview from './MarkdownPreview.vue'
 import PreviewToggle from './PreviewToggle.vue'
 import { execBlock, execMedia, execWrap } from './use-commands'
 
-const props = defineProps<{
+defineProps<{
   readonly modelValue: string
   readonly assetUrlMap?: ReadonlyMap<string, string>
   readonly assets?: readonly AssetDisplay[]
@@ -20,11 +21,17 @@ const emit = defineEmits<{
   'update:modelValue': [value: string]
   'paste:image': [file: File]
   'upload-asset': [file: File]
+  error: [message: string]
 }>()
 
 const previewing = ref(false)
 const textareaRef = ref<HTMLTextAreaElement>()
 const emitUpload = (f: File) => emit('upload-asset', f)
+const { onPaste, onDrop } = createPasteDrop({
+  textareaRef,
+  emitPaste: f => emit('paste:image', f),
+  emitUpload,
+})
 
 const handleInput = (event: Event) => {
   if (!(event.target instanceof HTMLTextAreaElement)) return
@@ -35,27 +42,14 @@ const wrap = (pre: string, suf: string) => {
   if (textareaRef.value) execWrap(textareaRef.value, pre, suf)
 }
 
-const handlePaste = (event: ClipboardEvent) => {
-  const file = extractMediaFile(event)
-  if (!file || !textareaRef.value) return
-  event.preventDefault()
-  document.execCommand('insertText', false, buildPasteTag(file))
-  emit('paste:image', file)
-}
-
-const handleDrop = (event: DragEvent) => {
-  const file = extractDropFile(event)
-  if (!file || !textareaRef.value) return
-  event.preventDefault()
-  document.execCommand('insertText', false, buildDropTag(file))
-  emitUpload(file)
-}
-
 const handleUpload = (file: File) => {
   if (!textareaRef.value) return
   insertUploadTag(textareaRef.value, file)
   emitUpload(file)
 }
+
+const handleImported = (markdown: string, images: readonly File[]) =>
+  insertImported(textareaRef.value, markdown, images, emitUpload)
 </script>
 
 <template>
@@ -63,6 +57,11 @@ const handleUpload = (file: File) => {
     <PreviewToggle
       :previewing="previewing"
       @toggle="() => { previewing = !previewing }"
+    />
+    <ImportDocsButton
+      v-if="!previewing"
+      @imported="handleImported"
+      @error="msg => $emit('error', msg)"
     />
     <MarkdownPreview
       v-if="previewing"
@@ -83,8 +82,8 @@ const handleUpload = (file: File) => {
       data-testid="editor-body"
       :value="modelValue"
       @input="handleInput"
-      @paste="handlePaste"
-      @drop="handleDrop"
+      @paste="onPaste"
+      @drop="onDrop"
       @dragover.prevent
       @keydown="e => handleKeyboard(e, wrap)"
     />

--- a/src/components/MarkdownEditor/editor-paste-drop.ts
+++ b/src/components/MarkdownEditor/editor-paste-drop.ts
@@ -1,0 +1,35 @@
+import { buildDropTag, extractDropFile } from './handle-drop'
+import { buildPasteTag, extractMediaFile } from './handle-paste'
+
+interface Deps {
+  readonly textareaRef: { readonly value: HTMLTextAreaElement | undefined }
+  readonly emitPaste: (file: File) => void
+  readonly emitUpload: (file: File) => void
+}
+
+const insert = (tag: string): void => {
+  document.execCommand('insertText', false, tag)
+}
+
+/**
+ * Factories for the paste / drop handlers on the editor textarea.
+ *
+ * @param deps ref to textarea plus emit callbacks
+ * @returns bound event handlers
+ */
+export const createPasteDrop = (deps: Deps) => ({
+  onPaste: (event: ClipboardEvent): void => {
+    const file = extractMediaFile(event)
+    if (!file || !deps.textareaRef.value) return
+    event.preventDefault()
+    insert(buildPasteTag(file))
+    deps.emitPaste(file)
+  },
+  onDrop: (event: DragEvent): void => {
+    const file = extractDropFile(event)
+    if (!file || !deps.textareaRef.value) return
+    event.preventDefault()
+    insert(buildDropTag(file))
+    deps.emitUpload(file)
+  },
+})

--- a/src/sw/handlers/content/update.ts
+++ b/src/sw/handlers/content/update.ts
@@ -1,56 +1,14 @@
-import { Effect, Either, pipe } from 'effect'
-import type { ContentType } from '@/types/content'
-import { isContentType } from '@/types/content'
-import { validateFrontmatter } from '@/validation/schemas/frontmatter'
+import { Effect, pipe } from 'effect'
 import { ValidationError } from '../../errors'
-import { writeAndStage } from '../../git/io/write-file'
-import { commitAndPush } from '../../git/remote/commit-and-push'
-import { assertPermission } from '../../rbac/permission-check'
-import { serializeFrontmatter } from '../shared/frontmatter'
-import { errorResponse, jsonResponse } from '../shared/json-response'
+import { errorResponse } from '../shared/json-response'
 import { parseBody } from '../shared/parse-body'
-import { newFilePath } from './base'
-import { resolveContentPath } from './resolve-path'
-import type { UpdateBody } from './update-body'
 import { isValidUpdate } from './update-body'
-
-const validate = (
-  b: UpdateBody
-): Effect.Effect<void, ValidationError> => {
-  if (!isContentType(b.type)) return Effect.succeed(undefined)
-  const result = validateFrontmatter(b.type as ContentType, b.frontmatter)
-  if (Either.isLeft(result)) {
-    return Effect.fail(new ValidationError({ message: result.left }))
-  }
-  return Effect.succeed(undefined)
-}
-
-const checkAndWrite = (b: UpdateBody) =>
-  pipe(
-    validate(b),
-    Effect.flatMap(() =>
-      assertPermission(
-        'update',
-        isContentType(b.type) ? (b.type as ContentType) : 'blog',
-        String(b.frontmatter['author'] ?? '')
-      )
-    ),
-    Effect.flatMap(() =>
-      Effect.promise(() => resolveContentPath(b.type, b.slug, b.lang))
-    ),
-    Effect.map(p => p ?? newFilePath(b.type, b.slug, b.lang)),
-    Effect.tap(path =>
-      Effect.tryPromise(() =>
-        writeAndStage(path, serializeFrontmatter(b.frontmatter, b.body))
-      )
-    ),
-    Effect.tap(() => Effect.tryPromise(() => commitAndPush(b.message))),
-    Effect.map(path => jsonResponse({ success: true, path }))
-  )
+import { writeUpdateBody } from './write-body'
 
 /**
  * Handle POST /api/github/content — create or update.
- * @param request - Incoming Request
+ *
+ * @param request incoming Request
  * @returns JSON response with success and path
  */
 export const handleContentUpdate = (request: Request): Promise<Response> =>
@@ -60,7 +18,7 @@ export const handleContentUpdate = (request: Request): Promise<Response> =>
       isValidUpdate,
       () => new ValidationError({ message: 'Missing required fields' })
     ),
-    Effect.flatMap(checkAndWrite),
+    Effect.flatMap(writeUpdateBody),
     Effect.catchTag('ForbiddenError', e =>
       Effect.succeed(errorResponse(e.message, 403))
     ),

--- a/src/sw/handlers/content/validate-update.ts
+++ b/src/sw/handlers/content/validate-update.ts
@@ -1,0 +1,25 @@
+import { Effect, Either } from 'effect'
+import type { ContentType } from '@/types/content'
+import { isContentType } from '@/types/content'
+import { validateFrontmatter } from '@/validation/schemas/frontmatter'
+import { ValidationError } from '../../errors'
+import type { UpdateBody } from './update-body'
+
+/**
+ * Validate the frontmatter inside an UpdateBody against its per-type
+ * schema. Returns a failing Effect when invalid so the rest of the
+ * pipeline short-circuits before any git operation.
+ *
+ * @param b parsed update body
+ * @returns Effect.void on success, ValidationError on failure
+ */
+export const validateUpdateBody = (
+  b: UpdateBody
+): Effect.Effect<void, ValidationError> => {
+  if (!isContentType(b.type)) return Effect.succeed(undefined)
+  const result = validateFrontmatter(b.type as ContentType, b.frontmatter)
+  if (Either.isLeft(result)) {
+    return Effect.fail(new ValidationError({ message: result.left }))
+  }
+  return Effect.succeed(undefined)
+}

--- a/src/sw/handlers/content/write-body.ts
+++ b/src/sw/handlers/content/write-body.ts
@@ -1,0 +1,43 @@
+import { Effect, pipe } from 'effect'
+import type { ContentType } from '@/types/content'
+import { isContentType } from '@/types/content'
+import { writeAndStage } from '../../git/io/write-file'
+import { commitAndPush } from '../../git/remote/commit-and-push'
+import { assertPermission } from '../../rbac/permission-check'
+import { serializeFrontmatter } from '../shared/frontmatter'
+import { jsonResponse } from '../shared/json-response'
+import { newFilePath } from './base'
+import { resolveContentPath } from './resolve-path'
+import type { UpdateBody } from './update-body'
+import { validateUpdateBody } from './validate-update'
+
+/**
+ * Validate → authorize → stage → commit → push pipeline for an
+ * already-parsed UpdateBody. Split out of update.ts for file-size
+ * budget.
+ *
+ * @param b parsed update body
+ * @returns Effect returning a JSON response with the written path
+ */
+export const writeUpdateBody = (b: UpdateBody) =>
+  pipe(
+    validateUpdateBody(b),
+    Effect.flatMap(() =>
+      assertPermission(
+        'update',
+        isContentType(b.type) ? (b.type as ContentType) : 'blog',
+        String(b.frontmatter['author'] ?? '')
+      )
+    ),
+    Effect.flatMap(() =>
+      Effect.promise(() => resolveContentPath(b.type, b.slug, b.lang))
+    ),
+    Effect.map(p => p ?? newFilePath(b.type, b.slug, b.lang)),
+    Effect.tap(path =>
+      Effect.tryPromise(() =>
+        writeAndStage(path, serializeFrontmatter(b.frontmatter, b.body))
+      )
+    ),
+    Effect.tap(() => Effect.tryPromise(() => commitAndPush(b.message))),
+    Effect.map(path => jsonResponse({ success: true, path }))
+  )

--- a/src/types/turndown-plugin-gfm.d.ts
+++ b/src/types/turndown-plugin-gfm.d.ts
@@ -1,0 +1,8 @@
+declare module 'turndown-plugin-gfm' {
+  import type TurndownService from 'turndown'
+
+  export const gfm: TurndownService.Plugin
+  export const tables: TurndownService.Plugin
+  export const strikethrough: TurndownService.Plugin
+  export const taskListItems: TurndownService.Plugin
+}

--- a/src/views/ContentEditView/create-handle-save.ts
+++ b/src/views/ContentEditView/create-handle-save.ts
@@ -1,37 +1,20 @@
-import { Either } from 'effect'
-import type { ComputedRef, Ref } from 'vue'
-import type { TrackDeploy } from '@/composables/useDeployStatus/deploy-context'
 import {
   clearPendingDeploy,
   setPendingDeploy,
 } from '@/composables/useDeployStatus/pending-deploy'
-import type { ContentType, Language } from '@/types/content'
-import { validateFrontmatter } from '@/validation/schemas/frontmatter'
+import type { HandleSaveDeps } from './handle-save-deps'
+import { guardFrontmatter } from './validate-save'
 
-interface HandleSaveDeps {
-  readonly hasAssets: ComputedRef<boolean>
-  readonly blogSave: (message: string) => Promise<string>
-  readonly buildPath: (lang: Language) => string
-  readonly currentLang: Ref<Language>
-  readonly saveCurrentLanguage: (
-    path: string,
-    message: string
-  ) => Promise<void>
-  readonly reloadContent: () => Promise<void>
-  readonly title: ComputedRef<string>
-  readonly contentType: ComputedRef<ContentType>
-  readonly frontmatter: () => Record<string, unknown>
-  readonly contentTypeName: ComputedRef<string>
-  readonly track?: TrackDeploy
-  readonly onError?: (msg: string) => void
-}
-
-const guard = (deps: HandleSaveDeps): string | undefined => {
-  const result = validateFrontmatter(
-    deps.contentType.value,
-    deps.frontmatter()
-  )
-  return Either.isLeft(result) ? result.left : undefined
+const persist = async (
+  deps: HandleSaveDeps,
+  message: string
+): Promise<void> => {
+  if (deps.hasAssets.value) {
+    await deps.blogSave(message)
+    return
+  }
+  const path = deps.buildPath(deps.currentLang.value)
+  await deps.saveCurrentLanguage(path, message)
 }
 
 /**
@@ -42,17 +25,11 @@ const guard = (deps: HandleSaveDeps): string | undefined => {
  */
 export const createHandleSave = (deps: HandleSaveDeps) => async () => {
   const message = `updated ${deps.title.value} in ${deps.contentTypeName.value}`
-  const gate = guard(deps)
-  if (gate !== undefined) {
-    throw new Error(gate)
-  }
+  const gate = guardFrontmatter(deps)
+  if (gate !== undefined) throw new Error(gate)
   setPendingDeploy(message)
   try {
-    if (deps.hasAssets.value) await deps.blogSave(message)
-    else {
-      const path = deps.buildPath(deps.currentLang.value)
-      await deps.saveCurrentLanguage(path, message)
-    }
+    await persist(deps, message)
     deps.track?.()
     await deps.reloadContent()
   } catch (err) {

--- a/src/views/ContentEditView/handle-save-deps.ts
+++ b/src/views/ContentEditView/handle-save-deps.ts
@@ -1,0 +1,22 @@
+import type { ComputedRef, Ref } from 'vue'
+import type { TrackDeploy } from '@/composables/useDeployStatus/deploy-context'
+import type { ContentType, Language } from '@/types/content'
+
+/** Dependencies injected into the save handler. */
+export interface HandleSaveDeps {
+  readonly hasAssets: ComputedRef<boolean>
+  readonly blogSave: (message: string) => Promise<string>
+  readonly buildPath: (lang: Language) => string
+  readonly currentLang: Ref<Language>
+  readonly saveCurrentLanguage: (
+    path: string,
+    message: string
+  ) => Promise<void>
+  readonly reloadContent: () => Promise<void>
+  readonly title: ComputedRef<string>
+  readonly contentType: ComputedRef<ContentType>
+  readonly frontmatter: () => Record<string, unknown>
+  readonly contentTypeName: ComputedRef<string>
+  readonly track?: TrackDeploy
+  readonly onError?: (msg: string) => void
+}

--- a/src/views/ContentEditView/validate-save.ts
+++ b/src/views/ContentEditView/validate-save.ts
@@ -1,0 +1,24 @@
+import { Either } from 'effect'
+import type { ComputedRef } from 'vue'
+import type { ContentType } from '@/types/content'
+import { validateFrontmatter } from '@/validation/schemas/frontmatter'
+
+interface GuardDeps {
+  readonly contentType: ComputedRef<ContentType>
+  readonly frontmatter: () => Record<string, unknown>
+}
+
+/**
+ * Return a human-readable error message when the current frontmatter
+ * does not match its per-type schema, or undefined if it is valid.
+ *
+ * @param deps accessors for content type and live frontmatter
+ * @returns error string or undefined
+ */
+export const guardFrontmatter = (deps: GuardDeps): string | undefined => {
+  const result = validateFrontmatter(
+    deps.contentType.value,
+    deps.frontmatter()
+  )
+  return Either.isLeft(result) ? result.left : undefined
+}


### PR DESCRIPTION
## Summary
- New toolbar button **Import from Docs**: upload .docx / .html / .md, get Markdown at caret.
- DOCX embedded images become local asset files and flow through the existing upload pipeline.
- Feature folder \`src/components/MarkdownEditor/ImportDocs/\` with 7 small modules, each under the 50-LoC limit.
- 14 new unit tests covering each helper.
- Incidental refactors to stay within file-size limits (no behaviour change).

Libraries added: \`mammoth\` (DOCX → HTML), \`turndown\` + \`turndown-plugin-gfm\` (HTML → Markdown).

Stacked on #18. Closes #13.

## Test plan
- [x] \`bun run type-check\`
- [x] \`bun run test:unit\` — 267/267 pass.
- [x] \`bun run validate\` — biome, oxlint, eslint-jsdoc, vue template depth, stylelint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)