### PR TITLE
fix(e2e): adapt suite to alt prompt and slug sanitization

### DIFF
--- a/e2e/content/asset-paste.spec.ts
+++ b/e2e/content/asset-paste.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 
 test.describe('Asset Paste Image', () => {
   test('should add pasted image to asset panel', async ({ page }) => {
+    acceptAltDialog(page)
     const am = new AssetManagerPage(page)
     await am.navigateToBlog('media-showcase')
     await am.expectPanelVisible()
@@ -18,6 +20,7 @@ test.describe('Asset Paste Image', () => {
   })
 
   test('should insert markdown reference on paste', async ({ page }) => {
+    acceptAltDialog(page, 'screenshot description')
     const am = new AssetManagerPage(page)
     await am.navigateToBlog('media-showcase')
     await am.expectPanelVisible()
@@ -27,7 +30,7 @@ test.describe('Asset Paste Image', () => {
     await dispatchMediaPaste(page, 'screenshot.png', 'image/png')
 
     await expect(editor).toHaveValue(
-      /!\[screenshot\.png\]\(\.\/assets\/screenshot\.png\)/,
+      /!\[screenshot description\]\(\.\/assets\/screenshot\.png\)/,
       { timeout: 10000 }
     )
   })

--- a/e2e/content/cmd-consistency.spec.ts
+++ b/e2e/content/cmd-consistency.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchDrop } from '../helpers/dispatch-drop'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'
@@ -7,6 +8,7 @@ const SLUG = 'media-showcase'
 
 test.describe('Paste vs Drop consistency', () => {
   test('paste and drop produce same image tag', async ({ page }) => {
+    acceptAltDialog(page, 'consistency')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
     const ta = ep.getEditorBody()

--- a/e2e/content/cmd-drop-media.spec.ts
+++ b/e2e/content/cmd-drop-media.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchDrop } from '../helpers/dispatch-drop'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -6,16 +7,16 @@ const SLUG = 'media-showcase'
 
 test.describe('Drop media insertion', () => {
   test('drop image produces markdown img', async ({ page }) => {
+    acceptAltDialog(page, 'a photo')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
     const ta = ep.getEditorBody()
     await ta.focus()
     await ta.fill('')
     await dispatchDrop(page, 'photo.png', 'image/png')
-    await expect(ta).toHaveValue(
-      /!\[photo\.png\]\(\.\/assets\/photo\.png\)/,
-      { timeout: 10000 }
-    )
+    await expect(ta).toHaveValue(/!\[a photo\]\(\.\/assets\/photo\.png\)/, {
+      timeout: 10000,
+    })
   })
 
   test('drop video produces <video> tag', async ({ page }) => {

--- a/e2e/content/cmd-media-picker.spec.ts
+++ b/e2e/content/cmd-media-picker.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'media-showcase'
 
 test.describe('Media picker insertion', () => {
   test('inserts image markdown via picker', async ({ page }) => {
+    acceptAltDialog(page)
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 

--- a/e2e/content/cmd-paste-media.spec.ts
+++ b/e2e/content/cmd-paste-media.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -6,16 +7,16 @@ const SLUG = 'media-showcase'
 
 test.describe('Paste media consistency', () => {
   test('paste image produces markdown img', async ({ page }) => {
+    acceptAltDialog(page, 'a photo')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
     const ta = ep.getEditorBody()
     await ta.focus()
     await ta.fill('')
     await dispatchMediaPaste(page, 'photo.png', 'image/png')
-    await expect(ta).toHaveValue(
-      /!\[photo\.png\]\(\.\/assets\/photo\.png\)/,
-      { timeout: 10000 }
-    )
+    await expect(ta).toHaveValue(/!\[a photo\]\(\.\/assets\/photo\.png\)/, {
+      timeout: 10000,
+    })
   })
 
   test('paste video produces <video> tag', async ({ page }) => {

--- a/e2e/content/cmd-undo.spec.ts
+++ b/e2e/content/cmd-undo.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -28,6 +29,7 @@ test.describe('Undo (Ctrl+Z)', () => {
   })
 
   test('undo reverts paste insertion', async ({ page }) => {
+    acceptAltDialog(page, 'a test')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', 'media-showcase')
     const ta = ep.getEditorBody()
@@ -35,7 +37,7 @@ test.describe('Undo (Ctrl+Z)', () => {
     await ta.fill('before')
 
     await dispatchMediaPaste(page, 'test.png', 'image/png')
-    await expect(ta).toHaveValue(/!\[test\.png\]/, {
+    await expect(ta).toHaveValue(/!\[a test\]/, {
       timeout: 10000,
     })
 

--- a/e2e/content/cmd-upload-insert.spec.ts
+++ b/e2e/content/cmd-upload-insert.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'media-showcase'
@@ -7,6 +8,7 @@ test.describe('Upload Insert', () => {
   test('should insert media tag when file is uploaded via picker', async ({
     page,
   }) => {
+    acceptAltDialog(page, 'uploaded')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
@@ -27,7 +29,7 @@ test.describe('Upload Insert', () => {
     })
 
     await expect(ta).toHaveValue(
-      /!\[uploaded-test\.png\]\(\.\/assets\/uploaded-test\.png\)/,
+      /!\[uploaded\]\(\.\/assets\/uploaded-test\.png\)/,
       { timeout: 10000 }
     )
   })

--- a/e2e/content/rename-slug.spec.ts
+++ b/e2e/content/rename-slug.spec.ts
@@ -15,12 +15,36 @@ test.describe('Rename Slug', () => {
     const input = page.locator('[data-testid="slug-input"]')
     await expect(input).toBeVisible({ timeout: 5000 })
 
+    // Sanitization strips non-[a-z0-9-]; "!!!" reduces to "" so the
+    // validator fires its empty-slug error.
     await input.clear()
-    await input.type('INVALID', { delay: 30 })
+    await input.type('!!!', { delay: 30 })
     await input.press('Enter')
     await expect(page.locator('[data-testid="slug-error"]')).toBeVisible({
       timeout: 5000,
     })
+  })
+
+  test('lowercases uppercase keystrokes on the fly', async ({ page }) => {
+    const ep = new ContentEditPage(page)
+    await ep.navigate('blog', SLUG)
+
+    await page.locator('[data-testid="edit-title"]').click()
+    const input = page.locator('[data-testid="slug-input"]')
+    await input.clear()
+    await input.type('FooBar', { delay: 30 })
+    await expect(input).toHaveValue('foobar')
+  })
+
+  test('strips non-Latin keystrokes', async ({ page }) => {
+    const ep = new ContentEditPage(page)
+    await ep.navigate('blog', SLUG)
+
+    await page.locator('[data-testid="edit-title"]').click()
+    const input = page.locator('[data-testid="slug-input"]')
+    await input.clear()
+    await input.type('пост-test', { delay: 30 })
+    await expect(input).toHaveValue('-test')
   })
 
   test('should reject slug exceeding max length', async ({ page }) => {

--- a/e2e/helpers/auto-alt-dialog.ts
+++ b/e2e/helpers/auto-alt-dialog.ts
@@ -1,0 +1,19 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Auto-accept the alt-text prompt fired by the editor on every
+ * image insertion. Without this any test that triggers a paste,
+ * drop, picker, or upload of an image will hang because Playwright
+ * blocks on the dialog. Each test that exercises the image-insert
+ * code path must call this once before the trigger.
+ *
+ * @param page - Playwright page
+ * @param alt - Alt text to feed into the prompt (defaults to "alt")
+ */
+export const acceptAltDialog = (page: Page, alt = 'alt'): void => {
+  page.on('dialog', dialog => {
+    const action =
+      dialog.type() === 'prompt' ? dialog.accept(alt) : dialog.dismiss()
+    void action
+  })
+}


### PR DESCRIPTION
Restores green CI after #67/#68. Image-insert specs now register an auto-accept dialog handler; rename-slug specs cover the new sanitization behavior.