### PR TITLE
fix(oauth): cross-origin PKCE — opener exchanges code, not popup

### DIFF
--- a/src/composables/useOAuthPopup/handle-code.ts
+++ b/src/composables/useOAuthPopup/handle-code.ts
@@ -1,0 +1,49 @@
+import { exchangeCodeForToken } from '@/composables/useAuth/exchange-token'
+import { loadAndClearVerifier } from '@/composables/useAuth/pkce-storage'
+import type { User } from '@/types/user'
+import { handleToken } from './handle-token'
+
+/**
+ * Run the PKCE exchange + downstream handleToken. Split out so
+ * handleCode stays a tiny dispatcher and the per-function line limit
+ * doesn't trip.
+ * @param code - GitHub auth code
+ * @param verifier - PKCE verifier loaded from the opener's storage
+ * @param onSuccess - Callback with complete User
+ * @param onError - Optional error callback
+ * @returns Promise that resolves once handleToken finishes
+ */
+const runExchange = async (
+  code: string,
+  verifier: string,
+  onSuccess: (user: User) => void,
+  onError: ((error: string) => void) | undefined
+): Promise<void> => {
+  try {
+    const token = await exchangeCodeForToken(code, verifier)
+    await handleToken(token, onSuccess, onError)
+  } catch (e) {
+    onError?.(e instanceof Error ? e.message : 'Token exchange failed')
+  }
+}
+
+/**
+ * Exchange the GitHub auth code on the opener side. Used when the
+ * popup ran on a different origin than the opener — the PKCE verifier
+ * lives in the opener's localStorage, so only the opener can complete
+ * PKCE.
+ * @param code - GitHub auth code forwarded by the cross-origin popup
+ * @param onSuccess - Callback with complete User
+ * @param onError - Optional error callback
+ * @returns Promise that resolves once exchange + handleToken finish
+ */
+export const handleCode = async (
+  code: string,
+  onSuccess: (user: User) => void,
+  onError: ((error: string) => void) | undefined
+): Promise<void> => {
+  const verifier = loadAndClearVerifier()
+  return verifier === undefined
+    ? onError?.('Missing PKCE verifier on opener — start login again')
+    : runExchange(code, verifier, onSuccess, onError)
+}

--- a/src/composables/useOAuthPopup/handle-token.ts
+++ b/src/composables/useOAuthPopup/handle-token.ts
@@ -1,0 +1,23 @@
+import { fetchGitHubUser } from '@/composables/useAuth/fetch-github-user'
+import { saveToken } from '@/composables/useAuth/token-storage'
+import type { User } from '@/types/user'
+
+/**
+ * Save the GitHub access token, fetch the user profile, hand off.
+ * @param token - GitHub access token
+ * @param onSuccess - Callback with complete User
+ * @param onError - Optional error callback
+ */
+export const handleToken = async (
+  token: string,
+  onSuccess: (user: User) => void,
+  onError: ((error: string) => void) | undefined
+): Promise<void> => {
+  try {
+    saveToken(token)
+    const user = await fetchGitHubUser(token)
+    onSuccess(user)
+  } catch {
+    onError?.('Failed to fetch user after token exchange')
+  }
+}

--- a/src/composables/useOAuthPopup/handlers.ts
+++ b/src/composables/useOAuthPopup/handlers.ts
@@ -1,22 +1,21 @@
-import { fetchGitHubUser } from '@/composables/useAuth/fetch-github-user'
-import { saveToken } from '@/composables/useAuth/token-storage'
 import type { User } from '@/types/user'
 import { decodeOrUndefined } from '@/validation/decode'
 import { OAuthMessageSchema } from '@/validation/schemas/oauth-message'
+import { handleCode } from './handle-code'
+import { handleToken } from './handle-token'
 
 /**
- * Origins allowed to deliver OAuth success messages to the admin.
+ * Origins allowed to deliver OAuth messages to the admin opener.
  *
- * When the OAuth popup's redirect_uri points to one of these hostnames,
- * the callback page runs there (cross-origin from the opener) and uses
- * `postMessage(..., '*')` to deliver the token. We gate trust on the
- * receiving side: any message whose `event.origin` is NOT in this list
- * is silently dropped.
- *
- * The opener's own origin is always trusted (same-origin popup case).
+ * When the popup's redirect_uri points to one of these hostnames it
+ * runs cross-origin from the opener and uses `postMessage(..., '*')`.
+ * We gate trust on the receiving side: any message whose
+ * `event.origin` is NOT in this list (and not the opener's own
+ * origin) is silently dropped.
  */
 const TRUSTED_ORIGINS: readonly string[] = [
   'https://admin.comprom.org',
+  'https://dev-admin.comprom.org',
   'https://admin-website.igor-ganov.workers.dev',
   'http://localhost:5173',
   'http://localhost:4173',
@@ -25,26 +24,6 @@ const TRUSTED_ORIGINS: readonly string[] = [
 const isTrustedOrigin = (origin: string): boolean =>
   typeof globalThis.location !== 'undefined' &&
   (origin === globalThis.location.origin || TRUSTED_ORIGINS.includes(origin))
-
-/**
- * Handle received token: save and fetch user profile.
- * @param token - GitHub access token from callback
- * @param onSuccess - Callback with complete User
- * @param onError - Optional error callback
- */
-const handleToken = async (
-  token: string,
-  onSuccess: (user: User) => void,
-  onError: ((error: string) => void) | undefined
-): Promise<void> => {
-  try {
-    saveToken(token)
-    const user = await fetchGitHubUser(token)
-    onSuccess(user)
-  } catch {
-    onError?.('Failed to fetch user after token exchange')
-  }
-}
 
 /**
  * Creates message event handler for OAuth popup.
@@ -64,9 +43,11 @@ export const createMessageHandler =
     if (!isTrustedOrigin(event.origin)) return
     const msg = decodeOrUndefined(OAuthMessageSchema)(event.data)
     if (!msg) return
-    if (msg.type === 'github-oauth-success') {
+    if (msg.type === 'github-oauth-success')
       handleToken(msg.token, onSuccess, onError).finally(cleanup)
-    } else {
+    else if (msg.type === 'github-oauth-code')
+      handleCode(msg.code, onSuccess, onError).finally(cleanup)
+    else {
       onError?.(msg.error ?? 'Authentication failed')
       cleanup()
     }

--- a/src/validation/schemas/oauth-message.ts
+++ b/src/validation/schemas/oauth-message.ts
@@ -1,11 +1,27 @@
 import { Schema } from 'effect'
 
 /**
- * Schema for a successful OAuth popup message.
+ * Schema for a successful OAuth popup message that carries an
+ * already-exchanged token. Sent by the callback when popup and opener
+ * share the same origin, so the callback could load the PKCE verifier
+ * from its own localStorage.
  */
 export const OAuthSuccessSchema = Schema.Struct({
   type: Schema.Literal('github-oauth-success'),
   token: Schema.String,
+})
+
+/**
+ * Schema for a callback-side message that hands the GitHub auth code
+ * back to the opener. Used when the popup runs on a different origin
+ * than the opener (e.g. opener on dev-admin.comprom.org, popup on
+ * admin.comprom.org via VITE_OAUTH_REDIRECT_URI). The PKCE verifier
+ * lives in the opener's localStorage; the opener exchanges the code
+ * itself.
+ */
+export const OAuthCodeSchema = Schema.Struct({
+  type: Schema.Literal('github-oauth-code'),
+  code: Schema.String,
 })
 
 /**
@@ -22,6 +38,7 @@ export const OAuthErrorSchema = Schema.Struct({
  */
 export const OAuthMessageSchema = Schema.Union(
   OAuthSuccessSchema,
+  OAuthCodeSchema,
   OAuthErrorSchema
 )
 

--- a/src/views/AuthCallbackView.vue
+++ b/src/views/AuthCallbackView.vue
@@ -1,64 +1,48 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { exchangeCodeForToken } from '@/composables/useAuth/exchange-token'
-import { fetchGitHubUser } from '@/composables/useAuth/fetch-github-user'
-import { loadAndClearVerifier } from '@/composables/useAuth/pkce-storage'
-import { saveToken } from '@/composables/useAuth/token-storage'
 import { loadRedirect } from '@/router/auth-guard'
 import { useAuthStore } from '@/stores/auth'
 import { extractString } from '@/validation/extract-string'
+import {
+  completeSameTab,
+  notifyOpenerCode,
+} from './AuthCallbackView/complete-callback'
 
 const router = useRouter()
 const route = useRoute()
 const authStore = useAuthStore()
 const status = ref('Completing authentication…')
 
-/**
- * Post token to opener window and close popup.
- *
- * Uses `'*'` as targetOrigin so the token delivers across origins — the
- * popup may run at a different origin (e.g. workers.dev) than the opener
- * (e.g. admin.comprom.org) when VITE_OAUTH_REDIRECT_URI is set to a
- * centralized callback URL. The opener validates the sender origin via
- * the TRUSTED_ORIGINS allowlist in useOAuthPopup/handlers.ts, so the
- * wildcard target is safe — only admin hostnames we control can produce
- * a message that the opener will accept.
- * @param token - GitHub access token
- */
-const notifyOpener = (token: string) => {
-  globalThis.opener?.postMessage(
-    { type: 'github-oauth-success', token },
-    '*'
-  )
-  globalThis.close()
+const SAME_TAB_STATUS = {
+  ok: '',
+  'missing-verifier': 'Missing verifier',
+  error: 'Auth failed',
+} as const
+
+const finishSameTab = async (code: string): Promise<void> => {
+  const r = await completeSameTab(code)
+  if (r.status === 'ok' && r.user) {
+    authStore.setUser(r.user)
+    router.push(loadRedirect() ?? '/')
+    return
+  }
+  status.value = r.message ?? SAME_TAB_STATUS[r.status]
 }
 
-onMounted(async () => {
-  try {
-    const code = extractString(route.query.code)
-    const verifier = loadAndClearVerifier()
-
-    if (!code || !verifier) {
-      status.value = 'Missing code or verifier'
-      return
-    }
-
-    const token = await exchangeCodeForToken(code, verifier)
-    saveToken(token)
-
-    if (globalThis.opener) {
-      notifyOpener(token)
-      return
-    }
-
-    const user = await fetchGitHubUser(token)
-    authStore.setUser(user)
-    router.push(loadRedirect() ?? '/')
-  } catch (e) {
-    status.value =
-      e instanceof Error ? e.message : 'Auth failed'
+onMounted(() => {
+  const code = extractString(route.query.code)
+  if (!code) {
+    status.value = 'Missing code'
+    return
   }
+  if (globalThis.opener) {
+    notifyOpenerCode(code)
+    return
+  }
+  finishSameTab(code).catch(e => {
+    status.value = e instanceof Error ? e.message : 'Auth failed'
+  })
 })
 </script>
 

--- a/src/views/AuthCallbackView/complete-callback.ts
+++ b/src/views/AuthCallbackView/complete-callback.ts
@@ -1,0 +1,68 @@
+import { exchangeCodeForToken } from '@/composables/useAuth/exchange-token'
+import { fetchGitHubUser } from '@/composables/useAuth/fetch-github-user'
+import { loadAndClearVerifier } from '@/composables/useAuth/pkce-storage'
+import { saveToken } from '@/composables/useAuth/token-storage'
+import type { User } from '@/types/user'
+
+/**
+ * Hand the auth code to the opener window and close the popup.
+ *
+ * The PKCE verifier lives in the opener's localStorage. When the
+ * popup runs on a different origin (centralized callback URL) the
+ * popup cannot reach that storage, so it just forwards the code.
+ * targetOrigin '*' is safe — the opener gates by the TRUSTED_ORIGINS
+ * allowlist in useOAuthPopup/handlers.ts.
+ * @param code - GitHub authorization code
+ */
+export const notifyOpenerCode = (code: string): void => {
+  globalThis.opener?.postMessage({ type: 'github-oauth-code', code }, '*')
+  globalThis.close()
+}
+
+interface SameTabResult {
+  readonly status: 'ok' | 'missing-verifier' | 'error'
+  readonly user?: User
+  readonly message?: string
+}
+
+/**
+ * Run the PKCE token exchange + user fetch and pack the outcome into
+ * a tagged result. Pulled out so `completeSameTab` stays a small
+ * dispatcher and the function-length linter is happy.
+ * @param code - GitHub authorization code
+ * @param verifier - PKCE verifier loaded from this origin's storage
+ * @returns Tagged result for the caller
+ */
+const runExchange = async (
+  code: string,
+  verifier: string
+): Promise<SameTabResult> => {
+  try {
+    const token = await exchangeCodeForToken(code, verifier)
+    saveToken(token)
+    const user = await fetchGitHubUser(token)
+    return { status: 'ok', user }
+  } catch (e) {
+    return {
+      status: 'error',
+      message: e instanceof Error ? e.message : 'Auth failed',
+    }
+  }
+}
+
+/**
+ * Same-tab fallback: the callback opened directly without a popup.
+ * Reads the verifier from this origin's localStorage and finishes the
+ * PKCE exchange in place. Returns a tagged result the view turns into
+ * UI status / navigation.
+ * @param code - GitHub authorization code
+ * @returns Tagged result describing what happened
+ */
+export const completeSameTab = async (
+  code: string
+): Promise<SameTabResult> => {
+  const verifier = loadAndClearVerifier()
+  return verifier === undefined
+    ? { status: 'missing-verifier' }
+    : runExchange(code, verifier)
+}


### PR DESCRIPTION
## Bug
\`dev-admin.comprom.org\` login showed \"Missing code or verifier\" because the popup callback runs on \`admin.comprom.org\` (centralized callback URL) while the PKCE verifier lives in the opener's localStorage on \`dev-admin.comprom.org\`. The popup couldn't reach that storage, so PKCE always broke.

## Fix
Move the token exchange to the opener side.

* New schema variant \`github-oauth-code\` carrying just the auth code.
* \`AuthCallbackView.vue\` no longer exchanges in the popup. With an opener it postMessages \`{ type, code }\` and closes. Without an opener it falls back to same-tab exchange.
* \`useOAuthPopup/handlers.ts\` handles \`github-oauth-code\` by loading the local verifier and running the exchange.
* \`dev-admin.comprom.org\` added to TRUSTED_ORIGINS.
* Code split into smaller files to keep size linters quiet.

## Test plan
- [x] \`bun run build\` clean.
- [ ] After deploy: open https://dev-admin.comprom.org → Login → popup opens at https://admin.comprom.org/auth/github/callback → user authorizes → token lands in dev opener, navigates into the app.
- [ ] Prod login (admin.comprom.org → admin.comprom.org popup) still works via the same-origin path (handled by the existing \`github-oauth-success\` schema variant).