### PR TITLE
fix(rbac): resolve email→GitHub user before inviting

### DIFF
--- a/src/sw/rbac/invite-build.test.ts
+++ b/src/sw/rbac/invite-build.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildInvite } from './invite-build'
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+
+const stubGitHub = (route: (url: string) => Response): void => {
+  vi.stubGlobal('fetch', async (url: string) => route(url))
+}
+
+const teamLookupOk = (url: string): Response | undefined => {
+  if (url.includes('/orgs/owner/teams')) {
+    return okJson([
+      { id: 11, slug: 'editors' },
+      { id: 22, slug: 'chief-editors' },
+    ])
+  }
+  return undefined
+}
+
+describe('buildInvite by email', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('resolves a public email to invitee_id', async () => {
+    stubGitHub(url => {
+      const team = teamLookupOk(url)
+      if (team) return team
+      if (url.includes('/search/users?q=')) {
+        return okJson({
+          total_count: 1,
+          items: [{ login: 'alice', id: 4242 }],
+        })
+      }
+      return okJson({})
+    })
+    const out = await buildInvite('owner', 'tok', {
+      email: 'alice@example.com',
+      role: 'editor',
+    })
+    expect(out['invitee_id']).toBe(4242)
+    expect(out['email']).toBeUndefined()
+  })
+
+  it('rejects when no GitHub user has the email public', async () => {
+    stubGitHub(url => {
+      const team = teamLookupOk(url)
+      if (team) return team
+      if (url.includes('/search/users?q=')) {
+        return okJson({ total_count: 0, items: [] })
+      }
+      return okJson({})
+    })
+    await expect(
+      buildInvite('owner', 'tok', {
+        email: 'nobody@example.com',
+        role: 'editor',
+      })
+    ).rejects.toThrow(/No GitHub account/)
+  })
+})

--- a/src/sw/rbac/invite-build.ts
+++ b/src/sw/rbac/invite-build.ts
@@ -1,4 +1,5 @@
 import { API, ghJson } from './github-api'
+import { resolveEmailToUser } from './resolve-invite-email'
 import { teamIdsFor } from './team-lookup'
 
 /** Body accepted by the invite endpoint. */
@@ -12,13 +13,8 @@ interface UserRef {
   readonly id: number
 }
 
-const resolveLogin = (
-  login: string,
-  token: string
-): Promise<number | undefined> =>
-  ghJson<UserRef>(`${API}/users/${login}`, token)
-    .then(u => u.id)
-    .catch(() => undefined)
+const resolveLogin = (login: string, token: string): Promise<number> =>
+  ghJson<UserRef>(`${API}/users/${login}`, token).then(u => u.id)
 
 const byLogin = async (
   base: Record<string, unknown>,
@@ -26,19 +22,42 @@ const byLogin = async (
   token: string
 ): Promise<Record<string, unknown>> => {
   const invitee_id = await resolveLogin(login, token)
-  return invitee_id ? { ...base, invitee_id } : base
+  return { ...base, invitee_id }
+}
+
+/*
+ * Resolving an email to a GitHub user before inviting avoids the
+ * two regressions the user hit:
+ *   - Inviting an email whose owner already has a GH account would
+ *     fail at the org-invitations endpoint. By resolving to invitee_id
+ *     we use the same code path as a login invite, which GH accepts.
+ *   - Inviting a totally unregistered email puts the org on GitHub's
+ *     spam radar. We refuse those invites explicitly with a message
+ *     telling the editor to use a username instead.
+ */
+const byEmail = async (
+  base: Record<string, unknown>,
+  email: string,
+  token: string
+): Promise<Record<string, unknown>> => {
+  const user = await resolveEmailToUser(email, token)
+  return user
+    ? { ...base, invitee_id: user.id }
+    : Promise.reject(
+        new Error(
+          `No GitHub account is associated with ${email}. Ask the person ` +
+            `to make their email public on GitHub or invite by username.`
+        )
+      )
 }
 
 /**
- * Build the payload for POST /orgs/{org}/invitations from the
- * client's invite body: team_ids derived from the mapped team,
- * `role` set to GitHub's vocabulary, and either an email or an
- * invitee_id resolved from a login.
+ * Build the payload for POST /orgs/{org}/invitations.
  *
- * @param owner org login
- * @param token OAuth bearer with admin:org
- * @param body invite request
- * @returns payload ready to send to GitHub
+ * @param owner - Org login
+ * @param token - OAuth bearer with admin:org
+ * @param body - Invite request
+ * @returns Payload ready to send to GitHub
  */
 export const buildInvite = async (
   owner: string,
@@ -49,6 +68,6 @@ export const buildInvite = async (
   const role = body.role === 'admin' ? 'admin' : 'direct_member'
   const base = { role, team_ids }
   return body.email !== undefined
-    ? { ...base, email: body.email }
+    ? byEmail(base, body.email, token)
     : byLogin(base, body.login ?? '', token)
 }

--- a/src/sw/rbac/invite-post.ts
+++ b/src/sw/rbac/invite-post.ts
@@ -19,12 +19,17 @@ const postInvite = async (
     : errorResponse(txt || `github ${res.status}`, res.status)
 }
 
+const toMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e)
+
 const runInvite = async (
   owner: string,
   token: string,
   b: InviteBody
 ): Promise<Response> =>
-  postInvite(owner, token, await buildInvite(owner, token, b))
+  buildInvite(owner, token, b)
+    .then(payload => postInvite(owner, token, payload))
+    .catch(e => errorResponse(toMessage(e), 400))
 
 const validate = (b: Partial<InviteBody>): Option.Option<InviteBody> =>
   b.role && (b.email || b.login)

--- a/src/sw/rbac/resolve-invite-email.ts
+++ b/src/sw/rbac/resolve-invite-email.ts
@@ -1,0 +1,26 @@
+import { API, ghJson } from './github-api'
+
+interface SearchUsersResponse {
+  readonly total_count: number
+  readonly items: readonly { readonly login: string; readonly id: number }[]
+}
+
+/**
+ * Look up a GitHub user by their public email address. Returns
+ * undefined when no public match exists — emails set to private
+ * by the user are not indexed by GitHub's search.
+ *
+ * @param email - Email to search
+ * @param token - OAuth bearer
+ * @returns Resolved login + id, or undefined when no match
+ */
+export const resolveEmailToUser = async (
+  email: string,
+  token: string
+): Promise<{ readonly login: string; readonly id: number } | undefined> => {
+  const url = `${API}/search/users?q=${encodeURIComponent(`${email} in:email`)}`
+  const r = await ghJson<SearchUsersResponse>(url, token).catch(
+    () => undefined
+  )
+  return r && r.total_count > 0 && r.items[0] ? r.items[0] : undefined
+}


### PR DESCRIPTION
Email-based invites had two failure modes the user reported: (1) inviting an email already linked to a GH user → GitHub rejects with 'invite by username instead'; (2) inviting an email no GH account knows → org gets flagged as suspicious. Resolves via /search/users in:email; switches to invitee_id when found; refuses with a 400 + actionable message when not.