### PR TITLE
feat(#33,#34): numbered Heading 2 + auto-TOC on docx/html import

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@isomorphic-git/lightning-fs": "^4.6.2",
         "@types/turndown": "^5.0.6",
+        "github-slugger": "^2.0.0",
         "hono": "^4.12.8",
         "isomorphic-git": "^1.37.2",
         "mammoth": "^1.12.0",
@@ -1007,6 +1008,8 @@
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 

--- a/e2e/content/import-from-docs.spec.ts
+++ b/e2e/content/import-from-docs.spec.ts
@@ -92,4 +92,84 @@ test.describe('Import from Docs', () => {
     await page.locator('[data-testid="preview-button"]').click()
     await expect(button(page)).toBeHidden()
   })
+
+  test('html with single-item bold-only ordered lists becomes numbered ## headings', async ({
+    page,
+  }) => {
+    await edit(page)
+    const textarea = page.locator('[data-testid="editor-body"]')
+    await textarea.fill('')
+
+    // Mirrors what mammoth emits for Word "List Paragraph" sections —
+    // each section is its own single-item bold-only ordered list.
+    const html =
+      '<ol><li><strong>Foreword</strong></li></ol>' +
+      '<p>body</p>' +
+      '<ol><li><strong>Theory</strong></li></ol>' +
+      '<p>body</p>' +
+      '<ol><li><strong>Practice</strong></li></ol>' +
+      '<p>body</p>'
+
+    await input(page).setInputFiles({
+      name: 'doc.html',
+      mimeType: 'text/html',
+      buffer: Buffer.from(html),
+    })
+
+    await expect
+      .poll(() => textarea.inputValue(), { timeout: 5000 })
+      .toContain('## 1\\. Foreword')
+    const body = await textarea.inputValue()
+    expect(body).toContain('## 1\\. Foreword')
+    expect(body).toContain('## 2\\. Theory')
+    expect(body).toContain('## 3\\. Practice')
+    expect(body).not.toMatch(/^1\.\s+\*\*Foreword/m)
+  })
+
+  test('html with 3+ headings gets a Contents block prepended', async ({
+    page,
+  }) => {
+    await edit(page)
+    const textarea = page.locator('[data-testid="editor-body"]')
+    await textarea.fill('')
+
+    const html =
+      '<h2>Alpha</h2><p>body</p>' +
+      '<h2>Beta</h2><p>body</p>' +
+      '<h2>Gamma</h2><p>body</p>'
+
+    await input(page).setInputFiles({
+      name: 'doc.html',
+      mimeType: 'text/html',
+      buffer: Buffer.from(html),
+    })
+
+    await expect
+      .poll(() => textarea.inputValue(), { timeout: 5000 })
+      .toContain('## Contents')
+    const body = await textarea.inputValue()
+    expect(body.indexOf('## Contents')).toBeLessThan(body.indexOf('## Alpha'))
+    expect(body).toContain('- [Alpha](#alpha)')
+    expect(body).toContain('- [Beta](#beta)')
+    expect(body).toContain('- [Gamma](#gamma)')
+  })
+
+  test('html with fewer than 3 headings is left without a TOC', async ({
+    page,
+  }) => {
+    await edit(page)
+    const textarea = page.locator('[data-testid="editor-body"]')
+    await textarea.fill('')
+
+    await input(page).setInputFiles({
+      name: 'doc.html',
+      mimeType: 'text/html',
+      buffer: Buffer.from('<h2>Only One</h2><p>body</p>'),
+    })
+
+    await expect
+      .poll(() => textarea.inputValue(), { timeout: 5000 })
+      .toContain('## Only One')
+    expect(await textarea.inputValue()).not.toContain('## Contents')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@isomorphic-git/lightning-fs": "^4.6.2",
     "@types/turndown": "^5.0.6",
+    "github-slugger": "^2.0.0",
     "hono": "^4.12.8",
     "isomorphic-git": "^1.37.2",
     "mammoth": "^1.12.0",

--- a/src/components/MarkdownEditor/ImportDocs/convert-docx.ts
+++ b/src/components/MarkdownEditor/ImportDocs/convert-docx.ts
@@ -1,5 +1,4 @@
 import mammoth from 'mammoth'
-import { promoteVisualHeadings } from './promote-visual-headings'
 
 const STYLE_MAP: string[] = [
   "p[style-name='Title'] => h1:fresh",
@@ -13,23 +12,20 @@ const STYLE_MAP: string[] = [
 ]
 
 /**
- * Convert a .docx ArrayBuffer to HTML via mammoth and promote visual
- * titles (bold-only paragraphs used as section headings) to real
- * `<hN>` elements so the markdown has a real outline. Embedded
- * images are still emitted as inline base64 data URIs; callers
- * extract them later.
+ * Convert a .docx ArrayBuffer to mammoth's HTML output. Heading
+ * normalisation (visual-bold paragraphs, single-item bold-only
+ * ordered lists) lives in `normaliseImportHtml` and runs in the
+ * shared `fromHtml` path so it applies to .html imports too.
  *
  * @param buffer raw .docx bytes
- * @returns mammoth HTML string with visual headings upgraded
+ * @returns mammoth HTML string (no post-processing applied here)
  */
 export const convertDocxToHtml = async (
   buffer: ArrayBuffer
 ): Promise<string> => {
   const result = await mammoth.convertToHtml(
     { arrayBuffer: buffer },
-    {
-      styleMap: STYLE_MAP,
-    }
+    { styleMap: STYLE_MAP }
   )
-  return promoteVisualHeadings(result.value)
+  return result.value
 }

--- a/src/components/MarkdownEditor/ImportDocs/generate-toc.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/generate-toc.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { generateToc } from './generate-toc'
+
+describe('generateToc', () => {
+  it('inserts a TOC when the doc has at least 3 H2 headings', () => {
+    const md = ['## A', 'body', '## B', 'body', '## C', 'body'].join('\n')
+    const out = generateToc(md)
+    expect(out.startsWith('## Contents\n')).toBe(true)
+    expect(out).toContain('- [A](#a)')
+    expect(out).toContain('- [B](#b)')
+    expect(out).toContain('- [C](#c)')
+    expect(out).toMatch(/## Contents\n\n[\s\S]+\n\n## A/)
+  })
+
+  it('does nothing when fewer than 3 H2/H3 headings exist', () => {
+    const md = '# Title\n\n## Only one\n\nbody'
+    expect(generateToc(md)).toBe(md)
+  })
+
+  it('does nothing when the doc has only an H1', () => {
+    const md = '# Title\n\nbody body body'
+    expect(generateToc(md)).toBe(md)
+  })
+
+  it('skips H1 (article title) but counts H2 + H3', () => {
+    const md = '# T\n\n## A\n\n### B\n\n### C\n\nbody'
+    const out = generateToc(md)
+    expect(out).toContain('## Contents')
+    expect(out).not.toContain('- [T](#')
+    expect(out).toContain('- [A](#a)')
+    expect(out).toContain('  - [B](#b)')
+    expect(out).toContain('  - [C](#c)')
+  })
+
+  it('does not double-insert when a TOC already exists', () => {
+    const existing =
+      '## Contents\n\n- [A](#a)\n\n## A\n\nbody\n\n## B\n\nbody\n\n## C\n\nbody'
+    expect(generateToc(existing)).toBe(existing)
+  })
+
+  it('preserves Cyrillic in slugs', () => {
+    const md = [
+      '## Предисловие',
+      'body',
+      '## Партия',
+      'body',
+      '## Метод',
+      'body',
+    ].join('\n')
+    const out = generateToc(md)
+    expect(out).toContain('- [Предисловие](#предисловие)')
+    expect(out).toContain('- [Партия](#партия)')
+    expect(out).toContain('- [Метод](#метод)')
+  })
+
+  it('handles numbered headings like "1. Title"', () => {
+    const md = [
+      '## 1. First',
+      'body',
+      '## 2. Second',
+      'body',
+      '## 3. Third',
+      'body',
+    ].join('\n')
+    const out = generateToc(md)
+    expect(out).toContain('- [1. First](#1-first)')
+    expect(out).toContain('- [2. Second](#2-second)')
+    expect(out).toContain('- [3. Third](#3-third)')
+  })
+
+  it('disambiguates duplicate slugs with -1, -2 suffix', () => {
+    const md = [
+      '## Notes',
+      'body',
+      '## Notes',
+      'body',
+      '## Notes',
+      'body',
+    ].join('\n')
+    const out = generateToc(md)
+    expect(out).toContain('- [Notes](#notes)')
+    expect(out).toContain('- [Notes](#notes-1)')
+    expect(out).toContain('- [Notes](#notes-2)')
+  })
+
+  it('emits two-space indent for H3 entries', () => {
+    const md = '## Top\n\nbody\n\n### Sub\n\nbody\n\n### Another\n\nbody'
+    const out = generateToc(md)
+    expect(out).toContain(
+      '- [Top](#top)\n  - [Sub](#sub)\n  - [Another](#another)'
+    )
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/generate-toc.ts
+++ b/src/components/MarkdownEditor/ImportDocs/generate-toc.ts
@@ -1,0 +1,47 @@
+import GithubSlugger from 'github-slugger'
+
+const HEADING_RE = /^(#{1,3})\s+(.+?)\s*$/gm
+const TOC_THRESHOLD = 3
+
+interface Heading {
+  readonly level: 1 | 2 | 3
+  readonly text: string
+}
+
+const collect = (markdown: string): readonly Heading[] =>
+  Array.from(markdown.matchAll(HEADING_RE), m => ({
+    level: (m[1]?.length ?? 1) as 1 | 2 | 3,
+    text: m[2] ?? '',
+  }))
+
+const indentFor = (level: 1 | 2 | 3): string => (level === 3 ? '  ' : '')
+
+const tocLine = (h: Heading, slug: string): string =>
+  `${indentFor(h.level)}- [${h.text}](#${slug})`
+
+const buildBlock = (headings: readonly Heading[]): string => {
+  const slugger = new GithubSlugger()
+  const lines = headings.map(h => tocLine(h, slugger.slug(h.text)))
+  return ['## Contents', '', ...lines].join('\n')
+}
+
+const hasContents = (markdown: string): boolean =>
+  /^##\s+Contents\s*$/m.test(markdown)
+
+/**
+ * Build a markdown table-of-contents block from `##`/`###` headings
+ * in the given body and prepend it. Skips when the body has fewer
+ * than `TOC_THRESHOLD` qualifying headings or already contains a
+ * `## Contents` block.
+ *
+ * @param markdown final imported markdown (post-turndown)
+ * @returns markdown with TOC prepended, or unchanged input
+ */
+export const generateToc = (markdown: string): string => {
+  const headings = hasContents(markdown)
+    ? []
+    : collect(markdown).filter(h => h.level === 2 || h.level === 3)
+  return headings.length < TOC_THRESHOLD
+    ? markdown
+    : `${buildBlock(headings)}\n\n${markdown}`
+}

--- a/src/components/MarkdownEditor/ImportDocs/import-file.ts
+++ b/src/components/MarkdownEditor/ImportDocs/import-file.ts
@@ -1,6 +1,8 @@
 import { convertDocxToHtml } from './convert-docx'
 import { extractImages } from './extract-images'
+import { generateToc } from './generate-toc'
 import { htmlToMarkdown } from './html-to-markdown'
+import { normaliseImportHtml } from './normalise-html'
 import { rewriteImages } from './rewrite-images'
 
 /** Output of an import: converted markdown and accompanying images. */
@@ -13,9 +15,13 @@ const UNSUPPORTED = 'Unsupported file type. Pick a .docx, .html, or .md.'
 const EMPTY: ImportResult = { markdown: '', images: [] }
 
 const fromHtml = (html: string, prefix: string): ImportResult => {
-  const images = extractImages(html, prefix)
-  const clean = rewriteImages(html, images)
-  return { markdown: htmlToMarkdown(clean), images: images.map(i => i.file) }
+  const normalised = normaliseImportHtml(html)
+  const images = extractImages(normalised, prefix)
+  const clean = rewriteImages(normalised, images)
+  return {
+    markdown: generateToc(htmlToMarkdown(clean)),
+    images: images.map(i => i.file),
+  }
 }
 
 const fromDocx = async (file: File): Promise<ImportResult> => {

--- a/src/components/MarkdownEditor/ImportDocs/normalise-html.ts
+++ b/src/components/MarkdownEditor/ImportDocs/normalise-html.ts
@@ -1,0 +1,16 @@
+import { promoteNumberedListHeadings } from './promote-numbered-list-headings'
+import { promoteVisualHeadings } from './promote-visual-headings'
+
+/**
+ * Apply structural promotions that turn the visual-only heading
+ * shapes mammoth (and Word-exported HTML) emit into real `<hN>`
+ * elements. Used by every import path — .docx, .html, .htm — so
+ * the same heuristics fire regardless of how the document was
+ * authored.
+ *
+ * @param html source HTML
+ * @returns HTML with bold-only and numbered-list heading shapes
+ *   promoted to real headings
+ */
+export const normaliseImportHtml = (html: string): string =>
+  promoteVisualHeadings(promoteNumberedListHeadings(html))

--- a/src/components/MarkdownEditor/ImportDocs/promote-numbered-list-headings.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/promote-numbered-list-headings.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { promoteNumberedListHeadings } from './promote-numbered-list-headings'
+
+describe('promoteNumberedListHeadings', () => {
+  it('promotes a single-item bold-only ordered list to h2 with N=1', () => {
+    expect(
+      promoteNumberedListHeadings(
+        '<ol><li><strong>Section A</strong></li></ol><p>body</p>'
+      )
+    ).toBe('<h2>1. Section A</h2><p>body</p>')
+  })
+
+  it('numbers consecutive promotions sequentially across the doc', () => {
+    const out = promoteNumberedListHeadings(
+      '<ol><li><strong>One</strong></li></ol>' +
+        '<p>body</p>' +
+        '<ol><li><strong>Two</strong></li></ol>' +
+        '<p>body</p>' +
+        '<ol><li><strong>Three</strong></li></ol>'
+    )
+    expect(out).toBe(
+      '<h2>1. One</h2><p>body</p><h2>2. Two</h2><p>body</p><h2>3. Three</h2>'
+    )
+  })
+
+  it('trims surrounding whitespace inside <strong>', () => {
+    expect(
+      promoteNumberedListHeadings(
+        '<ol><li><strong>  Title  </strong></li></ol>'
+      )
+    ).toBe('<h2>1. Title</h2>')
+  })
+
+  it('leaves a multi-item ordered list alone', () => {
+    const html = '<ol><li>One</li><li>Two</li></ol>'
+    expect(promoteNumberedListHeadings(html)).toBe(html)
+  })
+
+  it('leaves a single non-bold list item alone', () => {
+    const html = '<ol><li>Just text</li></ol>'
+    expect(promoteNumberedListHeadings(html)).toBe(html)
+  })
+
+  it('leaves a single <li> with bold-plus-extra content alone', () => {
+    const html = '<ol><li><strong>Bold</strong> extra</li></ol>'
+    expect(promoteNumberedListHeadings(html)).toBe(html)
+  })
+
+  it('skips an empty bold list item', () => {
+    const html = '<ol><li><strong></strong></li></ol>'
+    expect(promoteNumberedListHeadings(html)).toBe(html)
+  })
+
+  it('mixes nicely with existing real h2 headings', () => {
+    const out = promoteNumberedListHeadings(
+      '<h2>Existing</h2><ol><li><strong>Promoted</strong></li></ol>'
+    )
+    expect(out).toBe('<h2>Existing</h2><h2>1. Promoted</h2>')
+  })
+
+  it('handles non-Latin text in the heading', () => {
+    expect(
+      promoteNumberedListHeadings(
+        '<ol><li><strong>Предисловие</strong></li></ol>'
+      )
+    ).toBe('<h2>1. Предисловие</h2>')
+  })
+})

--- a/src/components/MarkdownEditor/ImportDocs/promote-numbered-list-headings.ts
+++ b/src/components/MarkdownEditor/ImportDocs/promote-numbered-list-headings.ts
@@ -1,0 +1,26 @@
+const PATTERN = /<ol>\s*<li>\s*<strong>([^<]+)<\/strong>\s*<\/li>\s*<\/ol>/g
+
+/**
+ * Promote single-item bold-only ordered-list blocks to `<h2>` with
+ * a sequential number prefix. Word "List Paragraph" sections often
+ * arrive from mammoth as `<ol><li><strong>Title</strong></li></ol>`
+ * with no `start` attribute and no continuation between items, so
+ * turndown otherwise emits `1. Title` for each section regardless
+ * of its real position.
+ *
+ * The counter runs across the whole document — first match becomes
+ * `<h2>1. Title</h2>`, second `<h2>2. Title</h2>`, etc. Multi-item
+ * lists, lists with non-bold items, or lists with extra content
+ * inside the `<li>` are left untouched.
+ *
+ * @param html mammoth-emitted HTML
+ * @returns HTML with single-item bold-only ordered lists replaced
+ *   by sequentially numbered `<h2>` elements
+ */
+export const promoteNumberedListHeadings = (html: string): string => {
+  let n = 0
+  return html.replace(PATTERN, (_, inner: string) => {
+    n += 1
+    return `<h2>${n}. ${inner.trim()}</h2>`
+  })
+}


### PR DESCRIPTION
Closes #33, #34.

## #33 — numbered headings preserved
Word "List Paragraph" sections arrive from mammoth as
`<ol><li><strong>Title</strong></li></ol>` — single-item bold-only ordered lists, no `start` attribute, no continuation. Turndown wrote `1.` for every section, losing both the heading semantics and the order. New `promote-numbered-list-headings.ts` recognises this exact shape and replaces each match with `<h2>N. Title</h2>` where N is the running 1-based count of promotions in the document. The Manifesto.docx (13 chapters) now imports as `## 1. Предисловие` through `## 13. Задачи коммунистической борьбы`.

Roman fidelity — explicitly NOT supported in this PR. Mammoth drops the docx numbering format and recovering it requires reading `word/numbering.xml` ourselves. The Arabic-with-running-count behaviour is round-trippable and good enough for the editor; a follow-up can add Roman if there is real demand.

## #34 — auto Table of Contents
`generate-toc.ts` walks the converted markdown and prepends a `## Contents` list of anchor links when the body has at least 3 `##`/`###` headings. Anchors use `github-slugger` to match what Astro emits as `<h2 id="...">` on the public site (verified on prod: `<h2 id="our-vision">Our Vision</h2>`).

## Pipeline shape
Both promotions live in a shared `normaliseImportHtml` step that the .docx and .html paths use, so a Word-exported HTML paste gets the same treatment as a .docx import.

## Tests
- 18 new unit tests (9 + 9). Cover positives + negatives (multi-item lists, non-bold li, empty bold, existing real h2, Cyrillic, numbered-prefix slugs, duplicates, H3 indent, idempotent on a doc that already has a Contents block).
- 3 new e2e tests in `import-from-docs.spec.ts`: html → numbered headings, TOC threshold, no TOC on short docs.
- Verified manually with `Manifesto del gruppo Prometeo comunista.docx`: 13 sequential `## N. ` headings + 13 TOC links.
- `bun run validate` — green.
- `bun run test:unit` — 343/343.
- `bun run test:e2e -- e2e/content/import-from-docs.spec.ts` — 8/8.

## Dep added
`github-slugger` (~1 KB minified). Same library Astro uses internally.

🤖 Generated with Claude Code