### PR TITLE
feat(#14): replace Save with Preview — persist only from the Preview page

### DIFF
--- a/e2e/content/asset-save.spec.ts
+++ b/e2e/content/asset-save.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
+import { openPreview } from './preview-save'
 
 test.describe('Asset Transactional Save', () => {
   test('should show save button with assets pending', async ({ page }) => {
@@ -7,7 +8,7 @@ test.describe('Asset Transactional Save', () => {
     await am.navigateToBlog('welcome-to-prometheus')
     await am.expectPanelVisible()
 
-    const saveBtn = page.locator('[data-testid="save-button"]')
+    const saveBtn = await openPreview(page)
     await expect(saveBtn).toBeVisible({ timeout: 10000 })
   })
 

--- a/e2e/content/create-edit-roundtrip.spec.ts
+++ b/e2e/content/create-edit-roundtrip.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { openPreview } from './preview-save'
 
 // Regression test for "creating article wipes frontmatter on next save":
 // the create→edit handover used to leave the pinia content store stale, so
@@ -78,7 +79,7 @@ test.describe('Content - create → edit round-trip', () => {
     await bodyEditor.press('End')
     await bodyEditor.type('\n\nedited body line')
 
-    const saveBtn = page.locator('[data-testid="save-button"]')
+    const saveBtn = await openPreview(page)
     await saveBtn.click()
 
     // Poll the SW file read until the body actually contains the new line

--- a/e2e/content/pending-deploy-status.spec.ts
+++ b/e2e/content/pending-deploy-status.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { waitForContentReady } from '../helpers/content-ready'
+import { openPreview } from './preview-save'
 
 // NOTE(deploy-history-rewrite): tests asserting pending-card transitions
 // through PENDING → BUILDING → replaced. The new GitHub-Actions-polled
@@ -14,10 +15,10 @@ test.describe
       await page.waitForURL(/\/edit\//)
       await waitForContentReady(page)
 
-      await page.getByTestId('save-button').click()
-      await expect(page.getByTestId('save-button')).toContainText('Saved', {
-        timeout: 30000,
-      })
+      await (await openPreview(page)).click()
+      await expect(
+        page.locator('[data-testid="preview-button"]')
+      ).toBeVisible({ timeout: 30000 })
 
       await page.goto('/')
       await expect(page.getByText('Recent Deployments')).toBeVisible({
@@ -40,10 +41,10 @@ test.describe
       await page.waitForURL(/\/edit\//)
       await waitForContentReady(page)
 
-      await page.getByTestId('save-button').click()
-      await expect(page.getByTestId('save-button')).toContainText('Saved', {
-        timeout: 30000,
-      })
+      await (await openPreview(page)).click()
+      await expect(
+        page.locator('[data-testid="preview-button"]')
+      ).toBeVisible({ timeout: 30000 })
 
       await page.goto('/')
       await expect(page.getByText('Recent Deployments')).toBeVisible({

--- a/e2e/content/pending-deploy-visible.spec.ts
+++ b/e2e/content/pending-deploy-visible.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { waitForContentReady } from '../helpers/content-ready'
+import { openPreview } from './preview-save'
 
 // NOTE(deploy-history-rewrite): pending-card concept no longer exists in
 // the new deploy history. Skipped until the deploy UX stabilizes.
@@ -18,11 +19,13 @@ test.describe
       await waitForContentReady(page)
 
       // 3. Save
-      const saveBtn = page.getByTestId('save-button')
+      const saveBtn = await openPreview(page)
       await saveBtn.click()
 
-      // 4. Wait for save to complete (checkmark)
-      await expect(saveBtn).toContainText('Saved', { timeout: 30000 })
+      // 4. Wait for save to complete (preview-button returns on success)
+      await expect(
+        page.locator('[data-testid="preview-button"]')
+      ).toBeVisible({ timeout: 30000 })
 
       // 5. Verify pending_deploy is in sessionStorage
       const hasPending = await page.evaluate(

--- a/e2e/content/preview-save.ts
+++ b/e2e/content/preview-save.ts
@@ -1,0 +1,16 @@
+import type { Locator, Page } from '@playwright/test'
+
+/**
+ * Click the editor's Preview button and return the Save button that
+ * appears on the preview page.
+ *
+ * Replaces the former "click save-button directly" flow introduced by
+ * issue #14 (Preview-before-save).
+ *
+ * @param page the Playwright Page
+ * @returns a Locator pointing at the Save button on the preview
+ */
+export const openPreview = async (page: Page): Promise<Locator> => {
+  await page.locator('[data-testid="preview-button"]').click()
+  return page.locator('[data-testid="save-button"]')
+}

--- a/e2e/content/prod-manual-verify.spec.ts
+++ b/e2e/content/prod-manual-verify.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
+import { openPreview } from './preview-save'
 
 // Manual verification probe run against the real prod admin. Inject
 // GITHUB_E2E_KEY, walk through every critical flow the user cares
@@ -172,7 +173,7 @@ test.describe('Prod manual verify', () => {
           r.request().method() === 'POST',
         { timeout: 30000 }
       )
-      await page.locator('[data-testid="save-button"]').click()
+      await (await openPreview(page)).click()
       const commitResp = await commitPromise
       const text = await commitResp.text()
       if (!/"sha":"[0-9a-f]{40}"/.test(text))

--- a/e2e/content/rename-slug.spec.ts
+++ b/e2e/content/rename-slug.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test'
 import { waitForNetworkIdle } from '../helpers/network'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 import { ContentEditPage } from '../pages/ContentEditPage'
+import { openPreview } from './preview-save'
 
 const SLUG = 'media-showcase'
 
@@ -111,7 +112,7 @@ test.describe('Rename Slug', () => {
     })
 
     // Save
-    await page.locator('[data-testid="save-button"]').click()
+    await (await openPreview(page)).click()
     await waitForNetworkIdle(page, { idleTime: 1000 })
 
     // Navigate back to list

--- a/e2e/content/save-auto-message.spec.ts
+++ b/e2e/content/save-auto-message.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { ContentEditPage } from '../pages/ContentEditPage'
+import { openPreview } from './preview-save'
 
 const SLUG = 'media-showcase'
 
@@ -17,7 +18,7 @@ test.describe('Auto Commit Message', () => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    const saveBtn = page.locator('[data-testid="save-button"]')
+    const saveBtn = await openPreview(page)
     await expect(saveBtn).toBeVisible()
     await expect(saveBtn).toBeEnabled()
   })

--- a/e2e/content/save-deploy-flow.spec.ts
+++ b/e2e/content/save-deploy-flow.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { waitForContentReady } from '../helpers/content-ready'
+import { openPreview } from './preview-save'
 
 const openFirstArticle = async (page: import('@playwright/test').Page) => {
   await page.goto('/content/blog')
@@ -12,14 +13,14 @@ const openFirstArticle = async (page: import('@playwright/test').Page) => {
 test.describe('Save Button States', () => {
   test('shows Save text initially', async ({ page }) => {
     await openFirstArticle(page)
-    const btn = page.getByTestId('save-button')
+    const btn = await openPreview(page)
     await expect(btn).toContainText('Save')
     await expect(btn).toBeEnabled()
   })
 
   test('disabled + spinner during save', async ({ page }) => {
     await openFirstArticle(page)
-    const btn = page.getByTestId('save-button')
+    const btn = await openPreview(page)
     await btn.click()
     await expect(btn).toHaveClass(/saving/, { timeout: 5000 })
     await expect(btn).toBeDisabled()
@@ -27,19 +28,22 @@ test.describe('Save Button States', () => {
 
   test('shows checkmark after save completes', async ({ page }) => {
     await openFirstArticle(page)
-    const btn = page.getByTestId('save-button')
+    const btn = await openPreview(page)
     await btn.click()
-    await expect(btn).toContainText('Saved', { timeout: 30000 })
-    await expect(btn).toHaveClass(/done/)
+    // Preview auto-exits on save success — preview-button reappears
+    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible({
+      timeout: 30000,
+    })
   })
 
   test('reverts to Save after 2 seconds', async ({ page }) => {
     await openFirstArticle(page)
-    const btn = page.getByTestId('save-button')
+    const btn = await openPreview(page)
     await btn.click()
-    await expect(btn).toContainText('Saved', { timeout: 30000 })
-    await expect(btn).toContainText('Save', { timeout: 5000 })
-    await expect(btn).toBeEnabled()
+    // Preview auto-exits on save success — preview-button reappears
+    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible({
+      timeout: 30000,
+    })
   })
 })
 
@@ -49,7 +53,7 @@ test.describe('Save Network Requests', () => {
     const p = page.waitForResponse(r =>
       r.url().includes('/api/github/file/stage')
     )
-    await page.getByTestId('save-button').click()
+    await (await openPreview(page)).click()
     expect((await p).status()).toBe(200)
   })
 
@@ -58,7 +62,7 @@ test.describe('Save Network Requests', () => {
     const p = page.waitForResponse(r =>
       r.url().includes('/api/github/commit')
     )
-    await page.getByTestId('save-button').click()
+    await (await openPreview(page)).click()
     const body = await (await p).json()
     expect(body).toHaveProperty('success')
     expect(body).toHaveProperty('sha')
@@ -68,8 +72,9 @@ test.describe('Save Network Requests', () => {
 test.describe('Deploy Bar After Save', () => {
   test('deploy bar appears after save', async ({ page }) => {
     await openFirstArticle(page)
-    await page.getByTestId('save-button').click()
-    await expect(page.getByTestId('save-button')).toContainText('Saved', {
+    await (await openPreview(page)).click()
+    // Preview auto-exits on save success — preview-button reappears
+    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible({
       timeout: 30000,
     })
     await expect(page.locator('.deploy-bar')).toBeVisible({
@@ -128,10 +133,10 @@ test.describe
 
     test('pending card is article, not link', async ({ page }) => {
       await openFirstArticle(page)
-      await page.getByTestId('save-button').click()
-      await expect(page.getByTestId('save-button')).toContainText('Saved', {
-        timeout: 30000,
-      })
+      await (await openPreview(page)).click()
+      await expect(
+        page.locator('[data-testid="preview-button"]')
+      ).toBeVisible({ timeout: 30000 })
       await page.goto('/')
       const pending = page.locator('.pending-card')
       if ((await pending.count()) > 0) {
@@ -141,10 +146,10 @@ test.describe
 
     test('pending card shows DEPLOYING badge', async ({ page }) => {
       await openFirstArticle(page)
-      await page.getByTestId('save-button').click()
-      await expect(page.getByTestId('save-button')).toContainText('Saved', {
-        timeout: 30000,
-      })
+      await (await openPreview(page)).click()
+      await expect(
+        page.locator('[data-testid="preview-button"]')
+      ).toBeVisible({ timeout: 30000 })
       await page.goto('/')
       const pending = page.locator('.pending-card')
       if ((await pending.count()) > 0) {

--- a/e2e/content/save-dirty-reset.spec.ts
+++ b/e2e/content/save-dirty-reset.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 import { waitForNetworkIdle } from '../helpers/network'
 import { ContentEditPage } from '../pages/ContentEditPage'
+import { openPreview } from './preview-save'
 
 const SLUG = 'media-showcase'
 
@@ -18,7 +19,7 @@ test.describe('Dirty State Reset After Save', () => {
     await page.keyboard.type(' test-edit')
 
     // Save and wait for all API calls to complete
-    await page.locator('[data-testid="save-button"]').click()
+    await (await openPreview(page)).click()
     await waitForNetworkIdle(page, { idleTime: 1000 })
 
     // Set up dialog listener — it should NOT fire

--- a/src/components/MarkdownEditor/EditorFooter.vue
+++ b/src/components/MarkdownEditor/EditorFooter.vue
@@ -2,25 +2,22 @@
 withDefaults(
   defineProps<{
     readonly disabled: boolean
-    readonly saving?: boolean
-    readonly saved?: boolean
   }>(),
-  { saving: false, saved: false }
+  {}
 )
 
-const emit = defineEmits<{ save: [] }>()
+const emit = defineEmits<{ preview: [] }>()
 </script>
 
 <template>
   <footer class="editor-footer">
     <button
       type="button"
-      data-testid="save-button"
-      :disabled="disabled || saving"
-      :class="{ saving, done: saved }"
-      @click="emit('save')"
+      data-testid="preview-button"
+      :disabled="disabled"
+      @click="emit('preview')"
     >
-      {{ saving ? '' : saved ? '✓ Saved' : 'Save' }}
+      Preview
     </button>
   </footer>
 </template>
@@ -54,22 +51,5 @@ button:disabled {
 
 button:hover:not(:disabled) {
   background: var(--color-border);
-}
-
-.done { color: hsl(140deg 60% 50%); }
-
-.saving::after {
-  content: '';
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  border: 2px solid var(--color-text-secondary);
-  border-top-color: var(--color-text);
-  border-radius: 50%;
-  animation: spin 0.6s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
 }
 </style>

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import AppLayout from '@/components/AppLayout.vue'
 import AssetPanel from '@/components/AssetManager/AssetPanel.vue'
 import CoverImage from '@/components/AssetManager/CoverImage.vue'
@@ -8,8 +9,10 @@ import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue
 import { renameContent } from '@/composables/useGitHubApi/rename-content'
 import type { Language } from '@/types/content'
 import ContentEditMain from './ContentEditView/ContentEditMain.vue'
+import ContentPreview from './ContentEditView/ContentPreview.vue'
 import EditBreadcrumb from './ContentEditView/EditBreadcrumb.vue'
 import { initEditPage } from './ContentEditView/init-edit-page'
+import PreviewFooter from './ContentEditView/PreviewFooter.vue'
 import { useEditPage } from './ContentEditView/useEditPage'
 
 const props = defineProps<{
@@ -17,8 +20,16 @@ const props = defineProps<{
   readonly slug: string
 }>()
 
+const previewing = ref(false)
 const p = useEditPage(props.type, props.slug)
 const { handleSave, saving, saved, saveError } = initEditPage(p)
+
+const enterPreview = () => { previewing.value = true }
+const exitPreview = () => { previewing.value = false }
+const onSave = async () => {
+  await handleSave()
+  if (saveError.value === null) exitPreview()
+}
 const updateBody = (v: string) => { p.editor.bodyContent.value = v }
 const updateFm = (d: Record<string, unknown>) => {
   p.editor.frontmatterData.value = d
@@ -50,17 +61,19 @@ const isRenameable =
       />
     </nav>
     <LanguageSelector
+      v-if="!previewing"
       :model-value="p.editor.currentLang.value"
       :available-languages="p.langs.value"
       @update:model-value="handleSwitchLang"
     />
     <CoverImage
-      v-if="p.hasCover.value && !p.editor.loadingFile.value"
+      v-if="!previewing && p.hasCover.value && !p.editor.loadingFile.value"
       :cover-url="p.assets.coverUrl.value"
       @delete-cover="p.ah.onRemoveCover"
       @upload-cover="p.ah.onUploadCover"
     />
     <ContentEditMain
+      v-if="!previewing"
       :body-content="p.editor.bodyContent.value"
       :frontmatter-data="p.editor.frontmatterData.value"
       :content-type="p.contentType.value"
@@ -72,13 +85,27 @@ const isRenameable =
       :assets="p.hasAssets.value ? p.assets.allAssets.value : undefined"
       @update:body-content="updateBody"
       @update:frontmatter="updateFm"
-      @save="handleSave"
+      @preview="enterPreview"
       @paste:image="p.ah.onPasteImage"
       @upload-asset="p.ah.onUploadAsset"
       @set-cover="p.ah.onSetCover"
     />
+    <ContentPreview
+      v-else
+      :body-content="p.editor.bodyContent.value"
+      :frontmatter-data="p.editor.frontmatterData.value"
+      :cover-url="p.assets.coverUrl.value"
+      :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
+    />
+    <PreviewFooter
+      v-if="previewing"
+      :saving="saving"
+      :saved="saved"
+      @save="onSave"
+      @back="exitPreview"
+    />
     <AssetPanel
-      v-if="p.hasAssets.value && !p.editor.loadingFile.value"
+      v-if="!previewing && p.hasAssets.value && !p.editor.loadingFile.value"
       :assets="p.assets.allAssets.value"
       @set-cover="p.ah.onSetCover"
       @delete-asset="p.ah.onDeleteAsset"

--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -9,8 +9,6 @@ defineProps<{
   readonly contentType: ContentType
   readonly slug?: string
   readonly loadingFile: boolean
-  readonly saving: boolean
-  readonly saved: boolean
   readonly assetUrlMap?: ReadonlyMap<string, string>
   readonly assets?: readonly AssetDisplay[]
 }>()
@@ -18,7 +16,7 @@ defineProps<{
 defineEmits<{
   'update:bodyContent': [value: string]
   'update:frontmatter': [data: Record<string, unknown>]
-  save: []
+  preview: []
   'paste:image': [file: File]
   'upload-asset': [file: File]
   'set-cover': [name: string]
@@ -38,11 +36,9 @@ defineEmits<{
       :slug="slug"
       :asset-url-map="assetUrlMap"
       :assets="assets"
-      :saving="saving"
-      :saved="saved"
       @update:body-content="$emit('update:bodyContent', $event)"
       @update:frontmatter="$emit('update:frontmatter', $event)"
-      @save="$emit('save')"
+      @preview="$emit('preview')"
       @paste:image="$emit('paste:image', $event)"
       @upload-asset="$emit('upload-asset', $event)"
       @set-cover="$emit('set-cover', $event)"

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -11,8 +11,6 @@ defineProps<{
   readonly frontmatterData: Record<string, unknown>
   readonly contentType: ContentType
   readonly slug?: string
-  readonly saving: boolean
-  readonly saved: boolean
   readonly assetUrlMap?: ReadonlyMap<string, string>
   readonly assets?: readonly AssetDisplay[]
 }>()
@@ -20,7 +18,7 @@ defineProps<{
 defineEmits<{
   'update:bodyContent': [value: string]
   'update:frontmatter': [data: Record<string, unknown>]
-  save: []
+  preview: []
   'paste:image': [file: File]
   'upload-asset': [file: File]
   'set-cover': [name: string]
@@ -55,8 +53,6 @@ const isNewspaper = (type: ContentType) => type === 'newspaper'
   />
   <EditorFooter
     :disabled="false"
-    :saving="saving"
-    :saved="saved"
-    @save="$emit('save')"
+    @preview="$emit('preview')"
   />
 </template>

--- a/src/views/ContentEditView/ContentPreview.vue
+++ b/src/views/ContentEditView/ContentPreview.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import MarkdownPreview from '@/components/MarkdownEditor/MarkdownPreview.vue'
+import PreviewHeader from './PreviewHeader.vue'
+
+defineProps<{
+  readonly bodyContent: string
+  readonly frontmatterData: Record<string, unknown>
+  readonly coverUrl?: string
+  readonly assetUrlMap?: ReadonlyMap<string, string>
+}>()
+</script>
+
+<template>
+  <article class="content-preview" data-testid="content-preview">
+    <PreviewHeader
+      :frontmatter="frontmatterData"
+      :cover-url="coverUrl"
+    />
+    <MarkdownPreview
+      :content="bodyContent"
+      :asset-url-map="assetUrlMap"
+    />
+  </article>
+</template>
+
+<style scoped>
+.content-preview {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  max-width: 800px;
+  margin-inline: auto;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+</style>

--- a/src/views/ContentEditView/PreviewFooter.vue
+++ b/src/views/ContentEditView/PreviewFooter.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    readonly saving?: boolean
+    readonly saved?: boolean
+  }>(),
+  { saving: false, saved: false }
+)
+
+const emit = defineEmits<{ save: []; back: [] }>()
+</script>
+
+<template>
+  <footer class="preview-footer">
+    <button
+      type="button"
+      class="btn-secondary"
+      data-testid="back-to-edit-button"
+      :disabled="saving"
+      @click="emit('back')"
+    >
+      Back to edit
+    </button>
+    <button
+      type="button"
+      class="btn-primary"
+      data-testid="save-button"
+      :disabled="saving"
+      :class="{ saving, done: saved }"
+      @click="emit('save')"
+    >
+      {{ saving ? '' : saved ? '✓ Saved' : 'Save' }}
+    </button>
+  </footer>
+</template>
+
+<style scoped>
+.preview-footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  padding: clamp(0.75rem, 2vw, 1rem);
+  border-top: 1px solid var(--color-border);
+}
+
+button {
+  min-width: 5rem;
+  min-height: 2.5rem;
+  padding: 0.5rem 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--color-border-hover);
+  color: var(--color-text);
+  border: none;
+}
+
+.btn-secondary {
+  background: transparent;
+  color: var(--color-text);
+}
+
+button:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
+.done {
+  color: hsl(140deg 60% 50%);
+}
+</style>

--- a/src/views/ContentEditView/PreviewHeader.vue
+++ b/src/views/ContentEditView/PreviewHeader.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  readonly frontmatter: Record<string, unknown>
+  readonly coverUrl?: string
+}>()
+
+const text = (key: string) => {
+  const v = props.frontmatter[key]
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+const title = computed(() => text('title'))
+const category = computed(() => text('category'))
+const publishDate = computed(() => text('publishDate'))
+</script>
+
+<template>
+  <header class="preview-header">
+    <img
+      v-if="coverUrl"
+      class="cover"
+      :src="coverUrl"
+      alt=""
+    >
+    <p v-if="category" class="category">
+      {{ category }}
+    </p>
+    <h1 v-if="title">
+      {{ title }}
+    </h1>
+    <time v-if="publishDate" class="date">
+      {{ publishDate }}
+    </time>
+  </header>
+</template>
+
+<style scoped>
+.preview-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.cover {
+  width: 100%;
+  border-radius: var(--radius-md);
+}
+
+.category {
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(1.5rem, 4vw, 2.25rem);
+  margin: 0;
+}
+
+.date {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- Edit page footer now says **Preview** (\`data-testid=\"preview-button\"\`).
- Clicking Preview hides the editor and renders a frontmatter-aware read-only view via \`ContentPreview.vue\`.
- A new \`PreviewFooter.vue\` offers **Save** + **Back to edit**. Save succeeds → preview auto-exits back to the editor.
- 9 e2e specs migrated through \`e2e/content/preview-save.ts::openPreview(page)\`.
- Stacked on #19 (Import from Docs). Closes #14.

## Test plan
- [x] \`bun run type-check\`
- [x] \`bun run test:unit\` — 267/267 pass.
- [x] \`bun run validate\` — biome / oxlint / eslint-jsdoc / vue depth / stylelint all green.
- [ ] e2e pass through the updated specs (left to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)