### PR TITLE
feat(#15): publish-confirm dialog when Save will publish

### DIFF
--- a/scripts/check-vue-template-depth/config.ts
+++ b/scripts/check-vue-template-depth/config.ts
@@ -11,6 +11,8 @@ export const config: Config = {
     'src/components/AppHeader.vue',
     'src/views/ContentEditView.vue',
     'src/components/CreateContentDialog/**/*.vue',
+    'src/views/ContentEditView/PublishConfirmDialog.vue',
+    'src/views/ContentEditView/PublishDialogCard.vue',
   ],
 } as const
 

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -1,54 +1,53 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import AppLayout from '@/components/AppLayout.vue'
 import AssetPanel from '@/components/AssetManager/AssetPanel.vue'
 import CoverImage from '@/components/AssetManager/CoverImage.vue'
 import ErrorMessage from '@/components/common/ErrorMessage.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue'
-import { renameContent } from '@/composables/useGitHubApi/rename-content'
-import type { Language } from '@/types/content'
 import ContentEditMain from './ContentEditView/ContentEditMain.vue'
 import ContentPreview from './ContentEditView/ContentPreview.vue'
 import EditBreadcrumb from './ContentEditView/EditBreadcrumb.vue'
 import { initEditPage } from './ContentEditView/init-edit-page'
 import PreviewFooter from './ContentEditView/PreviewFooter.vue'
+import PublishConfirmDialog from './ContentEditView/PublishConfirmDialog.vue'
+import { useSaveFlow } from './ContentEditView/use-save-flow'
 import { useEditPage } from './ContentEditView/useEditPage'
+import {
+  makeRename,
+  makeSwitchLang,
+  makeUpdaters,
+} from './ContentEditView/wire-handlers'
 
-const props = defineProps<{
-  readonly type: string
-  readonly slug: string
-}>()
-
+const props = defineProps<{ readonly type: string; readonly slug: string }>()
 const previewing = ref(false)
 const p = useEditPage(props.type, props.slug)
 const { handleSave, saving, saved, saveError } = initEditPage(p)
-
 const enterPreview = () => { previewing.value = true }
 const exitPreview = () => { previewing.value = false }
-const onSave = async () => {
-  await handleSave()
-  if (saveError.value === null) exitPreview()
-}
-const updateBody = (v: string) => { p.editor.bodyContent.value = v }
-const updateFm = (d: Record<string, unknown>) => {
-  p.editor.frontmatterData.value = d
-}
-const handleSwitchLang = (lang: Language) => {
-  const available = p.langs.value
-  if (available.has(lang)) {
-    p.editor.switchLanguage(lang, p.buildPath(lang))
-  } else {
-    p.editor.switchLanguage(lang)
-  }
-}
-const handleRename = async (newSlug: string) => {
-  await renameContent(props.type, props.slug, newSlug)
-  globalThis.location.replace(`/content/${props.type}/edit/${newSlug}`)
-}
-const isRenameable =
-  p.contentType.value !== 'pages' &&
-  p.contentType.value !== 'common'
+const flow = useSaveFlow({
+  contentType: () => p.contentType.value,
+  frontmatter: () => p.editor.frontmatterData.value,
+  handleSave,
+  saveError,
+  exitPreview,
+})
+
+const { updateBody, updateFm } = makeUpdaters(
+  p.editor.bodyContent,
+  p.editor.frontmatterData
+)
+const handleSwitchLang = makeSwitchLang({
+  langs: p.langs,
+  switchLanguage: p.editor.switchLanguage,
+  buildPath: p.buildPath,
+})
+const handleRename = makeRename(props.type, props.slug)
+const title = computed(() => String(p.editor.frontmatterData.value.title ?? p.slug))
+const isRenameable = computed(
+  () => p.contentType.value !== 'pages' && p.contentType.value !== 'common'
+)
 </script>
 
 <template>
@@ -79,8 +78,6 @@ const isRenameable =
       :content-type="p.contentType.value"
       :slug="p.slug"
       :loading-file="p.editor.loadingFile.value"
-      :saving="saving"
-      :saved="saved"
       :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
       :assets="p.hasAssets.value ? p.assets.allAssets.value : undefined"
       @update:body-content="updateBody"
@@ -101,7 +98,7 @@ const isRenameable =
       v-if="previewing"
       :saving="saving"
       :saved="saved"
-      @save="onSave"
+      @save="flow.onSave"
       @back="exitPreview"
     />
     <AssetPanel
@@ -110,6 +107,13 @@ const isRenameable =
       @set-cover="p.ah.onSetCover"
       @delete-asset="p.ah.onDeleteAsset"
       @upload-asset="p.ah.onUploadAsset"
+    />
+    <PublishConfirmDialog
+      :show="flow.showDialog.value"
+      :title="title"
+      :auto-public="flow.autoPublic.value"
+      @confirm="flow.onConfirm"
+      @cancel="flow.onCancel"
     />
     <LoadingOverlay :show="p.list.loadingList.value" />
     <ErrorMessage :error="saveError" />

--- a/src/views/ContentEditView/PublishConfirmDialog.vue
+++ b/src/views/ContentEditView/PublishConfirmDialog.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import PublishDialogCard from './PublishDialogCard.vue'
+import { onKeyStroke } from './use-keystroke'
+
+const props = defineProps<{
+  readonly show: boolean
+  readonly title: string
+  readonly autoPublic: boolean
+}>()
+
+const emit = defineEmits<{ confirm: []; cancel: [] }>()
+
+onKeyStroke('Escape', () => {
+  if (props.show) emit('cancel')
+})
+</script>
+
+<template>
+  <section
+    v-if="show"
+    class="dialog-overlay"
+    data-testid="publish-dialog"
+    role="alertdialog"
+    aria-labelledby="publish-dialog-title"
+    @click.self="emit('cancel')"
+  >
+    <PublishDialogCard
+      :title="title"
+      :auto-public="autoPublic"
+      @confirm="emit('confirm')"
+      @cancel="emit('cancel')"
+    />
+  </section>
+</template>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 50%);
+  z-index: 1000;
+  padding: 2rem;
+}
+</style>

--- a/src/views/ContentEditView/PublishDialogCard.vue
+++ b/src/views/ContentEditView/PublishDialogCard.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+defineProps<{
+  readonly title: string
+  readonly autoPublic: boolean
+}>()
+const emit = defineEmits<{ confirm: []; cancel: [] }>()
+defineExpose<{ focusCancel: () => void }>()
+</script>
+
+<template>
+  <article class="dialog">
+    <h2 id="publish-dialog-title">
+      Publish to live site?
+    </h2>
+    <p>
+      Saving <strong>{{ title }}</strong> will push the commit to
+      <code>develop</code>; the change will be visible on the public site
+      in about a minute.
+    </p>
+    <p v-if="autoPublic" class="hint">
+      This content type has no draft mode — every save is a publication.
+    </p>
+    <nav class="actions">
+      <button
+        type="button"
+        class="btn-cancel"
+        data-testid="publish-cancel-btn"
+        @click="emit('cancel')"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="btn-primary"
+        data-testid="publish-confirm-btn"
+        @click="emit('confirm')"
+      >
+        Publish and commit
+      </button>
+    </nav>
+  </article>
+</template>
+
+<style scoped>
+.dialog {
+  background: var(--color-background);
+  border-radius: var(--radius-md);
+  padding: clamp(1rem, 3vw, 1.5rem);
+  max-width: 480px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+h2 {
+  margin: 0;
+  font-size: clamp(1rem, 2.25vw, 1.25rem);
+}
+
+p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  line-height: 1.5;
+}
+
+.hint {
+  color: var(--color-warning, #b45309);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-sm);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  cursor: pointer;
+  border: 1px solid var(--color-border);
+}
+
+.btn-primary {
+  background: var(--color-border-hover);
+  color: var(--color-text);
+  border: none;
+}
+
+.btn-cancel {
+  background: transparent;
+  color: var(--color-text);
+}
+</style>

--- a/src/views/ContentEditView/use-keystroke.ts
+++ b/src/views/ContentEditView/use-keystroke.ts
@@ -1,0 +1,23 @@
+import { onBeforeUnmount, onMounted } from 'vue'
+
+/**
+ * Attach a global keydown listener that runs `handler` when the given
+ * key is pressed. Cleaned up on unmount.
+ *
+ * @param key the `event.key` value to match
+ * @param handler callback invoked on match
+ */
+export const onKeyStroke = (
+  key: string,
+  handler: (event: KeyboardEvent) => void
+): void => {
+  const listener = (event: KeyboardEvent) => {
+    if (event.key === key) handler(event)
+  }
+  onMounted(() => {
+    globalThis.addEventListener('keydown', listener)
+  })
+  onBeforeUnmount(() => {
+    globalThis.removeEventListener('keydown', listener)
+  })
+}

--- a/src/views/ContentEditView/use-save-flow.ts
+++ b/src/views/ContentEditView/use-save-flow.ts
@@ -1,0 +1,51 @@
+import { computed, ref } from 'vue'
+import type { ContentType } from '@/types/content'
+import { willPublish } from './will-publish'
+
+interface Deps {
+  readonly contentType: () => ContentType
+  readonly frontmatter: () => Record<string, unknown>
+  readonly handleSave: () => Promise<void>
+  readonly saveError: { readonly value: string | null }
+  readonly exitPreview: () => void
+}
+
+/**
+ * Owns the Save-from-Preview flow: opens a confirmation dialog when
+ * the save would publish to the live site; triggers handleSave on
+ * confirm; closes preview on success.
+ *
+ * @param deps contentType accessor, frontmatter accessor, save
+ *             handler from initEditPage, saveError ref, exitPreview
+ * @returns reactive dialog state + user-facing handlers
+ */
+export const useSaveFlow = (deps: Deps) => {
+  const showDialog = ref(false)
+  const autoPublic = computed(
+    () => deps.contentType() === 'pages' || deps.contentType() === 'common'
+  )
+
+  const commit = async () => {
+    await deps.handleSave()
+    if (deps.saveError.value === null) deps.exitPreview()
+  }
+
+  const onSave = async () => {
+    if (willPublish(deps.contentType(), deps.frontmatter())) {
+      showDialog.value = true
+      return
+    }
+    await commit()
+  }
+
+  const onConfirm = async () => {
+    showDialog.value = false
+    await commit()
+  }
+
+  const onCancel = () => {
+    showDialog.value = false
+  }
+
+  return { showDialog, autoPublic, onSave, onConfirm, onCancel }
+}

--- a/src/views/ContentEditView/will-publish.test.ts
+++ b/src/views/ContentEditView/will-publish.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { willPublish } from './will-publish'
+
+describe('willPublish', () => {
+  it('returns true for pages regardless of frontmatter', () => {
+    expect(willPublish('pages', {})).toBe(true)
+    expect(willPublish('pages', { published: false })).toBe(true)
+  })
+
+  it('returns true for common (auto-public)', () => {
+    expect(willPublish('common', {})).toBe(true)
+  })
+
+  it('returns true for blog when published flag is on', () => {
+    expect(willPublish('blog', { published: true })).toBe(true)
+  })
+
+  it('returns false for blog when published flag is missing', () => {
+    expect(willPublish('blog', {})).toBe(false)
+  })
+
+  it('returns false for blog when published flag is off', () => {
+    expect(willPublish('blog', { published: false })).toBe(false)
+  })
+
+  it('returns true for positions when published is on', () => {
+    expect(willPublish('positions', { published: true })).toBe(true)
+  })
+
+  it('returns false for newspaper when published is off', () => {
+    expect(willPublish('newspaper', { published: false })).toBe(false)
+  })
+
+  it('ignores non-boolean truthy "published" values', () => {
+    expect(willPublish('blog', { published: 'yes' })).toBe(false)
+  })
+})

--- a/src/views/ContentEditView/will-publish.ts
+++ b/src/views/ContentEditView/will-publish.ts
@@ -1,0 +1,25 @@
+import type { ContentType } from '@/types/content'
+
+const AUTO_PUBLIC: ReadonlySet<ContentType> = new Set(['pages', 'common'])
+
+/**
+ * Whether committing this frontmatter now makes the content publicly
+ * visible on the next site build.
+ *
+ * Rules:
+ * - `pages` and `common` have no publish gate — every save is a
+ *   publication.
+ * - For the other content types, a save is a publication only when
+ *   `frontmatter.published === true`.
+ *
+ * @param type content type being saved
+ * @param frontmatter live frontmatter snapshot
+ * @returns true when Save will make the content live
+ */
+export const willPublish = (
+  type: ContentType,
+  frontmatter: Record<string, unknown>
+): boolean => {
+  if (AUTO_PUBLIC.has(type)) return true
+  return frontmatter['published'] === true
+}

--- a/src/views/ContentEditView/wire-handlers.ts
+++ b/src/views/ContentEditView/wire-handlers.ts
@@ -1,0 +1,58 @@
+import type { Ref } from 'vue'
+import { renameContent } from '@/composables/useGitHubApi/rename-content'
+import type { Language } from '@/types/content'
+
+interface SwitchDeps {
+  readonly langs: { readonly value: ReadonlySet<Language> }
+  readonly switchLanguage: (lang: Language, path?: string) => void
+  readonly buildPath: (lang: Language) => string
+}
+
+/**
+ * Switch to `lang`, loading the file only when the store says the
+ * slug has a translation for that language.
+ *
+ * @param deps switch language callback + the current slug's langs ref
+ * @returns a function that switches + loads
+ */
+export const makeSwitchLang =
+  (deps: SwitchDeps) =>
+  (lang: Language): void => {
+    if (deps.langs.value.has(lang))
+      deps.switchLanguage(lang, deps.buildPath(lang))
+    else deps.switchLanguage(lang)
+  }
+
+/**
+ * Persist a rename via the SW API and hard-reload to the new URL so
+ * route state is clean.
+ *
+ * @param type content type (e.g. 'blog')
+ * @param oldSlug the slug being renamed
+ * @returns a function that performs the rename
+ */
+export const makeRename =
+  (type: string, oldSlug: string) =>
+  async (newSlug: string): Promise<void> => {
+    await renameContent(type, oldSlug, newSlug)
+    globalThis.location.replace(`/content/${type}/edit/${newSlug}`)
+  }
+
+/**
+ * Body / frontmatter setters pointing at the editor refs.
+ *
+ * @param body textarea content ref
+ * @param fm frontmatter record ref
+ * @returns setters used by ContentEditView event handlers
+ */
+export const makeUpdaters = (
+  body: Ref<string>,
+  fm: Ref<Record<string, unknown>>
+) => ({
+  updateBody: (v: string): void => {
+    body.value = v
+  },
+  updateFm: (d: Record<string, unknown>): void => {
+    fm.value = d
+  },
+})


### PR DESCRIPTION
## Summary
- \`PublishConfirmDialog.vue\` opens from the Save-on-Preview flow whenever the commit will become publicly visible.
- Trigger rules live in \`will-publish.ts\` (8 unit tests): pages + common always, blog / positions / newspaper only when \`published: true\`.
- \`use-save-flow.ts\` composable glues the dialog, \`handleSave\`, and the preview-exit on success.
- Dialog has role=alertdialog, Esc-to-cancel, click-outside-cancel.

Closes #15. Stacked on #20.

## Test plan
- [x] \`bun run type-check\`
- [x] \`bun run test:unit\` — 275/275 pass.
- [x] \`bun run validate\` — full lint/style/depth pipeline green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)