### PR TITLE
feat: add admin develop env (admin-dev.comprom.org)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,19 +2,32 @@ name: Deploy admin to Cloudflare Workers
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
+
+# Serialise per branch — when a fresh master commit lands while an
+# older deploy is still building, cancel the in-flight one. Same on
+# develop. Master and develop never collide because the group key
+# includes `github.ref`.
+concurrency:
+  group: deploy-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # VITE_* env vars are injected into the client bundle at build time by
-    # Vite. Without this, `import.meta.env.VITE_GITHUB_CLIENT_ID` resolves
-    # to undefined and the admin sends an empty client_id to GitHub on
-    # Login click — which renders as a 404 on github.com/login/oauth/authorize.
+    # VITE_* env vars are injected into the client bundle at build time
+    # by Vite. Branch-aware: master deploys point the SW at the
+    # public-website-content master branch and the prod public worker;
+    # develop deploys point at the develop branch and the dev public
+    # worker. VITE_OAUTH_REDIRECT_URI is hard-pinned to the prod
+    # callback so a single GitHub OAuth App handles both deployments —
+    # the popup runs on admin.comprom.org and cross-posts the token
+    # back to the original opener (allowlisted in useOAuthPopup).
     env:
       VITE_GITHUB_CLIENT_ID: ${{ vars.VITE_GITHUB_CLIENT_ID }}
       VITE_MOCK_AUTH: 'false'
-      VITE_GITHUB_BRANCH: master
+      VITE_GITHUB_BRANCH: ${{ github.ref_name == 'develop' && 'develop' || 'master' }}
+      VITE_OAUTH_REDIRECT_URI: 'https://admin.comprom.org/auth/github/callback'
     steps:
       - name: Cloning git repository
         uses: actions/checkout@v4
@@ -92,7 +105,7 @@ jobs:
           GITHUB_E2E_KEY: ${{ secrets.GH_E2E_PAT }}
           GITHUB_OWNER: communist-prometheus
           GITHUB_REPO: public-website-content
-          GITHUB_BRANCH: master
+          GITHUB_BRANCH: ${{ github.ref_name == 'develop' && 'develop' || 'master' }}
         run: |
           bunx playwright test --config=playwright.config.prod.ts \
             e2e-prod/prod-bundle-smoke.pw.ts --reporter=line
@@ -104,3 +117,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           packageManager: bun
           wranglerVersion: "4.80.0"
+          # Master deploys to the production worker; develop deploys to
+          # the `develop` env in wrangler.jsonc which targets the dev
+          # worker (admin-website-develop) on admin-dev.comprom.org.
+          command: ${{ github.ref_name == 'develop' && 'deploy --env develop' || 'deploy' }}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,5 +14,24 @@
   "vars": {
     "CF_ACCOUNT_ID": "c5b8f26375cab6f66eab9981fe3b6d3a",
     "CF_PROJECT_NAME": "public-website"
+  },
+  "env": {
+    // Develop environment — deploys from the `develop` branch into a
+    // separate CF Worker (admin-website-develop) bound to
+    // admin-dev.comprom.org. Reads/writes content from the `develop`
+    // branch of public-website-content (set by the deploy workflow via
+    // VITE_GITHUB_BRANCH). The deploy-status panel reads dev-side CF
+    // workflow runs by pointing CF_PROJECT_NAME at the dev public
+    // worker.
+    "develop": {
+      "name": "admin-website-develop",
+      "routes": [
+        { "pattern": "admin-dev.comprom.org", "custom_domain": true }
+      ],
+      "vars": {
+        "CF_ACCOUNT_ID": "c5b8f26375cab6f66eab9981fe3b6d3a",
+        "CF_PROJECT_NAME": "public-website-develop"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- \`wrangler.jsonc\` adds \`env.develop\` targeting \`admin-website-develop\` worker bound to \`admin-dev.comprom.org\`. Deploy-status panel on dev reads the dev public worker via \`CF_PROJECT_NAME=public-website-develop\`.
- \`deploy.yml\` triggers on master AND develop; branch-aware env:
  - \`VITE_GITHUB_BRANCH\` flips master/develop — SW pushes to the matching content branch.
  - \`GITHUB_BRANCH\` for the prod-bundle smoke test follows the same mapping.
  - \`VITE_OAUTH_REDIRECT_URI\` hard-pinned to the prod callback so one GitHub OAuth App serves both deployments. Popup runs on \`admin.comprom.org\`, cross-posts token back to the dev opener via the existing TRUSTED_ORIGINS allowlist in \`useOAuthPopup/handlers.ts\` (already includes \`admin.comprom.org\`, which is the popup origin trusted by the dev opener).
- Adds concurrency group keyed by ref.

## Test plan
- [x] \`bun run build\` clean.
- [ ] After merge: push develop ← master triggers first dev deploy, creates \`admin-website-develop\` worker.
- [ ] Attach \`admin-dev.comprom.org\` Custom Domain (wrangler does this on first \`deploy --env develop\`).
- [ ] Open \`admin-dev.comprom.org\`, click Login → popup at \`admin.comprom.org\` → token cross-posts back, dev admin authenticated.
- [ ] Edit a page in dev admin → commit lands on \`public-website-content/develop\` → triggers \`public-website\` develop deploy → \`dev.comprom.org\` reflects the change.