### PR TITLE
fix: move Subtitle field from Home to About

### DIFF
--- a/src/components/MarkdownEditor/fields-pages.ts
+++ b/src/components/MarkdownEditor/fields-pages.ts
@@ -22,7 +22,6 @@ export const pageFieldsBySlug: Readonly<
   home: [
     ...basePageFields,
     { key: 'heroTitle', label: 'Hero Title', type: 'text' },
-    { key: 'subtitle', label: 'Subtitle', type: 'textarea' },
     {
       key: 'latestNews',
       label: 'Latest News Label',
@@ -48,5 +47,8 @@ export const pageFieldsBySlug: Readonly<
     { key: 'heading', label: 'Heading', type: 'text' },
   ],
   manifest: basePageFields,
-  about: basePageFields,
+  about: [
+    ...basePageFields,
+    { key: 'subtitle', label: 'Subtitle', type: 'textarea' },
+  ],
 }


### PR DESCRIPTION
## Summary
Subtitle is the lead under the About h1 on /{lang}/about, not a home-local field. Move the Subtitle textarea from the Home edit form to the About edit form. Pairs with the public-website fix that drops home/subtitle and wires Hero to About's description.