### PR TITLE
fix(#29): import-from-docs reassembles Word footnotes as GFM [^N]

### DIFF
--- a/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { assembleWithFootnotes } from './assemble-footnotes'
+
+const toMd = (html: string): string => {
+  // Minimal stand-in for the turndown conversion in tests.
+  return html
+    .replace(/<em>([^<]+)<\/em>/g, '*$1*')
+    .replace(/<a[^>]*href="([^"]+)"[^>]*>([^<]+)<\/a>/g, '[$2]($1)')
+    .replace(/<\/p>\s*<p>/g, '\n\n')
+    .replace(/<[^>]+>/g, '')
+    .trim()
+}
+
+describe('assembleWithFootnotes', () => {
+  it('swaps placeholders with [^N] and appends definitions', () => {
+    const out = assembleWithFootnotes(
+      'text @@FOOTNOTE_REF_1@@ more @@FOOTNOTE_REF_2@@',
+      [
+        { id: 1, html: 'one' },
+        { id: 2, html: 'two' },
+      ],
+      toMd
+    )
+    expect(out).toBe('text [^1] more [^2]\n\n[^1]: one\n[^2]: two')
+  })
+
+  it('emits only one definition when the same footnote is referenced twice', () => {
+    const out = assembleWithFootnotes(
+      '@@FOOTNOTE_REF_3@@ and again @@FOOTNOTE_REF_3@@',
+      [{ id: 3, html: 'thrice' }],
+      toMd
+    )
+    expect(out).toBe('[^3] and again [^3]\n\n[^3]: thrice')
+  })
+
+  it('returns the body unchanged when there are no footnotes', () => {
+    expect(assembleWithFootnotes('hello', [], toMd)).toBe('hello')
+  })
+
+  it('strips orphan placeholders when no definition exists', () => {
+    const out = assembleWithFootnotes('word @@FOOTNOTE_REF_9@@ end', [], toMd)
+    expect(out).toBe('word  end')
+  })
+
+  it('keeps footnote bodies on a single line', () => {
+    const out = assembleWithFootnotes(
+      '@@FOOTNOTE_REF_1@@',
+      [{ id: 1, html: '<p>line one</p><p>line two</p>' }],
+      toMd
+    )
+    expect(out).toBe('[^1]\n\n[^1]: line one line two')
+  })
+
+  it('renders markdown inside footnote bodies (em + link)', () => {
+    const out = assembleWithFootnotes(
+      '@@FOOTNOTE_REF_4@@',
+      [{ id: 4, html: 'see <em>ref</em> at <a href="http://x">x</a>' }],
+      toMd
+    )
+    expect(out).toBe('[^4]\n\n[^4]: see *ref* at [x](http://x)')
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.ts
+++ b/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.ts
@@ -1,0 +1,41 @@
+import type { Footnote } from './extract-footnotes'
+import { footnotePlaceholder } from './extract-footnotes'
+
+const swapMarkers = (body: string, footnotes: readonly Footnote[]): string =>
+  footnotes.reduce(
+    (acc, f) => acc.split(footnotePlaceholder(f.id)).join(`[^${f.id}]`),
+    body
+  )
+
+const stripPlaceholders = (body: string): string =>
+  body.replace(/@@FOOTNOTE_REF_\d+@@/g, '')
+
+const renderDef = (id: number, markdown: string): string =>
+  `[^${id}]: ${markdown.trim().replace(/\n+/g, ' ')}`
+
+const footnoteSection = (
+  footnotes: readonly Footnote[],
+  toMd: (html: string) => string
+): string => footnotes.map(f => renderDef(f.id, toMd(f.html))).join('\n')
+
+/**
+ * Build the final markdown by swapping each `@@FOOTNOTE_REF_N@@`
+ * placeholder with `[^N]` and appending `[^N]: body` definitions
+ * at the end. Unresolved placeholders (ref with no matching body)
+ * are silently stripped so broken input never bleeds into the
+ * editor.
+ *
+ * @param body markdown produced from the cleaned HTML
+ * @param footnotes extracted footnote payloads
+ * @param toMd convert an HTML fragment to markdown (for bodies)
+ * @returns final markdown ready to insert into the editor
+ */
+export const assembleWithFootnotes = (
+  body: string,
+  footnotes: readonly Footnote[],
+  toMd: (html: string) => string
+): string => {
+  const swapped = stripPlaceholders(swapMarkers(body, footnotes))
+  const suffix = footnoteSection(footnotes, toMd)
+  return suffix === '' ? swapped : `${swapped.trimEnd()}\n\n${suffix}`
+}

--- a/src/components/MarkdownEditor/ImportDocs/extract-footnotes.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/extract-footnotes.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { extractFootnotes } from './extract-footnotes'
+
+const trailing = (...items: readonly string[]) =>
+  `<hr><ol>${items.join('')}</ol>`
+
+describe('extractFootnotes', () => {
+  it('returns input unchanged when no footnotes are present', () => {
+    const r = extractFootnotes('<p>body</p>')
+    expect(r.html).toBe('<p>body</p>')
+    expect(r.footnotes).toEqual([])
+  })
+
+  it('replaces <sup> reference with a placeholder', () => {
+    const r = extractFootnotes(
+      '<p>see<sup><a href="#footnote-1">[1]</a></sup></p>' +
+        trailing(
+          '<li id="footnote-1">body<a href="#footnote-ref-1">↑</a></li>'
+        )
+    )
+    expect(r.html).toBe('<p>see@@FOOTNOTE_REF_1@@</p>')
+    expect(r.footnotes).toEqual([{ id: 1, html: 'body' }])
+  })
+
+  it('strips the back-link from the footnote body', () => {
+    const r = extractFootnotes(
+      '<p>see<sup><a href="#endnote-3">[3]</a></sup></p>' +
+        trailing(
+          '<li id="endnote-3">see <em>reference</em> at <a href="http://x">x</a><a href="#endnote-ref-3">↑</a></li>'
+        )
+    )
+    expect(r.footnotes[0]?.html).toBe(
+      'see <em>reference</em> at <a href="http://x">x</a>'
+    )
+  })
+
+  it('sorts footnote bodies by numeric id even when emitted out of order', () => {
+    const r = extractFootnotes(
+      '<p>a<sup><a href="#footnote-2">[2]</a></sup> b<sup><a href="#footnote-1">[1]</a></sup></p>' +
+        trailing(
+          '<li id="footnote-2">two<a href="#footnote-ref-2">↑</a></li>',
+          '<li id="footnote-1">one<a href="#footnote-ref-1">↑</a></li>'
+        )
+    )
+    expect(r.footnotes.map(f => f.id)).toEqual([1, 2])
+  })
+
+  it('leaves plain <sup> unaffected (not a mammoth ref)', () => {
+    const r = extractFootnotes('<p>E=mc<sup>2</sup></p>')
+    expect(r.html).toBe('<p>E=mc<sup>2</sup></p>')
+    expect(r.footnotes).toEqual([])
+  })
+
+  it('handles multiple references to the same footnote', () => {
+    const r = extractFootnotes(
+      '<p>a<sup><a href="#footnote-1">[1]</a></sup> b<sup><a href="#footnote-1">[1]</a></sup></p>' +
+        trailing(
+          '<li id="footnote-1">one<a href="#footnote-ref-1">↑</a></li>'
+        )
+    )
+    expect(r.html).toBe('<p>a@@FOOTNOTE_REF_1@@ b@@FOOTNOTE_REF_1@@</p>')
+    expect(r.footnotes).toEqual([{ id: 1, html: 'one' }])
+  })
+
+  it('mixes footnote- and endnote- ids seamlessly', () => {
+    const r = extractFootnotes(
+      '<p>a<sup><a href="#footnote-1">[1]</a></sup> b<sup><a href="#endnote-2">[2]</a></sup></p>' +
+        trailing(
+          '<li id="footnote-1">f<a href="#footnote-ref-1">↑</a></li>',
+          '<li id="endnote-2">e<a href="#endnote-ref-2">↑</a></li>'
+        )
+    )
+    expect(r.footnotes.map(f => f.id)).toEqual([1, 2])
+  })
+
+  it('keeps sup ref when the trailing body is missing (malformed)', () => {
+    const r = extractFootnotes(
+      '<p>see<sup><a href="#footnote-9">[9]</a></sup></p>'
+    )
+    expect(r.html).toBe('<p>see@@FOOTNOTE_REF_9@@</p>')
+    expect(r.footnotes).toEqual([])
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/extract-footnotes.ts
+++ b/src/components/MarkdownEditor/ImportDocs/extract-footnotes.ts
@@ -1,0 +1,79 @@
+import { Option } from 'effect'
+
+/** One footnote parsed out of mammoth HTML. */
+export interface Footnote {
+  readonly id: number
+  readonly html: string
+}
+
+/** Result of stripping the footnote scaffolding from mammoth HTML. */
+export interface FootnoteExtract {
+  readonly html: string
+  readonly footnotes: readonly Footnote[]
+}
+
+const SUP_REF =
+  /<sup>\s*<a[^>]*href="#(?:footnote|endnote)-(\d+)"[^>]*>[^<]*<\/a>\s*<\/sup>/g
+
+const FOOTNOTE_ITEM =
+  /<li\s+id="(?:footnote|endnote)-(\d+)"[^>]*>([\s\S]*?)<\/li>/g
+
+const BACKLINK =
+  /<a\s+href="#(?:footnote|endnote)-ref-\d+"[^>]*>[\s\S]*?<\/a>/g
+
+const TRAILING_OL = /<hr[^>]*>\s*<ol>[\s\S]*?<\/ol>\s*$/i
+
+const placeholder = (id: number): string => `@@FOOTNOTE_REF_${id}@@`
+
+const stripBacklink = (html: string): string =>
+  html.replace(BACKLINK, '').trim()
+
+const parseItems = (block: string): readonly Footnote[] => {
+  const out: Footnote[] = []
+  for (const m of block.matchAll(FOOTNOTE_ITEM)) {
+    const id = Number(m[1])
+    const inner = stripBacklink(m[2] ?? '')
+    out.push({ id, html: inner })
+  }
+  return out
+}
+
+const findTrailing = (html: string): Option.Option<string> =>
+  Option.fromNullable(html.match(TRAILING_OL)?.[0])
+
+/**
+ * Pull mammoth's footnote/endnote scaffolding out of the HTML and
+ * return it separately. References `<sup><a href="#endnote-N">…` in
+ * the body are replaced with neutral placeholders that callers swap
+ * for GFM `[^N]` markers after markdown conversion. The trailing
+ * `<hr><ol>…</ol>` block of footnote bodies is removed from the HTML
+ * and returned as a sorted array of `{id, html}` entries.
+ *
+ * @param html mammoth-emitted HTML
+ * @returns cleaned HTML + footnotes ready for GFM assembly
+ */
+export const extractFootnotes = (html: string): FootnoteExtract => {
+  const withMarks = html.replace(SUP_REF, (_, id) => placeholder(Number(id)))
+  const trailing = findTrailing(withMarks)
+  const footnotes = Option.match(trailing, {
+    onNone: () => [] as readonly Footnote[],
+    onSome: parseItems,
+  })
+  const clean = Option.match(trailing, {
+    onNone: () => withMarks,
+    onSome: t => withMarks.replace(t, ''),
+  })
+  return {
+    html: clean,
+    footnotes: [...footnotes].sort((a, b) => a.id - b.id),
+  }
+}
+
+/**
+ * Public placeholder function for callers that need to swap the
+ * reference marker for real `[^N]` text after markdown conversion.
+ *
+ * @param id footnote id
+ * @returns the placeholder string used by extractFootnotes
+ */
+export const footnotePlaceholder = (id: number): string => placeholder(id)

--- a/src/components/MarkdownEditor/ImportDocs/html-to-markdown.ts
+++ b/src/components/MarkdownEditor/ImportDocs/html-to-markdown.ts
@@ -1,7 +1,7 @@
 import TurndownService from 'turndown'
 import { gfm } from 'turndown-plugin-gfm'
-
-let cached: TurndownService | undefined
+import { assembleWithFootnotes } from './assemble-footnotes'
+import { extractFootnotes } from './extract-footnotes'
 
 const build = (): TurndownService => {
   const td = new TurndownService({
@@ -13,13 +13,27 @@ const build = (): TurndownService => {
   return td
 }
 
+const holder: { instance: TurndownService | undefined } = {
+  instance: undefined,
+}
+
+const service = (): TurndownService => {
+  holder.instance = holder.instance ?? build()
+  return holder.instance
+}
+
+const toMarkdown = (html: string): string => service().turndown(html)
+
 /**
- * Convert HTML to GitHub-flavored Markdown.
+ * Convert HTML to GitHub-flavored Markdown. Strips mammoth's
+ * footnote scaffolding first and re-assembles it as GFM footnote
+ * syntax (`[^N]` + `[^N]: body`) at the bottom of the output.
  *
  * @param html source HTML
- * @returns Markdown output
+ * @returns Markdown output with real footnotes
  */
 export const htmlToMarkdown = (html: string): string => {
-  if (cached === undefined) cached = build()
-  return cached.turndown(html)
+  const { html: clean, footnotes } = extractFootnotes(html)
+  const body = toMarkdown(clean)
+  return assembleWithFootnotes(body, footnotes, toMarkdown)
 }


### PR DESCRIPTION
Close #29.

## Summary
Fix the import pipeline so that Word footnotes / endnotes convert to proper GFM footnote syntax (`[^N]` in the body + `[^N]: body` at the end) instead of landing as escaped broken-link markers.

## Before / After
Before: `word [\[1\]](#endnote-1)` (visible escaped brackets, link to a fragment that renders nowhere) plus a detached numbered list at the bottom with stray `↑` back-links.

After: `word [^1]` in the body + `[^1]: body text` at the end — remark-gfm renders these as real footnotes on the public site.

## Changes
- `extract-footnotes.ts` — pulls `<sup><a href="#(footnote|endnote)-N">` out of the body, replaces with neutral `@@FOOTNOTE_REF_N@@` placeholder; captures the trailing `<ol>` bodies with back-links stripped; returns sorted by id.
- `assemble-footnotes.ts` — swaps placeholders with `[^N]` and appends `[^N]: ...` definitions; orphan markers dropped.
- `html-to-markdown.ts` — wires the pipeline.
- No-if dogma respected (Option.match + reduce + map only).

## Tests
- 14 unit tests (8 extract + 6 assemble): orphan refs, mixed footnote/endnote ids, repeated refs, plain `<sup>` left alone, multi-paragraph footnote bodies kept on one line.
- `bun run test:unit` 311→325.
- `bun run test:e2e --project=chromium -- e2e/content/import-from-docs.spec.ts` — 5/5.
- `bun run validate` green.

🤖 Generated with Claude Code