### PR TITLE
fix(#52): seed translation files when a new language is added

### DIFF
--- a/src/stores/seed-build.test.ts
+++ b/src/stores/seed-build.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import type { ContentItem } from '@/types/content'
+import { buildSeed } from './seed-build'
+
+const item = (
+  slug: string,
+  lang: string,
+  extra: Record<string, unknown> = {}
+): ContentItem => ({
+  path: `pages/${slug}/index.${lang}.md`,
+  slug,
+  lang,
+  frontmatter: { title: slug, lang, ...extra },
+})
+
+describe('buildSeed', () => {
+  it('returns nothing when newLangs is empty', () => {
+    expect(buildSeed('pages', [item('home', 'en')], [])).toEqual([])
+  })
+
+  it('returns nothing when items is empty', () => {
+    expect(buildSeed('pages', [], ['de'])).toEqual([])
+  })
+
+  it('seeds one file per (slug × new lang) without existing translation', () => {
+    const items = [item('home', 'en'), item('about', 'en')]
+    const seeds = buildSeed('pages', items, ['de'])
+    expect(seeds.map(s => s.path)).toEqual([
+      'pages/home/index.de.md',
+      'pages/about/index.de.md',
+    ])
+  })
+
+  it('skips slugs that already have the new lang', () => {
+    const items = [item('home', 'en'), item('home', 'de')]
+    expect(buildSeed('pages', items, ['de'])).toEqual([])
+  })
+
+  it('seeds for two new langs at once', () => {
+    const items = [item('home', 'en')]
+    const seeds = buildSeed('pages', items, ['de', 'fr'])
+    expect(seeds.map(s => s.path)).toEqual([
+      'pages/home/index.de.md',
+      'pages/home/index.fr.md',
+    ])
+  })
+
+  it('clones template frontmatter and overrides lang', () => {
+    const items = [
+      item('home', 'en', { heroTitle: 'Welcome', latestNews: 'News' }),
+    ]
+    const seeds = buildSeed('pages', items, ['de'])
+    expect(seeds[0]?.content).toContain('title: home')
+    expect(seeds[0]?.content).toContain('heroTitle: Welcome')
+    expect(seeds[0]?.content).toContain('latestNews: News')
+    expect(seeds[0]?.content).toContain('lang: de')
+    expect(seeds[0]?.content).not.toContain('lang: en')
+  })
+
+  it('prefers en as the template, falls back to first available', () => {
+    const enFm = item('home', 'en', { heroTitle: 'EN' })
+    const ruFm = item('home', 'ru', { heroTitle: 'RU' })
+    const fromEn = buildSeed('pages', [enFm, ruFm], ['de'])
+    expect(fromEn[0]?.content).toContain('heroTitle: EN')
+
+    const fallback = buildSeed('pages', [ruFm], ['de'])
+    expect(fallback[0]?.content).toContain('heroTitle: RU')
+  })
+
+  it('emits empty body separator', () => {
+    const items = [item('home', 'en')]
+    const seeds = buildSeed('pages', items, ['de'])
+    expect(seeds[0]?.content.endsWith('---\n\n')).toBe(true)
+  })
+})

--- a/src/stores/seed-build.ts
+++ b/src/stores/seed-build.ts
@@ -1,0 +1,66 @@
+import { contentFile } from '@/config/content-paths'
+import type { ContentItem, ContentType } from '@/types/content'
+import { stringifyFrontmatter } from '@/utils/frontmatter/stringify'
+
+/** A seed file ready to stage: target path + serialised content. */
+export interface SeedFile {
+  readonly path: string
+  readonly content: string
+}
+
+const groupBySlug = (
+  items: readonly ContentItem[]
+): ReadonlyMap<string, readonly ContentItem[]> => {
+  const map = new Map<string, ContentItem[]>()
+  for (const it of items) {
+    const list = map.get(it.slug) ?? []
+    list.push(it)
+    map.set(it.slug, list)
+  }
+  return map
+}
+
+const pickTemplate = (
+  variants: readonly ContentItem[]
+): ContentItem | undefined =>
+  variants.find(v => v.lang === 'en') ?? variants[0]
+
+const seedsForSlug = (
+  type: ContentType,
+  slug: string,
+  variants: readonly ContentItem[],
+  newLangs: readonly string[]
+): readonly SeedFile[] => {
+  const template = pickTemplate(variants)
+  return template === undefined
+    ? []
+    : newLangs
+        .filter(lang => !variants.some(v => v.lang === lang))
+        .map(lang => ({
+          path: contentFile(type, slug, lang),
+          content: stringifyFrontmatter(
+            { ...template.frontmatter, lang },
+            ''
+          ),
+        }))
+}
+
+/**
+ * For every slug in `items`, produce a seed file per `newLangs` lang
+ * that doesn't already have a translation. Frontmatter is cloned from
+ * the picked template and the `lang` field is overwritten — body is
+ * intentionally empty so editors fill it in via admin.
+ *
+ * @param type - Content type (`pages` or `common`)
+ * @param items - All existing content items of that type
+ * @param newLangs - Lang codes that just got added
+ * @returns Files to stage; empty when nothing needs seeding
+ */
+export const buildSeed = (
+  type: ContentType,
+  items: readonly ContentItem[],
+  newLangs: readonly string[]
+): readonly SeedFile[] =>
+  [...groupBySlug(items)].flatMap(([slug, variants]) =>
+    seedsForSlug(type, slug, variants, newLangs)
+  )

--- a/src/stores/seed-translations.ts
+++ b/src/stores/seed-translations.ts
@@ -1,0 +1,41 @@
+import { commitStaged } from '@/composables/useGitHubApi/commit-staged'
+import { stageFile } from '@/composables/useGitHubApi/stage-file'
+import { fetchContentItems } from './content-fetch'
+import { buildSeed } from './seed-build'
+
+const stageAll = async (newLangs: readonly string[]): Promise<number> => {
+  let count = 0
+  for (const type of ['pages', 'common'] as const) {
+    const items = await fetchContentItems(type)
+    for (const seed of buildSeed(type, items, newLangs)) {
+      await stageFile(seed.path, seed.content)
+      count += 1
+    }
+  }
+  return count
+}
+
+const finalise = async (
+  count: number,
+  newLangs: readonly string[]
+): Promise<number> => {
+  const message = `Seed ${count} translation file(s) for ${newLangs.join(', ')}`
+  return count === 0 ? 0 : commitStaged(message).then(() => count)
+}
+
+/**
+ * Stage and commit translation seeds for newly-added languages.
+ *
+ * For each fixed-structure content type (`pages`, `common`), enumerate
+ * every existing slug and stage an empty-body file for each new lang
+ * that doesn't yet have one. Frontmatter cloned from a same-slug
+ * template (prefer `en`, else first available). Single commit covers
+ * all paths so the SW pushes one push.
+ *
+ * @param newLangs - Lang codes that just got added in Settings
+ * @returns Number of files staged + committed
+ */
+export const seedNewLanguages = async (
+  newLangs: readonly string[]
+): Promise<number> =>
+  newLangs.length === 0 ? 0 : finalise(await stageAll(newLangs), newLangs)

--- a/src/stores/settings-update.ts
+++ b/src/stores/settings-update.ts
@@ -1,9 +1,46 @@
 import type { Ref } from 'vue'
 import type { LanguageEntry } from '@/validation/schemas/languages'
+import { seedNewLanguages } from './seed-translations'
 import { saveLanguagesFile } from './settings-api'
 
+const newCodesIn = (
+  next: readonly LanguageEntry[],
+  prev: readonly LanguageEntry[]
+): readonly string[] => {
+  const known = new Set(prev.map(l => l.code))
+  return next.map(l => l.code).filter(c => !known.has(c))
+}
+
+interface ApplyDeps {
+  readonly res: Response
+  readonly entries: readonly LanguageEntry[]
+  readonly newLangs: readonly string[]
+  readonly languages: Ref<readonly LanguageEntry[]>
+  readonly fileSha: Ref<string>
+}
+
 /**
- * Create updater that saves languages to the API.
+ * Commit the API response into the store and run the per-lang seeder.
+ * Split out so `createUpdateLanguages` stays tiny.
+ * @param d - State refs + parsed payload
+ * @returns Always true (caller already decided ok)
+ */
+const applySaved = async (d: ApplyDeps): Promise<boolean> => {
+  d.languages.value = d.entries
+  const data = await d.res.json()
+  d.fileSha.value = data.content?.sha ?? d.fileSha.value
+  await seedNewLanguages(d.newLangs).catch(() => undefined)
+  return true
+}
+
+/**
+ * Create updater that saves languages to the API and, when a brand-new
+ * lang was added, stages + commits empty translation files for every
+ * `pages/*` and `common/*` slug under the new lang code. Without this
+ * fan-out the new lang only lives in `settings/languages.json` and
+ * editors can't open or save the per-slug files because the fixed-
+ * structure types don't expose a "create" UI.
+ *
  * @param languages - Reactive languages ref
  * @param fileSha - Reactive file SHA ref
  * @returns Async function that updates languages
@@ -11,11 +48,9 @@ import { saveLanguagesFile } from './settings-api'
 export const createUpdateLanguages =
   (languages: Ref<readonly LanguageEntry[]>, fileSha: Ref<string>) =>
   async (entries: readonly LanguageEntry[]): Promise<boolean> => {
+    const newLangs = newCodesIn(entries, languages.value)
     const res = await saveLanguagesFile(entries, fileSha.value)
-    if (res.ok) {
-      languages.value = entries
-      const data = await res.json()
-      fileSha.value = data.content?.sha ?? fileSha.value
-    }
     return res.ok
+      ? applySaved({ res, entries, newLangs, languages, fileSha })
+      : false
   }


### PR DESCRIPTION
## Summary
After saving \`settings/languages.json\` via Settings → Languages, the updater now diffs old vs new lang codes and runs a fan-out for any newly-added codes:

- \`buildSeed\` (pure) clones the same-slug \`en\` template (or first-available variant), overrides \`lang\`, leaves the body empty. Skips slugs already translated.
- \`seedNewLanguages\` enumerates \`pages\` and \`common\` via SW listing, stages every seed via \`/api/github/file/stage\`, and commits the batch with one push.
- \`createUpdateLanguages\` ties it together: save languages.json → if ok, kick off seeder. Seeder failures don't undo the languages.json save.

Closes #52.

## Test plan
- [x] \`buildSeed\` unit tests: 8 cases (empty inputs, dedup against existing translations, lang override, template selection, two-lang fan-out, body separator).
- [x] Full unit suite: 342/342 green.
- [ ] After merge to develop & deploy: open Settings → Languages, add a new lang. Inspect content repo: 7 new files (5 pages slugs + 2 common slugs) committed in one commit, frontmatter cloned from \`en\` with \`lang: <new>\`.
- [ ] Re-add the same lang as a no-op (already in list) → no extra commit.