### PR TITLE
fix(#53): asset dedup on addAsset

### DIFF
--- a/src/composables/useAssets/add-asset.test.ts
+++ b/src/composables/useAssets/add-asset.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { AssetItem } from '../useGitHubApi/asset-types'
+import { createAddAsset } from './add-asset'
+import type { AssetState } from './state'
+import type { PendingAsset } from './types'
+
+vi.mock('./create-blob-url', () => ({
+  createBlobUrl: (_b: string, type: string) =>
+    `blob:${type}-${Math.random()}`,
+}))
+vi.mock('./file-to-base64', () => ({
+  fileToBase64: async (f: File) => `b64:${f.name}:${f.size}`,
+}))
+
+const makeState = (
+  committed: readonly AssetItem[] = [],
+  pending: readonly PendingAsset[] = [],
+  deletes: ReadonlySet<string> = new Set()
+): AssetState => ({
+  committed: ref(committed),
+  pendingAdds: ref(pending),
+  pendingDeletes: ref(deletes),
+  coverPath: ref(undefined),
+  resolvedUrls: ref(new Map()),
+  loading: ref(false),
+})
+
+const pendingOf = (name: string): PendingAsset => ({
+  name,
+  base64: `b64-${name}`,
+  mimeType: 'image/png',
+  blobUrl: `blob:${name}-old`,
+})
+
+const file = (name: string, bytes = 'x'): File =>
+  new File([bytes], name, { type: 'image/png' })
+
+describe('createAddAsset', () => {
+  beforeEach(() => {
+    vi.stubGlobal('URL', {
+      ...URL,
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('appends a new asset when nothing collides', async () => {
+    const state = makeState()
+    await createAddAsset(state)(file('a.png'))
+    expect(state.pendingAdds.value).toHaveLength(1)
+    expect(state.pendingAdds.value[0]?.name).toBe('a.png')
+    expect(state.pendingDeletes.value.size).toBe(0)
+  })
+
+  it('replaces a same-name pending entry with the new bytes', async () => {
+    const state = makeState([], [pendingOf('a.png')])
+    await createAddAsset(state)(file('a.png', 'new'))
+    expect(state.pendingAdds.value).toHaveLength(1)
+    expect(state.pendingAdds.value[0]?.base64).toBe('b64:a.png:3')
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:a.png-old')
+  })
+
+  it('schedules a same-name committed asset for deletion', async () => {
+    const committed: AssetItem = {
+      path: 'blog/x/assets/a.png',
+      name: 'a.png',
+      mimeType: 'image/png',
+    }
+    const state = makeState([committed])
+    await createAddAsset(state)(file('a.png'))
+    expect(state.pendingDeletes.value.has('blog/x/assets/a.png')).toBe(true)
+  })
+
+  it('is idempotent: re-adding the same name does not grow pendingDeletes', async () => {
+    const committed: AssetItem = {
+      path: 'blog/x/assets/a.png',
+      name: 'a.png',
+      mimeType: 'image/png',
+    }
+    const state = makeState([committed])
+    const add = createAddAsset(state)
+    await add(file('a.png'))
+    await add(file('a.png', 'newer'))
+    expect(state.pendingDeletes.value.size).toBe(1)
+    expect(state.pendingAdds.value).toHaveLength(1)
+  })
+
+  it('keeps unrelated pending entries when replacing one name', async () => {
+    const state = makeState([], [pendingOf('a.png'), pendingOf('b.png')])
+    await createAddAsset(state)(file('a.png', 'new'))
+    expect(state.pendingAdds.value.map(p => p.name).sort()).toEqual([
+      'a.png',
+      'b.png',
+    ])
+  })
+})

--- a/src/composables/useAssets/add-asset.ts
+++ b/src/composables/useAssets/add-asset.ts
@@ -1,10 +1,19 @@
 import { createBlobUrl } from './create-blob-url'
+import { dedupPending, scheduleReplace } from './dedup-pending'
 import { fileToBase64 } from './file-to-base64'
 import type { AssetState } from './state'
 import type { PendingAsset } from './types'
 
 /**
  * Create a function that adds a file as a pending asset.
+ *
+ * Replace semantics: adding a file whose name matches an existing
+ * pending entry drops the old pending in favour of the new bytes
+ * (and revokes the old blob URL). Adding a file whose name matches
+ * an already-committed asset schedules the committed path for
+ * deletion in the next transactional save, so save ends with one
+ * file per name and no orphans accumulate.
+ *
  * @param state - Reactive asset state
  * @returns Async function accepting a File, returns PendingAsset
  */
@@ -19,6 +28,14 @@ export const createAddAsset =
       mimeType: file.type,
       blobUrl,
     }
-    state.pendingAdds.value = [...state.pendingAdds.value, asset]
+    const cleanedAdds = dedupPending(state.pendingAdds.value, file.name)
+    const sameCommitted = state.committed.value.find(
+      c => c.name === file.name
+    )
+    state.pendingAdds.value = [...cleanedAdds, asset]
+    state.pendingDeletes.value = scheduleReplace(
+      state.pendingDeletes.value,
+      sameCommitted?.path
+    )
     return asset
   }

--- a/src/composables/useAssets/dedup-pending.test.ts
+++ b/src/composables/useAssets/dedup-pending.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { dedupPending, scheduleReplace } from './dedup-pending'
+import type { PendingAsset } from './types'
+
+const pendingOf = (name: string, blobUrl = `blob:${name}`): PendingAsset => ({
+  name,
+  base64: 'data',
+  mimeType: 'image/png',
+  blobUrl,
+})
+
+describe('dedupPending', () => {
+  beforeEach(() => {
+    vi.stubGlobal('URL', {
+      ...URL,
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('returns input unchanged when no match', () => {
+    const out = dedupPending(
+      [pendingOf('a.png'), pendingOf('b.png')],
+      'c.png'
+    )
+    expect(out.map(p => p.name)).toEqual(['a.png', 'b.png'])
+  })
+
+  it('drops matching name and revokes its blob url', () => {
+    const a = pendingOf('a.png', 'blob:a-old')
+    const b = pendingOf('b.png')
+    const out = dedupPending([a, b], 'a.png')
+    expect(out.map(p => p.name)).toEqual(['b.png'])
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:a-old')
+  })
+
+  it('drops every match (multiple stale entries)', () => {
+    const a1 = pendingOf('dup.png', 'blob:a-1')
+    const a2 = pendingOf('dup.png', 'blob:a-2')
+    const out = dedupPending([a1, a2, pendingOf('keep.png')], 'dup.png')
+    expect(out.map(p => p.name)).toEqual(['keep.png'])
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:a-1')
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:a-2')
+  })
+})
+
+describe('scheduleReplace', () => {
+  it('returns the same set when committedPath is undefined', () => {
+    const set = new Set<string>()
+    expect(scheduleReplace(set, undefined)).toBe(set)
+  })
+
+  it('adds committedPath when missing', () => {
+    const out = scheduleReplace(new Set<string>(), 'a/b.png')
+    expect(out.has('a/b.png')).toBe(true)
+  })
+
+  it('returns the same set when path already present (idempotent)', () => {
+    const set = new Set<string>(['a/b.png'])
+    expect(scheduleReplace(set, 'a/b.png')).toBe(set)
+  })
+
+  it('keeps existing entries when adding a new one', () => {
+    const set = new Set<string>(['x.pdf'])
+    const out = scheduleReplace(set, 'y.pdf')
+    expect([...out].sort()).toEqual(['x.pdf', 'y.pdf'])
+  })
+})

--- a/src/composables/useAssets/dedup-pending.ts
+++ b/src/composables/useAssets/dedup-pending.ts
@@ -1,0 +1,49 @@
+import type { PendingAsset } from './types'
+
+const revokeIfMatch = (
+  asset: PendingAsset,
+  name: string
+): PendingAsset | undefined =>
+  asset.name === name
+    ? (URL.revokeObjectURL(asset.blobUrl), undefined)
+    : asset
+
+/**
+ * Drop any pending entries whose name matches `name`, revoking the
+ * blob URLs they held so we don't leak object URLs in memory.
+ *
+ * @param pending - Current pending-adds list
+ * @param name - File name being added
+ * @returns New list without same-name entries
+ */
+export const dedupPending = (
+  pending: readonly PendingAsset[],
+  name: string
+): readonly PendingAsset[] =>
+  pending.flatMap(a => {
+    const kept = revokeIfMatch(a, name)
+    return kept === undefined ? [] : [kept]
+  })
+
+const addToSet = <T>(s: ReadonlySet<T>, v: T): ReadonlySet<T> => {
+  const next = new Set(s)
+  next.add(v)
+  return next
+}
+
+/**
+ * If a committed asset with the same name exists, schedule its path
+ * for deletion in the next transactional save. Idempotent — re-adding
+ * the same name doesn't grow the delete set.
+ *
+ * @param deletes - Current pending-deletes set
+ * @param committedPath - Path of the committed file with the matching name, if any
+ * @returns New delete set (same instance if nothing changed)
+ */
+export const scheduleReplace = (
+  deletes: ReadonlySet<string>,
+  committedPath: string | undefined
+): ReadonlySet<string> =>
+  committedPath === undefined || deletes.has(committedPath)
+    ? deletes
+    : addToSet(deletes, committedPath)


### PR DESCRIPTION
## Summary
\`addAsset(file)\` was a pure append. Adding a same-name file (Replace PDF, dropping a new cover, etc.) stacked duplicates and left the previously-committed file orphaned after save. Asset folders kept growing across edits.

Replace semantics now:
- Same name already pending → drop the old entry, revoke its blob URL.
- Same name already committed → schedule that path in \`pendingDeletes\` so transactional save replaces it cleanly.
- Idempotent: re-adding the same name doesn't grow \`pendingDeletes\`.

Pulled the bookkeeping into a pure \`dedup-pending.ts\` so logic is covered by focused unit tests; \`add-asset.ts\` becomes a thin orchestrator.

Closes #53.

## Test plan
- [x] \`dedup-pending.test.ts\` — 7 cases (no-match identity, single drop with revoke, multi drop, undefined committedPath, missing/already-present in deletes, append vs preserve).
- [x] \`add-asset.test.ts\` — 5 cases (append, replace pending, schedule committed, idempotent, preserve unrelated).
- [x] Full unit suite: 354/354.
- [ ] Probe on dev: replace PDF on an existing newspaper → after save, asset list contains exactly one PDF + one cover (current count climbs across replaces).