### PR TITLE
fix(sw): surface real commit error instead of UnknownError

### DIFF
--- a/src/composables/useAssets/dedup-pending.ts
+++ b/src/composables/useAssets/dedup-pending.ts
@@ -1,12 +1,9 @@
 import type { PendingAsset } from './types'
 
-const revokeIfMatch = (
-  asset: PendingAsset,
-  name: string
-): PendingAsset | undefined =>
-  asset.name === name
-    ? (URL.revokeObjectURL(asset.blobUrl), undefined)
-    : asset
+const revoke = (asset: PendingAsset): readonly PendingAsset[] => {
+  URL.revokeObjectURL(asset.blobUrl)
+  return []
+}
 
 /**
  * Drop any pending entries whose name matches `name`, revoking the
@@ -20,10 +17,7 @@ export const dedupPending = (
   pending: readonly PendingAsset[],
   name: string
 ): readonly PendingAsset[] =>
-  pending.flatMap(a => {
-    const kept = revokeIfMatch(a, name)
-    return kept === undefined ? [] : [kept]
-  })
+  pending.flatMap(a => (a.name === name ? revoke(a) : [a]))
 
 const addToSet = <T>(s: ReadonlySet<T>, v: T): ReadonlySet<T> => {
   const next = new Set(s)

--- a/src/sw/git/remote/real-commit.ts
+++ b/src/sw/git/remote/real-commit.ts
@@ -7,6 +7,42 @@ import { loadGit } from '../load-git'
 
 type SWGitConfig = NonNullable<typeof workerState.config>
 
+const runCommit = async (
+  config: SWGitConfig,
+  message: string
+): Promise<string> => {
+  const start = Date.now()
+  const git = await loadGit()
+  const sha = await git.commit({
+    fs,
+    dir: REPO_DIR,
+    message,
+    author: {
+      name: config.authorName ?? 'Admin',
+      email: config.authorEmail ?? 'admin@prometheus.org',
+    },
+  })
+  log('info', 'git', `committed ${sha.slice(0, 7)}`)
+  const { pushToRemote } = await import('./push-to-remote')
+  await pushToRemote(config)
+  workerState.commitSha = sha
+  recordOp('commitAndPush', Date.now() - start)
+  return sha
+}
+
+/*
+ * `Effect.tryPromise` without a `catch` rewrites the rejection into a
+ * generic UnknownError whose `.message` reads "An unknown error
+ * occurred in Effect.tryPromise". The handler at /api/github/commit
+ * then bubbles that opaque text up to the user. We need the
+ * underlying isomorphic-git reason ("not a fast-forward",
+ * "401 Unauthorized", "RPC failed with HTTP 422", etc.) so failed
+ * saves are diagnosable. Coerce non-Error throws so callers always
+ * get a string-bearing Error.
+ */
+const preserveError = (e: unknown): Error =>
+  e instanceof Error ? e : new Error(String(e))
+
 /**
  * Execute real git commit + push to remote.
  * @param config - Validated SW git configuration
@@ -14,22 +50,7 @@ type SWGitConfig = NonNullable<typeof workerState.config>
  * @returns Effect yielding the commit SHA
  */
 export const realCommit = (config: SWGitConfig, message: string) =>
-  Effect.tryPromise(async () => {
-    const start = Date.now()
-    const git = await loadGit()
-    const sha = await git.commit({
-      fs,
-      dir: REPO_DIR,
-      message,
-      author: {
-        name: config.authorName ?? 'Admin',
-        email: config.authorEmail ?? 'admin@prometheus.org',
-      },
-    })
-    log('info', 'git', `committed ${sha.slice(0, 7)}`)
-    const { pushToRemote } = await import('./push-to-remote')
-    await pushToRemote(config)
-    workerState.commitSha = sha
-    recordOp('commitAndPush', Date.now() - start)
-    return sha
+  Effect.tryPromise({
+    try: () => runCommit(config, message),
+    catch: preserveError,
   })


### PR DESCRIPTION
## Summary
- `Effect.tryPromise` without a `catch` rewrote rejections as a generic UnknownError ("An unknown error occurred in Effect.tryPromise"), masking the real isomorphic-git reason behind failed saves.
- Switch to `{ try, catch: preserveError }` so the original Error (or a coerced Error if a non-Error was thrown) propagates to the /api/github/commit handler.
- Drive-by: drop a comma-operator in `dedup-pending.ts` that biome ci flagged.

## Why
A user reported "Save failed: Commit failed: An unknown error occurred in Effect.tryPromise" — undiagnosable without the underlying isomorphic-git message ("not a fast-forward", "401 Unauthorized", "RPC failed with HTTP 422", etc.). After this lands, the next failed save will surface the real cause.

## Test plan
- [ ] Deploy to dev-admin
- [ ] Reproduce the failing save and confirm the error dialog now shows the underlying isomorphic-git message
- [ ] All 352 unit tests still pass (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)