### PR TITLE
feat(notifications): toast UI + status indicator (#80)

### DIFF
--- a/e2e/notifications/toast.spec.ts
+++ b/e2e/notifications/toast.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('notifications: toast + indicator (1.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('info toast appears, can be dismissed manually', async ({ page }) => {
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeHidden()
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await expect(toast).toBeVisible()
+    await expect(toast).toContainText('info')
+    await toast.locator('[data-testid="notification-toast-dismiss"]').click()
+    await expect(toast).toBeHidden()
+  })
+
+  test('error toast is sticky and exposes a dismiss control', async ({
+    page,
+  }) => {
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-sticky', 'true')
+    const dismiss = toast.locator(
+      '[data-testid="notification-toast-dismiss"]'
+    )
+    await expect(dismiss).toHaveAttribute('aria-label', /dismiss/i)
+    await dismiss.click()
+    await expect(toast).toBeHidden()
+  })
+
+  test('indicator badge reflects the unread count', async ({ page }) => {
+    const badge = page.locator('[data-testid="notification-indicator-badge"]')
+    await expect(badge).toBeHidden()
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await expect(badge).toHaveText('1')
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await expect(badge).toHaveText('2')
+  })
+
+  test('only the most recent three toasts are visible', async ({ page }) => {
+    const trigger = page.locator('[data-testid="notify-trigger-error"]')
+    for (let i = 0; i < 5; i += 1) {
+      await trigger.click()
+    }
+    const visible = page.locator('[data-testid="notification-toast"]')
+    await expect(visible).toHaveCount(3)
+  })
+
+  test('toast stack uses an aria live region', async ({ page }) => {
+    const stack = page.locator('[data-testid="notification-toast-stack"]')
+    await expect(stack).toHaveAttribute('aria-live', /polite|assertive/)
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,5 +64,7 @@ watch(
 
 <template>
   <RouterView :key="route.fullPath" />
+  <NotificationToastStack />
+  <NotificationDevTrigger />
   <SWDebugPanel />
 </template>

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -34,6 +34,7 @@ const hash = __COMMIT_HASH__
 
 <template>
   <AppHeader>
+    <NotificationIndicator />
     <AuthButton />
   </AppHeader>
 

--- a/src/components/NotificationDevTrigger/NotificationDevTrigger.vue
+++ b/src/components/NotificationDevTrigger/NotificationDevTrigger.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { useNotifications } from '@/composables/useNotifications'
+import type { NotificationKind } from '@/stores/notifications'
+import { DEV_TRIGGER_KINDS } from './dev-kinds'
+
+const enabled = import.meta.env.VITE_MOCK_AUTH === 'true'
+const { notify } = useNotifications()
+
+const fire = (kind: NotificationKind): void => {
+  notify({
+    kind,
+    title: `${kind} sample`,
+    message: `dev-triggered ${kind} notification`,
+  })
+}
+</script>
+
+<template>
+  <aside
+    v-if="enabled"
+    class="dev-trigger"
+    data-testid="notify-dev-trigger"
+    aria-label="Dev notification triggers"
+  >
+    <button
+      v-for="kind in DEV_TRIGGER_KINDS"
+      :key="kind"
+      type="button"
+      :data-testid="`notify-trigger-${kind}`"
+      @click="fire(kind)"
+    >
+      {{ kind }}
+    </button>
+  </aside>
+</template>
+
+<style scoped>
+.dev-trigger {
+  position: fixed;
+  top: 80px;
+  left: 12px;
+  z-index: 100;
+  display: flex;
+  gap: 4px;
+  padding: 6px;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 6px;
+  font-family: monospace;
+}
+
+.dev-trigger button {
+  font-size: 11px;
+  padding: 4px 8px;
+  background: #222;
+  color: #ddd;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.dev-trigger button:hover {
+  background: #333;
+}
+</style>

--- a/src/components/NotificationDevTrigger/dev-kinds.ts
+++ b/src/components/NotificationDevTrigger/dev-kinds.ts
@@ -1,0 +1,10 @@
+import type { NotificationKind } from '@/stores/notifications'
+
+/** Notification kinds offered as quick-fire dev triggers. */
+export const DEV_TRIGGER_KINDS: ReadonlyArray<NotificationKind> = [
+  'info',
+  'warn',
+  'error',
+  'conflict',
+  'network',
+]

--- a/src/components/NotificationIndicator/BellIcon.vue
+++ b/src/components/NotificationIndicator/BellIcon.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const PATH =
+  'M12 22a2 2 0 0 0 2-2h-4a2 2 0 0 0 2 2zm6-6V11a6 6 0 1 0-12 0v5l-2 2v1h16v-1l-2-2z'
+</script>
+
+<template>
+  <svg
+    class="bell-icon"
+    viewBox="0 0 24 24"
+    width="18"
+    height="18"
+    aria-hidden="true"
+    fill="currentColor"
+  >
+    <path :d="PATH" />
+  </svg>
+</template>
+
+<style scoped>
+.bell-icon {
+  pointer-events: none;
+}
+</style>

--- a/src/components/NotificationIndicator/NotificationIndicator.vue
+++ b/src/components/NotificationIndicator/NotificationIndicator.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNotifications } from '@/composables/useNotifications'
+import { formatCount } from './format-count'
+import { INDICATOR_TEST_IDS } from './test-ids'
+
+const { entries } = useNotifications()
+const count = computed(() => entries.value.length)
+const badge = computed(() => formatCount(count.value))
+const ariaLabel = computed(() =>
+  count.value === 0
+    ? 'Notifications: none unread'
+    : `Notifications: ${count.value} unread`
+)
+</script>
+
+<template>
+  <button
+    type="button"
+    class="indicator"
+    :data-testid="INDICATOR_TEST_IDS.root"
+    :aria-label="ariaLabel"
+    :aria-disabled="true"
+  >
+    <BellIcon />
+    <span
+      v-if="badge"
+      :data-testid="INDICATOR_TEST_IDS.badge"
+      class="indicator-badge"
+    >{{ badge }}</span>
+  </button>
+</template>
+
+<style scoped>
+.indicator {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: not-allowed;
+  color: inherit;
+}
+
+.indicator:focus-visible {
+  outline: 2px solid var(--color-accent, #4fc3f7);
+  outline-offset: 2px;
+}
+
+.indicator-icon {
+  pointer-events: none;
+}
+
+.indicator-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+  color: #fff;
+  background: var(--color-error, #e53935);
+  border-radius: 9px;
+  border: 2px solid var(--color-background, #fff);
+}
+</style>

--- a/src/components/NotificationIndicator/format-count.test.ts
+++ b/src/components/NotificationIndicator/format-count.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { formatCount } from './format-count'
+
+describe('formatCount', () => {
+  it('returns empty string for zero', () => {
+    expect(formatCount(0)).toBe('')
+  })
+
+  it('returns the count verbatim for 1-9', () => {
+    expect(formatCount(1)).toBe('1')
+    expect(formatCount(9)).toBe('9')
+  })
+
+  it('returns the count verbatim for 10-99', () => {
+    expect(formatCount(10)).toBe('10')
+    expect(formatCount(99)).toBe('99')
+  })
+
+  it('caps at 99+ above the two-digit boundary', () => {
+    expect(formatCount(100)).toBe('99+')
+    expect(formatCount(9999)).toBe('99+')
+  })
+
+  it('clamps negatives and floors fractions', () => {
+    expect(formatCount(-1)).toBe('')
+    expect(formatCount(2.7)).toBe('2')
+  })
+})

--- a/src/components/NotificationIndicator/format-count.ts
+++ b/src/components/NotificationIndicator/format-count.ts
@@ -1,0 +1,21 @@
+/** Maximum count rendered exactly before falling back to '9+' / '99+'. */
+const SINGLE_DIGIT_MAX = 9
+const TWO_DIGIT_MAX = 99
+
+/**
+ * Render a notification count for the header badge. Counts above 9
+ * collapse to "9+", counts above 99 collapse to "99+", and zero
+ * returns an empty string so the caller can hide the badge entirely.
+ * @param count Non-negative integer count of unread notifications.
+ * @returns Display string for the badge or '' to hide it.
+ */
+export const formatCount = (count: number): string => {
+  const safe = Math.max(0, Math.floor(count))
+  return safe === 0
+    ? ''
+    : safe <= SINGLE_DIGIT_MAX
+      ? String(safe)
+      : safe <= TWO_DIGIT_MAX
+        ? `${safe}`
+        : '99+'
+}

--- a/src/components/NotificationIndicator/test-ids.ts
+++ b/src/components/NotificationIndicator/test-ids.ts
@@ -1,0 +1,5 @@
+/** Test IDs used by the header notification indicator. */
+export const INDICATOR_TEST_IDS = {
+  root: 'notification-indicator',
+  badge: 'notification-indicator-badge',
+} as const

--- a/src/components/NotificationToast/NotificationToast.vue
+++ b/src/components/NotificationToast/NotificationToast.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+import { useNotifications } from '@/composables/useNotifications'
+import type { NotificationEntry } from '@/stores/notifications'
+import { scheduleAutoDismiss } from './auto-dismiss'
+import { isStickyKind } from './is-sticky-kind'
+import { TOAST_TEST_IDS } from './test-ids'
+
+const props = defineProps<{ readonly entry: NotificationEntry }>()
+const { dismiss } = useNotifications()
+
+const onDismiss = (): void => {
+  dismiss(props.entry.id)
+}
+
+let cancel: (() => void) | undefined
+onMounted(() => {
+  cancel = scheduleAutoDismiss(props.entry.kind, onDismiss)
+})
+onUnmounted(() => {
+  cancel?.()
+})
+</script>
+
+<template>
+  <article
+    :data-testid="TOAST_TEST_IDS.toast"
+    :data-kind="entry.kind"
+    :data-sticky="String(isStickyKind(entry.kind))"
+    :class="['toast', `toast-kind-${entry.kind}`]"
+    :role="isStickyKind(entry.kind) ? 'alert' : 'status'"
+  >
+    <strong :data-testid="TOAST_TEST_IDS.title" class="toast-title">
+      {{ entry.title }}
+    </strong>
+    <span
+      v-if="entry.message"
+      :data-testid="TOAST_TEST_IDS.message"
+      class="toast-message"
+    >{{ entry.message }}</span>
+    <button
+      type="button"
+      class="toast-dismiss"
+      :aria-label="`dismiss ${entry.kind} notification`"
+      :data-testid="TOAST_TEST_IDS.dismiss"
+      @click="onDismiss"
+    >
+      ×
+    </button>
+  </article>
+</template>
+
+<style scoped>
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #ddd);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+  min-width: 240px;
+  max-width: 360px;
+}
+
+.toast-kind-info { border-left: 3px solid #4fc3f7; }
+.toast-kind-warn { border-left: 3px solid #ffb74d; }
+.toast-kind-error { border-left: 3px solid #e57373; }
+.toast-kind-conflict { border-left: 3px solid #ba68c8; }
+.toast-kind-network { border-left: 3px solid #aed581; }
+
+.toast-title {
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+
+.toast-message {
+  font-size: 0.8125rem;
+  color: var(--color-text, #444);
+}
+
+.toast-dismiss {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: inherit;
+  min-width: 32px;
+  min-height: 32px;
+  border-radius: 4px;
+}
+
+.toast-dismiss:hover,
+.toast-dismiss:focus-visible {
+  background: rgb(0 0 0 / 6%);
+  outline: none;
+}
+</style>

--- a/src/components/NotificationToast/NotificationToastStack.vue
+++ b/src/components/NotificationToast/NotificationToastStack.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNotifications } from '@/composables/useNotifications'
+import NotificationToast from './NotificationToast.vue'
+import { TOAST_TEST_IDS } from './test-ids'
+
+const MAX_VISIBLE = 3
+
+const { entries } = useNotifications()
+const visible = computed(() => entries.value.slice(-MAX_VISIBLE).reverse())
+</script>
+
+<template>
+  <output
+    :data-testid="TOAST_TEST_IDS.stack"
+    class="toast-stack"
+    aria-live="polite"
+    aria-atomic="false"
+  >
+    <NotificationToast
+      v-for="entry in visible"
+      :key="entry.id"
+      :entry="entry"
+    />
+  </output>
+</template>
+
+<style scoped>
+.toast-stack {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: var(--z-toast, 9990);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: max-content;
+}
+
+@media (width <= 600px) {
+  .toast-stack {
+    left: 16px;
+    right: 16px;
+  }
+}
+</style>

--- a/src/components/NotificationToast/auto-dismiss.test.ts
+++ b/src/components/NotificationToast/auto-dismiss.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AUTO_DISMISS_MS, scheduleAutoDismiss } from './auto-dismiss'
+
+describe('scheduleAutoDismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires dismiss after the timeout for transient kinds', () => {
+    const dismiss = vi.fn()
+    scheduleAutoDismiss('info', dismiss)
+    vi.advanceTimersByTime(AUTO_DISMISS_MS - 1)
+    expect(dismiss).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire for sticky kinds', () => {
+    const dismiss = vi.fn()
+    const cleanup = scheduleAutoDismiss('error', dismiss)
+    vi.advanceTimersByTime(AUTO_DISMISS_MS * 4)
+    expect(dismiss).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('cleanup cancels a pending dismiss', () => {
+    const dismiss = vi.fn()
+    const cleanup = scheduleAutoDismiss('warn', dismiss)
+    vi.advanceTimersByTime(AUTO_DISMISS_MS - 100)
+    cleanup()
+    vi.advanceTimersByTime(AUTO_DISMISS_MS * 2)
+    expect(dismiss).not.toHaveBeenCalled()
+  })
+
+  it('cleanup is idempotent for sticky kinds', () => {
+    const cleanup = scheduleAutoDismiss('conflict', vi.fn())
+    expect(() => {
+      cleanup()
+      cleanup()
+    }).not.toThrow()
+  })
+})

--- a/src/components/NotificationToast/auto-dismiss.ts
+++ b/src/components/NotificationToast/auto-dismiss.ts
@@ -1,0 +1,26 @@
+import type { NotificationKind } from '@/stores/notifications'
+import { isStickyKind } from './is-sticky-kind'
+
+/** Auto-dismiss delay (ms) for transient toasts. */
+export const AUTO_DISMISS_MS = 5_000
+
+/**
+ * Schedule an auto-dismiss for a transient notification. Sticky
+ * kinds (error/conflict/network) skip arming the timer entirely so
+ * the toast persists until the user dismisses it. The returned
+ * cleanup is safe to call regardless of kind.
+ * @param kind Notification kind that determines stickiness.
+ * @param dismiss Callback fired once the timer elapses.
+ * @returns Cleanup function the caller invokes on unmount.
+ */
+export const scheduleAutoDismiss = (
+  kind: NotificationKind,
+  dismiss: () => void
+): (() => void) => {
+  const handle = isStickyKind(kind)
+    ? undefined
+    : globalThis.setTimeout(dismiss, AUTO_DISMISS_MS)
+  return (): void => {
+    globalThis.clearTimeout(handle)
+  }
+}

--- a/src/components/NotificationToast/is-sticky-kind.test.ts
+++ b/src/components/NotificationToast/is-sticky-kind.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isStickyKind } from './is-sticky-kind'
+
+describe('isStickyKind', () => {
+  it('treats failure-class kinds as sticky', () => {
+    expect(isStickyKind('error')).toBe(true)
+    expect(isStickyKind('conflict')).toBe(true)
+    expect(isStickyKind('network')).toBe(true)
+  })
+
+  it('treats informational kinds as transient', () => {
+    expect(isStickyKind('info')).toBe(false)
+    expect(isStickyKind('warn')).toBe(false)
+  })
+})

--- a/src/components/NotificationToast/is-sticky-kind.ts
+++ b/src/components/NotificationToast/is-sticky-kind.ts
@@ -1,0 +1,18 @@
+import type { NotificationKind } from '@/stores/notifications'
+
+const STICKY: ReadonlySet<NotificationKind> = new Set([
+  'error',
+  'conflict',
+  'network',
+])
+
+/**
+ * A notification kind is "sticky" when the toast must stay on screen
+ * until the user dismisses it explicitly. Informational kinds are
+ * transient, so they auto-dismiss; failure-class kinds are sticky so
+ * the user does not lose actionable information.
+ * @param kind Notification kind to classify.
+ * @returns True when the kind requires explicit dismissal.
+ */
+export const isStickyKind = (kind: NotificationKind): boolean =>
+  STICKY.has(kind)

--- a/src/components/NotificationToast/test-ids.ts
+++ b/src/components/NotificationToast/test-ids.ts
@@ -1,0 +1,8 @@
+/** Test IDs used by the toast surface so tests can locate elements. */
+export const TOAST_TEST_IDS = {
+  stack: 'notification-toast-stack',
+  toast: 'notification-toast',
+  title: 'notification-toast-title',
+  message: 'notification-toast-message',
+  dismiss: 'notification-toast-dismiss',
+} as const


### PR DESCRIPTION
## Summary
- Lands Phase A / Epic 1 increment 1.2: surfaces notifications visually as bottom-right toasts and a Todoist-style header indicator with unread badge.
- Auto-dismiss `info`/`warn` after 5 s; `error` / `conflict` / `network` are sticky until the user dismisses them. Stack caps at 3 visible.
- Indicator badge hides at 0, shows 1–99 verbatim, caps at 99+. Click is a no-op until #81 wires the history drawer.
- `<NotificationDevTrigger>` (gated by `VITE_MOCK_AUTH=true`) provides one button per kind so e2e + local dev can fire each variant. Lives top-left, low z-index — never intercepts dismiss clicks.

## Decisions worth knowing
- Indicator aria-label is **"Notifications: N unread"**, NOT "No new notifications". The word `new` collided with `getByRole({ name: /new/i })` queries already used by content-creation tests — see new memory `feedback_aria_label_ambiguity.md`.
- E2E `beforeEach` waits for `networkidle` + visible anchor before interacting. The first goto in a fresh BrowserContext races against the SW `controllerchange` → `location.reload()` — see new memory `feedback_e2e_sw_settle.md`.

## Out of scope
- Persistent history drawer → #81 (1.3)
- Typed factories per category → #82 (1.4)
- Wiring real producers (push queue, conflict detector) → Epics 2–4

## Test plan
- [x] `bun run test:unit -- run` — 419/419 green
- [x] `bun run test:e2e -- e2e/notifications/` — 10/10 green (chromium + mobile-chromium)
- [x] `bun run test:e2e -- --project=chromium` — 228/228 green
- [x] `bun run validate` — type-check, biome ci, oxlint sonar, jsdoc, vue-depth, css all clean
- [x] mobile-chromium pre-existing baseline failures verified by stashing this branch and rerunning on develop — same 18 failures unrelated to this PR

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)