### PR TITLE
fix(editor): keep frontmatter when switching to a lang with no file

### DIFF
--- a/e2e-prod/repro-lang-switch-metadata.pw.ts
+++ b/e2e-prod/repro-lang-switch-metadata.pw.ts
@@ -1,0 +1,177 @@
+import 'dotenv/config'
+import process from 'node:process'
+import { expect, type Page, test } from '@playwright/test'
+
+/**
+ * Red repro: switching to a language that has no file yet wipes the
+ * frontmatter, which then makes Save fail validation
+ * (`category is missing`, etc.).
+ *
+ * User flow:
+ *   1. Open existing blog article (en file present)
+ *   2. Switch to a lang where the file doesn't exist (it/es)
+ *   3. Type body — frontmatter was wiped to {}
+ *   4. Save → validation error: "category is missing"
+ *
+ * Expected: when switching to a missing lang the frontmatter inherits
+ * from the previously-loaded language so Save succeeds — metadata is
+ * an entity-level property, not per-file.
+ */
+
+const BRANCH = process.env['GITHUB_BRANCH'] ?? 'develop'
+
+const TARGET_BASE =
+  process.env['REPRO_BASE_URL'] ?? 'https://dev-admin.comprom.org'
+const TARGET_PATH = '/content/blog/edit/demo-test-artiche'
+const PAT = process.env['GITHUB_E2E_KEY'] ?? ''
+
+const out = (s: string): void => {
+  process.stdout.write(`${s}\n`)
+}
+
+const wireDialogs = (page: Page): void => {
+  page.on('dialog', async d => {
+    out(`[dialog.${d.type()}] ${d.message().slice(0, 500)}`)
+    await d.dismiss().catch(() => undefined)
+  })
+}
+
+test('repro: switching to lang without file must keep frontmatter', async ({
+  page,
+}) => {
+  test.setTimeout(120_000)
+  if (!PAT) throw new Error('GITHUB_E2E_KEY required in .env')
+  wireDialogs(page)
+
+  await page.goto(`${TARGET_BASE}/`, { waitUntil: 'domcontentloaded' })
+  await page.evaluate(t => localStorage.setItem('gh_token', t), PAT)
+  await page.goto(`${TARGET_BASE}${TARGET_PATH}`, {
+    waitUntil: 'domcontentloaded',
+  })
+
+  // Wait for original (en) frontmatter to load.
+  const titleInput = page.locator('#fm-title')
+  await titleInput.waitFor({ state: 'visible', timeout: 60_000 })
+  const titleBefore = await titleInput.inputValue()
+  expect(titleBefore.length, 'en title must load').toBeGreaterThan(0)
+
+  // Pick a language tab that the article does NOT have a file for.
+  // The dev fixture has en + ru committed; it/es should be missing.
+  const langTabs = page.locator(
+    '[data-testid="language-selector"] [data-lang]'
+  )
+  const langs = await langTabs.evaluateAll(els =>
+    els.map(e => e.getAttribute('data-lang'))
+  )
+  out(`available langs: ${JSON.stringify(langs)}`)
+
+  const targetLang = langs.find(l => l && l !== 'en' && l !== 'ru') ?? 'it'
+
+  await page
+    .locator(`[data-testid="language-selector"] [data-lang="${targetLang}"]`)
+    .click()
+
+  // Wait for the language switch to settle (loadingFile flips off).
+  await page.waitForFunction(
+    () => {
+      const el = document.querySelector(
+        '[data-testid="loading-overlay"]'
+      ) as HTMLElement | null
+      return !el || el.style.display === 'none' || !el.offsetParent
+    },
+    undefined,
+    { timeout: 15_000 }
+  )
+
+  const titleAfter = await titleInput.inputValue()
+  out(`title before=${JSON.stringify(titleBefore.slice(0, 60))}`)
+  out(`title after=${JSON.stringify(titleAfter.slice(0, 60))}`)
+
+  // The metadata-as-entity assertion: switching to a lang with no
+  // file must NOT erase the title (or any required frontmatter).
+  expect(
+    titleAfter,
+    'frontmatter title must persist across language switch'
+  ).not.toBe('')
+
+  // Save must succeed for the new language too — type a body and save.
+  const editor = page.locator('[data-testid="editor-body"]')
+  const marker = `<!-- repro-lang-switch ${Date.now()} -->`
+  await editor.fill(marker)
+
+  const stagePuts: { readonly path: string; readonly status: number }[] = []
+  const commits: { readonly status: number; readonly body: string }[] = []
+  page.on('response', async r => {
+    const u = r.url()
+    if (
+      u.includes('/api/github/file/stage') &&
+      r.request().method() === 'PUT'
+    ) {
+      const post = (() => {
+        try {
+          return JSON.parse(r.request().postData() ?? '{}') as {
+            path?: string
+          }
+        } catch {
+          return {}
+        }
+      })()
+      stagePuts.push({ path: post.path ?? '<no>', status: r.status() })
+    }
+    if (u.includes('/api/github/commit')) {
+      commits.push({
+        status: r.status(),
+        body: (await r.text()).slice(0, 400),
+      })
+    }
+  })
+
+  await page.locator('[data-testid="preview-button"]').click()
+  await page
+    .locator('[data-testid="save-button"]')
+    .waitFor({ state: 'visible', timeout: 10_000 })
+  await page.locator('[data-testid="save-button"]').click()
+  const confirm = page.locator('[data-testid="publish-confirm-btn"]')
+  if (await confirm.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await confirm.click()
+  }
+
+  const ok = page.locator('[data-testid="preview-button"]')
+  const errEl = page.locator('[data-testid="error-message"]')
+  const winner = await Promise.race([
+    ok.waitFor({ state: 'visible', timeout: 30_000 }).then(() => 'ok'),
+    errEl.waitFor({ state: 'visible', timeout: 30_000 }).then(() => 'error'),
+  ]).catch(() => 'timeout')
+  out(`save winner: ${winner}`)
+  for (const p of stagePuts) out(`stage ${p.status} ${p.path}`)
+  for (const c of commits) out(`commit ${c.status} ${c.body}`)
+
+  // Cleanup the file we just created (avoid polluting the dev branch).
+  if (winner === 'ok' && stagePuts[0]?.path) {
+    const path = stagePuts[0].path
+    const url = `https://api.github.com/repos/communist-prometheus/public-website-content/contents/${path}?ref=${BRANCH}`
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${PAT}` },
+    })
+    if (res.ok) {
+      const data = (await res.json()) as { sha: string }
+      await fetch(
+        `https://api.github.com/repos/communist-prometheus/public-website-content/contents/${path}`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${PAT}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            message: `cleanup repro lang switch`,
+            sha: data.sha,
+            branch: BRANCH,
+          }),
+        }
+      )
+    }
+  }
+
+  expect(winner, 'save after lang switch must succeed').toBe('ok')
+})

--- a/e2e-prod/repro-save-broken.pw.ts
+++ b/e2e-prod/repro-save-broken.pw.ts
@@ -1,0 +1,150 @@
+import 'dotenv/config'
+import process from 'node:process'
+import { expect, type Page, test } from '@playwright/test'
+
+/**
+ * Red repro: edit save fails on dev-admin (and prod-admin).
+ *
+ * Drives the full save chain end-to-end: open existing article, type a
+ * marker into the body, Preview → Save → Confirm. The test asserts the
+ * Save dialog does NOT show an error and the page returns to edit mode.
+ * With the bug present, the dialog stays on screen with the underlying
+ * isomorphic-git reason (now visible thanks to PR #58).
+ *
+ * The captured error string is logged so we can diagnose without
+ * guessing.
+ */
+
+const TARGET_BASE =
+  process.env['REPRO_BASE_URL'] ?? 'https://dev-admin.comprom.org'
+const TARGET_PATH = '/content/blog/edit/demo-test-artiche'
+const PAT = process.env['GITHUB_E2E_KEY'] ?? ''
+
+interface Capture {
+  readonly stagePuts: { readonly path: string; readonly status: number }[]
+  readonly commits: {
+    readonly status: number
+    readonly body: string
+  }[]
+  errorBanner: string | undefined
+}
+
+const out = (s: string): void => {
+  process.stdout.write(`${s}\n`)
+}
+
+const wireCapture = (page: Page): Capture => {
+  const cap: Capture = {
+    stagePuts: [],
+    commits: [],
+    errorBanner: undefined,
+  }
+  page.on('response', async r => {
+    const u = r.url()
+    const m = r.request().method()
+    if (u.includes('/api/github/file/stage') && m === 'PUT') {
+      const post = (() => {
+        try {
+          return JSON.parse(r.request().postData() ?? '{}') as {
+            path?: string
+          }
+        } catch {
+          return {}
+        }
+      })()
+      cap.stagePuts.push({
+        path: post.path ?? '<no path>',
+        status: r.status(),
+      })
+    }
+    if (u.includes('/api/github/commit')) {
+      const body = await r.text().catch(() => '')
+      cap.commits.push({ status: r.status(), body: body.slice(0, 1000) })
+    }
+  })
+  page.on('console', m => {
+    if (m.type() === 'error') {
+      out(`[console.error] ${m.text().slice(0, 500)}`)
+    }
+  })
+  page.on('pageerror', e => {
+    out(`[pageerror] ${e.message}`)
+  })
+  return cap
+}
+
+test('repro: blog edit save must succeed', async ({ page }) => {
+  test.setTimeout(120_000)
+  if (!PAT) throw new Error('GITHUB_E2E_KEY required in .env')
+
+  const cap = wireCapture(page)
+
+  await page.goto(`${TARGET_BASE}/`, { waitUntil: 'domcontentloaded' })
+  await page.evaluate(t => localStorage.setItem('gh_token', t), PAT)
+  await page.goto(`${TARGET_BASE}${TARGET_PATH}`, {
+    waitUntil: 'domcontentloaded',
+  })
+
+  const editor = page.locator('[data-testid="editor-body"]')
+  await editor.waitFor({ state: 'visible', timeout: 60_000 })
+  await page.waitForFunction(
+    () => {
+      const ta = document.querySelector(
+        '[data-testid="editor-body"]'
+      ) as HTMLTextAreaElement | null
+      return !!ta && ta.value.length > 0
+    },
+    undefined,
+    { timeout: 60_000 }
+  )
+
+  const before = await editor.inputValue()
+  const marker = `<!-- repro-save-broken ${Date.now()} -->`
+  await editor.fill(`${before}\n\n${marker}`)
+
+  await page.locator('[data-testid="preview-button"]').click()
+  await page
+    .locator('[data-testid="save-button"]')
+    .waitFor({ state: 'visible', timeout: 10_000 })
+  await page.locator('[data-testid="save-button"]').click()
+
+  const confirm = page.locator('[data-testid="publish-confirm-btn"]')
+  const hasConfirm = await confirm
+    .isVisible({ timeout: 3_000 })
+    .catch(() => false)
+  if (hasConfirm) await confirm.click()
+
+  // Wait for either: success (preview-button reappears) or error
+  // (.save-error or alert-style dialog containing "failed").
+  const ok = page.locator('[data-testid="preview-button"]')
+  const errBanner = page
+    .locator('text=/Save failed|Commit failed|RPC failed/i')
+    .first()
+
+  const winner = await Promise.race([
+    ok.waitFor({ state: 'visible', timeout: 90_000 }).then(() => 'ok'),
+    errBanner
+      .waitFor({ state: 'visible', timeout: 90_000 })
+      .then(() => 'error'),
+  ]).catch(() => 'timeout')
+
+  if (winner !== 'ok') {
+    cap.errorBanner = await errBanner
+      .innerText()
+      .catch(() => '<no banner text>')
+  }
+
+  out(`=== REPRO RESULT ===`)
+  out(`winner: ${winner}`)
+  out(`stage PUTs: ${cap.stagePuts.length}`)
+  for (const p of cap.stagePuts) out(`     ${p.status} ${p.path}`)
+  out(`commit responses: ${cap.commits.length}`)
+  for (const c of cap.commits)
+    out(`     status=${c.status} body=${c.body.slice(0, 400)}`)
+  if (cap.errorBanner) out(`errorBanner: ${cap.errorBanner}`)
+
+  expect(winner, 'save chain must complete without error dialog').toBe('ok')
+  for (const c of cap.commits) {
+    expect(c.status, `commit response body=${c.body}`).toBeLessThan(400)
+  }
+})

--- a/e2e-prod/repro-save-create.pw.ts
+++ b/e2e-prod/repro-save-create.pw.ts
@@ -1,0 +1,219 @@
+import 'dotenv/config'
+import process from 'node:process'
+import { expect, type Page, test } from '@playwright/test'
+
+/**
+ * Red repro: full create-then-save flow against dev-admin.
+ *
+ * The plain edit save passed (`repro-save-broken.pw.ts`), so we widen
+ * coverage to the path the user said is also broken: creating a new
+ * blog article and saving it. We assert:
+ *   1. Stage PUT lands with 200
+ *   2. Commit POST lands with 200
+ *   3. The page returns to edit mode (preview-button visible) and no
+ *      "Save failed" / "Commit failed" banner appears.
+ *
+ * Cleans up the article on the content repo afterwards.
+ */
+
+const TARGET_BASE =
+  process.env['REPRO_BASE_URL'] ?? 'https://dev-admin.comprom.org'
+const PAT = process.env['GITHUB_E2E_KEY'] ?? ''
+const BRANCH = process.env['GITHUB_BRANCH'] ?? 'develop'
+const SLUG = `repro-create-${Date.now()}`
+
+interface Capture {
+  readonly stagePuts: { readonly path: string; readonly status: number }[]
+  readonly commits: { readonly status: number; readonly body: string }[]
+}
+
+const out = (s: string): void => {
+  process.stdout.write(`${s}\n`)
+}
+
+const wireCapture = (page: Page): Capture => {
+  const cap: Capture = { stagePuts: [], commits: [] }
+  page.on('response', async r => {
+    const u = r.url()
+    const m = r.request().method()
+    if (u.includes('/api/github/')) {
+      out(`[net] ${m} ${u} → ${r.status()}`)
+    }
+    if (u.includes('/api/github/file/stage') && m === 'PUT') {
+      const post = (() => {
+        try {
+          return JSON.parse(r.request().postData() ?? '{}') as {
+            path?: string
+          }
+        } catch {
+          return {}
+        }
+      })()
+      cap.stagePuts.push({ path: post.path ?? '<no>', status: r.status() })
+    }
+    if (u.includes('/api/github/commit')) {
+      const body = await r.text().catch(() => '')
+      cap.commits.push({ status: r.status(), body: body.slice(0, 800) })
+    }
+  })
+  page.on('requestfailed', r =>
+    out(
+      `[reqfailed] ${r.method()} ${r.url()} ${r.failure()?.errorText ?? ''}`
+    )
+  )
+  page.on('console', m => {
+    if (m.type() === 'error' || m.type() === 'warning') {
+      out(`[console.${m.type()}] ${m.text().slice(0, 500)}`)
+    }
+  })
+  page.on('pageerror', e => out(`[pageerror] ${e.message}`))
+  page.on('dialog', async d => {
+    out(`[dialog.${d.type()}] ${d.message().slice(0, 500)}`)
+    await d.dismiss().catch(() => undefined)
+  })
+  return cap
+}
+
+const cleanup = async (slug: string): Promise<void> => {
+  const path = `blog/${slug}/index.en.md`
+  const url = `https://api.github.com/repos/communist-prometheus/public-website-content/contents/${path}?ref=${BRANCH}`
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${PAT}` },
+  })
+  if (!res.ok) return
+  const data = (await res.json()) as { sha: string }
+  await fetch(
+    `https://api.github.com/repos/communist-prometheus/public-website-content/contents/${path}`,
+    {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${PAT}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: `cleanup repro ${slug}`,
+        sha: data.sha,
+        branch: BRANCH,
+      }),
+    }
+  )
+}
+
+test.afterAll(async () => {
+  if (PAT) await cleanup(SLUG)
+})
+
+test('repro: blog create then save must succeed', async ({ page }) => {
+  test.setTimeout(180_000)
+  if (!PAT) throw new Error('GITHUB_E2E_KEY required in .env')
+
+  const cap = wireCapture(page)
+
+  await page.goto(`${TARGET_BASE}/`, { waitUntil: 'domcontentloaded' })
+  await page.evaluate(t => localStorage.setItem('gh_token', t), PAT)
+
+  await page.goto(`${TARGET_BASE}/content/blog`, {
+    waitUntil: 'domcontentloaded',
+  })
+
+  const createBtn = page.locator('[data-testid="create-button"]')
+  await createBtn.waitFor({ state: 'visible', timeout: 30_000 })
+
+  // Wait for auth hydration: ContentViewMain swallows the create event
+  // when isAuthenticated is false. The header shows the avatar once auth
+  // resolves.
+  await page.waitForFunction(
+    () => {
+      const a = document.querySelector(
+        '[data-testid="user-avatar"], .user-avatar, header [src*="githubusercontent"]'
+      )
+      return !!a
+    },
+    undefined,
+    { timeout: 30_000 }
+  )
+
+  await createBtn.click()
+  await page.locator('.create-dialog[open]').waitFor({ state: 'attached' })
+  out(`[step] dialog open url=${page.url()}`)
+  await page.locator('#slug').fill(SLUG)
+  await page.locator('#title').fill(`Repro ${SLUG}`)
+  const desc = page.locator('#description')
+  if (await desc.count()) await desc.fill('repro description')
+  const cat = page.locator('#category')
+  if (await cat.count()) {
+    const opts = await cat.locator('option').allTextContents()
+    out(`[step] category options: ${JSON.stringify(opts)}`)
+    // Pick first non-disabled value
+    const values = await cat.locator('option').evaluateAll(els =>
+      els.map(e => ({
+        value: (e as HTMLOptionElement).value,
+        disabled: (e as HTMLOptionElement).disabled,
+      }))
+    )
+    const firstReal = values.find(v => v.value && !v.disabled)
+    if (firstReal) await cat.selectOption(firstReal.value)
+  }
+
+  await page.locator('[data-testid="create-submit"]').click()
+  out(`[step] create submitted, waiting for editor`)
+
+  const editor = page.locator('[data-testid="editor-body"]')
+  await editor.waitFor({ state: 'visible', timeout: 60_000 })
+  out(`[step] editor visible url=${page.url()}`)
+
+  await editor.fill(`# Repro ${SLUG}\n\nHello world.`)
+
+  out(`[step] clicking preview`)
+  await page.locator('[data-testid="preview-button"]').click()
+  await page
+    .locator('[data-testid="save-button"]')
+    .waitFor({ state: 'visible', timeout: 10_000 })
+  out(`[step] clicking save url=${page.url()}`)
+  await page.locator('[data-testid="save-button"]').click()
+
+  const confirm = page.locator('[data-testid="publish-confirm-btn"]')
+  if (await confirm.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    out(`[step] confirming publish dialog`)
+    await confirm.click()
+  } else {
+    out(`[step] no publish dialog`)
+  }
+
+  const ok = page.locator('[data-testid="preview-button"]')
+  const errEl = page.locator('[data-testid="error-message"]')
+  const winner = await Promise.race([
+    ok.waitFor({ state: 'visible', timeout: 30_000 }).then(() => 'ok'),
+    errEl.waitFor({ state: 'visible', timeout: 30_000 }).then(() => 'error'),
+  ]).catch(() => 'timeout')
+
+  out(`=== REPRO CREATE RESULT ===`)
+  out(`winner: ${winner}`)
+  out(`stage PUTs: ${cap.stagePuts.length}`)
+  for (const p of cap.stagePuts) out(`     ${p.status} ${p.path}`)
+  out(`commit responses: ${cap.commits.length}`)
+  for (const c of cap.commits)
+    out(`     status=${c.status} body=${c.body.slice(0, 400)}`)
+
+  const errText = await errEl.innerText().catch(() => '<no error message>')
+  out(`error-message text: ${errText}`)
+
+  // Also peek at save state directly via the page.
+  const state = await page.evaluate(() => ({
+    url: location.href,
+    bodyHasSaveBtn: !!document.querySelector('[data-testid="save-button"]'),
+    bodyHasPreviewBtn: !!document.querySelector(
+      '[data-testid="preview-button"]'
+    ),
+    errorMsg:
+      document.querySelector('[data-testid="error-message"]')?.textContent ??
+      '',
+  }))
+  out(`page state: ${JSON.stringify(state)}`)
+
+  expect(winner).toBe('ok')
+  expect(cap.stagePuts.length).toBeGreaterThan(0)
+  for (const p of cap.stagePuts) expect(p.status).toBeLessThan(400)
+  for (const c of cap.commits)
+    expect(c.status, `commit body=${c.body}`).toBeLessThan(400)
+})

--- a/src/composables/useContent/useMultiLangEditor/switch-language.test.ts
+++ b/src/composables/useContent/useMultiLangEditor/switch-language.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { Language } from '@/types/content'
+import { createSwitchLanguage } from './switch-language'
+import type { EditorDraft, MultiLangEditorState } from './types'
+
+const mkState = (
+  fm: Record<string, unknown>,
+  body: string
+): MultiLangEditorState => ({
+  currentLang: ref<Language>('en'),
+  frontmatterData: ref(fm),
+  bodyContent: ref(body),
+  loadingFile: ref(false),
+  isDirty: undefined,
+})
+
+const blogFm = {
+  title: 'Hello',
+  description: 'desc',
+  category: 'news',
+  lang: 'en',
+}
+
+describe('createSwitchLanguage — entity-level metadata', () => {
+  it('keeps frontmatter when target lang has no file and no cache', async () => {
+    const cache = new Map<Language, EditorDraft>()
+    const state = mkState({ ...blogFm }, '# body')
+    const fileSha = ref('sha-en')
+    const loadFn = vi.fn(async (_path: string) => undefined)
+
+    const switchLang = createSwitchLanguage(cache, state, fileSha, loadFn)
+    await switchLang('it')
+
+    expect(state.currentLang.value).toBe('it')
+    expect(loadFn).not.toHaveBeenCalled()
+    expect(state.frontmatterData.value['title']).toBe('Hello')
+    expect(state.frontmatterData.value['description']).toBe('desc')
+    expect(state.frontmatterData.value['category']).toBe('news')
+    expect(state.frontmatterData.value['lang']).toBe('it')
+  })
+
+  it('still loads from path when one is provided (existing-file path)', async () => {
+    const cache = new Map<Language, EditorDraft>()
+    const state = mkState({ ...blogFm }, '# body')
+    const fileSha = ref('sha-en')
+    const loadFn = vi.fn(async (_path: string) => undefined)
+
+    const switchLang = createSwitchLanguage(cache, state, fileSha, loadFn)
+    await switchLang('ru', 'blog/x/index.ru.md')
+
+    expect(loadFn).toHaveBeenCalledWith('blog/x/index.ru.md')
+  })
+
+  it('clears body when target lang has no file (fresh translation)', async () => {
+    const cache = new Map<Language, EditorDraft>()
+    const state = mkState({ ...blogFm }, '# en body')
+    const fileSha = ref('sha-en')
+    const loadFn = vi.fn(async (_path: string) => undefined)
+
+    const switchLang = createSwitchLanguage(cache, state, fileSha, loadFn)
+    await switchLang('it')
+
+    expect(state.bodyContent.value).toBe('')
+    expect(fileSha.value).toBe('')
+  })
+})

--- a/src/composables/useContent/useMultiLangEditor/switch-language.ts
+++ b/src/composables/useContent/useMultiLangEditor/switch-language.ts
@@ -3,6 +3,26 @@ import type { Language } from '@/types/content'
 import { snapshotAndSwitch, tryRestoreCached } from './switch-helpers'
 import type { EditorDraft, MultiLangEditorState } from './types'
 
+/*
+ * Frontmatter is an entity-level property — every language version of
+ * the same content shares title/description/category/etc. Only `lang`
+ * differs per file, and the body is independent. When the user
+ * switches to a language that has no file yet (and no prior draft in
+ * cache), seed the new draft with the previous frontmatter (with lang
+ * updated) and an empty body. Wiping frontmatter to {} here would make
+ * the next Save fail with "category is missing" / "title is missing".
+ */
+const seedFromCurrent = (
+  state: MultiLangEditorState,
+  lang: Language,
+  fileSha: Ref<string>
+): void => {
+  const previous = state.frontmatterData.value
+  state.frontmatterData.value = { ...previous, lang }
+  state.bodyContent.value = ''
+  fileSha.value = ''
+}
+
 /**
  * Creates a function that switches language with cache
  * @param cache - Draft cache map
@@ -25,7 +45,5 @@ export const createSwitchLanguage =
       await loadFn(path)
       return
     }
-    state.frontmatterData.value = {}
-    state.bodyContent.value = ''
-    fileSha.value = ''
+    seedFromCurrent(state, lang, fileSha)
   }


### PR DESCRIPTION
## Summary
Save was reported broken on both create and edit. Root cause: switching to a language whose file does not exist yet wiped \`frontmatterData\` to \`{}\` and \`bodyContent\` to \`''\`. The next Save then failed schema validation ("category is missing" / "title is missing"), since frontmatter is an entity-level property shared across language versions — only \`lang\` differs per file.

The fix seeds the new language draft from the previous frontmatter (with \`lang\` updated) and an empty body. Body remains per-file; metadata follows the entity.

Closes part of the user's failing-save report (issues #50/#59 chain).

## Tests
- **Unit (RED → GREEN)**: \`src/composables/useContent/useMultiLangEditor/switch-language.test.ts\` — three cases pinning the new contract: keeps frontmatter when target lang has no file, still loads from path when one is provided, and clears body but keeps fileSha empty.
- **E2E repros (RED-only on dev before merge)** added to \`e2e-prod/\`:
  - \`repro-save-broken.pw.ts\` — basic edit save (was already green).
  - \`repro-save-create.pw.ts\` — full create→save chain.
  - \`repro-lang-switch-metadata.pw.ts\` — was RED on dev-admin: \`#fm-title\` disappeared after lang switch, then save would have failed validation.

## Test plan
- [x] \`bun run check:ci\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run build\` — clean
- [x] \`vitest run\` — 358/358 pass
- [ ] After merge to develop, re-run \`bun run test:e2e:prod e2e-prod/repro-lang-switch-metadata.pw.ts\` to confirm green on dev-admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)