### PR TITLE
feat(notifications): typed factories per category + cta in toast (#82)

### DIFF
--- a/src/components/NotificationToast/NotificationToast.test.ts
+++ b/src/components/NotificationToast/NotificationToast.test.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NotificationEntry } from '@/stores/notifications'
+import { useNotificationsStore } from '@/stores/notifications'
+import NotificationToast from './NotificationToast.vue'
+import { TOAST_TEST_IDS } from './test-ids'
+
+const buildEntry = (
+  overrides: Partial<NotificationEntry> = {}
+): NotificationEntry => ({
+  id: 'fixed-id',
+  kind: 'error',
+  title: 'A title',
+  createdAt: 1,
+  ...overrides,
+})
+
+describe('NotificationToast', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders title and message', () => {
+    const entry = buildEntry({ message: 'something broke' })
+    const wrapper = mount(NotificationToast, { props: { entry } })
+    expect(wrapper.text()).toContain('A title')
+    expect(wrapper.text()).toContain('something broke')
+  })
+
+  it('omits the cta button when entry has no cta', () => {
+    const wrapper = mount(NotificationToast, {
+      props: { entry: buildEntry() },
+    })
+    expect(
+      wrapper.find(`[data-testid="${TOAST_TEST_IDS.cta}"]`).exists()
+    ).toBe(false)
+  })
+
+  it('renders the cta button and runs the supplied action on click', async () => {
+    const action = vi.fn()
+    const store = useNotificationsStore()
+    store.notify({
+      kind: 'network',
+      title: 'down',
+      cta: { label: 'Retry', action },
+    })
+    const real = store.entries[0]
+    expect(real).toBeDefined()
+    const wrapper = mount(NotificationToast, {
+      props: { entry: real as NotificationEntry },
+    })
+    const cta = wrapper.find(`[data-testid="${TOAST_TEST_IDS.cta}"]`)
+    expect(cta.exists()).toBe(true)
+    expect(cta.text()).toBe('Retry')
+    await cta.trigger('click')
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(store.entries).toHaveLength(0)
+  })
+})

--- a/src/components/NotificationToast/NotificationToast.vue
+++ b/src/components/NotificationToast/NotificationToast.vue
@@ -13,6 +13,11 @@ const onDismiss = (): void => {
   dismiss(props.entry.id)
 }
 
+const onCta = (): void => {
+  props.entry.cta?.action()
+  dismiss(props.entry.id)
+}
+
 let cancel: (() => void) | undefined
 onMounted(() => {
   cancel = scheduleAutoDismiss(props.entry.kind, onDismiss)
@@ -38,6 +43,15 @@ onUnmounted(() => {
       :data-testid="TOAST_TEST_IDS.message"
       class="toast-message"
     >{{ entry.message }}</span>
+    <button
+      v-if="entry.cta"
+      type="button"
+      class="toast-cta"
+      :data-testid="TOAST_TEST_IDS.cta"
+      @click="onCta"
+    >
+      {{ entry.cta.label }}
+    </button>
     <button
       type="button"
       class="toast-dismiss"
@@ -80,8 +94,26 @@ onUnmounted(() => {
   color: var(--color-text, #444);
 }
 
-.toast-dismiss {
+.toast-cta {
   margin-left: auto;
+  background: var(--color-accent, #4fc3f7);
+  color: #fff;
+  border: 0;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  padding: 4px 10px;
+  cursor: pointer;
+  min-height: 28px;
+}
+
+.toast-cta:hover,
+.toast-cta:focus-visible {
+  filter: brightness(110%);
+  outline: none;
+}
+
+.toast-dismiss {
   background: transparent;
   border: 0;
   font-size: 1.25rem;
@@ -90,6 +122,11 @@ onUnmounted(() => {
   min-width: 32px;
   min-height: 32px;
   border-radius: 4px;
+  margin-left: auto;
+}
+
+.toast-cta + .toast-dismiss {
+  margin-left: 0;
 }
 
 .toast-dismiss:hover,

--- a/src/components/NotificationToast/test-ids.ts
+++ b/src/components/NotificationToast/test-ids.ts
@@ -5,4 +5,5 @@ export const TOAST_TEST_IDS = {
   title: 'notification-toast-title',
   message: 'notification-toast-message',
   dismiss: 'notification-toast-dismiss',
+  cta: 'notification-toast-cta',
 } as const

--- a/src/composables/useNotifications/index.ts
+++ b/src/composables/useNotifications/index.ts
@@ -1,2 +1,9 @@
-/** Reactive notifications composable. */
+/** Reactive notifications composable + typed factories per category. */
+
+export { notifyConflictDetected } from './notify-conflict-detected'
+export { notifyInfo } from './notify-info'
+export { notifyNetworkDown } from './notify-network-down'
+export { notifyPushFailure } from './notify-push-failure'
+export { notifyValidationError } from './notify-validation-error'
+export type { PushFailureReason } from './push-failure-types'
 export { useNotifications } from './use-notifications'

--- a/src/composables/useNotifications/notify-conflict-detected.test.ts
+++ b/src/composables/useNotifications/notify-conflict-detected.test.ts
@@ -1,0 +1,34 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyConflictDetected } from './notify-conflict-detected'
+
+describe('notifyConflictDetected', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits a conflict entry mentioning the file count', () => {
+    notifyConflictDetected(['a.md', 'b.md', 'c.md'])
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('conflict')
+    expect(entry?.message).toContain('3')
+  })
+
+  it('attaches a Resolve cta when an action is supplied', () => {
+    const onResolve = vi.fn()
+    notifyConflictDetected(['a.md'], onResolve)
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.cta?.label).toBe('Resolve')
+    entry?.cta?.action()
+    expect(onResolve).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the cta when no action is supplied', () => {
+    notifyConflictDetected(['a.md'])
+    const store = useNotificationsStore()
+    expect(store.entries[0]?.cta).toBeUndefined()
+  })
+})

--- a/src/composables/useNotifications/notify-conflict-detected.ts
+++ b/src/composables/useNotifications/notify-conflict-detected.ts
@@ -1,0 +1,29 @@
+import type { NotificationCta } from '@/stores/notifications'
+import { useNotificationsStore } from '@/stores/notifications'
+
+const ctaFor = (
+  onResolve: (() => void) | undefined
+): NotificationCta | undefined =>
+  onResolve === undefined
+    ? undefined
+    : { label: 'Resolve', action: onResolve }
+
+/**
+ * Surface a sticky conflict notification listing the file count
+ * that needs resolution. When `onResolve` is supplied the toast
+ * exposes a "Resolve" CTA wired to it; callers point this at
+ * the conflict-resolution view.
+ * @param files Paths of files with unresolved merge conflicts.
+ * @param onResolve Optional CTA action that opens the resolution UI.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyConflictDetected = (
+  files: ReadonlyArray<string>,
+  onResolve?: () => void
+): string =>
+  useNotificationsStore().notify({
+    kind: 'conflict',
+    title: 'Merge conflict',
+    message: `${files.length} file(s) need resolution`,
+    cta: ctaFor(onResolve),
+  })

--- a/src/composables/useNotifications/notify-info.test.ts
+++ b/src/composables/useNotifications/notify-info.test.ts
@@ -1,0 +1,31 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyInfo } from './notify-info'
+
+describe('notifyInfo', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits an info entry with the supplied message', () => {
+    notifyInfo('Synced 3 changes')
+    const store = useNotificationsStore()
+    expect(store.entries).toHaveLength(1)
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('info')
+    expect(entry?.message).toBe('Synced 3 changes')
+  })
+
+  it('returns the entry id so callers can dismiss programmatically', () => {
+    const id = notifyInfo('hello')
+    const store = useNotificationsStore()
+    expect(id).toBe(store.entries[0]?.id)
+  })
+
+  it('does not attach a cta', () => {
+    notifyInfo('plain')
+    const store = useNotificationsStore()
+    expect(store.entries[0]?.cta).toBeUndefined()
+  })
+})

--- a/src/composables/useNotifications/notify-info.ts
+++ b/src/composables/useNotifications/notify-info.ts
@@ -1,0 +1,15 @@
+import { useNotificationsStore } from '@/stores/notifications'
+
+/**
+ * Surface a transient informational notification. Used by the
+ * sync pipeline to confirm successful drain operations and other
+ * positive feedback that should not block the user.
+ * @param msg Human-readable summary shown as the toast body.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyInfo = (msg: string): string =>
+  useNotificationsStore().notify({
+    kind: 'info',
+    title: 'Info',
+    message: msg,
+  })

--- a/src/composables/useNotifications/notify-network-down.test.ts
+++ b/src/composables/useNotifications/notify-network-down.test.ts
@@ -1,0 +1,29 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyNetworkDown } from './notify-network-down'
+
+describe('notifyNetworkDown', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits a network entry with no cta when called without a retry', () => {
+    notifyNetworkDown()
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('network')
+    expect(entry?.cta).toBeUndefined()
+  })
+
+  it('attaches a Retry cta wired to the supplied callback', () => {
+    const onRetry = vi.fn()
+    notifyNetworkDown(onRetry)
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.cta?.label).toBe('Retry')
+    expect(entry?.cta?.action).toBe(onRetry)
+    entry?.cta?.action()
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/composables/useNotifications/notify-network-down.ts
+++ b/src/composables/useNotifications/notify-network-down.ts
@@ -1,0 +1,23 @@
+import type { NotificationCta } from '@/stores/notifications'
+import { useNotificationsStore } from '@/stores/notifications'
+
+const ctaFor = (
+  onRetry: (() => void) | undefined
+): NotificationCta | undefined =>
+  onRetry === undefined ? undefined : { label: 'Retry', action: onRetry }
+
+/**
+ * Surface a sticky network notification telling the user the app
+ * is operating offline. When `onRetry` is supplied the toast
+ * exposes a "Retry" CTA wired to it; callers should use this to
+ * trigger the queued sync drain (Epic 3).
+ * @param onRetry Optional CTA action that resumes connectivity attempts.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyNetworkDown = (onRetry?: () => void): string =>
+  useNotificationsStore().notify({
+    kind: 'network',
+    title: 'Working offline',
+    message: 'Network unreachable',
+    cta: ctaFor(onRetry),
+  })

--- a/src/composables/useNotifications/notify-push-failure.test.ts
+++ b/src/composables/useNotifications/notify-push-failure.test.ts
@@ -1,0 +1,48 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyPushFailure } from './notify-push-failure'
+import type { PushFailureReason } from './push-failure-types'
+
+const REASONS: ReadonlyArray<PushFailureReason> = [
+  'network',
+  'auth',
+  'non-fast-forward',
+  'validation',
+  'unknown',
+]
+
+describe('notifyPushFailure', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits an error entry for every reason', () => {
+    for (const reason of REASONS) {
+      const store = useNotificationsStore()
+      store.clear()
+      notifyPushFailure(reason)
+      const entry = store.entries[0]
+      expect(entry?.kind).toBe('error')
+      expect(entry?.title.length).toBeGreaterThan(0)
+      expect(entry?.message?.length ?? 0).toBeGreaterThan(0)
+    }
+  })
+
+  it('appends the target ref to the message when supplied', () => {
+    notifyPushFailure('network', 'origin/develop')
+    const store = useNotificationsStore()
+    expect(store.entries[0]?.message).toContain('origin/develop')
+  })
+
+  it('produces a distinct copy per reason', () => {
+    const messages = new Set<string>()
+    for (const reason of REASONS) {
+      const store = useNotificationsStore()
+      store.clear()
+      notifyPushFailure(reason)
+      messages.add(store.entries[0]?.message ?? '')
+    }
+    expect(messages.size).toBe(REASONS.length)
+  })
+})

--- a/src/composables/useNotifications/notify-push-failure.ts
+++ b/src/composables/useNotifications/notify-push-failure.ts
@@ -1,0 +1,27 @@
+import { useNotificationsStore } from '@/stores/notifications'
+import { pushFailureCopy } from './push-failure-copy'
+import type { PushFailureReason } from './push-failure-types'
+
+const decorate = (base: string, target: string | undefined): string =>
+  target === undefined ? base : `${base} (${target})`
+
+/**
+ * Surface a sticky error notification describing why the latest
+ * push attempt failed. Optional target ref (e.g. `origin/develop`)
+ * is appended to the message so the user knows which remote was
+ * affected when several are configured.
+ * @param reason Classified push failure reason.
+ * @param target Optional remote ref to disambiguate the message.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyPushFailure = (
+  reason: PushFailureReason,
+  target?: string
+): string => {
+  const copy = pushFailureCopy(reason)
+  return useNotificationsStore().notify({
+    kind: 'error',
+    title: copy.title,
+    message: decorate(copy.message, target),
+  })
+}

--- a/src/composables/useNotifications/notify-validation-error.test.ts
+++ b/src/composables/useNotifications/notify-validation-error.test.ts
@@ -1,0 +1,20 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyValidationError } from './notify-validation-error'
+
+describe('notifyValidationError', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits an error entry naming the field and reason', () => {
+    notifyValidationError('slug', 'must be lowercase Latin')
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('error')
+    expect(entry?.title).toMatch(/validation/i)
+    expect(entry?.message).toContain('slug')
+    expect(entry?.message).toContain('must be lowercase Latin')
+  })
+})

--- a/src/composables/useNotifications/notify-validation-error.ts
+++ b/src/composables/useNotifications/notify-validation-error.ts
@@ -1,0 +1,16 @@
+import { useNotificationsStore } from '@/stores/notifications'
+
+/**
+ * Surface a non-sticky error notification reporting which form
+ * field violated validation and the human-readable reason. Use
+ * for soft validation that the user can correct in-place.
+ * @param field Name of the field that failed validation.
+ * @param why Reason fragment shown after the field name.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyValidationError = (field: string, why: string): string =>
+  useNotificationsStore().notify({
+    kind: 'error',
+    title: 'Validation failed',
+    message: `${field}: ${why}`,
+  })

--- a/src/composables/useNotifications/push-failure-copy.ts
+++ b/src/composables/useNotifications/push-failure-copy.ts
@@ -1,0 +1,43 @@
+import { Match } from 'effect'
+import type { PushFailureReason } from './push-failure-types'
+
+const FAILED = 'Push failed'
+const REJECTED = 'Push rejected'
+
+/** Title + body copy paired with a push-failure reason. */
+export type PushFailureCopy = {
+  readonly title: string
+  readonly message: string
+}
+
+/**
+ * Map a push-failure reason to user-facing title and body copy.
+ * Returning a record (not just a string) keeps the i18n boundary
+ * obvious and lets the caller decorate the message with a target
+ * ref without re-deriving the title.
+ * @param reason Classified push failure reason.
+ * @returns Title + message copy for the notification entry.
+ */
+export const pushFailureCopy = (reason: PushFailureReason): PushFailureCopy =>
+  Match.value(reason).pipe(
+    Match.when('network', () => ({
+      title: FAILED,
+      message: 'Network unreachable',
+    })),
+    Match.when('auth', () => ({
+      title: FAILED,
+      message: 'Re-authenticate to retry',
+    })),
+    Match.when('non-fast-forward', () => ({
+      title: REJECTED,
+      message: 'Remote moved on; pull or merge first',
+    })),
+    Match.when('validation', () => ({
+      title: REJECTED,
+      message: 'Server validation failed',
+    })),
+    Match.orElse(() => ({
+      title: FAILED,
+      message: 'Unexpected error',
+    }))
+  )

--- a/src/composables/useNotifications/push-failure-types.ts
+++ b/src/composables/useNotifications/push-failure-types.ts
@@ -1,0 +1,10 @@
+/**
+ * Reasons a push attempt may fail. Classification drives the
+ * notification copy and downstream retry policy in Epic 2.
+ */
+export type PushFailureReason =
+  | 'network'
+  | 'auth'
+  | 'non-fast-forward'
+  | 'validation'
+  | 'unknown'


### PR DESCRIPTION
## Summary
- Phase A / Epic 1 increment 1.4 — five typed factories so Epics 2–4 have a declarative API for offline failures, conflicts, validation errors, and informational events.
- `notifyPushFailure(reason, target?)`, `notifyConflictDetected(files, onResolve?)`, `notifyValidationError(field, why)`, `notifyNetworkDown(onRetry?)`, `notifyInfo(msg)`. Each returns the entry id for programmatic dismissal.
- `PushFailureReason` enum drives lookup via `Match.value` (no if/switch in app code) into `pushFailureCopy`.
- `NotificationToast` renders an optional CTA button when `entry.cta` is present — click runs the action and dismisses the toast.

## Out of scope
- Persistent history drawer → #81 (1.3)
- Real producers (push queue, conflict detector, etc.) → Epics 2–4

## Test plan
- [x] `bun run test:unit -- run` — 434/434 green
- [x] `bun run test:e2e -- e2e/notifications/` — 10/10 green
- [x] `bun run validate` — clean (type-check, biome ci, oxlint sonar, jsdoc, vue-depth, css)

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)