### PR TITLE
fix(editor): clean dirty flag + cover all bodyless content types

### DIFF
--- a/src/components/MarkdownEditor/page-body-policy.test.ts
+++ b/src/components/MarkdownEditor/page-body-policy.test.ts
@@ -22,8 +22,21 @@ describe('hasBodyEditor', () => {
     expect(hasBodyEditor('pages', 'about')).toBe(true)
   })
 
-  it('keeps body for blog entries (different content type)', () => {
+  it('keeps body for blog entries (body is rendered on detail page)', () => {
     expect(hasBodyEditor('blog', 'home')).toBe(true)
+  })
+
+  it('keeps body for positions entries (body is rendered)', () => {
+    expect(hasBodyEditor('positions', 'whatever')).toBe(true)
+  })
+
+  it('hides body for newspaper (only list page exists, body unused)', () => {
+    expect(hasBodyEditor('newspaper', 'issue-01')).toBe(false)
+  })
+
+  it('hides body for any common slug (translation tables only)', () => {
+    expect(hasBodyEditor('common', 'menu')).toBe(false)
+    expect(hasBodyEditor('common', 'labels')).toBe(false)
   })
 
   it('keeps body when slug is undefined (defensive default)', () => {

--- a/src/components/MarkdownEditor/page-body-policy.ts
+++ b/src/components/MarkdownEditor/page-body-policy.ts
@@ -1,16 +1,24 @@
 /*
- * Some `pages` slugs are pure containers for landing-page labels —
- * the public site reads their frontmatter (title, heroTitle, heading,
- * etc.) but never renders the body. Showing a markdown body editor
- * for them is misleading and pollutes the committed file with content
- * that is never used.
+ * Decide where a markdown body editor is meaningful, by mirroring
+ * exactly what public-website actually renders. Anywhere the
+ * template only consumes frontmatter (`entry.data.*`) and never
+ * calls `entry.render()` / `<Content />`, showing a body editor in
+ * admin would let editors type text into a void.
  *
- * Mirrors the templates in public-website/src/pages/[lang]/*.astro:
- *   - home: BaseLayout + Hero + NewsSection + PositionsWidget, no body.
- *   - blog-listing: posts grid, no body.
- *   - positions-listing: positions grid, no body.
- *   - manifest, about: do render body and stay editable.
+ * Public-website rendering map (verified in
+ * public-website/src/pages/[lang]/*.astro):
+ *   - blog/<slug>: body rendered  -> editor SHOWN
+ *   - positions/<slug>: body rendered -> editor SHOWN
+ *   - pages/manifest, pages/about: body rendered -> editor SHOWN
+ *   - pages/home, pages/blog-listing, pages/positions-listing:
+ *     frontmatter only -> editor HIDDEN
+ *   - newspaper/<slug>: only a list page exists; the detail "page"
+ *     is the PDF download. Body never rendered -> editor HIDDEN
+ *   - common/<slug> (menu, labels, ...): translation tables read
+ *     via `entry.data.*` only -> editor HIDDEN
  */
+const ALWAYS_BODYLESS: ReadonlySet<string> = new Set(['common', 'newspaper'])
+
 const BODYLESS_PAGE_SLUGS: ReadonlySet<string> = new Set([
   'home',
   'blog-listing',
@@ -18,10 +26,7 @@ const BODYLESS_PAGE_SLUGS: ReadonlySet<string> = new Set([
 ])
 
 /**
- * Whether the markdown body editor should render for this pages slug.
- * Always true for non-pages content types — only pages have the
- * frontmatter-only landing slugs.
- *
+ * Whether the markdown body editor should render for this entry.
  * @param contentType - Content type of the entry being edited
  * @param slug - Slug of the entry
  * @returns true when a body editor is meaningful for this entry
@@ -30,6 +35,8 @@ export const hasBodyEditor = (
   contentType: string,
   slug: string | undefined
 ): boolean =>
-  contentType !== 'pages' || slug === undefined
-    ? true
-    : !BODYLESS_PAGE_SLUGS.has(slug)
+  ALWAYS_BODYLESS.has(contentType)
+    ? false
+    : contentType !== 'pages' || slug === undefined
+      ? true
+      : !BODYLESS_PAGE_SLUGS.has(slug)

--- a/src/composables/useContent/useMultiLangEditor/build-actions.ts
+++ b/src/composables/useContent/useMultiLangEditor/build-actions.ts
@@ -44,6 +44,7 @@ export const buildNavActions = (
 ) => ({
   switchLanguage: createSwitchLanguage(
     ctx.cache,
+    ctx.originalCache,
     ctx.state,
     ctx.fileSha,
     loadLang

--- a/src/composables/useContent/useMultiLangEditor/dirty-after-switch.test.ts
+++ b/src/composables/useContent/useMultiLangEditor/dirty-after-switch.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { Language } from '@/types/content'
+import { createIsDirty } from './dirty-check'
+import { setLoadedDraft } from './set-loaded-draft'
+import { createSwitchLanguage } from './switch-language'
+import type { EditorDraft, MultiLangEditorState } from './types'
+
+const mkState = (
+  fm: Record<string, unknown>,
+  body: string,
+  lang: Language = 'en'
+): MultiLangEditorState => ({
+  currentLang: ref<Language>(lang),
+  frontmatterData: ref(fm),
+  bodyContent: ref(body),
+  loadingFile: ref(false),
+  isDirty: undefined,
+})
+
+const blogFm = {
+  title: 'Hello',
+  description: 'desc',
+  category: 'news',
+  lang: 'en',
+}
+
+describe('isDirty after switch to fresh language', () => {
+  it('stays clean when nothing was edited', async () => {
+    const cache = new Map<Language, EditorDraft>()
+    const originalCache = new Map<Language, EditorDraft>()
+    const state = mkState({ ...blogFm }, '# en body')
+    const fileSha = ref('sha-en')
+    const saveVersion = ref(0)
+    setLoadedDraft(cache, originalCache, 'en', blogFm, '# en body', 'sha-en')
+
+    const switchLang = createSwitchLanguage(
+      cache,
+      originalCache,
+      state,
+      fileSha,
+      vi.fn(async () => undefined)
+    )
+    await switchLang('it')
+
+    const isDirty = createIsDirty(
+      cache,
+      originalCache,
+      state,
+      fileSha,
+      saveVersion
+    )
+    expect(isDirty.value).toBe(false)
+  })
+})

--- a/src/composables/useContent/useMultiLangEditor/switch-language.test.ts
+++ b/src/composables/useContent/useMultiLangEditor/switch-language.test.ts
@@ -29,7 +29,13 @@ describe('createSwitchLanguage — entity-level metadata', () => {
     const fileSha = ref('sha-en')
     const loadFn = vi.fn(async (_path: string) => undefined)
 
-    const switchLang = createSwitchLanguage(cache, state, fileSha, loadFn)
+    const switchLang = createSwitchLanguage(
+      cache,
+      new Map(),
+      state,
+      fileSha,
+      loadFn
+    )
     await switchLang('it')
 
     expect(state.currentLang.value).toBe('it')
@@ -46,7 +52,13 @@ describe('createSwitchLanguage — entity-level metadata', () => {
     const fileSha = ref('sha-en')
     const loadFn = vi.fn(async (_path: string) => undefined)
 
-    const switchLang = createSwitchLanguage(cache, state, fileSha, loadFn)
+    const switchLang = createSwitchLanguage(
+      cache,
+      new Map(),
+      state,
+      fileSha,
+      loadFn
+    )
     await switchLang('ru', 'blog/x/index.ru.md')
 
     expect(loadFn).toHaveBeenCalledWith('blog/x/index.ru.md')
@@ -58,7 +70,13 @@ describe('createSwitchLanguage — entity-level metadata', () => {
     const fileSha = ref('sha-en')
     const loadFn = vi.fn(async (_path: string) => undefined)
 
-    const switchLang = createSwitchLanguage(cache, state, fileSha, loadFn)
+    const switchLang = createSwitchLanguage(
+      cache,
+      new Map(),
+      state,
+      fileSha,
+      loadFn
+    )
     await switchLang('it')
 
     expect(state.bodyContent.value).toBe('')

--- a/src/composables/useContent/useMultiLangEditor/switch-language.ts
+++ b/src/composables/useContent/useMultiLangEditor/switch-language.ts
@@ -11,21 +11,37 @@ import type { EditorDraft, MultiLangEditorState } from './types'
  * cache), seed the new draft with the previous frontmatter (with lang
  * updated) and an empty body. Wiping frontmatter to {} here would make
  * the next Save fail with "category is missing" / "title is missing".
+ *
+ * Seeding ALSO writes the same snapshot into originalCache so isDirty
+ * reports the freshly-switched draft as clean — the user has not
+ * edited anything yet, so the unsaved-changes guard must not fire.
  */
 const seedFromCurrent = (
+  cache: Map<Language, EditorDraft>,
+  originalCache: Map<Language, EditorDraft>,
   state: MultiLangEditorState,
   lang: Language,
   fileSha: Ref<string>
 ): void => {
   const previous = state.frontmatterData.value
-  state.frontmatterData.value = { ...previous, lang }
+  const seeded = { ...previous, lang }
+  state.frontmatterData.value = seeded
   state.bodyContent.value = ''
   fileSha.value = ''
+  const draft: EditorDraft = {
+    frontmatter: { ...seeded },
+    body: '',
+    sha: '',
+    loaded: true,
+  }
+  cache.set(lang, draft)
+  originalCache.set(lang, { ...draft, frontmatter: { ...seeded } })
 }
 
 /**
  * Creates a function that switches language with cache
  * @param cache - Draft cache map
+ * @param originalCache - Original cache map for clean-state comparison
  * @param state - Editor state
  * @param fileSha - File SHA ref
  * @param loadFn - Function to load a file by path
@@ -34,6 +50,7 @@ const seedFromCurrent = (
 export const createSwitchLanguage =
   (
     cache: Map<Language, EditorDraft>,
+    originalCache: Map<Language, EditorDraft>,
     state: MultiLangEditorState,
     fileSha: Ref<string>,
     loadFn: (path: string) => Promise<void>
@@ -45,5 +62,5 @@ export const createSwitchLanguage =
       await loadFn(path)
       return
     }
-    seedFromCurrent(state, lang, fileSha)
+    seedFromCurrent(cache, originalCache, state, lang, fileSha)
   }

--- a/src/views/ContentEditView/build-init-deps.ts
+++ b/src/views/ContentEditView/build-init-deps.ts
@@ -6,23 +6,22 @@ import { createInitEditor } from './useEditPageInit'
 type Page = ReturnType<typeof useEditPage>
 
 /*
- * Some pages slugs (home, blog-listing, positions-listing) are
- * frontmatter-only landing pages: their body is never rendered. Wrap
- * the editor init so any body content from disk is cleared on entry,
- * making the next save commit a clean frontmatter-only file.
+ * For entries whose public-website template does not render a body
+ * (newspaper, common, the frontmatter-only `pages` slugs), drop any
+ * body content loaded from disk AND realign both caches so isDirty
+ * reports clean post-init. Without realigning, the unsaved-changes
+ * guard would fire on first navigation because draft.body='' would
+ * not match originalCache.body=<loaded>.
  */
-const clearBodyless = (page: Page): void => {
-  page.editor.bodyContent.value = hasBodyEditor(
-    page.contentType.value,
-    page.slug
-  )
-    ? page.editor.bodyContent.value
-    : ''
+const applyBodylessReset = (page: Page): void => {
+  page.editor.bodyContent.value = ''
+  page.editor.markSaved()
 }
 
 const wrapBodyless = (page: Page, init: () => Promise<void>) => async () => {
   await init()
-  clearBodyless(page)
+  const showBody = hasBodyEditor(page.contentType.value, page.slug)
+  return showBody ? undefined : applyBodylessReset(page)
 }
 
 /**


### PR DESCRIPTION
## Summary
Two related fixes for #1 (dirty-on-untouched form) plus extending bodyless coverage per user feedback.

### Dirty flag stays false when nothing is touched
1. Lang-switch to a file-less language: seed both \`cache\` and \`originalCache\` with the cloned frontmatter so isDirty's cross-language scan can't latch on a stale entry.
2. Bodyless reset on init: after clearing \`bodyContent\` to \`''\`, call \`markSaved()\` so both caches align. Without it the form was dirty the moment a body-less entry opened.

### Cover all bodyless content types
- \`common/<slug>\` (menu, labels, ...) and \`newspaper/<slug>\` are also frontmatter-only on the public site — \`entry.render()\` is never called.
- Added an \`ALWAYS_BODYLESS\` set covering whole content types; the per-slug list now only applies to \`pages\`.

## Tests
- New \`dirty-after-switch.test.ts\` pins the lang-switch dirty regression.
- \`page-body-policy.test.ts\` grew from 7 to 10 cases (newspaper, common/menu, common/labels).
- All 375 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)