### PR TITLE
chore(e2e): stabilize repro-save-create

### DIFF
--- a/e2e-prod/repro-save-create.pw.ts
+++ b/e2e-prod/repro-save-create.pw.ts
@@ -195,21 +195,12 @@ test('repro: blog create then save must succeed', async ({ page }) => {
   for (const c of cap.commits)
     out(`     status=${c.status} body=${c.body.slice(0, 400)}`)
 
-  const errText = await errEl.innerText().catch(() => '<no error message>')
-  out(`error-message text: ${errText}`)
-
-  // Also peek at save state directly via the page.
-  const state = await page.evaluate(() => ({
-    url: location.href,
-    bodyHasSaveBtn: !!document.querySelector('[data-testid="save-button"]'),
-    bodyHasPreviewBtn: !!document.querySelector(
-      '[data-testid="preview-button"]'
-    ),
-    errorMsg:
-      document.querySelector('[data-testid="error-message"]')?.textContent ??
-      '',
-  }))
-  out(`page state: ${JSON.stringify(state)}`)
+  if (winner !== 'ok') {
+    const errText = await errEl
+      .innerText({ timeout: 1000 })
+      .catch(() => '<no error message>')
+    out(`error-message text: ${errText}`)
+  }
 
   expect(winner).toBe('ok')
   expect(cap.stagePuts.length).toBeGreaterThan(0)


### PR DESCRIPTION
Drops a post-success diagnostic block that kept the test alive past the 180s timeout because background SW polling fired continuously. Test now passes in ~22s, all 4 prod E2E specs green on dev-admin.