### PR TITLE
fix(#28): import-from-docs promotes bold-only paragraphs to real headings

### DIFF
--- a/src/components/MarkdownEditor/ImportDocs/convert-docx.ts
+++ b/src/components/MarkdownEditor/ImportDocs/convert-docx.ts
@@ -1,15 +1,35 @@
 import mammoth from 'mammoth'
+import { promoteVisualHeadings } from './promote-visual-headings'
+
+const STYLE_MAP: string[] = [
+  "p[style-name='Title'] => h1:fresh",
+  "p[style-name='Subtitle'] => h2:fresh",
+  "p[style-name='Heading 1'] => h1:fresh",
+  "p[style-name='Heading 2'] => h2:fresh",
+  "p[style-name='Heading 3'] => h3:fresh",
+  "p[style-name='Heading 4'] => h4:fresh",
+  "p[style-name='Heading 5'] => h5:fresh",
+  "p[style-name='Heading 6'] => h6:fresh",
+]
 
 /**
- * Convert a .docx ArrayBuffer to HTML via mammoth. Embedded images are
- * emitted as inline base64 data URIs; callers extract those later.
+ * Convert a .docx ArrayBuffer to HTML via mammoth and promote visual
+ * titles (bold-only paragraphs used as section headings) to real
+ * `<hN>` elements so the markdown has a real outline. Embedded
+ * images are still emitted as inline base64 data URIs; callers
+ * extract them later.
  *
  * @param buffer raw .docx bytes
- * @returns mammoth HTML string
+ * @returns mammoth HTML string with visual headings upgraded
  */
 export const convertDocxToHtml = async (
   buffer: ArrayBuffer
 ): Promise<string> => {
-  const result = await mammoth.convertToHtml({ arrayBuffer: buffer })
-  return result.value
+  const result = await mammoth.convertToHtml(
+    { arrayBuffer: buffer },
+    {
+      styleMap: STYLE_MAP,
+    }
+  )
+  return promoteVisualHeadings(result.value)
 }

--- a/src/components/MarkdownEditor/ImportDocs/promote-visual-headings.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/promote-visual-headings.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { promoteVisualHeadings } from './promote-visual-headings'
+
+describe('promoteVisualHeadings', () => {
+  it('promotes a single bold-only paragraph to h1 when no h1 exists', () => {
+    const out = promoteVisualHeadings(
+      '<p><strong>От редакции: новый этап</strong></p><p>body</p>'
+    )
+    expect(out).toBe('<h1>От редакции: новый этап</h1><p>body</p>')
+  })
+
+  it('promotes subsequent titles to h2', () => {
+    const out = promoteVisualHeadings(
+      '<p><strong>First</strong></p><p>body</p>' +
+        '<p><strong>Second</strong></p><p>body</p>' +
+        '<p><strong>Third</strong></p><p>body</p>'
+    )
+    expect(out).toBe(
+      '<h1>First</h1><p>body</p><h2>Second</h2><p>body</p><h2>Third</h2><p>body</p>'
+    )
+  })
+
+  it('emits h2 for the first promoted title when an h1 already exists', () => {
+    const out = promoteVisualHeadings(
+      '<h1>Real</h1><p><strong>Bold title</strong></p>'
+    )
+    expect(out).toBe('<h1>Real</h1><h2>Bold title</h2>')
+  })
+
+  it('leaves existing h1/h2 untouched', () => {
+    const out = promoteVisualHeadings('<h1>a</h1><h2>b</h2>')
+    expect(out).toBe('<h1>a</h1><h2>b</h2>')
+  })
+
+  it('keeps inline bold inside a sentence as-is', () => {
+    const out = promoteVisualHeadings(
+      '<p>This is <strong>emphatic</strong> text.</p>'
+    )
+    expect(out).toBe('<p>This is <strong>emphatic</strong> text.</p>')
+  })
+
+  it('keeps a bold sentence ending with full stop', () => {
+    const out = promoteVisualHeadings(
+      '<p><strong>This is important.</strong></p><p>body</p>'
+    )
+    expect(out).toBe('<p><strong>This is important.</strong></p><p>body</p>')
+  })
+
+  it('keeps a bold phrase longer than the title limit', () => {
+    const long = 'A'.repeat(200)
+    const out = promoteVisualHeadings(`<p><strong>${long}</strong></p>`)
+    expect(out).toBe(`<p><strong>${long}</strong></p>`)
+  })
+
+  it('ignores an empty strong paragraph', () => {
+    const out = promoteVisualHeadings('<p><strong></strong></p>')
+    expect(out).toBe('<p><strong></strong></p>')
+  })
+
+  it('allows title ending with a colon', () => {
+    const out = promoteVisualHeadings(
+      '<p><strong>Introduction:</strong></p><p>body</p>'
+    )
+    expect(out).toBe('<h1>Introduction:</h1><p>body</p>')
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/promote-visual-headings.ts
+++ b/src/components/MarkdownEditor/ImportDocs/promote-visual-headings.ts
@@ -1,0 +1,56 @@
+import { Match, Option } from 'effect'
+import { type PromoteCtx, splitBlocks, stepCtx } from './promote-walk'
+
+const TITLE_MAX_LEN = 160
+const TERMINATOR = /[.!…]$/
+const BOLD_ONLY = /^<p><strong>([^<]+)<\/strong><\/p>$/
+
+const isTitleShape = (text: string): boolean =>
+  Match.value(text).pipe(
+    Match.when(
+      t => t.length > 0 && t.length <= TITLE_MAX_LEN && !TERMINATOR.test(t),
+      () => true
+    ),
+    Match.orElse(() => false)
+  )
+
+const toHeading = (level: number, text: string): string =>
+  `<h${level}>${text}</h${level}>`
+
+const promoteParagraph = (
+  block: string,
+  ctx: PromoteCtx
+): Option.Option<string> =>
+  Option.fromNullable(block.match(BOLD_ONLY)).pipe(
+    Option.map(m => (m[1] ?? '').trim()),
+    Option.filter(isTitleShape),
+    Option.map(t => toHeading(ctx.firstLevelDone ? 2 : 1, t))
+  )
+
+const replaceBlock = (block: string, ctx: PromoteCtx): string =>
+  Option.match(promoteParagraph(block, ctx), {
+    onNone: () => block,
+    onSome: next => next,
+  })
+
+/**
+ * Walk mammoth HTML and promote `<p><strong>…</strong></p>` paragraphs
+ * whose inner text looks like a section title to real `<h1>` / `<h2>`.
+ * First promoted becomes `<h1>` unless the document already has one,
+ * otherwise `<h2>`. Running bold, long phrases, and sentences ending
+ * in terminal punctuation are left untouched.
+ *
+ * @param html mammoth HTML output
+ * @returns HTML with visual titles upgraded to real headings
+ */
+export const promoteVisualHeadings = (html: string): string => {
+  const ctx0: PromoteCtx = { firstLevelDone: /<h1[\s>]/i.test(html) }
+  let ctx = ctx0
+  return splitBlocks(html)
+    .map(b => {
+      const out = replaceBlock(b, ctx)
+      ctx = stepCtx(ctx, promoteParagraph(b, ctx))
+      return out
+    })
+    .join('')
+}

--- a/src/components/MarkdownEditor/ImportDocs/promote-walk.ts
+++ b/src/components/MarkdownEditor/ImportDocs/promote-walk.ts
@@ -1,0 +1,34 @@
+import { Match, Option } from 'effect'
+
+/** Context carried across the block walk. */
+export interface PromoteCtx {
+  readonly firstLevelDone: boolean
+}
+
+/**
+ * Split mammoth HTML into top-level block strings. Each block starts
+ * with `<p>`, `<h1..6>`, `<ol>`, `<ul>`, or `<hr>`. Tags inside a
+ * block (e.g. `<strong>` within `<p>`) stay attached to their parent.
+ *
+ * @param html mammoth-emitted HTML
+ * @returns array of block strings, preserving original order
+ */
+export const splitBlocks = (html: string): readonly string[] =>
+  html.split(/(?=<p[\s>]|<h[1-6][\s>]|<ol[\s>]|<ul[\s>]|<hr[\s>])/i)
+
+/**
+ * Fold a block-walk step into the running context, advancing
+ * `firstLevelDone` when a promotion has just occurred.
+ *
+ * @param acc previous context
+ * @param promoted whether the block was just upgraded to a heading
+ * @returns next context
+ */
+export const stepCtx = (
+  acc: PromoteCtx,
+  promoted: Option.Option<unknown>
+): PromoteCtx =>
+  Match.value(promoted).pipe(
+    Match.when(Option.isSome, () => ({ firstLevelDone: true })),
+    Match.orElse(() => acc)
+  )


### PR DESCRIPTION
Close #28.

## Summary
Fix the import pipeline so that visually-styled section titles in .docx (bold paragraphs, not actual Word Heading 1-6 styles) land in the editor as real markdown headings.

## Evidence on the real file
`Numero 1.docx` before: 1 real heading in 1738 lines of markdown.
After: 15+ properly structured `##` headings for every section title (От редакции, 1998 год, 2014 год, 2026 год, Смысл названия, Манифест группы, ...).

## Changes
- `convert-docx.ts` — mammoth styleMap covers Title/Subtitle/Heading 1-6 + calls the new promoter.
- `promote-visual-headings.ts` — pure helper, `Option` / `Match` only (obeys the no-if dogma shipped in #25).
- `promote-walk.ts` — block split + ctx fold split out to satisfy sonar max-lines.

## Tests
- 9 unit tests (positive + negative edges: inline bold, long phrases, terminal punctuation, pre-existing h1, empty strong).
- `bun run test:unit` 302→311.
- `bun run test:e2e --project=chromium -- e2e/content/import-from-docs.spec.ts` — 5/5.
- `bun run validate` green.

🤖 Generated with Claude Code