### PR TITLE
release: dirty form, RBAC, slug, alt, publish-flag bundle

### DIFF
--- a/e2e-prod/probe-pdf-upload.pw.ts
+++ b/e2e-prod/probe-pdf-upload.pw.ts
@@ -82,17 +82,25 @@ test('probe: PDF upload on dev', async ({ browser }) => {
     .waitFor({ state: 'visible', timeout: 60_000 })
 
   // Probe the pdfjs vendor lib explicitly so we know whether it loads.
-  const vendorCheck = await page.evaluate(async () => {
-    try {
-      const mod = await import('/vendor/pdf.min.mjs')
-      return {
-        ok: true,
-        hasGetDocument: typeof mod.getDocument === 'function',
+  // Wrapped in catch because the page may still be navigating when this
+  // fires (SW registration trips a re-render); this is a diagnostic, not
+  // a load-bearing assertion.
+  const vendorCheck = await page
+    .evaluate(async () => {
+      try {
+        const mod = await import('/vendor/pdf.min.mjs')
+        return {
+          ok: true,
+          hasGetDocument: typeof mod.getDocument === 'function',
+        }
+      } catch (e) {
+        return {
+          ok: false,
+          error: e instanceof Error ? e.message : String(e),
+        }
       }
-    } catch (e) {
-      return { ok: false, error: e instanceof Error ? e.message : String(e) }
-    }
-  })
+    })
+    .catch(e => ({ ok: false, error: `evaluate failed: ${String(e)}` }))
   out(`[probe] pdfjs vendor: ${JSON.stringify(vendorCheck)}`)
 
   // Now drive the actual UI upload path.

--- a/e2e/content/asset-paste.spec.ts
+++ b/e2e/content/asset-paste.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 
 test.describe('Asset Paste Image', () => {
   test('should add pasted image to asset panel', async ({ page }) => {
+    acceptAltDialog(page)
     const am = new AssetManagerPage(page)
     await am.navigateToBlog('media-showcase')
     await am.expectPanelVisible()
@@ -18,6 +20,7 @@ test.describe('Asset Paste Image', () => {
   })
 
   test('should insert markdown reference on paste', async ({ page }) => {
+    acceptAltDialog(page, 'screenshot description')
     const am = new AssetManagerPage(page)
     await am.navigateToBlog('media-showcase')
     await am.expectPanelVisible()
@@ -27,7 +30,7 @@ test.describe('Asset Paste Image', () => {
     await dispatchMediaPaste(page, 'screenshot.png', 'image/png')
 
     await expect(editor).toHaveValue(
-      /!\[screenshot\.png\]\(\.\/assets\/screenshot\.png\)/,
+      /!\[screenshot description\]\(\.\/assets\/screenshot\.png\)/,
       { timeout: 10000 }
     )
   })

--- a/e2e/content/cmd-consistency.spec.ts
+++ b/e2e/content/cmd-consistency.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchDrop } from '../helpers/dispatch-drop'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'
@@ -7,6 +8,7 @@ const SLUG = 'media-showcase'
 
 test.describe('Paste vs Drop consistency', () => {
   test('paste and drop produce same image tag', async ({ page }) => {
+    acceptAltDialog(page, 'consistency')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
     const ta = ep.getEditorBody()

--- a/e2e/content/cmd-drop-media.spec.ts
+++ b/e2e/content/cmd-drop-media.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchDrop } from '../helpers/dispatch-drop'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -6,16 +7,16 @@ const SLUG = 'media-showcase'
 
 test.describe('Drop media insertion', () => {
   test('drop image produces markdown img', async ({ page }) => {
+    acceptAltDialog(page, 'a photo')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
     const ta = ep.getEditorBody()
     await ta.focus()
     await ta.fill('')
     await dispatchDrop(page, 'photo.png', 'image/png')
-    await expect(ta).toHaveValue(
-      /!\[photo\.png\]\(\.\/assets\/photo\.png\)/,
-      { timeout: 10000 }
-    )
+    await expect(ta).toHaveValue(/!\[a photo\]\(\.\/assets\/photo\.png\)/, {
+      timeout: 10000,
+    })
   })
 
   test('drop video produces <video> tag', async ({ page }) => {

--- a/e2e/content/cmd-media-picker.spec.ts
+++ b/e2e/content/cmd-media-picker.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'media-showcase'
 
 test.describe('Media picker insertion', () => {
   test('inserts image markdown via picker', async ({ page }) => {
+    acceptAltDialog(page)
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 

--- a/e2e/content/cmd-paste-media.spec.ts
+++ b/e2e/content/cmd-paste-media.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -6,16 +7,16 @@ const SLUG = 'media-showcase'
 
 test.describe('Paste media consistency', () => {
   test('paste image produces markdown img', async ({ page }) => {
+    acceptAltDialog(page, 'a photo')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
     const ta = ep.getEditorBody()
     await ta.focus()
     await ta.fill('')
     await dispatchMediaPaste(page, 'photo.png', 'image/png')
-    await expect(ta).toHaveValue(
-      /!\[photo\.png\]\(\.\/assets\/photo\.png\)/,
-      { timeout: 10000 }
-    )
+    await expect(ta).toHaveValue(/!\[a photo\]\(\.\/assets\/photo\.png\)/, {
+      timeout: 10000,
+    })
   })
 
   test('paste video produces <video> tag', async ({ page }) => {

--- a/e2e/content/cmd-undo.spec.ts
+++ b/e2e/content/cmd-undo.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -28,6 +29,7 @@ test.describe('Undo (Ctrl+Z)', () => {
   })
 
   test('undo reverts paste insertion', async ({ page }) => {
+    acceptAltDialog(page, 'a test')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', 'media-showcase')
     const ta = ep.getEditorBody()
@@ -35,7 +37,7 @@ test.describe('Undo (Ctrl+Z)', () => {
     await ta.fill('before')
 
     await dispatchMediaPaste(page, 'test.png', 'image/png')
-    await expect(ta).toHaveValue(/!\[test\.png\]/, {
+    await expect(ta).toHaveValue(/!\[a test\]/, {
       timeout: 10000,
     })
 

--- a/e2e/content/cmd-upload-insert.spec.ts
+++ b/e2e/content/cmd-upload-insert.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test'
+import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'media-showcase'
@@ -7,6 +8,7 @@ test.describe('Upload Insert', () => {
   test('should insert media tag when file is uploaded via picker', async ({
     page,
   }) => {
+    acceptAltDialog(page, 'uploaded')
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
@@ -27,7 +29,7 @@ test.describe('Upload Insert', () => {
     })
 
     await expect(ta).toHaveValue(
-      /!\[uploaded-test\.png\]\(\.\/assets\/uploaded-test\.png\)/,
+      /!\[uploaded\]\(\.\/assets\/uploaded-test\.png\)/,
       { timeout: 10000 }
     )
   })

--- a/e2e/content/rename-slug.spec.ts
+++ b/e2e/content/rename-slug.spec.ts
@@ -15,12 +15,36 @@ test.describe('Rename Slug', () => {
     const input = page.locator('[data-testid="slug-input"]')
     await expect(input).toBeVisible({ timeout: 5000 })
 
+    // Sanitization strips non-[a-z0-9-]; "!!!" reduces to "" so the
+    // validator fires its empty-slug error.
     await input.clear()
-    await input.type('INVALID', { delay: 30 })
+    await input.type('!!!', { delay: 30 })
     await input.press('Enter')
     await expect(page.locator('[data-testid="slug-error"]')).toBeVisible({
       timeout: 5000,
     })
+  })
+
+  test('lowercases uppercase keystrokes on the fly', async ({ page }) => {
+    const ep = new ContentEditPage(page)
+    await ep.navigate('blog', SLUG)
+
+    await page.locator('[data-testid="edit-title"]').click()
+    const input = page.locator('[data-testid="slug-input"]')
+    await input.clear()
+    await input.type('FooBar', { delay: 30 })
+    await expect(input).toHaveValue('foobar')
+  })
+
+  test('strips non-Latin keystrokes', async ({ page }) => {
+    const ep = new ContentEditPage(page)
+    await ep.navigate('blog', SLUG)
+
+    await page.locator('[data-testid="edit-title"]').click()
+    const input = page.locator('[data-testid="slug-input"]')
+    await input.clear()
+    await input.type('пост-test', { delay: 30 })
+    await expect(input).toHaveValue('-test')
   })
 
   test('should reject slug exceeding max length', async ({ page }) => {

--- a/e2e/helpers/auto-alt-dialog.ts
+++ b/e2e/helpers/auto-alt-dialog.ts
@@ -1,0 +1,19 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Auto-accept the alt-text prompt fired by the editor on every
+ * image insertion. Without this any test that triggers a paste,
+ * drop, picker, or upload of an image will hang because Playwright
+ * blocks on the dialog. Each test that exercises the image-insert
+ * code path must call this once before the trigger.
+ *
+ * @param page - Playwright page
+ * @param alt - Alt text to feed into the prompt (defaults to "alt")
+ */
+export const acceptAltDialog = (page: Page, alt = 'alt'): void => {
+  page.on('dialog', dialog => {
+    const action =
+      dialog.type() === 'prompt' ? dialog.accept(alt) : dialog.dismiss()
+    void action
+  })
+}

--- a/src/components/CreateContentDialog/CreateContentDialog.vue
+++ b/src/components/CreateContentDialog/CreateContentDialog.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
-import { ref, useTemplateRef, watch } from 'vue'
+import { useTemplateRef, watch } from 'vue'
 import type { LabelEntry } from '@/stores/labels'
 import type { ContentType, Language } from '@/types/content'
+import { useCreateForm } from './form-state'
 import {
   buildCreateData,
   type CreateContentData,
   isFormValid,
 } from './helpers'
+import { createSlugInputHandler } from './slug-input'
 
 const props = defineProps<{
   readonly show: boolean
@@ -22,30 +24,15 @@ const emit = defineEmits<{
 }>()
 
 const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
+const { refs, snapshot } = useCreateForm(() => props.lang)
+const { slug, title, description, category, reset } = refs
+const onSlugInput = createSlugInputHandler(slug)
 
-const slug = ref('')
-const title = ref('')
-const description = ref('')
-const category = ref('')
-
-const reset = () => {
-  slug.value = ''
-  title.value = ''
-  description.value = ''
-  category.value = ''
-}
-
-const formState = () => ({
-  slug: slug.value, lang: props.lang, title: title.value,
-  description: description.value, category: category.value,
-})
-
+// Parent closes via `:show` once the request lands; on failure the
+// dialog stays open with the user's input intact for retry.
 const handleCreate = () => {
-  if (!isFormValid(formState())) return
-  emit('create', buildCreateData(props.contentType, formState()))
-  // Do NOT reset here — wait for parent to close via :show prop. If parent
-  // fails (network/API error), dialog stays open with the user's input intact
-  // so they can retry without re-typing.
+  if (!isFormValid(snapshot())) return
+  emit('create', buildCreateData(props.contentType, snapshot()))
 }
 
 const handleClose = () => {
@@ -53,13 +40,9 @@ const handleClose = () => {
   emit('close')
 }
 
-watch(() => props.show, (visible) => {
-  if (visible) {
-    reset()
-    dialogRef.value?.showModal()
-  } else {
-    dialogRef.value?.close()
-  }
+watch(() => props.show, visible => {
+  if (visible) { reset(); dialogRef.value?.showModal() }
+  else dialogRef.value?.close()
 })
 </script>
 
@@ -80,7 +63,17 @@ watch(() => props.show, (visible) => {
     </button>
     <fieldset :disabled="submitting" class="field-group">
       <label for="slug" class="field-label">Slug *</label>
-      <input id="slug" v-model="slug" type="text" required placeholder="my-article-slug" class="field-input" />
+      <input
+        id="slug"
+        :value="slug"
+        type="text"
+        required
+        placeholder="my-article-slug"
+        autocomplete="off"
+        spellcheck="false"
+        class="field-input"
+        @input="onSlugInput"
+      />
       <label for="title" class="field-label">Title *</label>
       <input id="title" v-model="title" type="text" required placeholder="Article Title" class="field-input" />
       <template v-if="contentType === 'blog' || contentType === 'positions' || contentType === 'newspaper'">

--- a/src/components/CreateContentDialog/form-state.ts
+++ b/src/components/CreateContentDialog/form-state.ts
@@ -1,0 +1,49 @@
+import { type Ref, ref } from 'vue'
+import type { Language } from '@/types/content'
+
+interface FormRefs {
+  readonly slug: Ref<string>
+  readonly title: Ref<string>
+  readonly description: Ref<string>
+  readonly category: Ref<string>
+  readonly reset: () => void
+}
+
+interface FormSnapshot {
+  readonly slug: string
+  readonly lang: Language
+  readonly title: string
+  readonly description: string
+  readonly category: string
+}
+
+/**
+ * Owns the four reactive refs backing the create-dialog inputs and
+ * exposes a helper for snapshotting them into the request payload
+ * shape.
+ *
+ * @param lang - Reactive accessor for the dialog's current language
+ * @returns Refs + snapshot helper bound to that language
+ */
+export const useCreateForm = (lang: () => Language) => {
+  const slug = ref('')
+  const title = ref('')
+  const description = ref('')
+  const category = ref('')
+  const reset = (): void => {
+    slug.value = ''
+    title.value = ''
+    description.value = ''
+    category.value = ''
+  }
+  const snapshot = (): FormSnapshot => ({
+    slug: slug.value,
+    lang: lang(),
+    title: title.value,
+    description: description.value,
+    category: category.value,
+  })
+  return { refs: { slug, title, description, category, reset }, snapshot }
+}
+
+export type { FormRefs, FormSnapshot }

--- a/src/components/CreateContentDialog/slug-input.ts
+++ b/src/components/CreateContentDialog/slug-input.ts
@@ -1,0 +1,28 @@
+import type { Ref } from 'vue'
+import { sanitizeSlug } from '@/utils/sanitize-slug'
+
+const inputs = (target: EventTarget | null): readonly HTMLInputElement[] =>
+  target instanceof HTMLInputElement ? [target] : []
+
+const applyClean =
+  (slug: Ref<string>) =>
+  (target: HTMLInputElement): void => {
+    const cleaned = sanitizeSlug(target.value)
+    slug.value = cleaned
+    target.value = cleaned
+  }
+
+/**
+ * Build an input handler that keeps a slug ref synced with a
+ * sanitized version of what the user typed. Mutates the input
+ * element's value too, so visually-rejected characters never
+ * appear in the field.
+ *
+ * @param slug - Reactive ref backing the slug field
+ * @returns Vue @input handler
+ */
+export const createSlugInputHandler =
+  (slug: Ref<string>) =>
+  (event: Event): void => {
+    inputs(event.target).forEach(applyClean(slug))
+  }

--- a/src/components/MarkdownEditor/CommandPanel.vue
+++ b/src/components/MarkdownEditor/CommandPanel.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { AssetDisplay } from '@/composables/useAssets/types'
-import { buildMediaTag } from './build-media-tag'
 import CmdButton from './CommandPanel/CmdButton.vue'
 import MediaPicker from './CommandPanel/MediaPicker.vue'
 import { BLOCK_CMDS, WRAP_CMDS } from './command-defs'
+import { buildInsertableMediaTag } from './insertable-media'
 import { COMMAND_PANEL_ID } from './test-ids'
 
 defineProps<{
@@ -18,7 +18,8 @@ const emit = defineEmits<{
 }>()
 
 const onMedia = (a: AssetDisplay) => {
-  emit('insert-media', buildMediaTag(a.name, a.mimeType))
+  const tag = buildInsertableMediaTag(a.name, a.mimeType)
+  if (tag) emit('insert-media', tag)
 }
 </script>
 

--- a/src/components/MarkdownEditor/build-media-tag.ts
+++ b/src/components/MarkdownEditor/build-media-tag.ts
@@ -1,12 +1,21 @@
 /**
- * Build a markdown/HTML tag for inserting a media asset.
+ * Build a markdown/HTML tag for inserting a media asset. For images
+ * the caller MUST supply an alt text; without one the public site
+ * would ship empty alt attributes. Non-image media keep using the
+ * filename as a fallback label.
+ *
  * @param name - Asset filename
  * @param mime - MIME type string
+ * @param alt - Author-supplied alt text (images only)
  * @returns Markdown image or HTML media tag
  */
-export const buildMediaTag = (name: string, mime: string): string => {
+export const buildMediaTag = (
+  name: string,
+  mime: string,
+  alt?: string
+): string => {
   const src = `./assets/${name}`
-  if (mime.startsWith('image/')) return `![${name}](${src})`
+  if (mime.startsWith('image/')) return `![${alt ?? name}](${src})`
   if (mime.startsWith('video/'))
     return `<video controls><source src="${src}" type="${mime}" /></video>`
   if (mime.startsWith('audio/'))

--- a/src/components/MarkdownEditor/editor-paste-drop.ts
+++ b/src/components/MarkdownEditor/editor-paste-drop.ts
@@ -22,14 +22,18 @@ export const createPasteDrop = (deps: Deps) => ({
     const file = extractMediaFile(event)
     if (!file || !deps.textareaRef.value) return
     event.preventDefault()
-    insert(buildPasteTag(file))
+    const tag = buildPasteTag(file)
+    if (!tag) return
+    insert(tag)
     deps.emitPaste(file)
   },
   onDrop: (event: DragEvent): void => {
     const file = extractDropFile(event)
     if (!file || !deps.textareaRef.value) return
     event.preventDefault()
-    insert(buildDropTag(file))
+    const tag = buildDropTag(file)
+    if (!tag) return
+    insert(tag)
     deps.emitUpload(file)
   },
 })

--- a/src/components/MarkdownEditor/handle-drop.test.ts
+++ b/src/components/MarkdownEditor/handle-drop.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildDropTag, extractDropFile } from './handle-drop'
 
 /**
@@ -27,20 +27,33 @@ describe('extractDropFile', () => {
 })
 
 describe('buildDropTag', () => {
-  it('wraps image tag in newlines', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('wraps image tag with prompted alt in newlines', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue('a fish')
     const f = new File([''], 'pic.png', { type: 'image/png' })
-    expect(buildDropTag(f)).toBe('\n![pic.png](./assets/pic.png)\n')
+    expect(buildDropTag(f)).toBe('\n![a fish](./assets/pic.png)\n')
   })
 
-  it('wraps video tag in newlines', () => {
+  it('returns undefined when the editor cancels the alt prompt', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
+    const f = new File([''], 'pic.png', { type: 'image/png' })
+    expect(buildDropTag(f)).toBeUndefined()
+  })
+
+  it('wraps video tag in newlines without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'clip.mp4', { type: 'video/mp4' })
     const tag = buildDropTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toMatch(/^\n<video controls>.*<\/video>\n$/)
   })
 
-  it('wraps audio tag in newlines', () => {
+  it('wraps audio tag in newlines without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'song.mp3', { type: 'audio/mpeg' })
     const tag = buildDropTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toMatch(/^\n<audio controls>.*<\/audio>\n$/)
   })
 })

--- a/src/components/MarkdownEditor/handle-drop.ts
+++ b/src/components/MarkdownEditor/handle-drop.ts
@@ -1,4 +1,4 @@
-import { buildMediaTag } from './build-media-tag'
+import { buildInsertableMediaTag } from './insertable-media'
 
 /** Minimal shape needed from a drag-like event. */
 interface DropLike {
@@ -16,9 +16,14 @@ export const extractDropFile = (event: DropLike): File | undefined =>
   event.dataTransfer?.files[0] ?? undefined
 
 /**
- * Build an insertion tag for a dropped file.
+ * Build an insertion tag for a dropped file. Returns undefined when
+ * the user cancels the alt-text prompt for an image — caller must
+ * skip insertion in that case.
+ *
  * @param file - Dropped file
- * @returns Markdown/HTML tag string
+ * @returns Markdown/HTML tag string, or undefined
  */
-export const buildDropTag = (file: File): string =>
-  `\n${buildMediaTag(file.name, file.type)}\n`
+export const buildDropTag = (file: File): string | undefined => {
+  const tag = buildInsertableMediaTag(file.name, file.type)
+  return tag === undefined ? undefined : `\n${tag}\n`
+}

--- a/src/components/MarkdownEditor/handle-paste.test.ts
+++ b/src/components/MarkdownEditor/handle-paste.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildPasteTag, extractMediaFile } from './handle-paste'
 
 /**
@@ -45,21 +45,34 @@ describe('extractMediaFile', () => {
 })
 
 describe('buildPasteTag', () => {
-  it('produces image markdown', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('produces image markdown with prompted alt text', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue('an apple')
     const f = new File([''], 'pic.png', { type: 'image/png' })
-    expect(buildPasteTag(f)).toBe('\n![pic.png](./assets/pic.png)\n')
+    expect(buildPasteTag(f)).toBe('\n![an apple](./assets/pic.png)\n')
   })
 
-  it('produces video HTML', () => {
+  it('returns undefined when the editor cancels the alt prompt', () => {
+    vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
+    const f = new File([''], 'pic.png', { type: 'image/png' })
+    expect(buildPasteTag(f)).toBeUndefined()
+  })
+
+  it('produces video HTML without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'clip.mp4', { type: 'video/mp4' })
     const tag = buildPasteTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toContain('<video controls>')
     expect(tag).toContain('src="./assets/clip.mp4"')
   })
 
-  it('produces audio HTML', () => {
+  it('produces audio HTML without prompting', () => {
+    const spy = vi.spyOn(globalThis, 'prompt').mockReturnValue(null)
     const f = new File([''], 'song.mp3', { type: 'audio/mpeg' })
     const tag = buildPasteTag(f)
+    expect(spy).not.toHaveBeenCalled()
     expect(tag).toContain('<audio controls>')
     expect(tag).toContain('src="./assets/song.mp3"')
   })

--- a/src/components/MarkdownEditor/handle-paste.ts
+++ b/src/components/MarkdownEditor/handle-paste.ts
@@ -1,4 +1,4 @@
-import { buildMediaTag } from './build-media-tag'
+import { buildInsertableMediaTag } from './insertable-media'
 
 /**
  * Check if a MIME type is a supported media type.
@@ -41,9 +41,14 @@ export const extractMediaFile = (event: PasteLike): File | undefined => {
 }
 
 /**
- * Build an insertion tag for a pasted file.
+ * Build an insertion tag for a pasted file. Returns undefined when
+ * the user cancels the alt-text prompt for an image — caller must
+ * skip insertion in that case.
+ *
  * @param file - Pasted file
- * @returns Markdown/HTML tag string with newlines
+ * @returns Markdown/HTML tag string with newlines, or undefined
  */
-export const buildPasteTag = (file: File): string =>
-  `\n${buildMediaTag(file.name, file.type)}\n`
+export const buildPasteTag = (file: File): string | undefined => {
+  const tag = buildInsertableMediaTag(file.name, file.type)
+  return tag === undefined ? undefined : `\n${tag}\n`
+}

--- a/src/components/MarkdownEditor/handle-upload.ts
+++ b/src/components/MarkdownEditor/handle-upload.ts
@@ -1,8 +1,11 @@
-import { buildMediaTag } from './build-media-tag'
+import { buildInsertableMediaTag } from './insertable-media'
 import { execMedia } from './use-commands'
 
 /**
- * Insert a media tag for an uploaded file into the textarea.
+ * Insert a media tag for an uploaded file into the textarea. Skips
+ * insertion when the editor cancels the alt-text prompt for an
+ * image — empty-alt images must never reach the file.
+ *
  * @param el - Textarea element
  * @param file - Uploaded file
  */
@@ -10,5 +13,7 @@ export const insertUploadTag = (
   el: HTMLTextAreaElement,
   file: File
 ): void => {
-  execMedia(el, buildMediaTag(file.name, file.type))
+  const tag = buildInsertableMediaTag(file.name, file.type)
+  const list = tag === undefined ? [] : [tag]
+  for (const t of list) execMedia(el, t)
 }

--- a/src/components/MarkdownEditor/insertable-media.test.ts
+++ b/src/components/MarkdownEditor/insertable-media.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildInsertableMediaTag } from './insertable-media'
+
+const mockPrompt = (returns: string | null) =>
+  vi.spyOn(globalThis, 'prompt').mockImplementation(() => returns)
+
+describe('buildInsertableMediaTag', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('uses the prompted alt text for images', () => {
+    mockPrompt('A red square')
+    const out = buildInsertableMediaTag('hero.png', 'image/png')
+    expect(out).toBe('![A red square](./assets/hero.png)')
+  })
+
+  it('returns undefined when the editor cancels the prompt', () => {
+    mockPrompt(null)
+    const out = buildInsertableMediaTag('hero.png', 'image/png')
+    expect(out).toBeUndefined()
+  })
+
+  it('returns undefined when the prompt is empty', () => {
+    mockPrompt('   ')
+    const out = buildInsertableMediaTag('hero.png', 'image/png')
+    expect(out).toBeUndefined()
+  })
+
+  it('does not prompt for non-image media (uses filename as label)', () => {
+    const spy = mockPrompt(null)
+    const out = buildInsertableMediaTag('clip.mp4', 'video/mp4')
+    expect(spy).not.toHaveBeenCalled()
+    expect(out).toContain('<video controls>')
+  })
+
+  it('does not prompt for documents', () => {
+    const spy = mockPrompt(null)
+    const out = buildInsertableMediaTag('spec.pdf', 'application/pdf')
+    expect(spy).not.toHaveBeenCalled()
+    expect(out).toBe('[spec.pdf](./assets/spec.pdf)')
+  })
+})

--- a/src/components/MarkdownEditor/insertable-media.ts
+++ b/src/components/MarkdownEditor/insertable-media.ts
@@ -1,0 +1,24 @@
+import { buildMediaTag } from './build-media-tag'
+import { requestImageAlt } from './request-alt'
+
+const isImage = (mime: string): boolean => mime.startsWith('image/')
+
+/**
+ * Build the insertion tag for a media item, prompting the editor
+ * for alt text when the file is an image. Returns undefined when
+ * the editor cancels the alt-text prompt — the caller must skip
+ * insertion in that case so empty-alt images never reach the
+ * committed file.
+ *
+ * @param name - Asset filename
+ * @param mime - MIME type string
+ * @returns Tag to insert, or undefined when aborted
+ */
+export const buildInsertableMediaTag = (
+  name: string,
+  mime: string
+): string | undefined => {
+  const alt = isImage(mime) ? requestImageAlt() : undefined
+  const aborted = isImage(mime) && alt === undefined
+  return aborted ? undefined : buildMediaTag(name, mime, alt)
+}

--- a/src/components/MarkdownEditor/request-alt.ts
+++ b/src/components/MarkdownEditor/request-alt.ts
@@ -1,0 +1,15 @@
+/**
+ * Ask the editor for an alt text for the image they are about to
+ * insert. Returns undefined when the user cancels or leaves the
+ * prompt empty — callers MUST treat that as "abort the insertion"
+ * so we never end up with empty-alt images on the public site.
+ *
+ * @returns Trimmed alt text, or undefined when the user backed out
+ */
+export const requestImageAlt = (): string | undefined => {
+  const raw = globalThis.prompt(
+    'Describe this image for screen readers (alt text). Required.'
+  )
+  const trimmed = raw?.trim() ?? ''
+  return trimmed.length > 0 ? trimmed : undefined
+}

--- a/src/components/common/EditableSlug.vue
+++ b/src/components/common/EditableSlug.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { createSlugInputHandler } from '@/components/CreateContentDialog/slug-input'
 import { validateSlug } from '@/utils/validate-slug'
 
 const props = defineProps<{
@@ -41,6 +42,8 @@ const onKeydown = (e: KeyboardEvent) => {
   if (e.key === 'Enter') confirm()
   if (e.key === 'Escape') cancel()
 }
+
+const onSlugInput = createSlugInputHandler(draft)
 </script>
 
 <template>
@@ -54,9 +57,12 @@ const onKeydown = (e: KeyboardEvent) => {
   </h1>
   <span v-else class="slug-editor">
     <input
-      v-model="draft"
+      :value="draft"
       data-testid="slug-input"
       class="slug-input"
+      autocomplete="off"
+      spellcheck="false"
+      @input="onSlugInput"
       @keydown="onKeydown"
       @blur="confirm"
     />

--- a/src/sw/rbac/invite-build.test.ts
+++ b/src/sw/rbac/invite-build.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { buildInvite } from './invite-build'
+
+const okJson = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+
+const stubGitHub = (route: (url: string) => Response): void => {
+  vi.stubGlobal('fetch', async (url: string) => route(url))
+}
+
+const teamLookupOk = (url: string): Response | undefined => {
+  if (url.includes('/orgs/owner/teams')) {
+    return okJson([
+      { id: 11, slug: 'editors' },
+      { id: 22, slug: 'chief-editors' },
+    ])
+  }
+  return undefined
+}
+
+describe('buildInvite by email', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('resolves a public email to invitee_id', async () => {
+    stubGitHub(url => {
+      const team = teamLookupOk(url)
+      if (team) return team
+      if (url.includes('/search/users?q=')) {
+        return okJson({
+          total_count: 1,
+          items: [{ login: 'alice', id: 4242 }],
+        })
+      }
+      return okJson({})
+    })
+    const out = await buildInvite('owner', 'tok', {
+      email: 'alice@example.com',
+      role: 'editor',
+    })
+    expect(out['invitee_id']).toBe(4242)
+    expect(out['email']).toBeUndefined()
+  })
+
+  it('rejects when no GitHub user has the email public', async () => {
+    stubGitHub(url => {
+      const team = teamLookupOk(url)
+      if (team) return team
+      if (url.includes('/search/users?q=')) {
+        return okJson({ total_count: 0, items: [] })
+      }
+      return okJson({})
+    })
+    await expect(
+      buildInvite('owner', 'tok', {
+        email: 'nobody@example.com',
+        role: 'editor',
+      })
+    ).rejects.toThrow(/No GitHub account/)
+  })
+})

--- a/src/sw/rbac/invite-build.ts
+++ b/src/sw/rbac/invite-build.ts
@@ -1,4 +1,5 @@
 import { API, ghJson } from './github-api'
+import { resolveEmailToUser } from './resolve-invite-email'
 import { teamIdsFor } from './team-lookup'
 
 /** Body accepted by the invite endpoint. */
@@ -12,13 +13,8 @@ interface UserRef {
   readonly id: number
 }
 
-const resolveLogin = (
-  login: string,
-  token: string
-): Promise<number | undefined> =>
-  ghJson<UserRef>(`${API}/users/${login}`, token)
-    .then(u => u.id)
-    .catch(() => undefined)
+const resolveLogin = (login: string, token: string): Promise<number> =>
+  ghJson<UserRef>(`${API}/users/${login}`, token).then(u => u.id)
 
 const byLogin = async (
   base: Record<string, unknown>,
@@ -26,19 +22,42 @@ const byLogin = async (
   token: string
 ): Promise<Record<string, unknown>> => {
   const invitee_id = await resolveLogin(login, token)
-  return invitee_id ? { ...base, invitee_id } : base
+  return { ...base, invitee_id }
+}
+
+/*
+ * Resolving an email to a GitHub user before inviting avoids the
+ * two regressions the user hit:
+ *   - Inviting an email whose owner already has a GH account would
+ *     fail at the org-invitations endpoint. By resolving to invitee_id
+ *     we use the same code path as a login invite, which GH accepts.
+ *   - Inviting a totally unregistered email puts the org on GitHub's
+ *     spam radar. We refuse those invites explicitly with a message
+ *     telling the editor to use a username instead.
+ */
+const byEmail = async (
+  base: Record<string, unknown>,
+  email: string,
+  token: string
+): Promise<Record<string, unknown>> => {
+  const user = await resolveEmailToUser(email, token)
+  return user
+    ? { ...base, invitee_id: user.id }
+    : Promise.reject(
+        new Error(
+          `No GitHub account is associated with ${email}. Ask the person ` +
+            `to make their email public on GitHub or invite by username.`
+        )
+      )
 }
 
 /**
- * Build the payload for POST /orgs/{org}/invitations from the
- * client's invite body: team_ids derived from the mapped team,
- * `role` set to GitHub's vocabulary, and either an email or an
- * invitee_id resolved from a login.
+ * Build the payload for POST /orgs/{org}/invitations.
  *
- * @param owner org login
- * @param token OAuth bearer with admin:org
- * @param body invite request
- * @returns payload ready to send to GitHub
+ * @param owner - Org login
+ * @param token - OAuth bearer with admin:org
+ * @param body - Invite request
+ * @returns Payload ready to send to GitHub
  */
 export const buildInvite = async (
   owner: string,
@@ -49,6 +68,6 @@ export const buildInvite = async (
   const role = body.role === 'admin' ? 'admin' : 'direct_member'
   const base = { role, team_ids }
   return body.email !== undefined
-    ? { ...base, email: body.email }
+    ? byEmail(base, body.email, token)
     : byLogin(base, body.login ?? '', token)
 }

--- a/src/sw/rbac/invite-post.ts
+++ b/src/sw/rbac/invite-post.ts
@@ -19,12 +19,17 @@ const postInvite = async (
     : errorResponse(txt || `github ${res.status}`, res.status)
 }
 
+const toMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e)
+
 const runInvite = async (
   owner: string,
   token: string,
   b: InviteBody
 ): Promise<Response> =>
-  postInvite(owner, token, await buildInvite(owner, token, b))
+  buildInvite(owner, token, b)
+    .then(payload => postInvite(owner, token, payload))
+    .catch(e => errorResponse(toMessage(e), 400))
 
 const validate = (b: Partial<InviteBody>): Option.Option<InviteBody> =>
   b.role && (b.email || b.login)

--- a/src/sw/rbac/org-role-membership.ts
+++ b/src/sw/rbac/org-role-membership.ts
@@ -1,0 +1,47 @@
+import { API, ghHeaders } from './github-api'
+import { ensureOk } from './response-ok'
+import { teamMembershipOp } from './team-membership-ops'
+import { TEAM_SLUGS, type TeamRole } from './team-slugs'
+
+/**
+ * PUT the org membership for a user. Throws on a non-OK response
+ * so the caller surfaces a real error.
+ *
+ * @param owner - Org login
+ * @param login - User login
+ * @param role - admin or member
+ * @param token - OAuth bearer with admin:org
+ */
+export const setOrgRole = async (
+  owner: string,
+  login: string,
+  role: 'admin' | 'member',
+  token: string
+): Promise<void> => {
+  const res = await fetch(`${API}/orgs/${owner}/memberships/${login}`, {
+    method: 'PUT',
+    headers: { ...ghHeaders(token), 'content-type': 'application/json' },
+    body: JSON.stringify({ role }),
+  })
+  await ensureOk(res, 'org-membership')
+}
+
+/**
+ * Add a user to one of the reserved app-role teams. Throws on a
+ * non-OK response.
+ *
+ * @param owner - Org login
+ * @param login - User login
+ * @param token - OAuth bearer
+ * @param team - Target team role
+ */
+export const addToTeam = async (
+  owner: string,
+  login: string,
+  token: string,
+  team: TeamRole
+): Promise<void> => {
+  const slug = TEAM_SLUGS[team]
+  const res = await teamMembershipOp(owner, slug, login, token, 'PUT')
+  await ensureOk(res, `team-membership ${slug}`)
+}

--- a/src/sw/rbac/org-role-ops.test.ts
+++ b/src/sw/rbac/org-role-ops.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyRole } from './org-role-ops'
+
+interface Call {
+  readonly url: string
+  readonly method: string
+}
+
+const stubFetch = (response: () => Response) => {
+  const calls: Call[] = []
+  vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+    calls.push({ url, method: init.method ?? 'GET' })
+    return response()
+  })
+  return calls
+}
+
+describe('applyRole', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('promotes a direct org member to editor by PUTing the editor team', async () => {
+    const calls = stubFetch(() => new Response('{}', { status: 200 }))
+    await applyRole('owner', 'tok', { login: 'alice', role: 'editor' })
+
+    const editorPut = calls.find(
+      c => c.method === 'PUT' && c.url.includes('/teams/editors/memberships/')
+    )
+    expect(editorPut).toBeDefined()
+  })
+
+  it('throws when the org-membership PUT fails', async () => {
+    vi.stubGlobal('fetch', async (url: string) =>
+      url.includes('/memberships/') && !url.includes('/teams/')
+        ? new Response('forbidden', { status: 403 })
+        : new Response('{}', { status: 200 })
+    )
+    await expect(
+      applyRole('owner', 'tok', { login: 'bob', role: 'admin' })
+    ).rejects.toThrow(/403|forbidden|membership/i)
+  })
+
+  it('throws when adding to the target team fails', async () => {
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      const method = init.method ?? 'GET'
+      const isTeamPut = method === 'PUT' && url.includes('/teams/')
+      return isTeamPut
+        ? new Response('forbidden', { status: 403 })
+        : new Response('{}', { status: 200 })
+    })
+    await expect(
+      applyRole('owner', 'tok', { login: 'bob', role: 'editor' })
+    ).rejects.toThrow(/403|forbidden|team/i)
+  })
+
+  it('ignores 404 from clearReservedTeams (user was not in those teams)', async () => {
+    vi.stubGlobal('fetch', async (url: string, init: RequestInit) => {
+      const method = init.method ?? 'GET'
+      const isTeamDelete = method === 'DELETE' && url.includes('/teams/')
+      return isTeamDelete
+        ? new Response('not found', { status: 404 })
+        : new Response('{}', { status: 200 })
+    })
+    await expect(
+      applyRole('owner', 'tok', { login: 'bob', role: 'editor' })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/sw/rbac/org-role-ops.ts
+++ b/src/sw/rbac/org-role-ops.ts
@@ -1,25 +1,13 @@
 import { Match, Option } from 'effect'
-import { API, ghHeaders } from './github-api'
-import { clearReservedTeams, teamMembershipOp } from './team-membership-ops'
-import { TEAM_SLUGS, type TeamRole } from './team-slugs'
+import { addToTeam, setOrgRole } from './org-role-membership'
+import { clearReservedTeams } from './team-membership-ops'
+import type { TeamRole } from './team-slugs'
 
 /** Body of a role-change request. */
 export interface SetRoleBody {
   readonly login: string
   readonly role: 'admin' | 'chief-editor' | 'editor' | 'none'
 }
-
-const setOrgRole = (
-  owner: string,
-  login: string,
-  role: 'admin' | 'member',
-  token: string
-): Promise<Response> =>
-  fetch(`${API}/orgs/${owner}/memberships/${login}`, {
-    method: 'PUT',
-    headers: { ...ghHeaders(token), 'content-type': 'application/json' },
-    body: JSON.stringify({ role }),
-  })
 
 const toTeamRole = (role: SetRoleBody['role']): Option.Option<TeamRole> =>
   Match.value(role).pipe(
@@ -33,9 +21,13 @@ const toTeamRole = (role: SetRoleBody['role']): Option.Option<TeamRole> =>
  * role (admin or member), clear reserved team memberships, add
  * to the target team when the role is editor or chief-editor.
  *
- * @param owner org login
- * @param token OAuth bearer with admin:org
- * @param body role-change payload
+ * Every fetch result is checked: a non-OK response from any of
+ * the three steps surfaces as a thrown error so the SW handler
+ * can return 5xx and the UI can react.
+ *
+ * @param owner - Org login
+ * @param token - OAuth bearer with admin:org
+ * @param body - Role-change payload
  */
 export const applyRole = async (
   owner: string,
@@ -46,8 +38,7 @@ export const applyRole = async (
   await setOrgRole(owner, body.login, orgRole, token)
   await clearReservedTeams(owner, body.login, token)
   await Option.match(toTeamRole(body.role), {
-    onNone: () => Promise.resolve<unknown>(undefined),
-    onSome: r =>
-      teamMembershipOp(owner, TEAM_SLUGS[r], body.login, token, 'PUT'),
+    onNone: () => Promise.resolve(),
+    onSome: r => addToTeam(owner, body.login, token, r),
   })
 }

--- a/src/sw/rbac/resolve-invite-email.ts
+++ b/src/sw/rbac/resolve-invite-email.ts
@@ -1,0 +1,26 @@
+import { API, ghJson } from './github-api'
+
+interface SearchUsersResponse {
+  readonly total_count: number
+  readonly items: readonly { readonly login: string; readonly id: number }[]
+}
+
+/**
+ * Look up a GitHub user by their public email address. Returns
+ * undefined when no public match exists — emails set to private
+ * by the user are not indexed by GitHub's search.
+ *
+ * @param email - Email to search
+ * @param token - OAuth bearer
+ * @returns Resolved login + id, or undefined when no match
+ */
+export const resolveEmailToUser = async (
+  email: string,
+  token: string
+): Promise<{ readonly login: string; readonly id: number } | undefined> => {
+  const url = `${API}/search/users?q=${encodeURIComponent(`${email} in:email`)}`
+  const r = await ghJson<SearchUsersResponse>(url, token).catch(
+    () => undefined
+  )
+  return r && r.total_count > 0 && r.items[0] ? r.items[0] : undefined
+}

--- a/src/sw/rbac/response-ok.ts
+++ b/src/sw/rbac/response-ok.ts
@@ -1,0 +1,21 @@
+/**
+ * Throw a meaningful error when a GitHub API response is not OK.
+ * Reads a tiny slice of the response body so the message is
+ * actionable. 404 is treated as a soft success on the
+ * `clearReservedTeams` path (the user simply was not in the team).
+ *
+ * @param res - Raw fetch Response
+ * @param label - Operation label included in the thrown message
+ * @returns Resolves on OK, rejects with the body excerpt otherwise
+ */
+export const ensureOk = async (
+  res: Response,
+  label: string
+): Promise<void> => {
+  const detail = res.ok ? '' : (await res.text().catch(() => '')) || ''
+  return res.ok
+    ? undefined
+    : Promise.reject(
+        new Error(`${label} ${res.status}: ${detail.slice(0, 200)}`)
+      )
+}

--- a/src/utils/sanitize-slug.test.ts
+++ b/src/utils/sanitize-slug.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeSlug } from './sanitize-slug'
+
+describe('sanitizeSlug', () => {
+  it('keeps lowercase letters, digits, hyphens', () => {
+    expect(sanitizeSlug('my-blog-2024')).toBe('my-blog-2024')
+  })
+
+  it('lowercases uppercase letters', () => {
+    expect(sanitizeSlug('My-Blog-Post')).toBe('my-blog-post')
+  })
+
+  it('strips Cyrillic / non-Latin', () => {
+    expect(sanitizeSlug('пост-test')).toBe('-test')
+  })
+
+  it('strips spaces and punctuation', () => {
+    expect(sanitizeSlug('hello world!')).toBe('helloworld')
+  })
+
+  it('strips underscores (we use hyphens only)', () => {
+    expect(sanitizeSlug('my_post')).toBe('mypost')
+  })
+
+  it('returns empty when nothing valid', () => {
+    expect(sanitizeSlug('!!!')).toBe('')
+    expect(sanitizeSlug('')).toBe('')
+  })
+
+  it('preserves multiple hyphens (deduping is not its job)', () => {
+    expect(sanitizeSlug('a--b---c')).toBe('a--b---c')
+  })
+})

--- a/src/utils/sanitize-slug.ts
+++ b/src/utils/sanitize-slug.ts
@@ -1,0 +1,14 @@
+/**
+ * Strip everything that is not lowercase Latin, digits, or hyphen
+ * from a slug input. Uppercase letters are folded to lowercase so
+ * editors can paste their preferred case and we accept it.
+ *
+ * Mirrors the runtime contract validated in `validate-slug.ts` so
+ * the input field cannot hold any character that would later fail
+ * validation.
+ *
+ * @param raw - Raw user input
+ * @returns Sanitized slug — empty string if nothing was usable
+ */
+export const sanitizeSlug = (raw: string): string =>
+  raw.toLowerCase().replace(/[^a-z0-9-]+/g, '')

--- a/src/views/SettingsView/InviteDialog.vue
+++ b/src/views/SettingsView/InviteDialog.vue
@@ -1,42 +1,53 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
-const props = defineProps<{ readonly open: boolean; readonly busy: boolean }>()
+const props = defineProps<{
+  readonly open: boolean
+  readonly busy: boolean
+  readonly error?: string
+}>()
 const emit = defineEmits<{
-  submit: [payload: {
-    readonly email?: string
-    readonly login?: string
-    readonly role: 'admin' | 'chief-editor' | 'editor'
-  }]
+  submit: [
+    payload: {
+      readonly email?: string
+      readonly login?: string
+      readonly role: 'admin' | 'chief-editor' | 'editor'
+    },
+  ]
   cancel: []
 }>()
 
 const identifier = ref('')
 const role = ref<'admin' | 'chief-editor' | 'editor'>('editor')
-const error = ref<string | undefined>(undefined)
+const localError = ref<string | undefined>(undefined)
+const shownError = computed(() => localError.value ?? props.error)
 
 const reset = () => {
   identifier.value = ''
   role.value = 'editor'
-  error.value = undefined
+  localError.value = undefined
 }
 
 const onSubmit = () => {
   const v = identifier.value.trim()
   if (v === '') {
-    error.value = 'Enter a GitHub login or email'
+    localError.value = 'Enter a GitHub login or email'
     return
   }
+  localError.value = undefined
   const looksLikeEmail = v.includes('@')
-  emit('submit', looksLikeEmail ? { email: v, role: role.value } : { login: v, role: role.value })
+  emit(
+    'submit',
+    looksLikeEmail
+      ? { email: v, role: role.value }
+      : { login: v, role: role.value }
+  )
 }
 
 const onCancel = () => {
   reset()
   emit('cancel')
 }
-
-void props
 </script>
 
 <template>
@@ -73,7 +84,13 @@ void props
           <option value="admin">Admin</option>
         </select>
       </label>
-      <p v-if="error" class="error-hint">{{ error }}</p>
+      <p
+        v-if="shownError"
+        class="error-hint"
+        data-testid="invite-error"
+      >
+        {{ shownError }}
+      </p>
       <div class="actions">
         <button
           type="button"

--- a/src/views/SettingsView/MembersSection.vue
+++ b/src/views/SettingsView/MembersSection.vue
@@ -53,9 +53,18 @@ const s = useMembersSection()
     >
       Read-only — your role does not allow changes.
     </p>
+    <p
+      v-if="s.error.value && !s.dialogOpen.value"
+      class="op-error"
+      data-testid="members-error"
+      role="alert"
+    >
+      {{ s.error.value }}
+    </p>
     <InviteDialog
       :open="s.dialogOpen.value"
       :busy="s.busy.value"
+      :error="s.error.value"
       @submit="s.onInvite"
       @cancel="s.closeDialog"
     />
@@ -102,5 +111,12 @@ h2 {
 .read-only {
   margin-top: 0.5rem;
   font-style: italic;
+}
+
+.op-error {
+  margin-top: 0.75rem;
+  color: var(--color-error, #e53935);
+  font-size: 0.875rem;
+  white-space: pre-wrap;
 }
 </style>

--- a/src/views/SettingsView/members-actions.ts
+++ b/src/views/SettingsView/members-actions.ts
@@ -3,34 +3,39 @@ import { createInvite, revokeInvite } from './org-invite-api'
 import { setOrgRole } from './org-role-api'
 import type { InviteRequest } from './roles-api-types'
 
-const withBusy =
-  (busy: Ref<boolean>, reload: () => Promise<void>) =>
-  async (fn: () => Promise<unknown>): Promise<void> => {
-    busy.value = true
-    try {
-      await fn()
-      await reload()
-    } finally {
-      busy.value = false
-    }
+interface Bag {
+  readonly busy: Ref<boolean>
+  readonly error: Ref<string | undefined>
+  readonly reload: () => Promise<void>
+  readonly closeDialog: () => void
+}
+
+const toMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e)
+
+const withBusy = (bag: Bag) => async (fn: () => Promise<void>) => {
+  bag.busy.value = true
+  bag.error.value = undefined
+  try {
+    await fn()
+    await bag.reload()
+  } catch (e) {
+    bag.error.value = toMessage(e)
+  } finally {
+    bag.busy.value = false
   }
+}
 
 /**
  * Build the three Members-section mutation handlers (role change,
- * invite, revoke). They share a busy flag and reload the list on
- * every successful mutation.
+ * invite, revoke). They share a busy flag, surface any error into
+ * the section's error ref, and reload the list on success.
  *
- * @param busy shared ref toggled around each async op
- * @param reload callback to refresh the members payload
- * @param closeDialog callback to close the invite dialog on success
- * @returns handler map
+ * @param bag - busy / error / reload / closeDialog wiring
+ * @returns Handler map
  */
-export const buildMemberActions = (
-  busy: Ref<boolean>,
-  reload: () => Promise<void>,
-  closeDialog: () => void
-) => {
-  const run = withBusy(busy, reload)
+export const buildMemberActions = (bag: Bag) => {
+  const run = withBusy(bag)
   return {
     onRoleChange: (
       login: string,
@@ -39,7 +44,7 @@ export const buildMemberActions = (
     onInvite: (req: InviteRequest) =>
       run(async () => {
         await createInvite(req)
-        closeDialog()
+        bag.closeDialog()
       }),
     onRevoke: (id: number) => run(() => revokeInvite(id)),
   }

--- a/src/views/SettingsView/members-public-state.ts
+++ b/src/views/SettingsView/members-public-state.ts
@@ -1,0 +1,35 @@
+import type { buildMembersState } from './members-section-state'
+
+type S = ReturnType<typeof buildMembersState>
+
+interface DialogControls {
+  readonly openDialog: () => void
+  readonly closeDialog: () => void
+}
+
+/**
+ * Project the buildMembersState bag plus dialog handlers and
+ * actions into the shape consumed by MembersSection.vue.
+ *
+ * @param s - State bag
+ * @param ctl - Dialog open/close controls bundle
+ * @param actions - Action handler map
+ * @returns Public bundle for the section template
+ */
+export const projectMembersPublic = <A extends Record<string, unknown>>(
+  s: S,
+  ctl: DialogControls,
+  actions: A
+) => ({
+  sorted: s.sorted,
+  invitations: s.invitations,
+  loading: s.loading,
+  dialogOpen: s.dialogOpen,
+  busy: s.busy,
+  error: s.error,
+  disabled: s.disabled,
+  canEditSettings: s.canEditSettings,
+  openDialog: ctl.openDialog,
+  closeDialog: ctl.closeDialog,
+  ...actions,
+})

--- a/src/views/SettingsView/members-section-state.ts
+++ b/src/views/SettingsView/members-section-state.ts
@@ -24,6 +24,7 @@ export const buildMembersState = () => {
   const { canEditSettings } = usePermissions()
   const dialogOpen = ref(false)
   const busy = ref(false)
+  const error = ref<string | undefined>(undefined)
   const sorted = computed(() => sortByRank(members.value))
   const disabled = computed(() => busy.value || !canEditSettings.value)
   return {
@@ -34,6 +35,7 @@ export const buildMembersState = () => {
     canEditSettings,
     dialogOpen,
     busy,
+    error,
     sorted,
     disabled,
   }

--- a/src/views/SettingsView/org-invite-api.ts
+++ b/src/views/SettingsView/org-invite-api.ts
@@ -1,35 +1,41 @@
 import { swFetch } from '@/composables/useSWBridge/sw-fetch'
 import type { InviteRequest } from './roles-api-types'
 
+const errorBody = async (res: Response): Promise<string> => {
+  const txt = await res.text().catch(() => '')
+  return txt.length > 0 ? txt : `github ${res.status}`
+}
+
+const okOrThrow = async (res: Response): Promise<Response> =>
+  res.ok ? res : Promise.reject(new Error(await errorBody(res)))
+
 /**
  * Create a pending GitHub org invitation with the requested app
- * role. Accepts either email or login.
+ * role. Accepts either email or login. Throws when the SW or
+ * GitHub returned a non-OK status so the dialog surfaces the real
+ * reason instead of silently closing on failure.
  *
- * @param req invite payload
- * @returns id of the created invitation or undefined on failure
+ * @param req - Invite payload
+ * @returns Id of the created invitation
  */
-export const createInvite = async (
-  req: InviteRequest
-): Promise<number | undefined> => {
-  const res = await swFetch('/api/github/org-invite', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(req),
-  })
-  return res.ok
-    ? ((await res.json()) as { readonly id: number }).id
-    : undefined
+export const createInvite = async (req: InviteRequest): Promise<number> => {
+  const res = await okOrThrow(
+    await swFetch('/api/github/org-invite', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(req),
+    })
+  )
+  return ((await res.json()) as { readonly id: number }).id
 }
 
 /**
- * Revoke a pending invitation by id.
+ * Revoke a pending invitation by id. Throws on non-OK.
  *
- * @param id invitation id
- * @returns true on success
+ * @param id - Invitation id
  */
-export const revokeInvite = async (id: number): Promise<boolean> => {
-  const res = await swFetch(`/api/github/org-invite/${id}`, {
-    method: 'DELETE',
-  })
-  return res.ok
+export const revokeInvite = async (id: number): Promise<void> => {
+  await okOrThrow(
+    await swFetch(`/api/github/org-invite/${id}`, { method: 'DELETE' })
+  )
 }

--- a/src/views/SettingsView/useMembersSection.ts
+++ b/src/views/SettingsView/useMembersSection.ts
@@ -1,12 +1,13 @@
 import { onMounted } from 'vue'
 import { buildMemberActions } from './members-actions'
+import { projectMembersPublic } from './members-public-state'
 import { buildMembersState } from './members-section-state'
 
 /**
  * Own the Members section state: list, invites, dialog, busy flag,
- * and the three mutation handlers (role change, invite, revoke).
+ * error ref, and the three mutation handlers.
  *
- * @returns reactive state + handlers for MembersSection.vue
+ * @returns Reactive state + handlers for MembersSection.vue
  */
 export const useMembersSection = () => {
   const s = buildMembersState()
@@ -17,17 +18,11 @@ export const useMembersSection = () => {
     s.dialogOpen.value = false
   }
   onMounted(s.load)
-  const actions = buildMemberActions(s.busy, s.load, closeDialog)
-  return {
-    sorted: s.sorted,
-    invitations: s.invitations,
-    loading: s.loading,
-    dialogOpen: s.dialogOpen,
+  const actions = buildMemberActions({
     busy: s.busy,
-    disabled: s.disabled,
-    canEditSettings: s.canEditSettings,
-    openDialog,
+    error: s.error,
+    reload: s.load,
     closeDialog,
-    ...actions,
-  }
+  })
+  return projectMembersPublic(s, { openDialog, closeDialog }, actions)
 }


### PR DESCRIPTION
## Summary
Promotes #65 → #72 to prod-admin. dev-admin verified green via 4-spec save E2E suite.

Includes:
- #65 dirty-form fix + bodyless body editor coverage
- #67 slug input restriction
- #68 alt text required on image insert
- #69 RBAC error surfacing (silent failures fixed)
- #70 invite email→user resolution
- #71 e2e suite repairs for the new alt/slug behaviors
- #72 pdfjs vendor probe tolerance

🤖 Generated with [Claude Code](https://claude.com/claude-code)