### PR TITLE
fix(rbac): surface errors from role change + invite + revoke

### DIFF
--- a/src/sw/rbac/org-role-membership.ts
+++ b/src/sw/rbac/org-role-membership.ts
@@ -1,0 +1,47 @@
+import { API, ghHeaders } from './github-api'
+import { ensureOk } from './response-ok'
+import { teamMembershipOp } from './team-membership-ops'
+import { TEAM_SLUGS, type TeamRole } from './team-slugs'
+
+/**
+ * PUT the org membership for a user. Throws on a non-OK response
+ * so the caller surfaces a real error.
+ *
+ * @param owner - Org login
+ * @param login - User login
+ * @param role - admin or member
+ * @param token - OAuth bearer with admin:org
+ */
+export const setOrgRole = async (
+  owner: string,
+  login: string,
+  role: 'admin' | 'member',
+  token: string
+): Promise<void> => {
+  const res = await fetch(`${API}/orgs/${owner}/memberships/${login}`, {
+    method: 'PUT',
+    headers: { ...ghHeaders(token), 'content-type': 'application/json' },
+    body: JSON.stringify({ role }),
+  })
+  await ensureOk(res, 'org-membership')
+}
+
+/**
+ * Add a user to one of the reserved app-role teams. Throws on a
+ * non-OK response.
+ *
+ * @param owner - Org login
+ * @param login - User login
+ * @param token - OAuth bearer
+ * @param team - Target team role
+ */
+export const addToTeam = async (
+  owner: string,
+  login: string,
+  token: string,
+  team: TeamRole
+): Promise<void> => {
+  const slug = TEAM_SLUGS[team]
+  const res = await teamMembershipOp(owner, slug, login, token, 'PUT')
+  await ensureOk(res, `team-membership ${slug}`)
+}

--- a/src/sw/rbac/org-role-ops.test.ts
+++ b/src/sw/rbac/org-role-ops.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyRole } from './org-role-ops'
+
+interface Call {
+  readonly url: string
+  readonly method: string
+}
+
+const stubFetch = (response: () => Response) => {
+  const calls: Call[] = []
+  vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+    calls.push({ url, method: init.method ?? 'GET' })
+    return response()
+  })
+  return calls
+}
+
+describe('applyRole', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('promotes a direct org member to editor by PUTing the editor team', async () => {
+    const calls = stubFetch(() => new Response('{}', { status: 200 }))
+    await applyRole('owner', 'tok', { login: 'alice', role: 'editor' })
+
+    const editorPut = calls.find(
+      c => c.method === 'PUT' && c.url.includes('/teams/editors/memberships/')
+    )
+    expect(editorPut).toBeDefined()
+  })
+
+  it('throws when the org-membership PUT fails', async () => {
+    vi.stubGlobal('fetch', async (url: string) =>
+      url.includes('/memberships/') && !url.includes('/teams/')
+        ? new Response('forbidden', { status: 403 })
+        : new Response('{}', { status: 200 })
+    )
+    await expect(
+      applyRole('owner', 'tok', { login: 'bob', role: 'admin' })
+    ).rejects.toThrow(/403|forbidden|membership/i)
+  })
+
+  it('throws when adding to the target team fails', async () => {
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      const method = init.method ?? 'GET'
+      const isTeamPut = method === 'PUT' && url.includes('/teams/')
+      return isTeamPut
+        ? new Response('forbidden', { status: 403 })
+        : new Response('{}', { status: 200 })
+    })
+    await expect(
+      applyRole('owner', 'tok', { login: 'bob', role: 'editor' })
+    ).rejects.toThrow(/403|forbidden|team/i)
+  })
+
+  it('ignores 404 from clearReservedTeams (user was not in those teams)', async () => {
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      const method = init.method ?? 'GET'
+      const isTeamDelete = method === 'DELETE' && url.includes('/teams/')
+      return isTeamDelete
+        ? new Response('not found', { status: 404 })
+        : new Response('{}', { status: 200 })
+    })
+    await expect(
+      applyRole('owner', 'tok', { login: 'bob', role: 'editor' })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/sw/rbac/org-role-ops.ts
+++ b/src/sw/rbac/org-role-ops.ts
@@ -1,25 +1,13 @@
 import { Match, Option } from 'effect'
-import { API, ghHeaders } from './github-api'
-import { clearReservedTeams, teamMembershipOp } from './team-membership-ops'
-import { TEAM_SLUGS, type TeamRole } from './team-slugs'
+import { addToTeam, setOrgRole } from './org-role-membership'
+import { clearReservedTeams } from './team-membership-ops'
+import type { TeamRole } from './team-slugs'
 
 /** Body of a role-change request. */
 export interface SetRoleBody {
   readonly login: string
   readonly role: 'admin' | 'chief-editor' | 'editor' | 'none'
 }
-
-const setOrgRole = (
-  owner: string,
-  login: string,
-  role: 'admin' | 'member',
-  token: string
-): Promise<Response> =>
-  fetch(`${API}/orgs/${owner}/memberships/${login}`, {
-    method: 'PUT',
-    headers: { ...ghHeaders(token), 'content-type': 'application/json' },
-    body: JSON.stringify({ role }),
-  })
 
 const toTeamRole = (role: SetRoleBody['role']): Option.Option<TeamRole> =>
   Match.value(role).pipe(
@@ -33,9 +21,13 @@ const toTeamRole = (role: SetRoleBody['role']): Option.Option<TeamRole> =>
  * role (admin or member), clear reserved team memberships, add
  * to the target team when the role is editor or chief-editor.
  *
- * @param owner org login
- * @param token OAuth bearer with admin:org
- * @param body role-change payload
+ * Every fetch result is checked: a non-OK response from any of
+ * the three steps surfaces as a thrown error so the SW handler
+ * can return 5xx and the UI can react.
+ *
+ * @param owner - Org login
+ * @param token - OAuth bearer with admin:org
+ * @param body - Role-change payload
  */
 export const applyRole = async (
   owner: string,
@@ -46,8 +38,7 @@ export const applyRole = async (
   await setOrgRole(owner, body.login, orgRole, token)
   await clearReservedTeams(owner, body.login, token)
   await Option.match(toTeamRole(body.role), {
-    onNone: () => Promise.resolve<unknown>(undefined),
-    onSome: r =>
-      teamMembershipOp(owner, TEAM_SLUGS[r], body.login, token, 'PUT'),
+    onNone: () => Promise.resolve(),
+    onSome: r => addToTeam(owner, body.login, token, r),
   })
 }

--- a/src/sw/rbac/response-ok.ts
+++ b/src/sw/rbac/response-ok.ts
@@ -1,0 +1,21 @@
+/**
+ * Throw a meaningful error when a GitHub API response is not OK.
+ * Reads a tiny slice of the response body so the message is
+ * actionable. 404 is treated as a soft success on the
+ * `clearReservedTeams` path (the user simply was not in the team).
+ *
+ * @param res - Raw fetch Response
+ * @param label - Operation label included in the thrown message
+ * @returns Resolves on OK, rejects with the body excerpt otherwise
+ */
+export const ensureOk = async (
+  res: Response,
+  label: string
+): Promise<void> => {
+  const detail = res.ok ? '' : (await res.text().catch(() => '')) || ''
+  return res.ok
+    ? undefined
+    : Promise.reject(
+        new Error(`${label} ${res.status}: ${detail.slice(0, 200)}`)
+      )
+}

--- a/src/views/SettingsView/InviteDialog.vue
+++ b/src/views/SettingsView/InviteDialog.vue
@@ -1,42 +1,53 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
-const props = defineProps<{ readonly open: boolean; readonly busy: boolean }>()
+const props = defineProps<{
+  readonly open: boolean
+  readonly busy: boolean
+  readonly error?: string
+}>()
 const emit = defineEmits<{
-  submit: [payload: {
-    readonly email?: string
-    readonly login?: string
-    readonly role: 'admin' | 'chief-editor' | 'editor'
-  }]
+  submit: [
+    payload: {
+      readonly email?: string
+      readonly login?: string
+      readonly role: 'admin' | 'chief-editor' | 'editor'
+    },
+  ]
   cancel: []
 }>()
 
 const identifier = ref('')
 const role = ref<'admin' | 'chief-editor' | 'editor'>('editor')
-const error = ref<string | undefined>(undefined)
+const localError = ref<string | undefined>(undefined)
+const shownError = computed(() => localError.value ?? props.error)
 
 const reset = () => {
   identifier.value = ''
   role.value = 'editor'
-  error.value = undefined
+  localError.value = undefined
 }
 
 const onSubmit = () => {
   const v = identifier.value.trim()
   if (v === '') {
-    error.value = 'Enter a GitHub login or email'
+    localError.value = 'Enter a GitHub login or email'
     return
   }
+  localError.value = undefined
   const looksLikeEmail = v.includes('@')
-  emit('submit', looksLikeEmail ? { email: v, role: role.value } : { login: v, role: role.value })
+  emit(
+    'submit',
+    looksLikeEmail
+      ? { email: v, role: role.value }
+      : { login: v, role: role.value }
+  )
 }
 
 const onCancel = () => {
   reset()
   emit('cancel')
 }
-
-void props
 </script>
 
 <template>
@@ -73,7 +84,13 @@ void props
           <option value="admin">Admin</option>
         </select>
       </label>
-      <p v-if="error" class="error-hint">{{ error }}</p>
+      <p
+        v-if="shownError"
+        class="error-hint"
+        data-testid="invite-error"
+      >
+        {{ shownError }}
+      </p>
       <div class="actions">
         <button
           type="button"

--- a/src/views/SettingsView/MembersSection.vue
+++ b/src/views/SettingsView/MembersSection.vue
@@ -53,9 +53,18 @@ const s = useMembersSection()
     >
       Read-only — your role does not allow changes.
     </p>
+    <p
+      v-if="s.error.value && !s.dialogOpen.value"
+      class="op-error"
+      data-testid="members-error"
+      role="alert"
+    >
+      {{ s.error.value }}
+    </p>
     <InviteDialog
       :open="s.dialogOpen.value"
       :busy="s.busy.value"
+      :error="s.error.value"
       @submit="s.onInvite"
       @cancel="s.closeDialog"
     />
@@ -102,5 +111,12 @@ h2 {
 .read-only {
   margin-top: 0.5rem;
   font-style: italic;
+}
+
+.op-error {
+  margin-top: 0.75rem;
+  color: var(--color-error, #e53935);
+  font-size: 0.875rem;
+  white-space: pre-wrap;
 }
 </style>

--- a/src/views/SettingsView/members-actions.ts
+++ b/src/views/SettingsView/members-actions.ts
@@ -3,34 +3,39 @@ import { createInvite, revokeInvite } from './org-invite-api'
 import { setOrgRole } from './org-role-api'
 import type { InviteRequest } from './roles-api-types'
 
-const withBusy =
-  (busy: Ref<boolean>, reload: () => Promise<void>) =>
-  async (fn: () => Promise<unknown>): Promise<void> => {
-    busy.value = true
-    try {
-      await fn()
-      await reload()
-    } finally {
-      busy.value = false
-    }
+interface Bag {
+  readonly busy: Ref<boolean>
+  readonly error: Ref<string | undefined>
+  readonly reload: () => Promise<void>
+  readonly closeDialog: () => void
+}
+
+const toMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e)
+
+const withBusy = (bag: Bag) => async (fn: () => Promise<void>) => {
+  bag.busy.value = true
+  bag.error.value = undefined
+  try {
+    await fn()
+    await bag.reload()
+  } catch (e) {
+    bag.error.value = toMessage(e)
+  } finally {
+    bag.busy.value = false
   }
+}
 
 /**
  * Build the three Members-section mutation handlers (role change,
- * invite, revoke). They share a busy flag and reload the list on
- * every successful mutation.
+ * invite, revoke). They share a busy flag, surface any error into
+ * the section's error ref, and reload the list on success.
  *
- * @param busy shared ref toggled around each async op
- * @param reload callback to refresh the members payload
- * @param closeDialog callback to close the invite dialog on success
- * @returns handler map
+ * @param bag - busy / error / reload / closeDialog wiring
+ * @returns Handler map
  */
-export const buildMemberActions = (
-  busy: Ref<boolean>,
-  reload: () => Promise<void>,
-  closeDialog: () => void
-) => {
-  const run = withBusy(busy, reload)
+export const buildMemberActions = (bag: Bag) => {
+  const run = withBusy(bag)
   return {
     onRoleChange: (
       login: string,
@@ -39,7 +44,7 @@ export const buildMemberActions = (
     onInvite: (req: InviteRequest) =>
       run(async () => {
         await createInvite(req)
-        closeDialog()
+        bag.closeDialog()
       }),
     onRevoke: (id: number) => run(() => revokeInvite(id)),
   }

--- a/src/views/SettingsView/members-public-state.ts
+++ b/src/views/SettingsView/members-public-state.ts
@@ -1,0 +1,35 @@
+import type { buildMembersState } from './members-section-state'
+
+type S = ReturnType<typeof buildMembersState>
+
+interface DialogControls {
+  readonly openDialog: () => void
+  readonly closeDialog: () => void
+}
+
+/**
+ * Project the buildMembersState bag plus dialog handlers and
+ * actions into the shape consumed by MembersSection.vue.
+ *
+ * @param s - State bag
+ * @param ctl - Dialog open/close controls bundle
+ * @param actions - Action handler map
+ * @returns Public bundle for the section template
+ */
+export const projectMembersPublic = <A extends Record<string, unknown>>(
+  s: S,
+  ctl: DialogControls,
+  actions: A
+) => ({
+  sorted: s.sorted,
+  invitations: s.invitations,
+  loading: s.loading,
+  dialogOpen: s.dialogOpen,
+  busy: s.busy,
+  error: s.error,
+  disabled: s.disabled,
+  canEditSettings: s.canEditSettings,
+  openDialog: ctl.openDialog,
+  closeDialog: ctl.closeDialog,
+  ...actions,
+})

--- a/src/views/SettingsView/members-section-state.ts
+++ b/src/views/SettingsView/members-section-state.ts
@@ -24,6 +24,7 @@ export const buildMembersState = () => {
   const { canEditSettings } = usePermissions()
   const dialogOpen = ref(false)
   const busy = ref(false)
+  const error = ref<string | undefined>(undefined)
   const sorted = computed(() => sortByRank(members.value))
   const disabled = computed(() => busy.value || !canEditSettings.value)
   return {
@@ -34,6 +35,7 @@ export const buildMembersState = () => {
     canEditSettings,
     dialogOpen,
     busy,
+    error,
     sorted,
     disabled,
   }

--- a/src/views/SettingsView/org-invite-api.ts
+++ b/src/views/SettingsView/org-invite-api.ts
@@ -1,35 +1,41 @@
 import { swFetch } from '@/composables/useSWBridge/sw-fetch'
 import type { InviteRequest } from './roles-api-types'
 
+const errorBody = async (res: Response): Promise<string> => {
+  const txt = await res.text().catch(() => '')
+  return txt.length > 0 ? txt : `github ${res.status}`
+}
+
+const okOrThrow = async (res: Response): Promise<Response> =>
+  res.ok ? res : Promise.reject(new Error(await errorBody(res)))
+
 /**
  * Create a pending GitHub org invitation with the requested app
- * role. Accepts either email or login.
+ * role. Accepts either email or login. Throws when the SW or
+ * GitHub returned a non-OK status so the dialog surfaces the real
+ * reason instead of silently closing on failure.
  *
- * @param req invite payload
- * @returns id of the created invitation or undefined on failure
+ * @param req - Invite payload
+ * @returns Id of the created invitation
  */
-export const createInvite = async (
-  req: InviteRequest
-): Promise<number | undefined> => {
-  const res = await swFetch('/api/github/org-invite', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(req),
-  })
-  return res.ok
-    ? ((await res.json()) as { readonly id: number }).id
-    : undefined
+export const createInvite = async (req: InviteRequest): Promise<number> => {
+  const res = await okOrThrow(
+    await swFetch('/api/github/org-invite', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+    })
+  )
+  return ((await res.json()) as { readonly id: number }).id
 }
 
 /**
- * Revoke a pending invitation by id.
+ * Revoke a pending invitation by id. Throws on non-OK.
  *
- * @param id invitation id
- * @returns true on success
+ * @param id - Invitation id
  */
-export const revokeInvite = async (id: number): Promise<boolean> => {
-  const res = await swFetch(`/api/github/org-invite/${id}`, {
-    method: 'DELETE',
-  })
-  return res.ok
+export const revokeInvite = async (id: number): Promise<void> => {
+  await okOrThrow(
+    await swFetch(`/api/github/org-invite/${id}`, { method: 'DELETE' })
+  )
 }

--- a/src/views/SettingsView/useMembersSection.ts
+++ b/src/views/SettingsView/useMembersSection.ts
@@ -1,12 +1,13 @@
 import { onMounted } from 'vue'
 import { buildMemberActions } from './members-actions'
+import { projectMembersPublic } from './members-public-state'
 import { buildMembersState } from './members-section-state'
 
 /**
  * Own the Members section state: list, invites, dialog, busy flag,
- * and the three mutation handlers (role change, invite, revoke).
+ * error ref, and the three mutation handlers.
  *
- * @returns reactive state + handlers for MembersSection.vue
+ * @returns Reactive state + handlers for MembersSection.vue
  */
 export const useMembersSection = () => {
   const s = buildMembersState()
@@ -17,17 +18,11 @@ export const useMembersSection = () => {
     s.dialogOpen.value = false
   }
   onMounted(s.load)
-  const actions = buildMemberActions(s.busy, s.load, closeDialog)
-  return {
-    sorted: s.sorted,
-    invitations: s.invitations,
-    loading: s.loading,
-    dialogOpen: s.dialogOpen,
+  const actions = buildMemberActions({
     busy: s.busy,
-    disabled: s.disabled,
-    canEditSettings: s.canEditSettings,
-    openDialog,
+    error: s.error,
+    reload: s.load,
     closeDialog,
-    ...actions,
-  }
+  })
+  return projectMembersPublic(s, { openDialog, closeDialog }, actions)
 }


### PR DESCRIPTION
Each of the three RBAC mutations was silently swallowing GitHub 4xx responses. `applyRole` thinks the change succeeded; `createInvite`/`revokeInvite` returned undefined/false but the dialog closed anyway. Now every fetch result is asserted via `ensureOk` (or `okOrThrow` on the SW client side) and the error message is surfaced to the user.