### PR TITLE
chore: biome format on repro-slug-alt

### DIFF
--- a/e2e-prod/repro-slug-alt.pw.ts
+++ b/e2e-prod/repro-slug-alt.pw.ts
@@ -72,9 +72,11 @@ test.describe('post-deploy slug + alt', () => {
         '[data-testid="editor-body"]'
       ) as HTMLTextAreaElement
       const dt = new DataTransfer()
-      dt.items.add(new File([new Uint8Array([137, 80, 78, 71])], 'pic.png', {
-        type: 'image/png',
-      }))
+      dt.items.add(
+        new File([new Uint8Array([137, 80, 78, 71])], 'pic.png', {
+          type: 'image/png',
+        })
+      )
       el.dispatchEvent(
         new ClipboardEvent('paste', {
           clipboardData: dt,


### PR DESCRIPTION
Fixes the develop deploy that #74 broke on a multi-line File argument formatting.