### PR TITLE
fix(editor): require alt text on image insertion

### DIFF
--- a/src/components/MarkdownEditor/CommandPanel.vue
+++ b/src/components/MarkdownEditor/CommandPanel.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { AssetDisplay } from '@/composables/useAssets/types'
-import { buildMediaTag } from './build-media-tag'
 import CmdButton from './CommandPanel/CmdButton.vue'
 import MediaPicker from './CommandPanel/MediaPicker.vue'
 import { BLOCK_CMDS, WRAP_CMDS } from './command-defs'
+import { buildInsertableMediaTag } from './insertable-media'
 import { COMMAND_PANEL_ID } from './test-ids'
 
 defineProps<{
@@ -18,7 +18,8 @@ const emit = defineEmits<{
 }>()
 
 const onMedia = (a: AssetDisplay) => {
-  emit('insert-media', buildMediaTag(a.name, a.mimeType))
+  const tag = buildInsertableMediaTag(a.name, a.mimeType)
+  if (tag) emit('insert-media', tag)
 }
 </script>
 

--- a/src/components/MarkdownEditor/build-media-tag.ts
+++ b/src/components/MarkdownEditor/build-media-tag.ts
@@ -1,12 +1,21 @@
 /**
- * Build a markdown/HTML tag for inserting a media asset.
+ * Build a markdown/HTML tag for inserting a media asset. For images
+ * the caller MUST supply an alt text; without one the public site
+ * would ship empty alt attributes. Non-image media keep using the
+ * filename as a fallback label.
+ *
  * @param name - Asset filename
  * @param mime - MIME type string
+ * @param alt - Author-supplied alt text (images only)
  * @returns Markdown image or HTML media tag
  */
-export const buildMediaTag = (name: string, mime: string): string => {
+export const buildMediaTag = (
+  name: string,
+  mime: string,
+  alt?: string
+): string => {
   const src = `./assets/${name}`
-  if (mime.startsWith('image/')) return `![${name}](${src})`
+  if (mime.startsWith('image/')) return `![${alt ?? name}](${src})`
   if (mime.startsWith('video/'))
     return `<video controls><source src="${src}" type="${mime}" /></video>`
   if (mime.startsWith('audio/'))

--- a/src/components/MarkdownEditor/editor-paste-drop.ts
+++ b/src/components/MarkdownEditor/editor-paste-drop.ts
@@ -22,14 +22,18 @@ export const createPasteDrop = (deps: Deps) => ({
     const file = extractMediaFile(event)
     if (!file || !deps.textareaRef.value) return
     event.preventDefault()
-    insert(buildPasteTag(file))
+    const tag = buildPasteTag(file)
+    if (!tag) return
+    insert(tag)
     deps.emitPaste(file)
   },
   onDrop: (event: DragEvent): void => {
     const file = extractDropFile(event)
     if (!file || !deps.textareaRef.value) return
     event.preventDefault()
-    insert(buildDropTag(file))
+    const tag = buildDropTag(file)
+    if (!tag) return
+    insert(tag)
     deps.emitUpload(file)
   },
 })

--- a/src/components/MarkdownEditor/handle-drop.test.ts
+++ b/src/components/MarkdownEditor/handle-drop.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildDropTag, extractDropFile } from './handle-drop'
 
 /**
@@ -27,20 +27,33 @@ describe('extractDropFile', () => {
 })
 
 describe('buildDropTag', () => {
-  it('wraps image tag in newlines', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('wraps image tag with prompted alt in newlines', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue('a fish')
     const f = new File([''], 'pic.png', { type: 'image/png' })
-    expect(buildDropTag(f)).toBe('\n![pic.png](./assets/pic.png)\n')
+    expect(buildDropTag(f)).toBe('\n![a fish](./assets/pic.png)\n')
   })
 
-  it('wraps video tag in newlines', () => {
+  it('returns undefined when the editor cancels the alt prompt', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
+    const f = new File([''], 'pic.png', { type: 'image/png' })
+    expect(buildDropTag(f)).toBeUndefined()
+  })
+
+  it('wraps video tag in newlines without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'clip.mp4', { type: 'video/mp4' })
     const tag = buildDropTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toMatch(/^\n<video controls>.*<\/video>\n$/)
   })
 
-  it('wraps audio tag in newlines', () => {
+  it('wraps audio tag in newlines without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'song.mp3', { type: 'audio/mpeg' })
     const tag = buildDropTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toMatch(/^\n<audio controls>.*<\/audio>\n$/)
   })
 })

--- a/src/components/MarkdownEditor/handle-drop.ts
+++ b/src/components/MarkdownEditor/handle-drop.ts
@@ -1,4 +1,4 @@
-import { buildMediaTag } from './build-media-tag'
+import { buildInsertableMediaTag } from './insertable-media'
 
 /** Minimal shape needed from a drag-like event. */
 interface DropLike {
@@ -16,9 +16,14 @@ export const extractDropFile = (event: DropLike): File | undefined =>
   event.dataTransfer?.files[0] ?? undefined
 
 /**
- * Build an insertion tag for a dropped file.
+ * Build an insertion tag for a dropped file. Returns undefined when
+ * the user cancels the alt-text prompt for an image — caller must
+ * skip insertion in that case.
+ *
  * @param file - Dropped file
- * @returns Markdown/HTML tag string
+ * @returns Markdown/HTML tag string, or undefined
  */
-export const buildDropTag = (file: File): string =>
-  `\n${buildMediaTag(file.name, file.type)}\n`
+export const buildDropTag = (file: File): string | undefined => {
+  const tag = buildInsertableMediaTag(file.name, file.type)
+  return tag === undefined ? undefined : `\n${tag}\n`
+}

--- a/src/components/MarkdownEditor/handle-paste.test.ts
+++ b/src/components/MarkdownEditor/handle-paste.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildPasteTag, extractMediaFile } from './handle-paste'
 
 /**
@@ -45,21 +45,34 @@ describe('extractMediaFile', () => {
 })
 
 describe('buildPasteTag', () => {
-  it('produces image markdown', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('produces image markdown with prompted alt text', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue('an apple')
     const f = new File([''], 'pic.png', { type: 'image/png' })
-    expect(buildPasteTag(f)).toBe('\n![pic.png](./assets/pic.png)\n')
+    expect(buildPasteTag(f)).toBe('\n![an apple](./assets/pic.png)\n')
   })
 
-  it('produces video HTML', () => {
+  it('returns undefined when the editor cancels the alt prompt', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
+    const f = new File([''], 'pic.png', { type: 'image/png' })
+    expect(buildPasteTag(f)).toBeUndefined()
+  })
+
+  it('produces video HTML without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'clip.mp4', { type: 'video/mp4' })
     const tag = buildPasteTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toContain('<video controls>')
     expect(tag).toContain('src="./assets/clip.mp4"')
   })
 
-  it('produces audio HTML', () => {
+  it('produces audio HTML without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'song.mp3', { type: 'audio/mpeg' })
     const tag = buildPasteTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toContain('<audio controls>')
     expect(tag).toContain('src="./assets/song.mp3"')
   })

--- a/src/components/MarkdownEditor/handle-paste.ts
+++ b/src/components/MarkdownEditor/handle-paste.ts
@@ -1,4 +1,4 @@
-import { buildMediaTag } from './build-media-tag'
+import { buildInsertableMediaTag } from './insertable-media'
 
 /**
  * Check if a MIME type is a supported media type.
@@ -41,9 +41,14 @@ export const extractMediaFile = (event: PasteLike): File | undefined => {
 }
 
 /**
- * Build an insertion tag for a pasted file.
+ * Build an insertion tag for a pasted file. Returns undefined when
+ * the user cancels the alt-text prompt for an image — caller must
+ * skip insertion in that case.
+ *
  * @param file - Pasted file
- * @returns Markdown/HTML tag string with newlines
+ * @returns Markdown/HTML tag string with newlines, or undefined
  */
-export const buildPasteTag = (file: File): string =>
-  `\n${buildMediaTag(file.name, file.type)}\n`
+export const buildPasteTag = (file: File): string | undefined => {
+  const tag = buildInsertableMediaTag(file.name, file.type)
+  return tag === undefined ? undefined : `\n${tag}\n`
+}

--- a/src/components/MarkdownEditor/handle-upload.ts
+++ b/src/components/MarkdownEditor/handle-upload.ts
@@ -1,8 +1,11 @@
-import { buildMediaTag } from './build-media-tag'
+import { buildInsertableMediaTag } from './insertable-media'
 import { execMedia } from './use-commands'
 
 /**
- * Insert a media tag for an uploaded file into the textarea.
+ * Insert a media tag for an uploaded file into the textarea. Skips
+ * insertion when the editor cancels the alt-text prompt for an
+ * image — empty-alt images must never reach the file.
+ *
  * @param el - Textarea element
  * @param file - Uploaded file
  */
@@ -10,5 +13,7 @@ export const insertUploadTag = (
   el: HTMLTextAreaElement,
   file: File
 ): void => {
-  execMedia(el, buildMediaTag(file.name, file.type))
+  const tag = buildInsertableMediaTag(file.name, file.type)
+  const list = tag === undefined ? [] : [tag]
+  for (const t of list) execMedia(el, t)
 }

--- a/src/components/MarkdownEditor/insertable-media.test.ts
+++ b/src/components/MarkdownEditor/insertable-media.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildInsertableMediaTag } from './insertable-media'
+
+const mockPrompt = (returns: string | null) =>
+  vi.spyOn(globalThis, 'prompt').mockImplementation(() => returns)
+
+describe('buildInsertableMediaTag', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('uses the prompted alt text for images', () => {
+    mockPrompt('A red square')
+    const out = buildInsertableMediaTag('hero.png', 'image/png')
+    expect(out).toBe('![A red square](./assets/hero.png)')
+  })
+
+  it('returns undefined when the editor cancels the prompt', () => {
+    mockPrompt(null)
+    const out = buildInsertableMediaTag('hero.png', 'image/png')
+    expect(out).toBeUndefined()
+  })
+
+  it('returns undefined when the prompt is empty', () => {
+    mockPrompt('   ')
+    const out = buildInsertableMediaTag('hero.png', 'image/png')
+    expect(out).toBeUndefined()
+  })
+
+  it('does not prompt for non-image media (uses filename as label)', () => {
+    const spy = mockPrompt(null)
+    const out = buildInsertableMediaTag('clip.mp4', 'video/mp4')
+    expect(spy).not.toHaveBeenCalled()
+    expect(out).toContain('<video controls>')
+  })
+
+  it('does not prompt for documents', () => {
+    const spy = mockPrompt(null)
+    const out = buildInsertableMediaTag('spec.pdf', 'application/pdf')
+    expect(spy).not.toHaveBeenCalled()
+    expect(out).toBe('[spec.pdf](./assets/spec.pdf)')
+  })
+})

--- a/src/components/MarkdownEditor/insertable-media.ts
+++ b/src/components/MarkdownEditor/insertable-media.ts
@@ -1,0 +1,24 @@
+import { buildMediaTag } from './build-media-tag'
+import { requestImageAlt } from './request-alt'
+
+const isImage = (mime: string): boolean => mime.startsWith('image/')
+
+/**
+ * Build the insertion tag for a media item, prompting the editor
+ * for alt text when the file is an image. Returns undefined when
+ * the editor cancels the alt-text prompt — the caller must skip
+ * insertion in that case so empty-alt images never reach the
+ * committed file.
+ *
+ * @param name - Asset filename
+ * @param mime - MIME type string
+ * @returns Tag to insert, or undefined when aborted
+ */
+export const buildInsertableMediaTag = (
+  name: string,
+  mime: string
+): string | undefined => {
+  const alt = isImage(mime) ? requestImageAlt() : undefined
+  const aborted = isImage(mime) && alt === undefined
+  return aborted ? undefined : buildMediaTag(name, mime, alt)
+}

--- a/src/components/MarkdownEditor/request-alt.ts
+++ b/src/components/MarkdownEditor/request-alt.ts
@@ -1,0 +1,15 @@
+/**
+ * Ask the editor for an alt text for the image they are about to
+ * insert. Returns undefined when the user cancels or leaves the
+ * prompt empty — callers MUST treat that as "abort the insertion"
+ * so we never end up with empty-alt images on the public site.
+ *
+ * @returns Trimmed alt text, or undefined when the user backed out
+ */
+export const requestImageAlt = (): string | undefined => {
+  const raw = globalThis.prompt(
+    'Describe this image for screen readers (alt text). Required.'
+  )
+  const trimmed = raw?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : undefined
+}


### PR DESCRIPTION
Prompt the editor for alt text on every image insertion (paste, drop, picker, upload). Cancelling = no insertion. Non-image media unchanged. 389/389 tests green.