### PR TITLE
chore: stabilize slug rename prod E2E in suite mode

### DIFF
--- a/e2e-prod/repro-slug-alt.pw.ts
+++ b/e2e-prod/repro-slug-alt.pw.ts
@@ -31,13 +31,29 @@ test.describe('post-deploy slug + alt', () => {
   test('slug input strips uppercase + non-Latin keystrokes', async ({
     page,
   }) => {
-    const heading = page.locator('[data-testid="edit-title"]')
-    await heading.waitFor({ state: 'visible', timeout: 60_000 })
-    await heading.click()
-    const input = page.locator('[data-testid="slug-input"]')
-    await input.waitFor({ state: 'visible', timeout: 10_000 })
-    await input.fill('')
+    // Wait for the editor body to load — until then a click on the
+    // heading races with Vue re-rendering EditableSlug and silently
+    // gets eaten. The test was flaky in suite mode because the prior
+    // test left network in flight; isolation fixed it but only by
+    // accident. Hold for editor-body before touching the heading.
+    await page
+      .locator('[data-testid="editor-body"]')
+      .waitFor({ state: 'visible', timeout: 60_000 })
 
+    const heading = page.locator('[data-testid="edit-title"]')
+    await heading.waitFor({ state: 'visible', timeout: 30_000 })
+    const input = page.locator('[data-testid="slug-input"]')
+    await expect
+      .poll(
+        async () => {
+          await heading.click({ trial: false }).catch(() => undefined)
+          return await input.isVisible().catch(() => false)
+        },
+        { timeout: 15_000, intervals: [500, 1000] }
+      )
+      .toBe(true)
+
+    await input.fill('')
     await input.type('FooBar', { delay: 20 })
     expect(await input.inputValue()).toBe('foobar')
 


### PR DESCRIPTION
Race against Vue re-render of EditableSlug — wait for editor-body before clicking the heading, then poll until the input becomes visible. Suite-mode 6/6 now consistent.