### PR TITLE
feat(notifications): in-memory store + composable (#79)

### DIFF
--- a/src/composables/README.md
+++ b/src/composables/README.md
@@ -12,3 +12,4 @@ Vue composables encapsulating business logic. Each composable is decomposed into
 - `useOAuthPopup` -- PKCE OAuth popup flow (authorize URL, popup monitor, token exchange)
 - `useDropdown` -- dropdown open/close state
 - `useUnsavedGuard` -- warn before navigating away with unsaved changes
+- `useNotifications` -- reactive notifications API; returns readonly entries and bound `notify` / `dismiss` / `clear` actions backed by the `notifications` Pinia store

--- a/src/composables/useNotifications/index.ts
+++ b/src/composables/useNotifications/index.ts
@@ -1,0 +1,2 @@
+/** Reactive notifications composable. */
+export { useNotifications } from './use-notifications'

--- a/src/composables/useNotifications/use-notifications.test.ts
+++ b/src/composables/useNotifications/use-notifications.test.ts
@@ -1,0 +1,38 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { isRef } from 'vue'
+import { useNotifications } from './use-notifications'
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns a reactive entries ref and bound actions', () => {
+    const api = useNotifications()
+    expect(isRef(api.entries)).toBe(true)
+    expect(api.entries.value).toEqual([])
+    expect(typeof api.notify).toBe('function')
+    expect(typeof api.dismiss).toBe('function')
+    expect(typeof api.clear).toBe('function')
+  })
+
+  it('mutations through the composable propagate to entries', () => {
+    const { entries, notify, dismiss, clear } = useNotifications()
+    const id = notify({ kind: 'info', title: 'hi' })
+    expect(entries.value).toHaveLength(1)
+    dismiss(id)
+    expect(entries.value).toHaveLength(0)
+    notify({ kind: 'warn', title: 'a' })
+    notify({ kind: 'warn', title: 'b' })
+    clear()
+    expect(entries.value).toEqual([])
+  })
+
+  it('two consumers share the same store', () => {
+    const a = useNotifications()
+    const b = useNotifications()
+    a.notify({ kind: 'info', title: 'shared' })
+    expect(b.entries.value).toHaveLength(1)
+  })
+})

--- a/src/composables/useNotifications/use-notifications.ts
+++ b/src/composables/useNotifications/use-notifications.ts
@@ -1,0 +1,19 @@
+import { storeToRefs } from 'pinia'
+import { useNotificationsStore } from '@/stores/notifications'
+
+/**
+ * Reactive notifications API. Returns a readonly view of the queue
+ * plus bound notify/dismiss/clear actions, suitable for direct use
+ * in `<script setup>` and helper composables alike.
+ * @returns Readonly entries ref + bound store actions.
+ */
+export const useNotifications = () => {
+  const store = useNotificationsStore()
+  const { entries } = storeToRefs(store)
+  return {
+    entries,
+    notify: store.notify,
+    dismiss: store.dismiss,
+    clear: store.clear,
+  }
+}

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -7,3 +7,4 @@ Pinia state management stores. Each store is decomposed: the `defineStore` file 
 - `auth` -- user authentication state, token sync to SW, login/logout actions
 - `content` -- global content item cache, loaded once on auth, filtered by type
 - `settings` -- application language settings, loaded from `languages.json` in the content repo
+- `notifications` -- in-memory queue of typed notifications (`info` / `warn` / `error` / `conflict` / `network`); consumed via the `useNotifications` composable. Persistence and UI come in later increments of the offline-first initiative.

--- a/src/stores/notifications-add.ts
+++ b/src/stores/notifications-add.ts
@@ -1,0 +1,26 @@
+import type { Ref } from 'vue'
+import { generateNotificationId } from './notifications-id'
+import type {
+  NotificationEntry,
+  NotificationInput,
+} from './notifications-types'
+
+/**
+ * Build the `notify` action. Appends a new entry built from the
+ * caller input plus a fresh id and timestamp, and returns the id
+ * so that the caller can later dismiss it programmatically.
+ * @param items Reactive ref backing the queue.
+ * @returns Function that pushes an entry and returns its id.
+ */
+export const createNotifyAction =
+  (items: Ref<readonly NotificationEntry[]>) =>
+  (input: NotificationInput): string => {
+    const id = generateNotificationId()
+    const entry: NotificationEntry = {
+      id,
+      createdAt: Date.now(),
+      ...input,
+    }
+    items.value = [...items.value, entry]
+    return id
+  }

--- a/src/stores/notifications-dismiss.ts
+++ b/src/stores/notifications-dismiss.ts
@@ -1,0 +1,15 @@
+import type { Ref } from 'vue'
+import type { NotificationEntry } from './notifications-types'
+
+/**
+ * Build the `dismiss` action. Removes the entry whose id matches;
+ * returns silently when the id is unknown so call sites can fire
+ * a dismiss without first reading the queue.
+ * @param items Reactive ref backing the queue.
+ * @returns Function that removes one entry by id.
+ */
+export const createDismissAction =
+  (items: Ref<readonly NotificationEntry[]>) =>
+  (id: string): void => {
+    items.value = items.value.filter(entry => entry.id !== id)
+  }

--- a/src/stores/notifications-id.ts
+++ b/src/stores/notifications-id.ts
@@ -1,0 +1,10 @@
+/**
+ * Build a stable identifier for a notification entry. Uses
+ * `crypto.randomUUID` when available; otherwise falls back to a
+ * timestamp + random base-36 fragment which is unique enough for
+ * the in-memory queue lifecycle.
+ * @returns Opaque unique identifier.
+ */
+export const generateNotificationId = (): string =>
+  globalThis.crypto?.randomUUID?.() ??
+  `n-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`

--- a/src/stores/notifications-state.ts
+++ b/src/stores/notifications-state.ts
@@ -1,0 +1,23 @@
+import { ref } from 'vue'
+import { createNotifyAction } from './notifications-add'
+import { createDismissAction } from './notifications-dismiss'
+import type { NotificationEntry } from './notifications-types'
+
+/**
+ * Build the reactive state and actions for the notifications store.
+ * Kept separate from the Pinia wrapper so the same factory can be
+ * exercised in unit tests without spinning up a full app.
+ * @returns Bound state ref plus notify/dismiss/clear actions.
+ */
+export const createNotificationsState = () => {
+  const items = ref<readonly NotificationEntry[]>([])
+  const clear = (): void => {
+    items.value = []
+  }
+  return {
+    entries: items,
+    notify: createNotifyAction(items),
+    dismiss: createDismissAction(items),
+    clear,
+  }
+}

--- a/src/stores/notifications-types.ts
+++ b/src/stores/notifications-types.ts
@@ -1,0 +1,26 @@
+/** Category of a notification — drives styling, icon, and stickiness. */
+export type NotificationKind =
+  | 'info'
+  | 'warn'
+  | 'error'
+  | 'conflict'
+  | 'network'
+
+/** Optional call-to-action attached to a notification entry. */
+export type NotificationCta = {
+  readonly label: string
+  readonly action: () => void
+}
+
+/** A single entry stored in the notifications queue. */
+export type NotificationEntry = {
+  readonly id: string
+  readonly kind: NotificationKind
+  readonly title: string
+  readonly message?: string
+  readonly createdAt: number
+  readonly cta?: NotificationCta
+}
+
+/** Caller-supplied shape — id and createdAt are assigned by the store. */
+export type NotificationInput = Omit<NotificationEntry, 'id' | 'createdAt'>

--- a/src/stores/notifications.test.ts
+++ b/src/stores/notifications.test.ts
@@ -1,0 +1,95 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from './notifications'
+
+describe('notifications store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('starts with empty entries', () => {
+    const store = useNotificationsStore()
+    expect(store.entries).toEqual([])
+  })
+
+  it('notify pushes an entry and returns its id', () => {
+    const store = useNotificationsStore()
+    const id = store.notify({ kind: 'info', title: 'hello' })
+    expect(id).toMatch(/.+/)
+    expect(store.entries).toHaveLength(1)
+    const entry = store.entries[0]
+    expect(entry?.id).toBe(id)
+    expect(entry?.kind).toBe('info')
+    expect(entry?.title).toBe('hello')
+  })
+
+  it('notify assigns unique ids', () => {
+    const store = useNotificationsStore()
+    const a = store.notify({ kind: 'info', title: 'a' })
+    const b = store.notify({ kind: 'info', title: 'b' })
+    expect(a).not.toBe(b)
+  })
+
+  it('notify stamps createdAt to a current timestamp', () => {
+    const before = Date.now()
+    const store = useNotificationsStore()
+    store.notify({ kind: 'warn', title: 'tick' })
+    const ts = store.entries[0]?.createdAt ?? 0
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('notify preserves an attached cta', () => {
+    const store = useNotificationsStore()
+    const action = (): void => undefined
+    store.notify({
+      kind: 'network',
+      title: 'down',
+      cta: { label: 'Retry', action },
+    })
+    const entry = store.entries[0]
+    expect(entry?.cta?.label).toBe('Retry')
+    expect(entry?.cta?.action).toBe(action)
+  })
+
+  it('notify accepts every category without type errors', () => {
+    const store = useNotificationsStore()
+    const kinds = ['info', 'warn', 'error', 'conflict', 'network'] as const
+    for (const kind of kinds) {
+      store.notify({ kind, title: kind })
+    }
+    expect(store.entries.map(e => e.kind)).toEqual([...kinds])
+  })
+
+  it('dismiss removes the entry with the given id', () => {
+    const store = useNotificationsStore()
+    const id = store.notify({ kind: 'info', title: 'x' })
+    store.notify({ kind: 'error', title: 'y' })
+    store.dismiss(id)
+    expect(store.entries).toHaveLength(1)
+    expect(store.entries[0]?.title).toBe('y')
+  })
+
+  it('dismiss with an unknown id is a no-op', () => {
+    const store = useNotificationsStore()
+    store.notify({ kind: 'info', title: 'x' })
+    store.dismiss('does-not-exist')
+    expect(store.entries).toHaveLength(1)
+  })
+
+  it('clear empties all entries', () => {
+    const store = useNotificationsStore()
+    store.notify({ kind: 'info', title: 'x' })
+    store.notify({ kind: 'info', title: 'y' })
+    store.clear()
+    expect(store.entries).toEqual([])
+  })
+
+  it('exposes entries as a frozen view of the queue', () => {
+    const store = useNotificationsStore()
+    store.notify({ kind: 'info', title: 'x' })
+    const snapshot = store.entries
+    store.notify({ kind: 'info', title: 'y' })
+    expect(snapshot).not.toBe(store.entries)
+  })
+})

--- a/src/stores/notifications.ts
+++ b/src/stores/notifications.ts
@@ -1,0 +1,14 @@
+import { defineStore } from 'pinia'
+import { createNotificationsState } from './notifications-state'
+
+export type {
+  NotificationCta,
+  NotificationEntry,
+  NotificationInput,
+  NotificationKind,
+} from './notifications-types'
+
+/** Pinia store backing the in-memory notifications queue. */
+export const useNotificationsStore = defineStore('notifications', () =>
+  createNotificationsState()
+)


### PR DESCRIPTION
## Summary
- Lands Phase A / Epic 1 increment 1.1 — the in-memory notifications backbone that Epic 2–4 increments will hook into to surface push failures, conflicts, and validation errors.
- Pinia store `notifications` with five typed kinds (`info` / `warn` / `error` / `conflict` / `network`); each entry stamped with id + createdAt on insert.
- `useNotifications` composable: readonly `entries` ref + bound `notify` / `dismiss` / `clear`. Two consumers share the same store (verified by tests).
- Action factories split per file (`notifications-add.ts`, `-dismiss.ts`, `-state.ts`, `-id.ts`) to keep every file ≤ 50 non-blank lines.

## Out of scope
- Toast UI + status indicator → #80 (1.2)
- Persistent history drawer → #81 (1.3)
- Typed factories per category → #82 (1.4)
- Any consumer (push queue, conflict detector, validation) → Epics 2–4

## Test plan
- [x] `bun run test:unit -- run src/stores/notifications.test.ts src/composables/useNotifications/` — 13/13 green
- [x] `bun run test:unit -- run` (full suite) — 408/408 green
- [x] `bun run validate` — type-check, biome ci, oxlint sonar, jsdoc lint, vue-depth, css all clean

Closes #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)