### PR TITLE
fix(editor): restrict slug input to [a-z0-9-]

### DIFF
--- a/src/components/CreateContentDialog/CreateContentDialog.vue
+++ b/src/components/CreateContentDialog/CreateContentDialog.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { ref, useTemplateRef, watch } from 'vue'
+import { useTemplateRef, watch } from 'vue'
 import type { LabelEntry } from '@/stores/labels'
 import type { ContentType, Language } from '@/types/content'
+import { useCreateForm } from './form-state'
 import {
   buildCreateData,
   type CreateContentData,
   isFormValid,
 } from './helpers'
+import { createSlugInputHandler } from './slug-input'
 
 const props = defineProps<{
   readonly show: boolean
@@ -22,30 +24,15 @@ const emit = defineEmits<{
 }>()
 
 const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
+const { refs, snapshot } = useCreateForm(() => props.lang)
+const { slug, title, description, category, reset } = refs
+const onSlugInput = createSlugInputHandler(slug)
 
-const slug = ref('')
-const title = ref('')
-const description = ref('')
-const category = ref('')
-
-const reset = () => {
-  slug.value = ''
-  title.value = ''
-  description.value = ''
-  category.value = ''
-}
-
-const formState = () => ({
-  slug: slug.value, lang: props.lang, title: title.value,
-  description: description.value, category: category.value,
-})
-
+// Parent closes via `:show` once the request lands; on failure the
+// dialog stays open with the user's input intact for retry.
 const handleCreate = () => {
-  if (!isFormValid(formState())) return
-  emit('create', buildCreateData(props.contentType, formState()))
-  // Do NOT reset here — wait for parent to close via :show prop. If parent
-  // fails (network/API error), dialog stays open with the user's input intact
-  // so they can retry without re-typing.
+  if (!isFormValid(snapshot())) return
+  emit('create', buildCreateData(props.contentType, snapshot()))
 }
 
 const handleClose = () => {
@@ -53,13 +40,9 @@ const handleClose = () => {
   emit('close')
 }
 
-watch(() => props.show, (visible) => {
-  if (visible) {
-    reset()
-    dialogRef.value?.showModal()
-  } else {
-    dialogRef.value?.close()
-  }
+watch(() => props.show, visible => {
+  if (visible) { reset(); dialogRef.value?.showModal() }
+  else dialogRef.value?.close()
 })
 </script>
 
@@ -80,7 +63,17 @@ watch(() => props.show, (visible) => {
     </button>
     <fieldset :disabled="submitting" class="field-group">
       <label for="slug" class="field-label">Slug *</label>
-      <input id="slug" v-model="slug" type="text" required placeholder="my-article-slug" class="field-input" />
+      <input
+        id="slug"
+        :value="slug"
+        type="text"
+        required
+        placeholder="my-article-slug"
+        autocomplete="off"
+        spellcheck="false"
+        class="field-input"
+        @input="onSlugInput"
+      />
       <label for="title" class="field-label">Title *</label>
       <input id="title" v-model="title" type="text" required placeholder="Article Title" class="field-input" />
       <template v-if="contentType === 'blog' || contentType === 'positions' || contentType === 'newspaper'">

--- a/src/components/CreateContentDialog/form-state.ts
+++ b/src/components/CreateContentDialog/form-state.ts
@@ -1,0 +1,49 @@
+import { type Ref, ref } from 'vue'
+import type { Language } from '@/types/content'
+
+interface FormRefs {
+  readonly slug: Ref<string>
+  readonly title: Ref<string>
+  readonly description: Ref<string>
+  readonly category: Ref<string>
+  readonly reset: () => void
+}
+
+interface FormSnapshot {
+  readonly slug: string
+  readonly lang: Language
+  readonly title: string
+  readonly description: string
+  readonly category: string
+}
+
+/**
+ * Owns the four reactive refs backing the create-dialog inputs and
+ * exposes a helper for snapshotting them into the request payload
+ * shape.
+ *
+ * @param lang - Reactive accessor for the dialog's current language
+ * @returns Refs + snapshot helper bound to that language
+ */
+export const useCreateForm = (lang: () => Language) => {
+  const slug = ref('')
+  const title = ref('')
+  const description = ref('')
+  const category = ref('')
+  const reset = (): void => {
+    slug.value = ''
+    title.value = ''
+    description.value = ''
+    category.value = ''
+  }
+  const snapshot = (): FormSnapshot => ({
+    slug: slug.value,
+    lang: lang(),
+    title: title.value,
+    description: description.value,
+    category: category.value,
+  })
+  return { refs: { slug, title, description, category, reset }, snapshot }
+}
+
+export type { FormRefs, FormSnapshot }

--- a/src/components/CreateContentDialog/slug-input.ts
+++ b/src/components/CreateContentDialog/slug-input.ts
@@ -1,0 +1,28 @@
+import type { Ref } from 'vue'
+import { sanitizeSlug } from '@/utils/sanitize-slug'
+
+const inputs = (target: EventTarget | null): readonly HTMLInputElement[] =>
+  target instanceof HTMLInputElement ? [target] : []
+
+const applyClean =
+  (slug: Ref<string>) =>
+  (target: HTMLInputElement): void => {
+    const cleaned = sanitizeSlug(target.value)
+    slug.value = cleaned
+    target.value = cleaned
+  }
+
+/**
+ * Build an input handler that keeps a slug ref synced with a
+ * sanitized version of what the user typed. Mutates the input
+ * element's value too, so visually-rejected characters never
+ * appear in the field.
+ *
+ * @param slug - Reactive ref backing the slug field
+ * @returns Vue @input handler
+ */
+export const createSlugInputHandler =
+  (slug: Ref<string>) =>
+  (event: Event): void => {
+    inputs(event.target).forEach(applyClean(slug))
+  }

--- a/src/components/common/EditableSlug.vue
+++ b/src/components/common/EditableSlug.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { createSlugInputHandler } from '@/components/CreateContentDialog/slug-input'
 import { validateSlug } from '@/utils/validate-slug'
 
 const props = defineProps<{
@@ -41,6 +42,8 @@ const onKeydown = (e: KeyboardEvent) => {
   if (e.key === 'Enter') confirm()
   if (e.key === 'Escape') cancel()
 }
+
+const onSlugInput = createSlugInputHandler(draft)
 </script>
 
 <template>
@@ -54,9 +57,12 @@ const onKeydown = (e: KeyboardEvent) => {
   </h1>
   <span v-else class="slug-editor">
     <input
-      v-model="draft"
+      :value="draft"
       data-testid="slug-input"
       class="slug-input"
+      autocomplete="off"
+      spellcheck="false"
+      @input="onSlugInput"
       @keydown="onKeydown"
       @blur="confirm"
     />

--- a/src/utils/sanitize-slug.test.ts
+++ b/src/utils/sanitize-slug.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeSlug } from './sanitize-slug'
+
+describe('sanitizeSlug', () => {
+  it('keeps lowercase letters, digits, hyphens', () => {
+    expect(sanitizeSlug('my-blog-2024')).toBe('my-blog-2024')
+  })
+
+  it('lowercases uppercase letters', () => {
+    expect(sanitizeSlug('My-Blog-Post')).toBe('my-blog-post')
+  })
+
+  it('strips Cyrillic / non-Latin', () => {
+    expect(sanitizeSlug('пост-test')).toBe('-test')
+  })
+
+  it('strips spaces and punctuation', () => {
+    expect(sanitizeSlug('hello world!')).toBe('helloworld')
+  })
+
+  it('strips underscores (we use hyphens only)', () => {
+    expect(sanitizeSlug('my_post')).toBe('mypost')
+  })
+
+  it('returns empty when nothing valid', () => {
+    expect(sanitizeSlug('!!!')).toBe('')
+    expect(sanitizeSlug('')).toBe('')
+  })
+
+  it('preserves multiple hyphens (deduping is not its job)', () => {
+    expect(sanitizeSlug('a--b---c')).toBe('a--b---c')
+  })
+})

--- a/src/utils/sanitize-slug.ts
+++ b/src/utils/sanitize-slug.ts
@@ -1,0 +1,14 @@
+/**
+ * Strip everything that is not lowercase Latin, digits, or hyphen
+ * from a slug input. Uppercase letters are folded to lowercase so
+ * editors can paste their preferred case and we accept it.
+ *
+ * Mirrors the runtime contract validated in `validate-slug.ts` so
+ * the input field cannot hold any character that would later fail
+ * validation.
+ *
+ * @param raw - Raw user input
+ * @returns Sanitized slug — empty string if nothing was usable
+ */
+export const sanitizeSlug = (raw: string): string =>
+  raw.toLowerCase().replace(/[^a-z0-9-]+/g, '')


### PR DESCRIPTION
Sanitizes typed/pasted characters in real time on both the create dialog and the inline rename input. New helper + 7 unit cases. 382/382 tests green.