### PR TITLE
fix(editor): newspaper cover override + sticky footers + button hovers

### DIFF
--- a/src/components/MarkdownEditor/EditorFooter.vue
+++ b/src/components/MarkdownEditor/EditorFooter.vue
@@ -24,10 +24,14 @@ const emit = defineEmits<{ preview: [] }>()
 
 <style scoped>
 .editor-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
   display: flex;
   padding: clamp(0.75rem, 2vw, 1rem);
   border-top: 1px solid var(--color-border);
   justify-content: flex-end;
+  background: var(--color-background);
 }
 
 button {

--- a/src/components/MarkdownEditor/PdfUpload.vue
+++ b/src/components/MarkdownEditor/PdfUpload.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
+import { shouldAutoSetCover } from './pdf-cover-policy'
 import { createDragHandlers } from './pdf-upload-handlers'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
+  readonly currentCover?: string
 }>()
 
 const emit = defineEmits<{
@@ -24,12 +26,20 @@ const pdfAsset = computed(() =>
 
 const triggerUpload = () => { inputRef.value?.click() }
 
+/*
+ * On every PDF upload we extract the first page and add it to assets
+ * (so editors can swap to it later). We only auto-set frontmatter.image
+ * when there is no cover yet — if the user has chosen a custom cover
+ * we must not silently overwrite it.
+ */
 const handleFile = async (file: File) => {
   if (file.type !== 'application/pdf') return
   emit('upload-pdf', file)
   const m = await import('@/features/newspaper/extract-pdf-cover')
   const cover = await m.extractPdfCover(file)
-  if (cover) { emit('upload-cover', cover); emit('set-cover', 'cover.png') }
+  if (!cover) return
+  emit('upload-cover', cover)
+  if (shouldAutoSetCover(props.currentCover)) emit('set-cover', 'cover.png')
 }
 
 const handleChange = (event: Event) => {

--- a/src/components/MarkdownEditor/pdf-cover-policy.test.ts
+++ b/src/components/MarkdownEditor/pdf-cover-policy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAutoSetCover } from './pdf-cover-policy'
+
+describe('shouldAutoSetCover', () => {
+  it('auto-sets when there is no cover yet', () => {
+    expect(shouldAutoSetCover(undefined)).toBe(true)
+  })
+
+  it('auto-sets when cover string is empty', () => {
+    expect(shouldAutoSetCover('')).toBe(true)
+  })
+
+  it('preserves existing cover when one is set manually', () => {
+    expect(shouldAutoSetCover('manual.png')).toBe(false)
+  })
+
+  it('preserves existing cover even when same as auto-default name', () => {
+    // If editor previously kept the auto cover.png, keep it — the
+    // policy is "user chose a cover" regardless of which file.
+    expect(shouldAutoSetCover('cover.png')).toBe(false)
+  })
+})

--- a/src/components/MarkdownEditor/pdf-cover-policy.ts
+++ b/src/components/MarkdownEditor/pdf-cover-policy.ts
@@ -1,0 +1,12 @@
+/**
+ * Decide whether a freshly extracted PDF cover should overwrite the
+ * frontmatter image. We only auto-set when the entry has no cover
+ * picked yet — once an editor has chosen a custom image we must not
+ * silently replace it on the next PDF upload.
+ *
+ * @param currentCover - frontmatter.image, or undefined when missing
+ * @returns true when the new cover should also be wired into frontmatter
+ */
+export const shouldAutoSetCover = (
+  currentCover: string | undefined
+): boolean => currentCover === undefined || currentCover === ''

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -26,6 +26,13 @@ defineEmits<{
 }>()
 
 const isNewspaper = (type: ContentType) => type === 'newspaper'
+
+const currentCover = (
+  fm: Record<string, unknown>
+): string | undefined => {
+  const v = fm['image']
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
 </script>
 
 <template>
@@ -39,6 +46,7 @@ const isNewspaper = (type: ContentType) => type === 'newspaper'
   <PdfUpload
     v-if="isNewspaper(contentType)"
     :assets="assets"
+    :current-cover="currentCover(frontmatterData)"
     @upload-pdf="$emit('upload-asset', $event)"
     @upload-cover="$emit('upload-asset', $event)"
     @set-cover="$emit('set-cover', $event)"

--- a/src/views/ContentEditView/PreviewFooter.vue
+++ b/src/views/ContentEditView/PreviewFooter.vue
@@ -36,11 +36,15 @@ const emit = defineEmits<{ save: []; back: [] }>()
 
 <style scoped>
 .preview-footer {
+  position: sticky;
+  bottom: 0;
+  z-index: 5;
   display: flex;
   gap: 0.75rem;
   justify-content: flex-end;
   padding: clamp(0.75rem, 2vw, 1rem);
   border-top: 1px solid var(--color-border);
+  background: var(--color-background);
 }
 
 button {
@@ -51,6 +55,7 @@ button {
   border-radius: var(--radius-md);
   font-size: clamp(0.875rem, 2vw, 1rem);
   cursor: pointer;
+  transition: background var(--transition-fast);
 }
 
 .btn-primary {
@@ -59,9 +64,17 @@ button {
   border: none;
 }
 
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-border);
+}
+
 .btn-secondary {
   background: transparent;
   color: var(--color-text);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--color-background-soft);
 }
 
 button:disabled {

--- a/src/views/ContentEditView/PublishDialogCard.vue
+++ b/src/views/ContentEditView/PublishDialogCard.vue
@@ -89,6 +89,7 @@ button {
   font-size: clamp(0.875rem, 2vw, 1rem);
   cursor: pointer;
   border: 1px solid var(--color-border);
+  transition: background var(--transition-fast);
 }
 
 .btn-primary {
@@ -97,8 +98,16 @@ button {
   border: none;
 }
 
+.btn-primary:hover {
+  background: var(--color-border);
+}
+
 .btn-cancel {
   background: transparent;
   color: var(--color-text);
+}
+
+.btn-cancel:hover {
+  background: var(--color-background-soft);
 }
 </style>

--- a/src/views/ContentEditView/page-computeds.test.ts
+++ b/src/views/ContentEditView/page-computeds.test.ts
@@ -1,0 +1,48 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import type { useContentList } from '@/composables/useContent/useContentList'
+import { createPageComputeds } from './page-computeds'
+
+type List = ReturnType<typeof useContentList>
+
+const fakeList = (): List =>
+  ({
+    items: ref([]),
+    reloadContent: async (): Promise<void> => undefined,
+    loadingList: ref(false),
+  }) as unknown as List
+
+describe('createPageComputeds.hasCover', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('is true for blog', () => {
+    expect(createPageComputeds('blog', 'x', fakeList()).hasCover.value).toBe(
+      true
+    )
+  })
+
+  it('is true for positions', () => {
+    expect(
+      createPageComputeds('positions', 'x', fakeList()).hasCover.value
+    ).toBe(true)
+  })
+
+  it('is true for newspaper (manual cover override)', () => {
+    expect(
+      createPageComputeds('newspaper', 'x', fakeList()).hasCover.value
+    ).toBe(true)
+  })
+
+  it('is false for pages', () => {
+    expect(createPageComputeds('pages', 'x', fakeList()).hasCover.value).toBe(
+      false
+    )
+  })
+
+  it('is false for common', () => {
+    expect(
+      createPageComputeds('common', 'x', fakeList()).hasCover.value
+    ).toBe(false)
+  })
+})

--- a/src/views/ContentEditView/page-computeds.ts
+++ b/src/views/ContentEditView/page-computeds.ts
@@ -23,7 +23,12 @@ export const createPageComputeds = (
   isAuth: computed(() => !!useAuthStore().user),
   contentType: computed(() => validType),
   hasAssets: computed(() => NESTED_TYPES.has(validType)),
-  hasCover: computed(() => validType === 'blog' || validType === 'positions'),
+  hasCover: computed(
+    () =>
+      validType === 'blog' ||
+      validType === 'positions' ||
+      validType === 'newspaper'
+  ),
   isBlog: computed(() => validType === 'blog'),
   langs: computed(() => getAvailableLanguages(list.items.value, slug)),
   buildPath: (lang: Language) => contentFile(validType, slug, lang),


### PR DESCRIPTION
## Summary
Three editor-flow regressions reported by the user — bundled because the touched components overlap.

### #36 — newspaper cover
- \`hasCover\` excluded \`newspaper\`, so the manual cover override UI (\`CoverImage\`) never rendered for newspapers; editors had no way to pick a custom cover.
- On every PDF upload \`PdfUpload\` unconditionally emitted \`set-cover('cover.png')\` — silently overwriting any custom cover the user had set.
- Now: include newspaper in \`hasCover\`. Auto-set the extracted first page as cover **only** when no cover is currently set; otherwise just save the screenshot to assets and keep the existing image. Pure decision lives in \`pdf-cover-policy.ts\` so it's testable.

### #38 — button hovers
- \`PreviewFooter\` (Back to edit / Save) and \`PublishDialogCard\` (Cancel / Publish and commit) had no \`:hover\` rules — flat. Added consistent transitions matching the rest of the codebase.

### #39 — sticky footers
- \`EditorFooter\` and \`PreviewFooter\` scrolled away with content so editors had to scroll to reach Preview / Save. Pinned both with \`position: sticky; bottom: 0\` against the document scroll.

## Tests
- \`pdf-cover-policy.test.ts\` — 4 cases pinning the auto-set decision.
- \`page-computeds.test.ts\` — 5 cases for hasCover (newspaper now true).
- \`bun run check:ci\`, \`vitest run\` (364/364), \`bun run build\` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)