### PR TITLE
feat: register `about` page slug

### DIFF
--- a/src/components/MarkdownEditor/fields-pages.ts
+++ b/src/components/MarkdownEditor/fields-pages.ts
@@ -47,4 +47,5 @@ export const pageFieldsBySlug: Readonly<
     { key: 'heading', label: 'Heading', type: 'text' },
   ],
   manifest: basePageFields,
+  about: basePageFields,
 }


### PR DESCRIPTION
## Summary
- Adds \`about\` to \`pageFieldsBySlug\` so editing the new About page surfaces title + description fields.
- Pairs with the public-website PR that introduces \`pages/about/\`.

## Test plan
- [x] \`bun run build\` clean.
- [x] Admin chromium e2e for pages flow still green.
- [ ] Manual: open /content/pages/edit/about on prod after deploy.