### PR TITLE
fix(#38): home shows pending deploy entry while polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ coverage
 # Vitest
 __screenshots__/
 
+# Prod-verify Playwright probe artefacts
+screenshots/
+
 # Vite
 *.timestamp-*-*.mjs
 

--- a/e2e-prod/verify-edit-flow.pw.ts
+++ b/e2e-prod/verify-edit-flow.pw.ts
@@ -1,0 +1,184 @@
+import 'dotenv/config'
+import { mkdirSync } from 'node:fs'
+import process from 'node:process'
+import type { Page } from '@playwright/test'
+import { expect, test } from '@playwright/test'
+
+/**
+ * Manual prod verification for issues #36, #37, #38.
+ *
+ * Drives https://admin.comprom.org/content/pages/edit/manifest end to
+ * end: switch to ru, edit body, Preview → Save → Confirm. Captures
+ * the stage PUT path, deploy-bar visibility, sessionStorage pending
+ * deploy, and the home dashboard.
+ *
+ * Requires GITHUB_E2E_KEY in .env (used as the localStorage gh_token).
+ */
+const PROD = 'https://admin.comprom.org'
+const SHOTS = 'screenshots/prod-verify-39'
+
+mkdirSync(SHOTS, { recursive: true })
+
+const out = (s: string): void => {
+  process.stdout.write(`${s}\n`)
+}
+
+interface Capture {
+  readonly stagePuts: { readonly path: string }[]
+  readonly commitResps: { readonly status: number; readonly body: string }[]
+}
+
+const recordStage = (cap: Capture, postData: string | undefined): void => {
+  try {
+    const post = JSON.parse(postData ?? '{}') as { path?: string }
+    if (post.path) cap.stagePuts.push({ path: post.path })
+  } catch {
+    /* ignore */
+  }
+}
+
+const recordCommit = async (
+  cap: Capture,
+  status: number,
+  body: Promise<string>
+): Promise<void> => {
+  cap.commitResps.push({ status, body: (await body.catch(() => '')) ?? '' })
+}
+
+const wireCapture = (page: Page): Capture => {
+  const cap: Capture = { stagePuts: [], commitResps: [] }
+  page.on('response', async r => {
+    const url = r.url()
+    const isStage =
+      url.includes('/api/github/file/stage') && r.request().method() === 'PUT'
+    const isCommit = url.includes('/api/github/commit')
+    if (isStage) recordStage(cap, r.request().postData() ?? undefined)
+    if (isCommit) await recordCommit(cap, r.status(), r.text())
+  })
+  return cap
+}
+
+test('prod: manifest+ru save lands on ru, deploy-bar appears', async ({
+  page,
+}) => {
+  test.setTimeout(180_000)
+  const token = process.env['GITHUB_E2E_KEY']
+  if (!token) throw new Error('Set GITHUB_E2E_KEY in .env')
+
+  const cap = wireCapture(page)
+
+  await page.goto(`${PROD}/`, { waitUntil: 'domcontentloaded' })
+  await page.evaluate(t => localStorage.setItem('gh_token', t), token)
+  await page.goto(`${PROD}/content/pages/edit/manifest`, {
+    waitUntil: 'domcontentloaded',
+  })
+
+  const editor = page.locator('[data-testid="editor-body"]')
+  await editor.waitFor({ state: 'visible', timeout: 60_000 })
+  await page.waitForFunction(
+    () => {
+      const ta = document.querySelector(
+        '[data-testid="editor-body"]'
+      ) as HTMLTextAreaElement | null
+      return !!ta && ta.value.length > 10
+    },
+    undefined,
+    { timeout: 60_000 }
+  )
+  await page.screenshot({
+    path: `${SHOTS}/01-manifest-en.png`,
+    fullPage: true,
+  })
+
+  // #36: in-editor preview-toggle is gone.
+  const toggleCount = await page
+    .locator('[data-testid="preview-toggle"]')
+    .count()
+  expect(toggleCount).toBe(0)
+
+  await page
+    .locator('[data-testid="language-selector"] [data-lang="ru"]')
+    .click()
+  await page.waitForFunction(
+    () => {
+      const ta = document.querySelector(
+        '[data-testid="editor-body"]'
+      ) as HTMLTextAreaElement | null
+      return !!ta && /Наш|манифест/u.test(ta.value)
+    },
+    undefined,
+    { timeout: 30_000 }
+  )
+  await page.screenshot({
+    path: `${SHOTS}/02-manifest-ru.png`,
+    fullPage: true,
+  })
+
+  const before = await editor.inputValue()
+  const marker = `<!-- prod-verify-39 ${Date.now()} -->`
+  await editor.fill(`${before}\n\n${marker}`)
+
+  await page.locator('[data-testid="preview-button"]').click()
+  await page
+    .locator('[data-testid="save-button"]')
+    .waitFor({ state: 'visible', timeout: 10_000 })
+  await page.screenshot({
+    path: `${SHOTS}/03-preview-mode.png`,
+    fullPage: true,
+  })
+
+  await page.locator('[data-testid="save-button"]').click()
+  await page
+    .locator('[data-testid="publish-confirm-btn"]')
+    .waitFor({ state: 'visible', timeout: 10_000 })
+  await page.screenshot({
+    path: `${SHOTS}/04-confirm.png`,
+    fullPage: true,
+  })
+
+  await page.locator('[data-testid="publish-confirm-btn"]').click()
+
+  // Wait for save to land — preview-button reappears in edit mode.
+  await page
+    .locator('[data-testid="preview-button"]')
+    .waitFor({ state: 'visible', timeout: 120_000 })
+  await page.screenshot({
+    path: `${SHOTS}/05-after-save.png`,
+    fullPage: true,
+  })
+
+  const deployBarVisible = await page
+    .locator('.deploy-bar')
+    .isVisible({ timeout: 5_000 })
+    .catch(() => false)
+  const deployBarClass = await page
+    .locator('.deploy-bar')
+    .getAttribute('class')
+    .catch(() => '')
+  const pending = await page.evaluate(() =>
+    sessionStorage.getItem('pending_deploy')
+  )
+
+  await page.goto(`${PROD}/`, { waitUntil: 'domcontentloaded' })
+  await page
+    .locator('section.deploy-list')
+    .waitFor({ state: 'visible', timeout: 30_000 })
+    .catch(() => undefined)
+  await page.screenshot({ path: `${SHOTS}/06-home.png`, fullPage: true })
+  const homeHTML = await page
+    .locator('section.deploy-list')
+    .innerHTML()
+    .catch(() => '<not found>')
+
+  out('=== PROD VERIFY RESULT ===')
+  out(`#36 preview-toggle count: ${toggleCount}`)
+  out(`#37 stage PUTs: ${cap.stagePuts.length}`)
+  for (const p of cap.stagePuts) out(`     ${p.path}`)
+  out(`#37 commit responses: ${cap.commitResps.length}`)
+  for (const c of cap.commitResps)
+    out(`     status=${c.status} body=${c.body.slice(0, 200)}`)
+  out(`#38 deploy-bar visible: ${deployBarVisible}`)
+  out(`#38 deploy-bar class: ${deployBarClass}`)
+  out(`#38 pending_deploy: ${pending}`)
+  out(`#38 home first 600 chars: ${homeHTML.slice(0, 600)}`)
+})

--- a/e2e/content/regression-38-pages-save-shows-deploy.spec.ts
+++ b/e2e/content/regression-38-pages-save-shows-deploy.spec.ts
@@ -53,14 +53,21 @@ test.describe('Issue #38 — saving a page surfaces the deploy in the UI', () =>
     )
     expect(pending).not.toBeNull()
 
-    // Home dashboard must list the new pending entry.
+    // Home dashboard must list the new pending entry, even while
+    // GitHub Actions polling is still in flight (the issue user saw
+    // on prod was "Loading deployments..." masking the entry).
     await page.goto('/')
     await expect(page.locator('section.deploy-list h2')).toContainText(
       /recent deployments/i,
       { timeout: 10000 }
     )
     await expect(
-      page.locator('section.deploy-list').locator('article, li, div').first()
+      page.locator('section.deploy-list .deploy-item').first()
     ).toBeVisible({ timeout: 10000 })
+    await expect(
+      page.locator('section.deploy-list .status', {
+        hasText: /loading deployments/i,
+      })
+    ).toHaveCount(0)
   })
 })

--- a/src/views/HomeView/DeployHistory/DeployList.vue
+++ b/src/views/HomeView/DeployHistory/DeployList.vue
@@ -11,16 +11,17 @@ defineProps<{
 <template>
   <section class="deploy-list">
     <h2>Recent Deployments</h2>
-    <p v-if="loading" class="status">Loading deployments...</p>
-    <p v-else-if="deploys.length === 0" class="status">
-      No deployments found
-    </p>
     <DeployItem
       v-for="d in deploys"
-      v-else
       :key="d.run.id"
       :build="d"
     />
+    <p v-if="loading && deploys.length === 0" class="status">
+      Loading deployments...
+    </p>
+    <p v-else-if="!loading && deploys.length === 0" class="status">
+      No deployments found
+    </p>
   </section>
 </template>
 


### PR DESCRIPTION
## Summary
- Reproduced #38 live on admin.comprom.org. After Preview→Save→Confirm on pages/manifest, the deploy bar correctly shows \`building\` and \`pending_deploy\` is in sessionStorage — but the home dashboard rendered \`Loading deployments...\` and masked the optimistic pending entry while GH workflow polling was still in flight. That matches the user's "на хом пейдже не появляется ничего".
- \`DeployList.vue\` now always renders the entries it has; "Loading…" only shows when the list is genuinely empty AND polling.
- Tightens \`e2e/content/regression-38-pages-save-shows-deploy.spec.ts\` to assert \`.deploy-item\` is visible AND the \`Loading deployments\` status is gone.
- Adds \`e2e-prod/verify-edit-flow.pw.ts\` as an opt-in probe so this exact scenario can be re-run on prod via \`bun run test:e2e:prod\`.

## Notes on #36 / #37 from the prod probe
- #36: \`preview-toggle\` count is 0 on prod ✓ — the previous PR is live.
- #37: stage PUT path was \`pages/manifest/index.ru.md\` and the commit returned a real GH SHA. Save honours the selected language correctly. The original report was likely a side-effect of the #36 PreviewToggle confusion, now resolved. Will close #37 with this evidence.

## Test plan
- [x] e2e \`regression-38\` GREEN with the fix.
- [ ] After merge: rerun the prod probe and confirm \`/\` shows the \`.deploy-item\` for the pending entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)