### PR TITLE
chore(editor): hide markdown body for frontmatter-only pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ public/sw.js
 # Auto-generated type definitions
 src/components.d.ts
 .wrangler
+.claude/scheduled_tasks.lock

--- a/src/components/MarkdownEditor/page-body-policy.test.ts
+++ b/src/components/MarkdownEditor/page-body-policy.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { hasBodyEditor } from './page-body-policy'
+
+describe('hasBodyEditor', () => {
+  it('hides body for the home landing page', () => {
+    expect(hasBodyEditor('pages', 'home')).toBe(false)
+  })
+
+  it('hides body for blog-listing', () => {
+    expect(hasBodyEditor('pages', 'blog-listing')).toBe(false)
+  })
+
+  it('hides body for positions-listing', () => {
+    expect(hasBodyEditor('pages', 'positions-listing')).toBe(false)
+  })
+
+  it('keeps body for manifest', () => {
+    expect(hasBodyEditor('pages', 'manifest')).toBe(true)
+  })
+
+  it('keeps body for about', () => {
+    expect(hasBodyEditor('pages', 'about')).toBe(true)
+  })
+
+  it('keeps body for blog entries (different content type)', () => {
+    expect(hasBodyEditor('blog', 'home')).toBe(true)
+  })
+
+  it('keeps body when slug is undefined (defensive default)', () => {
+    expect(hasBodyEditor('pages', undefined)).toBe(true)
+  })
+})

--- a/src/components/MarkdownEditor/page-body-policy.ts
+++ b/src/components/MarkdownEditor/page-body-policy.ts
@@ -1,0 +1,35 @@
+/*
+ * Some `pages` slugs are pure containers for landing-page labels —
+ * the public site reads their frontmatter (title, heroTitle, heading,
+ * etc.) but never renders the body. Showing a markdown body editor
+ * for them is misleading and pollutes the committed file with content
+ * that is never used.
+ *
+ * Mirrors the templates in public-website/src/pages/[lang]/*.astro:
+ *   - home: BaseLayout + Hero + NewsSection + PositionsWidget, no body.
+ *   - blog-listing: posts grid, no body.
+ *   - positions-listing: positions grid, no body.
+ *   - manifest, about: do render body and stay editable.
+ */
+const BODYLESS_PAGE_SLUGS: ReadonlySet<string> = new Set([
+  'home',
+  'blog-listing',
+  'positions-listing',
+])
+
+/**
+ * Whether the markdown body editor should render for this pages slug.
+ * Always true for non-pages content types — only pages have the
+ * frontmatter-only landing slugs.
+ *
+ * @param contentType - Content type of the entry being edited
+ * @param slug - Slug of the entry
+ * @returns true when a body editor is meaningful for this entry
+ */
+export const hasBodyEditor = (
+  contentType: string,
+  slug: string | undefined
+): boolean =>
+  contentType !== 'pages' || slug === undefined
+    ? true
+    : !BODYLESS_PAGE_SLUGS.has(slug)

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -3,6 +3,7 @@ import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
 import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
 import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
+import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import type { ContentType } from '@/types/content'
 
@@ -27,9 +28,7 @@ defineEmits<{
 
 const isNewspaper = (type: ContentType) => type === 'newspaper'
 
-const currentCover = (
-  fm: Record<string, unknown>
-): string | undefined => {
+const currentCover = (fm: Record<string, unknown>): string | undefined => {
   const v = fm['image']
   return typeof v === 'string' && v.length > 0 ? v : undefined
 }
@@ -52,7 +51,7 @@ const currentCover = (
     @set-cover="$emit('set-cover', $event)"
   />
   <MarkdownEditorBody
-    v-else
+    v-else-if="hasBodyEditor(contentType, slug)"
     :model-value="bodyContent"
     :asset-url-map="assetUrlMap"
     :assets="assets"

--- a/src/views/ContentEditView/build-init-deps.ts
+++ b/src/views/ContentEditView/build-init-deps.ts
@@ -1,8 +1,29 @@
+import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
 import { createInitAll } from './create-init-all'
 import type { useEditPage } from './useEditPage'
 import { createInitEditor } from './useEditPageInit'
 
 type Page = ReturnType<typeof useEditPage>
+
+/*
+ * Some pages slugs (home, blog-listing, positions-listing) are
+ * frontmatter-only landing pages: their body is never rendered. Wrap
+ * the editor init so any body content from disk is cleared on entry,
+ * making the next save commit a clean frontmatter-only file.
+ */
+const clearBodyless = (page: Page): void => {
+  page.editor.bodyContent.value = hasBodyEditor(
+    page.contentType.value,
+    page.slug
+  )
+    ? page.editor.bodyContent.value
+    : ''
+}
+
+const wrapBodyless = (page: Page, init: () => Promise<void>) => async () => {
+  await init()
+  clearBodyless(page)
+}
 
 /**
  * Build the init-all function from page state.
@@ -11,12 +32,15 @@ type Page = ReturnType<typeof useEditPage>
  */
 export const buildInitAll = (page: Page) => {
   const { editor, list, langs, assets, hasAssets } = page
-  const initEditor = createInitEditor({
-    ...editor,
-    loadContent: list.loadContent,
-    availableLanguages: langs,
-    buildPath: page.buildPath,
-  })
+  const initEditor = wrapBodyless(
+    page,
+    createInitEditor({
+      ...editor,
+      loadContent: list.loadContent,
+      availableLanguages: langs,
+      buildPath: page.buildPath,
+    })
+  )
   return createInitAll({
     initEditor,
     hasAssets,


### PR DESCRIPTION
## Summary
\`home\`, \`blog-listing\`, \`positions-listing\` are landing pages whose public-website templates only consume frontmatter (\`title\`, \`heroTitle\`, \`heading\`, \`latestNews\`, etc.) and **never render the markdown body**. Showing a body editor for them in admin was misleading and meant we kept committing content into files that nothing reads.

- New \`page-body-policy.ts\` encapsulates the per-slug decision (\`hasBodyEditor\`).
- \`ContentEditMainBody\` only mounts \`MarkdownEditorBody\` when the page is body-bearing (manifest, about, etc.).
- \`build-init-deps\` wraps the editor init so any body content loaded from disk for a body-less page is cleared on entry; the next save commits a clean frontmatter-only file.

## Tests
- 7 unit tests in \`page-body-policy.test.ts\` pin the policy.
- \`bun run check:ci\`, \`vitest run\` (371/371), \`bun run build\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)