### PR TITLE
feat: add Subtitle field to home page edit form

### DIFF
--- a/src/components/MarkdownEditor/fields-pages.ts
+++ b/src/components/MarkdownEditor/fields-pages.ts
@@ -47,4 +47,5 @@ export const pageFieldsBySlug: Readonly<
     { key: 'heading', label: 'Heading', type: 'text' },
   ],
   manifest: basePageFields,
+  about: basePageFields,
 }

--- a/src/components/MarkdownEditor/fields-pages.ts
+++ b/src/components/MarkdownEditor/fields-pages.ts
@@ -22,6 +22,7 @@ export const pageFieldsBySlug: Readonly<
   home: [
     ...basePageFields,
     { key: 'heroTitle', label: 'Hero Title', type: 'text' },
+    { key: 'subtitle', label: 'Subtitle', type: 'textarea' },
     {
       key: 'latestNews',
       label: 'Latest News Label',


### PR DESCRIPTION
## Summary
- Adds a Subtitle textarea to the home page edit form. Pairs with the public-website schema introducing optional \`subtitle\`.

## Test plan
- [x] \`bun run build\` clean.
- [x] frontmatter-validation chromium e2e green.
- [ ] Manual: open /content/pages/edit/home on prod after deploy and confirm Subtitle field appears next to Hero Title.