### PR TITLE
feat(notifications): persistent history drawer with IDB (#81)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "eslint": "^10.2.0",
         "eslint-plugin-jsdoc": "^62.7.0",
         "eslint-plugin-sonarjs": "4.0.0",
+        "fake-indexeddb": "^6.2.5",
         "happy-dom": "^20.6.3",
         "husky": "^9.1.7",
         "jiti": "^2.6.1",
@@ -944,6 +945,8 @@
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": "cli.js" }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 

--- a/e2e/notifications/drawer.spec.ts
+++ b/e2e/notifications/drawer.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('notifications: history drawer (1.3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('indicator click opens drawer with the queued entries', async ({
+    page,
+  }) => {
+    const drawer = page.locator('[data-testid="notification-drawer"]')
+    await expect(drawer).toBeHidden()
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    await expect(drawer).toBeVisible()
+    await expect(
+      page.locator('[data-testid="notification-drawer-item"]')
+    ).toHaveCount(2)
+  })
+
+  test('history persists across reload', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    await expect(
+      page.locator('[data-testid="notification-drawer-item"]')
+    ).toHaveCount(1)
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+    await page.locator('[data-testid="notification-indicator"]').click()
+    await expect(
+      page.locator('[data-testid="notification-drawer-item"]')
+    ).toHaveCount(1)
+  })
+
+  test('clear all empties the history', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    const items = page.locator('[data-testid="notification-drawer-item"]')
+    await expect(items).toHaveCount(2)
+    await page.locator('[data-testid="notification-drawer-clear"]').click()
+    await expect(items).toHaveCount(0)
+    await expect(
+      page.locator('[data-testid="notification-drawer-empty"]')
+    ).toBeVisible()
+  })
+
+  test('filter by kind narrows the list', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    const items = page.locator('[data-testid="notification-drawer-item"]')
+    await expect(items).toHaveCount(3)
+    await page
+      .locator('[data-testid="notification-drawer-filter-error"]')
+      .click()
+    await expect(items).toHaveCount(2)
+    for (const item of await items.all()) {
+      await expect(item).toHaveAttribute('data-kind', 'error')
+    }
+  })
+
+  test('mark all read flips items to data-read=true', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    const items = page.locator('[data-testid="notification-drawer-item"]')
+    await expect(items).toHaveCount(2)
+    await page
+      .locator('[data-testid="notification-drawer-mark-read"]')
+      .click()
+    for (const item of await items.all()) {
+      await expect(item).toHaveAttribute('data-read', 'true')
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^10.2.0",
     "eslint-plugin-jsdoc": "^62.7.0",
     "eslint-plugin-sonarjs": "4.0.0",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.6.3",
     "husky": "^9.1.7",
     "jiti": "^2.6.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,12 +14,14 @@ import {
 } from '@/composables/useDeployStatus/pending-deploy'
 import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polling'
 import type { DeployBuild } from '@/composables/useDeployStatus/workflow-types'
+import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
 const route = useRoute()
 const authStore = useAuthStore()
 const contentStore = useContentStore()
+useNotificationsPersistence()
 
 // Single app-wide poller. Pauses automatically once every visible
 // run is terminal; resumes when a save hits `requestPoll` via
@@ -65,6 +67,7 @@ watch(
 <template>
   <RouterView :key="route.fullPath" />
   <NotificationToastStack />
+  <NotificationDrawer />
   <NotificationDevTrigger />
   <SWDebugPanel />
 </template>

--- a/src/components/NotificationDrawer/DrawerFilters.vue
+++ b/src/components/NotificationDrawer/DrawerFilters.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { DRAWER_FILTERS, type DrawerFilter } from './drawer-filters'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly active: DrawerFilter }>()
+defineEmits<{ readonly select: [filter: DrawerFilter] }>()
+</script>
+
+<template>
+  <nav class="drawer-filters" aria-label="Filter by kind">
+    <button
+      v-for="filter in DRAWER_FILTERS"
+      :key="filter"
+      type="button"
+      :class="['filter-chip', { active: active === filter }]"
+      :data-testid="`${DRAWER_TEST_IDS.filter}-${filter}`"
+      :data-active="String(active === filter)"
+      @click="$emit('select', filter)"
+    >
+      {{ filter }}
+    </button>
+  </nav>
+</template>
+
+<style scoped>
+.drawer-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.filter-chip {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border, #ddd);
+  background: transparent;
+  cursor: pointer;
+}
+
+.filter-chip.active {
+  background: var(--color-accent, #4fc3f7);
+  color: #fff;
+  border-color: transparent;
+}
+</style>

--- a/src/components/NotificationDrawer/DrawerHeader.vue
+++ b/src/components/NotificationDrawer/DrawerHeader.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineEmits<{
+  readonly markRead: []
+  readonly clear: []
+  readonly close: []
+}>()
+</script>
+
+<template>
+  <header class="drawer-header">
+    <strong class="drawer-title">Notifications</strong>
+    <button
+      type="button"
+      :data-testid="DRAWER_TEST_IDS.markAllRead"
+      @click="$emit('markRead')"
+    >
+      Mark all read
+    </button>
+    <button
+      type="button"
+      :data-testid="DRAWER_TEST_IDS.clearAll"
+      @click="$emit('clear')"
+    >
+      Clear all
+    </button>
+    <button
+      type="button"
+      aria-label="Close notifications drawer"
+      :data-testid="DRAWER_TEST_IDS.close"
+      @click="$emit('close')"
+    >
+      ×
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.drawer-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.drawer-title {
+  font-size: 1rem;
+  margin-right: auto;
+}
+</style>

--- a/src/components/NotificationDrawer/DrawerList.vue
+++ b/src/components/NotificationDrawer/DrawerList.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { HistoryEntry } from '@/stores/notifications-history'
+import HistoryItem from './HistoryItem.vue'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly entries: ReadonlyArray<HistoryEntry> }>()
+defineEmits<{ readonly dismiss: [id: string] }>()
+</script>
+
+<template>
+  <section
+    v-if="entries.length === 0"
+    class="drawer-empty"
+    :data-testid="DRAWER_TEST_IDS.empty"
+  >
+    No notifications.
+  </section>
+  <ul v-else class="drawer-list">
+    <HistoryItem
+      v-for="entry in entries"
+      :key="entry.id"
+      :entry="entry"
+      @dismiss="$emit('dismiss', $event)"
+    />
+  </ul>
+</template>
+
+<style scoped>
+.drawer-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--color-text-muted, #888);
+  font-size: 0.875rem;
+}
+
+.drawer-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+</style>

--- a/src/components/NotificationDrawer/HistoryItem.vue
+++ b/src/components/NotificationDrawer/HistoryItem.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import type { HistoryEntry } from '@/stores/notifications-history'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly entry: HistoryEntry }>()
+defineEmits<{ readonly dismiss: [id: string] }>()
+</script>
+
+<template>
+  <article
+    :data-testid="DRAWER_TEST_IDS.item"
+    :data-kind="entry.kind"
+    :data-read="String(entry.readAt !== undefined)"
+    :class="['history-item', `history-item-kind-${entry.kind}`]"
+  >
+    <strong class="history-item-title">{{ entry.title }}</strong>
+    <span v-if="entry.message" class="history-item-message">
+      {{ entry.message }}
+    </span>
+    <button
+      type="button"
+      class="history-item-dismiss"
+      :aria-label="`dismiss ${entry.kind} entry`"
+      :data-testid="DRAWER_TEST_IDS.itemDismiss"
+      @click="$emit('dismiss', entry.id)"
+    >
+      ×
+    </button>
+  </article>
+</template>
+
+<style scoped>
+.history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #ddd);
+  position: relative;
+}
+
+.history-item[data-read='false'] {
+  border-left: 3px solid var(--color-accent, #4fc3f7);
+}
+
+.history-item-kind-error,
+.history-item-kind-conflict { border-color: #e57373; }
+
+.history-item-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.history-item-message {
+  font-size: 0.8125rem;
+  color: var(--color-text, #444);
+}
+
+.history-item-dismiss {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: transparent;
+  border: 0;
+  font-size: 1rem;
+  cursor: pointer;
+  color: inherit;
+  min-width: 28px;
+  min-height: 28px;
+  border-radius: 4px;
+}
+
+.history-item-dismiss:hover,
+.history-item-dismiss:focus-visible {
+  background: rgb(0 0 0 / 6%);
+  outline: none;
+}
+</style>

--- a/src/components/NotificationDrawer/NotificationDrawer.vue
+++ b/src/components/NotificationDrawer/NotificationDrawer.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { useNotificationDrawer } from '@/composables/useNotificationDrawer'
+import { useNotificationsHistoryStore } from '@/stores/notifications-history'
+import DrawerFilters from './DrawerFilters.vue'
+import DrawerHeader from './DrawerHeader.vue'
+import DrawerList from './DrawerList.vue'
+import type { DrawerFilter } from './drawer-filters'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+const drawer = useNotificationDrawer()
+const history = useNotificationsHistoryStore()
+
+const onSelectFilter = (next: DrawerFilter): void => {
+  history.filter = next
+}
+const onItemDismiss = (id: string): void => {
+  void history.removeEntry(id)
+}
+const onMarkAllRead = (): void => {
+  void history.markAllRead()
+}
+const onClearAll = (): void => {
+  void history.clear()
+}
+</script>
+
+<template>
+  <aside
+    v-if="drawer.isOpen.value"
+    class="drawer"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Notifications history"
+    :data-testid="DRAWER_TEST_IDS.drawer"
+  >
+    <DrawerHeader
+      @mark-read="onMarkAllRead"
+      @clear="onClearAll"
+      @close="drawer.close"
+    />
+    <DrawerFilters :active="history.filter" @select="onSelectFilter" />
+    <DrawerList :entries="history.visible" @dismiss="onItemDismiss" />
+  </aside>
+</template>
+
+<style scoped>
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 100vw);
+  z-index: 9991;
+  background: var(--color-background, #fff);
+  border-left: 1px solid var(--color-border, #ddd);
+  box-shadow: -4px 0 12px rgb(0 0 0 / 8%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  overflow-y: auto;
+}
+</style>

--- a/src/components/NotificationDrawer/drawer-filters.ts
+++ b/src/components/NotificationDrawer/drawer-filters.ts
@@ -1,0 +1,14 @@
+import type { NotificationKind } from '@/stores/notifications'
+
+/** Filter buttons rendered above the history list. */
+export type DrawerFilter = NotificationKind | 'all'
+
+/** Stable order of filter chips shown in the drawer toolbar. */
+export const DRAWER_FILTERS: ReadonlyArray<DrawerFilter> = [
+  'all',
+  'info',
+  'warn',
+  'error',
+  'conflict',
+  'network',
+]

--- a/src/components/NotificationDrawer/test-ids.ts
+++ b/src/components/NotificationDrawer/test-ids.ts
@@ -1,0 +1,11 @@
+/** Test IDs used by the notifications history drawer. */
+export const DRAWER_TEST_IDS = {
+  drawer: 'notification-drawer',
+  close: 'notification-drawer-close',
+  markAllRead: 'notification-drawer-mark-read',
+  clearAll: 'notification-drawer-clear',
+  empty: 'notification-drawer-empty',
+  filter: 'notification-drawer-filter',
+  item: 'notification-drawer-item',
+  itemDismiss: 'notification-drawer-item-dismiss',
+} as const

--- a/src/components/NotificationIndicator/NotificationIndicator.vue
+++ b/src/components/NotificationIndicator/NotificationIndicator.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useNotificationDrawer } from '@/composables/useNotificationDrawer'
 import { useNotifications } from '@/composables/useNotifications'
 import { formatCount } from './format-count'
 import { INDICATOR_TEST_IDS } from './test-ids'
 
+const drawer = useNotificationDrawer()
 const { entries } = useNotifications()
 const count = computed(() => entries.value.length)
 const badge = computed(() => formatCount(count.value))
@@ -20,7 +22,7 @@ const ariaLabel = computed(() =>
     class="indicator"
     :data-testid="INDICATOR_TEST_IDS.root"
     :aria-label="ariaLabel"
-    :aria-disabled="true"
+    @click="drawer.toggle"
   >
     <BellIcon />
     <span
@@ -42,7 +44,7 @@ const ariaLabel = computed(() =>
   background: transparent;
   border: 0;
   border-radius: 50%;
-  cursor: not-allowed;
+  cursor: pointer;
   color: inherit;
 }
 

--- a/src/composables/useNotificationDrawer/index.ts
+++ b/src/composables/useNotificationDrawer/index.ts
@@ -1,0 +1,2 @@
+/** Notifications history drawer open/close composable. */
+export { useNotificationDrawer } from './use-notification-drawer'

--- a/src/composables/useNotificationDrawer/use-notification-drawer.ts
+++ b/src/composables/useNotificationDrawer/use-notification-drawer.ts
@@ -1,0 +1,22 @@
+import { ref } from 'vue'
+
+const isOpen = ref(false)
+
+/**
+ * Module-shared state and actions controlling the notifications
+ * history drawer. Module-level ref keeps the API trivial for the
+ * single drawer instance the app mounts at root.
+ * @returns Reactive `isOpen` plus open/close/toggle actions.
+ */
+export const useNotificationDrawer = () => ({
+  isOpen,
+  open: (): void => {
+    isOpen.value = true
+  },
+  close: (): void => {
+    isOpen.value = false
+  },
+  toggle: (): void => {
+    isOpen.value = !isOpen.value
+  },
+})

--- a/src/composables/useNotifications/use-notification-persistence.ts
+++ b/src/composables/useNotifications/use-notification-persistence.ts
@@ -1,0 +1,45 @@
+import { storeToRefs } from 'pinia'
+import { watch } from 'vue'
+import {
+  type NotificationEntry,
+  useNotificationsStore,
+} from '@/stores/notifications'
+import { useNotificationsHistoryStore } from '@/stores/notifications-history'
+
+/**
+ * Strip non-cloneable fields (CTA actions are functions and IDB
+ * structured-clone rejects functions) before persisting. The CTA
+ * is dropped entirely — history entries are read-only records.
+ * @param entry Source queue entry.
+ * @returns IDB-safe history entry.
+ */
+const toPersistable = (entry: NotificationEntry): NotificationEntry => {
+  const { cta: _cta, ...rest } = entry
+  return rest
+}
+
+/**
+ * Wire the transient notifications queue to the persistent history
+ * store: hydrate from IDB on mount, append every new entry as it
+ * is added to the queue. Call once at app boot — typically inside
+ * a setup-only component such as `App.vue`.
+ * @returns void
+ */
+export const useNotificationsPersistence = (): void => {
+  const queue = useNotificationsStore()
+  const history = useNotificationsHistoryStore()
+  const { entries } = storeToRefs(queue)
+  void history.hydrate()
+  watch(
+    entries,
+    (next, prev) => {
+      const seen = new Set((prev ?? []).map(entry => entry.id))
+      next
+        .filter(entry => !seen.has(entry.id))
+        .forEach(entry => {
+          void history.appendEntry(toPersistable(entry))
+        })
+    },
+    { flush: 'post' }
+  )
+}

--- a/src/stores/notifications-history-actions.ts
+++ b/src/stores/notifications-history-actions.ts
@@ -1,0 +1,41 @@
+import type { Ref } from 'vue'
+import { listAll } from './notifications-history-idb'
+import {
+  append,
+  clearAll as dbClearAll,
+  markAllRead as dbMarkAllRead,
+  removeOne,
+} from './notifications-history-idb-write'
+import type { HistoryEntry } from './notifications-history-types'
+
+/**
+ * Build the async history actions bound to the supplied entries
+ * ref. Each action writes through to IDB and refreshes the ref.
+ * @param items Reactive entries ref backing the store.
+ * @returns Object exposing `refresh`, `appendEntry`, `markAllRead`,
+ *          `removeEntry`, and `clear` actions.
+ */
+export const createHistoryActions = (items: Ref<readonly HistoryEntry[]>) => {
+  const refresh = async (): Promise<void> => {
+    items.value = await listAll()
+  }
+  return {
+    refresh,
+    appendEntry: async (entry: HistoryEntry): Promise<void> => {
+      await append(entry)
+      await refresh()
+    },
+    markAllRead: async (): Promise<void> => {
+      await dbMarkAllRead()
+      await refresh()
+    },
+    removeEntry: async (id: string): Promise<void> => {
+      await removeOne(id)
+      await refresh()
+    },
+    clear: async (): Promise<void> => {
+      await dbClearAll()
+      await refresh()
+    },
+  }
+}

--- a/src/stores/notifications-history-idb-write.ts
+++ b/src/stores/notifications-history-idb-write.ts
@@ -1,0 +1,65 @@
+import {
+  fromRequest,
+  listAll,
+  MAX_HISTORY,
+  txStore,
+} from './notifications-history-idb'
+import type { HistoryEntry } from './notifications-history-types'
+
+const evictOverflow = async (): Promise<void> => {
+  const all = await listAll()
+  const overflow = all.length - MAX_HISTORY
+  const toRemove = overflow > 0 ? all.slice(0, overflow) : []
+  await Promise.all(
+    toRemove.map(async entry => {
+      const store = await txStore('readwrite')
+      await fromRequest(store.delete(entry.id))
+    })
+  )
+}
+
+/**
+ * Append a new history entry, evicting the oldest entries when the
+ * total exceeds the FIFO cap.
+ * @param entry Entry to append; id must already be assigned.
+ * @returns Resolves once write + eviction complete.
+ */
+export const append = async (entry: HistoryEntry): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.put(entry))
+  await evictOverflow()
+}
+
+/**
+ * Stamp every unread entry as read with the current timestamp.
+ * @returns Resolves once all writes complete.
+ */
+export const markAllRead = async (): Promise<void> => {
+  const all = await listAll()
+  const stamp = Date.now()
+  await Promise.all(
+    all.map(async entry => {
+      const store = await txStore('readwrite')
+      await fromRequest(store.put({ ...entry, readAt: stamp }))
+    })
+  )
+}
+
+/**
+ * Remove a single entry by id.
+ * @param id Entry id; missing ids are silently ignored.
+ * @returns Resolves once the delete completes.
+ */
+export const removeOne = async (id: string): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.delete(id))
+}
+
+/**
+ * Wipe all persisted history entries.
+ * @returns Resolves once the store is empty.
+ */
+export const clearAll = async (): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.clear())
+}

--- a/src/stores/notifications-history-idb.test.ts
+++ b/src/stores/notifications-history-idb.test.ts
@@ -1,0 +1,70 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { listAll, MAX_HISTORY } from './notifications-history-idb'
+import {
+  append,
+  clearAll,
+  markAllRead,
+  removeOne,
+} from './notifications-history-idb-write'
+import type { HistoryEntry } from './notifications-history-types'
+
+const entry = (id: string, createdAt: number): HistoryEntry => ({
+  id,
+  kind: 'info',
+  title: `t-${id}`,
+  createdAt,
+})
+
+describe('notifications history idb', () => {
+  beforeEach(async () => {
+    await clearAll()
+  })
+  afterEach(async () => {
+    await clearAll()
+  })
+
+  it('append + listAll round-trip preserves order by createdAt', async () => {
+    await append(entry('a', 200))
+    await append(entry('b', 100))
+    await append(entry('c', 300))
+    const all = await listAll()
+    expect(all.map(e => e.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('FIFO eviction trims oldest above MAX_HISTORY', async () => {
+    const total = MAX_HISTORY + 5
+    for (let i = 0; i < total; i += 1) {
+      await append(entry(`e${i}`, i))
+    }
+    const all = await listAll()
+    expect(all).toHaveLength(MAX_HISTORY)
+    expect(all[0]?.id).toBe('e5')
+    expect(all[all.length - 1]?.id).toBe(`e${total - 1}`)
+  })
+
+  it('markAllRead stamps readAt on every entry', async () => {
+    await append(entry('a', 1))
+    await append(entry('b', 2))
+    await markAllRead()
+    const all = await listAll()
+    for (const e of all) {
+      expect(e.readAt).toBeGreaterThan(0)
+    }
+  })
+
+  it('removeOne deletes only the requested id', async () => {
+    await append(entry('a', 1))
+    await append(entry('b', 2))
+    await removeOne('a')
+    const all = await listAll()
+    expect(all.map(e => e.id)).toEqual(['b'])
+  })
+
+  it('clearAll empties the store', async () => {
+    await append(entry('a', 1))
+    await append(entry('b', 2))
+    await clearAll()
+    expect(await listAll()).toEqual([])
+  })
+})

--- a/src/stores/notifications-history-idb.ts
+++ b/src/stores/notifications-history-idb.ts
@@ -1,0 +1,55 @@
+import type { HistoryEntry } from './notifications-history-types'
+
+const DB_NAME = 'admin-notifications'
+const STORE_NAME = 'history'
+const VERSION = 1
+
+/** Maximum entries retained in the persisted history. */
+export const MAX_HISTORY = 200
+
+/**
+ * Wrap an `IDBRequest` as a Promise that resolves with `result`
+ * on success and rejects with `error` on failure.
+ * @param request The IDB request to await.
+ * @returns Promise resolving with the request result.
+ */
+const promisify = <T>(request: IDBRequest<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    request.onsuccess = (): void => resolve(request.result)
+    request.onerror = (): void => reject(request.error)
+  })
+
+const openDb = (): Promise<IDBDatabase> => {
+  const req = globalThis.indexedDB.open(DB_NAME, VERSION)
+  req.onupgradeneeded = (): void => {
+    req.result.createObjectStore(STORE_NAME, { keyPath: 'id' })
+  }
+  return promisify(req)
+}
+
+/**
+ * Acquire a fresh transactional object store. Each public action
+ * opens its own transaction so async awaits never span an
+ * already-completed IDB transaction.
+ * @param mode Transaction mode.
+ * @returns Object store handle inside a fresh transaction.
+ */
+export const txStore = async (
+  mode: IDBTransactionMode
+): Promise<IDBObjectStore> => {
+  const db = await openDb()
+  return db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)
+}
+
+/** Wrap an IDBRequest as a Promise; resolves with `result`. */
+export const fromRequest = promisify
+
+/**
+ * Read every persisted history entry sorted oldest-first.
+ * @returns Frozen array of all entries.
+ */
+export const listAll = async (): Promise<readonly HistoryEntry[]> => {
+  const store = await txStore('readonly')
+  const all: readonly HistoryEntry[] = await fromRequest(store.getAll())
+  return [...all].sort((a, b) => a.createdAt - b.createdAt)
+}

--- a/src/stores/notifications-history-state.ts
+++ b/src/stores/notifications-history-state.ts
@@ -1,0 +1,34 @@
+import { ref } from 'vue'
+import { createHistoryActions } from './notifications-history-actions'
+import type { HistoryEntry } from './notifications-history-types'
+import {
+  createHistoryViews,
+  type HistoryFilter,
+} from './notifications-history-views'
+
+/**
+ * Build the reactive state and async actions for the notifications
+ * history store. Hydration is lazy — call `hydrate()` once at app
+ * boot to populate the entries ref from IDB.
+ * @returns Refs (entries, hydrated, filter) plus computed views
+ *          (visible, unreadCount) plus async actions.
+ */
+export const createNotificationsHistoryState = () => {
+  const items = ref<readonly HistoryEntry[]>([])
+  const hydrated = ref(false)
+  const filter = ref<HistoryFilter>('all')
+  const actions = createHistoryActions(items)
+  const views = createHistoryViews(items, filter)
+  const hydrate = async (): Promise<void> => {
+    await actions.refresh()
+    hydrated.value = true
+  }
+  return {
+    entries: items,
+    hydrated,
+    filter,
+    ...views,
+    hydrate,
+    ...actions,
+  }
+}

--- a/src/stores/notifications-history-types.ts
+++ b/src/stores/notifications-history-types.ts
@@ -1,0 +1,7 @@
+import type { NotificationEntry } from './notifications-types'
+
+/** Persisted history entry — same shape as a queue entry plus a
+ * read timestamp that turns "unread" into "read" in the drawer. */
+export type HistoryEntry = NotificationEntry & {
+  readonly readAt?: number
+}

--- a/src/stores/notifications-history-views.ts
+++ b/src/stores/notifications-history-views.ts
@@ -1,0 +1,27 @@
+import { computed, type Ref } from 'vue'
+import type { HistoryEntry } from './notifications-history-types'
+import type { NotificationKind } from './notifications-types'
+
+/** Filter chip selection used by the drawer. */
+export type HistoryFilter = NotificationKind | 'all'
+
+/**
+ * Build the derived state computeds for the history store: a
+ * filtered `visible` view plus an `unreadCount` for the indicator.
+ * @param items Reactive entries ref backing the store.
+ * @param filter Reactive filter chip selection.
+ * @returns Object exposing `visible` and `unreadCount` computeds.
+ */
+export const createHistoryViews = (
+  items: Ref<readonly HistoryEntry[]>,
+  filter: Ref<HistoryFilter>
+) => ({
+  visible: computed(() =>
+    filter.value === 'all'
+      ? items.value
+      : items.value.filter(e => e.kind === filter.value)
+  ),
+  unreadCount: computed(
+    () => items.value.filter(e => e.readAt === undefined).length
+  ),
+})

--- a/src/stores/notifications-history.ts
+++ b/src/stores/notifications-history.ts
@@ -1,0 +1,10 @@
+import { defineStore } from 'pinia'
+import { createNotificationsHistoryState } from './notifications-history-state'
+
+export type { HistoryEntry } from './notifications-history-types'
+
+/** Pinia store backing the persistent notifications history drawer. */
+export const useNotificationsHistoryStore = defineStore(
+  'notifications-history',
+  () => createNotificationsHistoryState()
+)


### PR DESCRIPTION
## Summary
- Phase A / Epic 1 increment 1.3 — completes Epic 1. Notifications now persist across reloads and surface via a side drawer.
- IDB layer (`src/stores/notifications-history-*`) with FIFO eviction at 200 entries; round-trip, eviction, mark-read, remove, clear covered by unit tests against `fake-indexeddb`.
- `useNotificationsPersistence` composable mounted in `App.vue` bridges the transient queue to the persistent history. Strips `cta` before write — functions are not structured-cloneable. New memory: `feedback_idb_structured_clone.md`.
- `<NotificationDrawer>` slide-in from the right, opened by the (no-longer-disabled) header bell. Decomposed into `DrawerHeader / DrawerFilters / DrawerList / HistoryItem` to satisfy the template-depth-2 budget.
- Mark-all-read stamps `readAt`; clear-all wipes IDB; filter chips narrow the list per kind; empty state shown when filtered slice is empty.

## Test plan
- [x] `bun run test:unit -- run` — 444/444 green
- [x] `bun run test:e2e -- e2e/notifications/ --project=chromium` — 10/10 green (5 toast + 5 drawer specs)
- [x] `bun run validate` — biome ci, oxlint sonar, jsdoc, vue-depth, css all clean
- [x] `fake-indexeddb` added as dev dependency for unit IDB coverage

## Out of scope / deferred
- Bell badge currently tracks live queue (kept 1.2 semantics). Persisted-unread badge can be a follow-up if product wants it.
- No focus-trap inside the drawer yet — backdrop click also not wired (close via header X). Both are common-case follow-ups.

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)