### PR TITLE
release: notifications system Epic 1 (1.1+1.2+1.3+1.4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "eslint": "^10.2.0",
         "eslint-plugin-jsdoc": "^62.7.0",
         "eslint-plugin-sonarjs": "4.0.0",
+        "fake-indexeddb": "^6.2.5",
         "happy-dom": "^20.6.3",
         "husky": "^9.1.7",
         "jiti": "^2.6.1",
@@ -944,6 +945,8 @@
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": "cli.js" }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fake-indexeddb": ["fake-indexeddb@6.2.5", "", {}, "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w=="],
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 

--- a/e2e/notifications/drawer.spec.ts
+++ b/e2e/notifications/drawer.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('notifications: history drawer (1.3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('indicator click opens drawer with the queued entries', async ({
+    page,
+  }) => {
+    const drawer = page.locator('[data-testid="notification-drawer"]')
+    await expect(drawer).toBeHidden()
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    await expect(drawer).toBeVisible()
+    await expect(
+      page.locator('[data-testid="notification-drawer-item"]')
+    ).toHaveCount(2)
+  })
+
+  test('history persists across reload', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    await expect(
+      page.locator('[data-testid="notification-drawer-item"]')
+    ).toHaveCount(1)
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+    await page.locator('[data-testid="notification-indicator"]').click()
+    await expect(
+      page.locator('[data-testid="notification-drawer-item"]')
+    ).toHaveCount(1)
+  })
+
+  test('clear all empties the history', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    const items = page.locator('[data-testid="notification-drawer-item"]')
+    await expect(items).toHaveCount(2)
+    await page.locator('[data-testid="notification-drawer-clear"]').click()
+    await expect(items).toHaveCount(0)
+    await expect(
+      page.locator('[data-testid="notification-drawer-empty"]')
+    ).toBeVisible()
+  })
+
+  test('filter by kind narrows the list', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    const items = page.locator('[data-testid="notification-drawer-item"]')
+    await expect(items).toHaveCount(3)
+    await page
+      .locator('[data-testid="notification-drawer-filter-error"]')
+      .click()
+    await expect(items).toHaveCount(2)
+    for (const item of await items.all()) {
+      await expect(item).toHaveAttribute('data-kind', 'error')
+    }
+  })
+
+  test('mark all read flips items to data-read=true', async ({ page }) => {
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await page.locator('[data-testid="notification-indicator"]').click()
+    const items = page.locator('[data-testid="notification-drawer-item"]')
+    await expect(items).toHaveCount(2)
+    await page
+      .locator('[data-testid="notification-drawer-mark-read"]')
+      .click()
+    for (const item of await items.all()) {
+      await expect(item).toHaveAttribute('data-read', 'true')
+    }
+  })
+})

--- a/e2e/notifications/toast.spec.ts
+++ b/e2e/notifications/toast.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('notifications: toast + indicator (1.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('info toast appears, can be dismissed manually', async ({ page }) => {
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeHidden()
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await expect(toast).toBeVisible()
+    await expect(toast).toContainText('info')
+    await toast.locator('[data-testid="notification-toast-dismiss"]').click()
+    await expect(toast).toBeHidden()
+  })
+
+  test('error toast is sticky and exposes a dismiss control', async ({
+    page,
+  }) => {
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-sticky', 'true')
+    const dismiss = toast.locator(
+      '[data-testid="notification-toast-dismiss"]'
+    )
+    await expect(dismiss).toHaveAttribute('aria-label', /dismiss/i)
+    await dismiss.click()
+    await expect(toast).toBeHidden()
+  })
+
+  test('indicator badge reflects the unread count', async ({ page }) => {
+    const badge = page.locator('[data-testid="notification-indicator-badge"]')
+    await expect(badge).toBeHidden()
+    await page.locator('[data-testid="notify-trigger-info"]').click()
+    await expect(badge).toHaveText('1')
+    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await expect(badge).toHaveText('2')
+  })
+
+  test('only the most recent three toasts are visible', async ({ page }) => {
+    const trigger = page.locator('[data-testid="notify-trigger-error"]')
+    for (let i = 0; i < 5; i += 1) {
+      await trigger.click()
+    }
+    const visible = page.locator('[data-testid="notification-toast"]')
+    await expect(visible).toHaveCount(3)
+  })
+
+  test('toast stack uses an aria live region', async ({ page }) => {
+    const stack = page.locator('[data-testid="notification-toast-stack"]')
+    await expect(stack).toHaveAttribute('aria-live', /polite|assertive/)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^10.2.0",
     "eslint-plugin-jsdoc": "^62.7.0",
     "eslint-plugin-sonarjs": "4.0.0",
+    "fake-indexeddb": "^6.2.5",
     "happy-dom": "^20.6.3",
     "husky": "^9.1.7",
     "jiti": "^2.6.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,12 +14,14 @@ import {
 } from '@/composables/useDeployStatus/pending-deploy'
 import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polling'
 import type { DeployBuild } from '@/composables/useDeployStatus/workflow-types'
+import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
 const route = useRoute()
 const authStore = useAuthStore()
 const contentStore = useContentStore()
+useNotificationsPersistence()
 
 // Single app-wide poller. Pauses automatically once every visible
 // run is terminal; resumes when a save hits `requestPoll` via
@@ -65,6 +67,7 @@ watch(
 <template>
   <RouterView :key="route.fullPath" />
   <NotificationToastStack />
+  <NotificationDrawer />
   <NotificationDevTrigger />
   <SWDebugPanel />
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -64,5 +64,7 @@ watch(
 
 <template>
   <RouterView :key="route.fullPath" />
+  <NotificationToastStack />
+  <NotificationDevTrigger />
   <SWDebugPanel />
 </template>

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -34,6 +34,7 @@ const hash = __COMMIT_HASH__
 
 <template>
   <AppHeader>
+    <NotificationIndicator />
     <AuthButton />
   </AppHeader>
 

--- a/src/components/NotificationDevTrigger/NotificationDevTrigger.vue
+++ b/src/components/NotificationDevTrigger/NotificationDevTrigger.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { useNotifications } from '@/composables/useNotifications'
+import type { NotificationKind } from '@/stores/notifications'
+import { DEV_TRIGGER_KINDS } from './dev-kinds'
+
+const enabled = import.meta.env.VITE_MOCK_AUTH === 'true'
+const { notify } = useNotifications()
+
+const fire = (kind: NotificationKind): void => {
+  notify({
+    kind,
+    title: `${kind} sample`,
+    message: `dev-triggered ${kind} notification`,
+  })
+}
+</script>
+
+<template>
+  <aside
+    v-if="enabled"
+    class="dev-trigger"
+    data-testid="notify-dev-trigger"
+    aria-label="Dev notification triggers"
+  >
+    <button
+      v-for="kind in DEV_TRIGGER_KINDS"
+      :key="kind"
+      type="button"
+      :data-testid="`notify-trigger-${kind}`"
+      @click="fire(kind)"
+    >
+      {{ kind }}
+    </button>
+  </aside>
+</template>
+
+<style scoped>
+.dev-trigger {
+  position: fixed;
+  top: 80px;
+  left: 12px;
+  z-index: 100;
+  display: flex;
+  gap: 4px;
+  padding: 6px;
+  background: rgb(0 0 0 / 70%);
+  border-radius: 6px;
+  font-family: monospace;
+}
+
+.dev-trigger button {
+  font-size: 11px;
+  padding: 4px 8px;
+  background: #222;
+  color: #ddd;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.dev-trigger button:hover {
+  background: #333;
+}
+</style>

--- a/src/components/NotificationDevTrigger/dev-kinds.ts
+++ b/src/components/NotificationDevTrigger/dev-kinds.ts
@@ -1,0 +1,10 @@
+import type { NotificationKind } from '@/stores/notifications'
+
+/** Notification kinds offered as quick-fire dev triggers. */
+export const DEV_TRIGGER_KINDS: ReadonlyArray<NotificationKind> = [
+  'info',
+  'warn',
+  'error',
+  'conflict',
+  'network',
+]

--- a/src/components/NotificationDrawer/DrawerFilters.vue
+++ b/src/components/NotificationDrawer/DrawerFilters.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { DRAWER_FILTERS, type DrawerFilter } from './drawer-filters'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly active: DrawerFilter }>()
+defineEmits<{ readonly select: [filter: DrawerFilter] }>()
+</script>
+
+<template>
+  <nav class="drawer-filters" aria-label="Filter by kind">
+    <button
+      v-for="filter in DRAWER_FILTERS"
+      :key="filter"
+      type="button"
+      :class="['filter-chip', { active: active === filter }]"
+      :data-testid="`${DRAWER_TEST_IDS.filter}-${filter}`"
+      :data-active="String(active === filter)"
+      @click="$emit('select', filter)"
+    >
+      {{ filter }}
+    </button>
+  </nav>
+</template>
+
+<style scoped>
+.drawer-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.filter-chip {
+  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border, #ddd);
+  background: transparent;
+  cursor: pointer;
+}
+
+.filter-chip.active {
+  background: var(--color-accent, #4fc3f7);
+  color: #fff;
+  border-color: transparent;
+}
+</style>

--- a/src/components/NotificationDrawer/DrawerHeader.vue
+++ b/src/components/NotificationDrawer/DrawerHeader.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineEmits<{
+  readonly markRead: []
+  readonly clear: []
+  readonly close: []
+}>()
+</script>
+
+<template>
+  <header class="drawer-header">
+    <strong class="drawer-title">Notifications</strong>
+    <button
+      type="button"
+      :data-testid="DRAWER_TEST_IDS.markAllRead"
+      @click="$emit('markRead')"
+    >
+      Mark all read
+    </button>
+    <button
+      type="button"
+      :data-testid="DRAWER_TEST_IDS.clearAll"
+      @click="$emit('clear')"
+    >
+      Clear all
+    </button>
+    <button
+      type="button"
+      aria-label="Close notifications drawer"
+      :data-testid="DRAWER_TEST_IDS.close"
+      @click="$emit('close')"
+    >
+      ×
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.drawer-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.drawer-title {
+  font-size: 1rem;
+  margin-right: auto;
+}
+</style>

--- a/src/components/NotificationDrawer/DrawerList.vue
+++ b/src/components/NotificationDrawer/DrawerList.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { HistoryEntry } from '@/stores/notifications-history'
+import HistoryItem from './HistoryItem.vue'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly entries: ReadonlyArray<HistoryEntry> }>()
+defineEmits<{ readonly dismiss: [id: string] }>()
+</script>
+
+<template>
+  <section
+    v-if="entries.length === 0"
+    class="drawer-empty"
+    :data-testid="DRAWER_TEST_IDS.empty"
+  >
+    No notifications.
+  </section>
+  <ul v-else class="drawer-list">
+    <HistoryItem
+      v-for="entry in entries"
+      :key="entry.id"
+      :entry="entry"
+      @dismiss="$emit('dismiss', $event)"
+    />
+  </ul>
+</template>
+
+<style scoped>
+.drawer-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--color-text-muted, #888);
+  font-size: 0.875rem;
+}
+
+.drawer-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+</style>

--- a/src/components/NotificationDrawer/HistoryItem.vue
+++ b/src/components/NotificationDrawer/HistoryItem.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+import type { HistoryEntry } from '@/stores/notifications-history'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly entry: HistoryEntry }>()
+defineEmits<{ readonly dismiss: [id: string] }>()
+</script>
+
+<template>
+  <article
+    :data-testid="DRAWER_TEST_IDS.item"
+    :data-kind="entry.kind"
+    :data-read="String(entry.readAt !== undefined)"
+    :class="['history-item', `history-item-kind-${entry.kind}`]"
+  >
+    <strong class="history-item-title">{{ entry.title }}</strong>
+    <span v-if="entry.message" class="history-item-message">
+      {{ entry.message }}
+    </span>
+    <button
+      type="button"
+      class="history-item-dismiss"
+      :aria-label="`dismiss ${entry.kind} entry`"
+      :data-testid="DRAWER_TEST_IDS.itemDismiss"
+      @click="$emit('dismiss', entry.id)"
+    >
+      ×
+    </button>
+  </article>
+</template>
+
+<style scoped>
+.history-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: 4px;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #ddd);
+  position: relative;
+}
+
+.history-item[data-read='false'] {
+  border-left: 3px solid var(--color-accent, #4fc3f7);
+}
+
+.history-item-kind-error,
+.history-item-kind-conflict { border-color: #e57373; }
+
+.history-item-title {
+  font-size: 0.875rem;
+  font-weight: 700;
+}
+
+.history-item-message {
+  font-size: 0.8125rem;
+  color: var(--color-text, #444);
+}
+
+.history-item-dismiss {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: transparent;
+  border: 0;
+  font-size: 1rem;
+  cursor: pointer;
+  color: inherit;
+  min-width: 28px;
+  min-height: 28px;
+  border-radius: 4px;
+}
+
+.history-item-dismiss:hover,
+.history-item-dismiss:focus-visible {
+  background: rgb(0 0 0 / 6%);
+  outline: none;
+}
+</style>

--- a/src/components/NotificationDrawer/NotificationDrawer.vue
+++ b/src/components/NotificationDrawer/NotificationDrawer.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { useNotificationDrawer } from '@/composables/useNotificationDrawer'
+import { useNotificationsHistoryStore } from '@/stores/notifications-history'
+import DrawerFilters from './DrawerFilters.vue'
+import DrawerHeader from './DrawerHeader.vue'
+import DrawerList from './DrawerList.vue'
+import type { DrawerFilter } from './drawer-filters'
+import { DRAWER_TEST_IDS } from './test-ids'
+
+const drawer = useNotificationDrawer()
+const history = useNotificationsHistoryStore()
+
+const onSelectFilter = (next: DrawerFilter): void => {
+  history.filter = next
+}
+const onItemDismiss = (id: string): void => {
+  void history.removeEntry(id)
+}
+const onMarkAllRead = (): void => {
+  void history.markAllRead()
+}
+const onClearAll = (): void => {
+  void history.clear()
+}
+</script>
+
+<template>
+  <aside
+    v-if="drawer.isOpen.value"
+    class="drawer"
+    role="dialog"
+    aria-modal="true"
+    aria-label="Notifications history"
+    :data-testid="DRAWER_TEST_IDS.drawer"
+  >
+    <DrawerHeader
+      @mark-read="onMarkAllRead"
+      @clear="onClearAll"
+      @close="drawer.close"
+    />
+    <DrawerFilters :active="history.filter" @select="onSelectFilter" />
+    <DrawerList :entries="history.visible" @dismiss="onItemDismiss" />
+  </aside>
+</template>
+
+<style scoped>
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(360px, 100vw);
+  z-index: 9991;
+  background: var(--color-background, #fff);
+  border-left: 1px solid var(--color-border, #ddd);
+  box-shadow: -4px 0 12px rgb(0 0 0 / 8%);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  overflow-y: auto;
+}
+</style>

--- a/src/components/NotificationDrawer/drawer-filters.ts
+++ b/src/components/NotificationDrawer/drawer-filters.ts
@@ -1,0 +1,14 @@
+import type { NotificationKind } from '@/stores/notifications'
+
+/** Filter buttons rendered above the history list. */
+export type DrawerFilter = NotificationKind | 'all'
+
+/** Stable order of filter chips shown in the drawer toolbar. */
+export const DRAWER_FILTERS: ReadonlyArray<DrawerFilter> = [
+  'all',
+  'info',
+  'warn',
+  'error',
+  'conflict',
+  'network',
+]

--- a/src/components/NotificationDrawer/test-ids.ts
+++ b/src/components/NotificationDrawer/test-ids.ts
@@ -1,0 +1,11 @@
+/** Test IDs used by the notifications history drawer. */
+export const DRAWER_TEST_IDS = {
+  drawer: 'notification-drawer',
+  close: 'notification-drawer-close',
+  markAllRead: 'notification-drawer-mark-read',
+  clearAll: 'notification-drawer-clear',
+  empty: 'notification-drawer-empty',
+  filter: 'notification-drawer-filter',
+  item: 'notification-drawer-item',
+  itemDismiss: 'notification-drawer-item-dismiss',
+} as const

--- a/src/components/NotificationIndicator/BellIcon.vue
+++ b/src/components/NotificationIndicator/BellIcon.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const PATH =
+  'M12 22a2 2 0 0 0 2-2h-4a2 2 0 0 0 2 2zm6-6V11a6 6 0 1 0-12 0v5l-2 2v1h16v-1l-2-2z'
+</script>
+
+<template>
+  <svg
+    class="bell-icon"
+    viewBox="0 0 24 24"
+    width="18"
+    height="18"
+    aria-hidden="true"
+    fill="currentColor"
+  >
+    <path :d="PATH" />
+  </svg>
+</template>
+
+<style scoped>
+.bell-icon {
+  pointer-events: none;
+}
+</style>

--- a/src/components/NotificationIndicator/NotificationIndicator.vue
+++ b/src/components/NotificationIndicator/NotificationIndicator.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNotifications } from '@/composables/useNotifications'
+import { formatCount } from './format-count'
+import { INDICATOR_TEST_IDS } from './test-ids'
+
+const { entries } = useNotifications()
+const count = computed(() => entries.value.length)
+const badge = computed(() => formatCount(count.value))
+const ariaLabel = computed(() =>
+  count.value === 0
+    ? 'Notifications: none unread'
+    : `Notifications: ${count.value} unread`
+)
+</script>
+
+<template>
+  <button
+    type="button"
+    class="indicator"
+    :data-testid="INDICATOR_TEST_IDS.root"
+    :aria-label="ariaLabel"
+    :aria-disabled="true"
+  >
+    <BellIcon />
+    <span
+      v-if="badge"
+      :data-testid="INDICATOR_TEST_IDS.badge"
+      class="indicator-badge"
+    >{{ badge }}</span>
+  </button>
+</template>
+
+<style scoped>
+.indicator {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: transparent;
+  border: 0;
+  border-radius: 50%;
+  cursor: not-allowed;
+  color: inherit;
+}
+
+.indicator:focus-visible {
+  outline: 2px solid var(--color-accent, #4fc3f7);
+  outline-offset: 2px;
+}
+
+.indicator-icon {
+  pointer-events: none;
+}
+
+.indicator-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+  color: #fff;
+  background: var(--color-error, #e53935);
+  border-radius: 9px;
+  border: 2px solid var(--color-background, #fff);
+}
+</style>

--- a/src/components/NotificationIndicator/NotificationIndicator.vue
+++ b/src/components/NotificationIndicator/NotificationIndicator.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useNotificationDrawer } from '@/composables/useNotificationDrawer'
 import { useNotifications } from '@/composables/useNotifications'
 import { formatCount } from './format-count'
 import { INDICATOR_TEST_IDS } from './test-ids'
 
+const drawer = useNotificationDrawer()
 const { entries } = useNotifications()
 const count = computed(() => entries.value.length)
 const badge = computed(() => formatCount(count.value))
@@ -20,7 +22,7 @@ const ariaLabel = computed(() =>
     class="indicator"
     :data-testid="INDICATOR_TEST_IDS.root"
     :aria-label="ariaLabel"
-    :aria-disabled="true"
+    @click="drawer.toggle"
   >
     <BellIcon />
     <span
@@ -42,7 +44,7 @@ const ariaLabel = computed(() =>
   background: transparent;
   border: 0;
   border-radius: 50%;
-  cursor: not-allowed;
+  cursor: pointer;
   color: inherit;
 }
 

--- a/src/components/NotificationIndicator/format-count.test.ts
+++ b/src/components/NotificationIndicator/format-count.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { formatCount } from './format-count'
+
+describe('formatCount', () => {
+  it('returns empty string for zero', () => {
+    expect(formatCount(0)).toBe('')
+  })
+
+  it('returns the count verbatim for 1-9', () => {
+    expect(formatCount(1)).toBe('1')
+    expect(formatCount(9)).toBe('9')
+  })
+
+  it('returns the count verbatim for 10-99', () => {
+    expect(formatCount(10)).toBe('10')
+    expect(formatCount(99)).toBe('99')
+  })
+
+  it('caps at 99+ above the two-digit boundary', () => {
+    expect(formatCount(100)).toBe('99+')
+    expect(formatCount(9999)).toBe('99+')
+  })
+
+  it('clamps negatives and floors fractions', () => {
+    expect(formatCount(-1)).toBe('')
+    expect(formatCount(2.7)).toBe('2')
+  })
+})

--- a/src/components/NotificationIndicator/format-count.ts
+++ b/src/components/NotificationIndicator/format-count.ts
@@ -1,0 +1,21 @@
+/** Maximum count rendered exactly before falling back to '9+' / '99+'. */
+const SINGLE_DIGIT_MAX = 9
+const TWO_DIGIT_MAX = 99
+
+/**
+ * Render a notification count for the header badge. Counts above 9
+ * collapse to "9+", counts above 99 collapse to "99+", and zero
+ * returns an empty string so the caller can hide the badge entirely.
+ * @param count Non-negative integer count of unread notifications.
+ * @returns Display string for the badge or '' to hide it.
+ */
+export const formatCount = (count: number): string => {
+  const safe = Math.max(0, Math.floor(count))
+  return safe === 0
+    ? ''
+    : safe <= SINGLE_DIGIT_MAX
+      ? String(safe)
+      : safe <= TWO_DIGIT_MAX
+        ? `${safe}`
+        : '99+'
+}

--- a/src/components/NotificationIndicator/test-ids.ts
+++ b/src/components/NotificationIndicator/test-ids.ts
@@ -1,0 +1,5 @@
+/** Test IDs used by the header notification indicator. */
+export const INDICATOR_TEST_IDS = {
+  root: 'notification-indicator',
+  badge: 'notification-indicator-badge',
+} as const

--- a/src/components/NotificationToast/NotificationToast.test.ts
+++ b/src/components/NotificationToast/NotificationToast.test.ts
@@ -1,0 +1,60 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { NotificationEntry } from '@/stores/notifications'
+import { useNotificationsStore } from '@/stores/notifications'
+import NotificationToast from './NotificationToast.vue'
+import { TOAST_TEST_IDS } from './test-ids'
+
+const buildEntry = (
+  overrides: Partial<NotificationEntry> = {}
+): NotificationEntry => ({
+  id: 'fixed-id',
+  kind: 'error',
+  title: 'A title',
+  createdAt: 1,
+  ...overrides,
+})
+
+describe('NotificationToast', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders title and message', () => {
+    const entry = buildEntry({ message: 'something broke' })
+    const wrapper = mount(NotificationToast, { props: { entry } })
+    expect(wrapper.text()).toContain('A title')
+    expect(wrapper.text()).toContain('something broke')
+  })
+
+  it('omits the cta button when entry has no cta', () => {
+    const wrapper = mount(NotificationToast, {
+      props: { entry: buildEntry() },
+    })
+    expect(
+      wrapper.find(`[data-testid="${TOAST_TEST_IDS.cta}"]`).exists()
+    ).toBe(false)
+  })
+
+  it('renders the cta button and runs the supplied action on click', async () => {
+    const action = vi.fn()
+    const store = useNotificationsStore()
+    store.notify({
+      kind: 'network',
+      title: 'down',
+      cta: { label: 'Retry', action },
+    })
+    const real = store.entries[0]
+    expect(real).toBeDefined()
+    const wrapper = mount(NotificationToast, {
+      props: { entry: real as NotificationEntry },
+    })
+    const cta = wrapper.find(`[data-testid="${TOAST_TEST_IDS.cta}"]`)
+    expect(cta.exists()).toBe(true)
+    expect(cta.text()).toBe('Retry')
+    await cta.trigger('click')
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(store.entries).toHaveLength(0)
+  })
+})

--- a/src/components/NotificationToast/NotificationToast.vue
+++ b/src/components/NotificationToast/NotificationToast.vue
@@ -13,6 +13,11 @@ const onDismiss = (): void => {
   dismiss(props.entry.id)
 }
 
+const onCta = (): void => {
+  props.entry.cta?.action()
+  dismiss(props.entry.id)
+}
+
 let cancel: (() => void) | undefined
 onMounted(() => {
   cancel = scheduleAutoDismiss(props.entry.kind, onDismiss)
@@ -38,6 +43,15 @@ onUnmounted(() => {
       :data-testid="TOAST_TEST_IDS.message"
       class="toast-message"
     >{{ entry.message }}</span>
+    <button
+      v-if="entry.cta"
+      type="button"
+      class="toast-cta"
+      :data-testid="TOAST_TEST_IDS.cta"
+      @click="onCta"
+    >
+      {{ entry.cta.label }}
+    </button>
     <button
       type="button"
       class="toast-dismiss"
@@ -80,8 +94,26 @@ onUnmounted(() => {
   color: var(--color-text, #444);
 }
 
-.toast-dismiss {
+.toast-cta {
   margin-left: auto;
+  background: var(--color-accent, #4fc3f7);
+  color: #fff;
+  border: 0;
+  border-radius: 4px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  padding: 4px 10px;
+  cursor: pointer;
+  min-height: 28px;
+}
+
+.toast-cta:hover,
+.toast-cta:focus-visible {
+  filter: brightness(110%);
+  outline: none;
+}
+
+.toast-dismiss {
   background: transparent;
   border: 0;
   font-size: 1.25rem;
@@ -90,6 +122,11 @@ onUnmounted(() => {
   min-width: 32px;
   min-height: 32px;
   border-radius: 4px;
+  margin-left: auto;
+}
+
+.toast-cta + .toast-dismiss {
+  margin-left: 0;
 }
 
 .toast-dismiss:hover,

--- a/src/components/NotificationToast/NotificationToast.vue
+++ b/src/components/NotificationToast/NotificationToast.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { onMounted, onUnmounted } from 'vue'
+import { useNotifications } from '@/composables/useNotifications'
+import type { NotificationEntry } from '@/stores/notifications'
+import { scheduleAutoDismiss } from './auto-dismiss'
+import { isStickyKind } from './is-sticky-kind'
+import { TOAST_TEST_IDS } from './test-ids'
+
+const props = defineProps<{ readonly entry: NotificationEntry }>()
+const { dismiss } = useNotifications()
+
+const onDismiss = (): void => {
+  dismiss(props.entry.id)
+}
+
+let cancel: (() => void) | undefined
+onMounted(() => {
+  cancel = scheduleAutoDismiss(props.entry.kind, onDismiss)
+})
+onUnmounted(() => {
+  cancel?.()
+})
+</script>
+
+<template>
+  <article
+    :data-testid="TOAST_TEST_IDS.toast"
+    :data-kind="entry.kind"
+    :data-sticky="String(isStickyKind(entry.kind))"
+    :class="['toast', `toast-kind-${entry.kind}`]"
+    :role="isStickyKind(entry.kind) ? 'alert' : 'status'"
+  >
+    <strong :data-testid="TOAST_TEST_IDS.title" class="toast-title">
+      {{ entry.title }}
+    </strong>
+    <span
+      v-if="entry.message"
+      :data-testid="TOAST_TEST_IDS.message"
+      class="toast-message"
+    >{{ entry.message }}</span>
+    <button
+      type="button"
+      class="toast-dismiss"
+      :aria-label="`dismiss ${entry.kind} notification`"
+      :data-testid="TOAST_TEST_IDS.dismiss"
+      @click="onDismiss"
+    >
+      ×
+    </button>
+  </article>
+</template>
+
+<style scoped>
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-border, #ddd);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 12%);
+  min-width: 240px;
+  max-width: 360px;
+}
+
+.toast-kind-info { border-left: 3px solid #4fc3f7; }
+.toast-kind-warn { border-left: 3px solid #ffb74d; }
+.toast-kind-error { border-left: 3px solid #e57373; }
+.toast-kind-conflict { border-left: 3px solid #ba68c8; }
+.toast-kind-network { border-left: 3px solid #aed581; }
+
+.toast-title {
+  font-weight: 700;
+  font-size: 0.875rem;
+}
+
+.toast-message {
+  font-size: 0.8125rem;
+  color: var(--color-text, #444);
+}
+
+.toast-dismiss {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  font-size: 1.25rem;
+  cursor: pointer;
+  color: inherit;
+  min-width: 32px;
+  min-height: 32px;
+  border-radius: 4px;
+}
+
+.toast-dismiss:hover,
+.toast-dismiss:focus-visible {
+  background: rgb(0 0 0 / 6%);
+  outline: none;
+}
+</style>

--- a/src/components/NotificationToast/NotificationToastStack.vue
+++ b/src/components/NotificationToast/NotificationToastStack.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNotifications } from '@/composables/useNotifications'
+import NotificationToast from './NotificationToast.vue'
+import { TOAST_TEST_IDS } from './test-ids'
+
+const MAX_VISIBLE = 3
+
+const { entries } = useNotifications()
+const visible = computed(() => entries.value.slice(-MAX_VISIBLE).reverse())
+</script>
+
+<template>
+  <output
+    :data-testid="TOAST_TEST_IDS.stack"
+    class="toast-stack"
+    aria-live="polite"
+    aria-atomic="false"
+  >
+    <NotificationToast
+      v-for="entry in visible"
+      :key="entry.id"
+      :entry="entry"
+    />
+  </output>
+</template>
+
+<style scoped>
+.toast-stack {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  z-index: var(--z-toast, 9990);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: max-content;
+}
+
+@media (width <= 600px) {
+  .toast-stack {
+    left: 16px;
+    right: 16px;
+  }
+}
+</style>

--- a/src/components/NotificationToast/auto-dismiss.test.ts
+++ b/src/components/NotificationToast/auto-dismiss.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AUTO_DISMISS_MS, scheduleAutoDismiss } from './auto-dismiss'
+
+describe('scheduleAutoDismiss', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires dismiss after the timeout for transient kinds', () => {
+    const dismiss = vi.fn()
+    scheduleAutoDismiss('info', dismiss)
+    vi.advanceTimersByTime(AUTO_DISMISS_MS - 1)
+    expect(dismiss).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire for sticky kinds', () => {
+    const dismiss = vi.fn()
+    const cleanup = scheduleAutoDismiss('error', dismiss)
+    vi.advanceTimersByTime(AUTO_DISMISS_MS * 4)
+    expect(dismiss).not.toHaveBeenCalled()
+    cleanup()
+  })
+
+  it('cleanup cancels a pending dismiss', () => {
+    const dismiss = vi.fn()
+    const cleanup = scheduleAutoDismiss('warn', dismiss)
+    vi.advanceTimersByTime(AUTO_DISMISS_MS - 100)
+    cleanup()
+    vi.advanceTimersByTime(AUTO_DISMISS_MS * 2)
+    expect(dismiss).not.toHaveBeenCalled()
+  })
+
+  it('cleanup is idempotent for sticky kinds', () => {
+    const cleanup = scheduleAutoDismiss('conflict', vi.fn())
+    expect(() => {
+      cleanup()
+      cleanup()
+    }).not.toThrow()
+  })
+})

--- a/src/components/NotificationToast/auto-dismiss.ts
+++ b/src/components/NotificationToast/auto-dismiss.ts
@@ -1,0 +1,26 @@
+import type { NotificationKind } from '@/stores/notifications'
+import { isStickyKind } from './is-sticky-kind'
+
+/** Auto-dismiss delay (ms) for transient toasts. */
+export const AUTO_DISMISS_MS = 5_000
+
+/**
+ * Schedule an auto-dismiss for a transient notification. Sticky
+ * kinds (error/conflict/network) skip arming the timer entirely so
+ * the toast persists until the user dismisses it. The returned
+ * cleanup is safe to call regardless of kind.
+ * @param kind Notification kind that determines stickiness.
+ * @param dismiss Callback fired once the timer elapses.
+ * @returns Cleanup function the caller invokes on unmount.
+ */
+export const scheduleAutoDismiss = (
+  kind: NotificationKind,
+  dismiss: () => void
+): (() => void) => {
+  const handle = isStickyKind(kind)
+    ? undefined
+    : globalThis.setTimeout(dismiss, AUTO_DISMISS_MS)
+  return (): void => {
+    globalThis.clearTimeout(handle)
+  }
+}

--- a/src/components/NotificationToast/is-sticky-kind.test.ts
+++ b/src/components/NotificationToast/is-sticky-kind.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { isStickyKind } from './is-sticky-kind'
+
+describe('isStickyKind', () => {
+  it('treats failure-class kinds as sticky', () => {
+    expect(isStickyKind('error')).toBe(true)
+    expect(isStickyKind('conflict')).toBe(true)
+    expect(isStickyKind('network')).toBe(true)
+  })
+
+  it('treats informational kinds as transient', () => {
+    expect(isStickyKind('info')).toBe(false)
+    expect(isStickyKind('warn')).toBe(false)
+  })
+})

--- a/src/components/NotificationToast/is-sticky-kind.ts
+++ b/src/components/NotificationToast/is-sticky-kind.ts
@@ -1,0 +1,18 @@
+import type { NotificationKind } from '@/stores/notifications'
+
+const STICKY: ReadonlySet<NotificationKind> = new Set([
+  'error',
+  'conflict',
+  'network',
+])
+
+/**
+ * A notification kind is "sticky" when the toast must stay on screen
+ * until the user dismisses it explicitly. Informational kinds are
+ * transient, so they auto-dismiss; failure-class kinds are sticky so
+ * the user does not lose actionable information.
+ * @param kind Notification kind to classify.
+ * @returns True when the kind requires explicit dismissal.
+ */
+export const isStickyKind = (kind: NotificationKind): boolean =>
+  STICKY.has(kind)

--- a/src/components/NotificationToast/test-ids.ts
+++ b/src/components/NotificationToast/test-ids.ts
@@ -5,4 +5,5 @@ export const TOAST_TEST_IDS = {
   title: 'notification-toast-title',
   message: 'notification-toast-message',
   dismiss: 'notification-toast-dismiss',
+  cta: 'notification-toast-cta',
 } as const

--- a/src/components/NotificationToast/test-ids.ts
+++ b/src/components/NotificationToast/test-ids.ts
@@ -1,0 +1,8 @@
+/** Test IDs used by the toast surface so tests can locate elements. */
+export const TOAST_TEST_IDS = {
+  stack: 'notification-toast-stack',
+  toast: 'notification-toast',
+  title: 'notification-toast-title',
+  message: 'notification-toast-message',
+  dismiss: 'notification-toast-dismiss',
+} as const

--- a/src/composables/README.md
+++ b/src/composables/README.md
@@ -12,3 +12,4 @@ Vue composables encapsulating business logic. Each composable is decomposed into
 - `useOAuthPopup` -- PKCE OAuth popup flow (authorize URL, popup monitor, token exchange)
 - `useDropdown` -- dropdown open/close state
 - `useUnsavedGuard` -- warn before navigating away with unsaved changes
+- `useNotifications` -- reactive notifications API; returns readonly entries and bound `notify` / `dismiss` / `clear` actions backed by the `notifications` Pinia store

--- a/src/composables/useNotificationDrawer/index.ts
+++ b/src/composables/useNotificationDrawer/index.ts
@@ -1,0 +1,2 @@
+/** Notifications history drawer open/close composable. */
+export { useNotificationDrawer } from './use-notification-drawer'

--- a/src/composables/useNotificationDrawer/use-notification-drawer.ts
+++ b/src/composables/useNotificationDrawer/use-notification-drawer.ts
@@ -1,0 +1,22 @@
+import { ref } from 'vue'
+
+const isOpen = ref(false)
+
+/**
+ * Module-shared state and actions controlling the notifications
+ * history drawer. Module-level ref keeps the API trivial for the
+ * single drawer instance the app mounts at root.
+ * @returns Reactive `isOpen` plus open/close/toggle actions.
+ */
+export const useNotificationDrawer = () => ({
+  isOpen,
+  open: (): void => {
+    isOpen.value = true
+  },
+  close: (): void => {
+    isOpen.value = false
+  },
+  toggle: (): void => {
+    isOpen.value = !isOpen.value
+  },
+})

--- a/src/composables/useNotifications/index.ts
+++ b/src/composables/useNotifications/index.ts
@@ -1,0 +1,2 @@
+/** Reactive notifications composable. */
+export { useNotifications } from './use-notifications'

--- a/src/composables/useNotifications/index.ts
+++ b/src/composables/useNotifications/index.ts
@@ -1,2 +1,9 @@
-/** Reactive notifications composable. */
+/** Reactive notifications composable + typed factories per category. */
+
+export { notifyConflictDetected } from './notify-conflict-detected'
+export { notifyInfo } from './notify-info'
+export { notifyNetworkDown } from './notify-network-down'
+export { notifyPushFailure } from './notify-push-failure'
+export { notifyValidationError } from './notify-validation-error'
+export type { PushFailureReason } from './push-failure-types'
 export { useNotifications } from './use-notifications'

--- a/src/composables/useNotifications/notify-conflict-detected.test.ts
+++ b/src/composables/useNotifications/notify-conflict-detected.test.ts
@@ -1,0 +1,34 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyConflictDetected } from './notify-conflict-detected'
+
+describe('notifyConflictDetected', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits a conflict entry mentioning the file count', () => {
+    notifyConflictDetected(['a.md', 'b.md', 'c.md'])
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('conflict')
+    expect(entry?.message).toContain('3')
+  })
+
+  it('attaches a Resolve cta when an action is supplied', () => {
+    const onResolve = vi.fn()
+    notifyConflictDetected(['a.md'], onResolve)
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.cta?.label).toBe('Resolve')
+    entry?.cta?.action()
+    expect(onResolve).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the cta when no action is supplied', () => {
+    notifyConflictDetected(['a.md'])
+    const store = useNotificationsStore()
+    expect(store.entries[0]?.cta).toBeUndefined()
+  })
+})

--- a/src/composables/useNotifications/notify-conflict-detected.ts
+++ b/src/composables/useNotifications/notify-conflict-detected.ts
@@ -1,0 +1,29 @@
+import type { NotificationCta } from '@/stores/notifications'
+import { useNotificationsStore } from '@/stores/notifications'
+
+const ctaFor = (
+  onResolve: (() => void) | undefined
+): NotificationCta | undefined =>
+  onResolve === undefined
+    ? undefined
+    : { label: 'Resolve', action: onResolve }
+
+/**
+ * Surface a sticky conflict notification listing the file count
+ * that needs resolution. When `onResolve` is supplied the toast
+ * exposes a "Resolve" CTA wired to it; callers point this at
+ * the conflict-resolution view.
+ * @param files Paths of files with unresolved merge conflicts.
+ * @param onResolve Optional CTA action that opens the resolution UI.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyConflictDetected = (
+  files: ReadonlyArray<string>,
+  onResolve?: () => void
+): string =>
+  useNotificationsStore().notify({
+    kind: 'conflict',
+    title: 'Merge conflict',
+    message: `${files.length} file(s) need resolution`,
+    cta: ctaFor(onResolve),
+  })

--- a/src/composables/useNotifications/notify-info.test.ts
+++ b/src/composables/useNotifications/notify-info.test.ts
@@ -1,0 +1,31 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyInfo } from './notify-info'
+
+describe('notifyInfo', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits an info entry with the supplied message', () => {
+    notifyInfo('Synced 3 changes')
+    const store = useNotificationsStore()
+    expect(store.entries).toHaveLength(1)
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('info')
+    expect(entry?.message).toBe('Synced 3 changes')
+  })
+
+  it('returns the entry id so callers can dismiss programmatically', () => {
+    const id = notifyInfo('hello')
+    const store = useNotificationsStore()
+    expect(id).toBe(store.entries[0]?.id)
+  })
+
+  it('does not attach a cta', () => {
+    notifyInfo('plain')
+    const store = useNotificationsStore()
+    expect(store.entries[0]?.cta).toBeUndefined()
+  })
+})

--- a/src/composables/useNotifications/notify-info.ts
+++ b/src/composables/useNotifications/notify-info.ts
@@ -1,0 +1,15 @@
+import { useNotificationsStore } from '@/stores/notifications'
+
+/**
+ * Surface a transient informational notification. Used by the
+ * sync pipeline to confirm successful drain operations and other
+ * positive feedback that should not block the user.
+ * @param msg Human-readable summary shown as the toast body.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyInfo = (msg: string): string =>
+  useNotificationsStore().notify({
+    kind: 'info',
+    title: 'Info',
+    message: msg,
+  })

--- a/src/composables/useNotifications/notify-network-down.test.ts
+++ b/src/composables/useNotifications/notify-network-down.test.ts
@@ -1,0 +1,29 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyNetworkDown } from './notify-network-down'
+
+describe('notifyNetworkDown', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits a network entry with no cta when called without a retry', () => {
+    notifyNetworkDown()
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('network')
+    expect(entry?.cta).toBeUndefined()
+  })
+
+  it('attaches a Retry cta wired to the supplied callback', () => {
+    const onRetry = vi.fn()
+    notifyNetworkDown(onRetry)
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.cta?.label).toBe('Retry')
+    expect(entry?.cta?.action).toBe(onRetry)
+    entry?.cta?.action()
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/composables/useNotifications/notify-network-down.ts
+++ b/src/composables/useNotifications/notify-network-down.ts
@@ -1,0 +1,23 @@
+import type { NotificationCta } from '@/stores/notifications'
+import { useNotificationsStore } from '@/stores/notifications'
+
+const ctaFor = (
+  onRetry: (() => void) | undefined
+): NotificationCta | undefined =>
+  onRetry === undefined ? undefined : { label: 'Retry', action: onRetry }
+
+/**
+ * Surface a sticky network notification telling the user the app
+ * is operating offline. When `onRetry` is supplied the toast
+ * exposes a "Retry" CTA wired to it; callers should use this to
+ * trigger the queued sync drain (Epic 3).
+ * @param onRetry Optional CTA action that resumes connectivity attempts.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyNetworkDown = (onRetry?: () => void): string =>
+  useNotificationsStore().notify({
+    kind: 'network',
+    title: 'Working offline',
+    message: 'Network unreachable',
+    cta: ctaFor(onRetry),
+  })

--- a/src/composables/useNotifications/notify-push-failure.test.ts
+++ b/src/composables/useNotifications/notify-push-failure.test.ts
@@ -1,0 +1,48 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyPushFailure } from './notify-push-failure'
+import type { PushFailureReason } from './push-failure-types'
+
+const REASONS: ReadonlyArray<PushFailureReason> = [
+  'network',
+  'auth',
+  'non-fast-forward',
+  'validation',
+  'unknown',
+]
+
+describe('notifyPushFailure', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits an error entry for every reason', () => {
+    for (const reason of REASONS) {
+      const store = useNotificationsStore()
+      store.clear()
+      notifyPushFailure(reason)
+      const entry = store.entries[0]
+      expect(entry?.kind).toBe('error')
+      expect(entry?.title.length).toBeGreaterThan(0)
+      expect(entry?.message?.length ?? 0).toBeGreaterThan(0)
+    }
+  })
+
+  it('appends the target ref to the message when supplied', () => {
+    notifyPushFailure('network', 'origin/develop')
+    const store = useNotificationsStore()
+    expect(store.entries[0]?.message).toContain('origin/develop')
+  })
+
+  it('produces a distinct copy per reason', () => {
+    const messages = new Set<string>()
+    for (const reason of REASONS) {
+      const store = useNotificationsStore()
+      store.clear()
+      notifyPushFailure(reason)
+      messages.add(store.entries[0]?.message ?? '')
+    }
+    expect(messages.size).toBe(REASONS.length)
+  })
+})

--- a/src/composables/useNotifications/notify-push-failure.ts
+++ b/src/composables/useNotifications/notify-push-failure.ts
@@ -1,0 +1,27 @@
+import { useNotificationsStore } from '@/stores/notifications'
+import { pushFailureCopy } from './push-failure-copy'
+import type { PushFailureReason } from './push-failure-types'
+
+const decorate = (base: string, target: string | undefined): string =>
+  target === undefined ? base : `${base} (${target})`
+
+/**
+ * Surface a sticky error notification describing why the latest
+ * push attempt failed. Optional target ref (e.g. `origin/develop`)
+ * is appended to the message so the user knows which remote was
+ * affected when several are configured.
+ * @param reason Classified push failure reason.
+ * @param target Optional remote ref to disambiguate the message.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyPushFailure = (
+  reason: PushFailureReason,
+  target?: string
+): string => {
+  const copy = pushFailureCopy(reason)
+  return useNotificationsStore().notify({
+    kind: 'error',
+    title: copy.title,
+    message: decorate(copy.message, target),
+  })
+}

--- a/src/composables/useNotifications/notify-validation-error.test.ts
+++ b/src/composables/useNotifications/notify-validation-error.test.ts
@@ -1,0 +1,20 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from '@/stores/notifications'
+import { notifyValidationError } from './notify-validation-error'
+
+describe('notifyValidationError', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('emits an error entry naming the field and reason', () => {
+    notifyValidationError('slug', 'must be lowercase Latin')
+    const store = useNotificationsStore()
+    const entry = store.entries[0]
+    expect(entry?.kind).toBe('error')
+    expect(entry?.title).toMatch(/validation/i)
+    expect(entry?.message).toContain('slug')
+    expect(entry?.message).toContain('must be lowercase Latin')
+  })
+})

--- a/src/composables/useNotifications/notify-validation-error.ts
+++ b/src/composables/useNotifications/notify-validation-error.ts
@@ -1,0 +1,16 @@
+import { useNotificationsStore } from '@/stores/notifications'
+
+/**
+ * Surface a non-sticky error notification reporting which form
+ * field violated validation and the human-readable reason. Use
+ * for soft validation that the user can correct in-place.
+ * @param field Name of the field that failed validation.
+ * @param why Reason fragment shown after the field name.
+ * @returns Id of the emitted notification entry.
+ */
+export const notifyValidationError = (field: string, why: string): string =>
+  useNotificationsStore().notify({
+    kind: 'error',
+    title: 'Validation failed',
+    message: `${field}: ${why}`,
+  })

--- a/src/composables/useNotifications/push-failure-copy.ts
+++ b/src/composables/useNotifications/push-failure-copy.ts
@@ -1,0 +1,43 @@
+import { Match } from 'effect'
+import type { PushFailureReason } from './push-failure-types'
+
+const FAILED = 'Push failed'
+const REJECTED = 'Push rejected'
+
+/** Title + body copy paired with a push-failure reason. */
+export type PushFailureCopy = {
+  readonly title: string
+  readonly message: string
+}
+
+/**
+ * Map a push-failure reason to user-facing title and body copy.
+ * Returning a record (not just a string) keeps the i18n boundary
+ * obvious and lets the caller decorate the message with a target
+ * ref without re-deriving the title.
+ * @param reason Classified push failure reason.
+ * @returns Title + message copy for the notification entry.
+ */
+export const pushFailureCopy = (reason: PushFailureReason): PushFailureCopy =>
+  Match.value(reason).pipe(
+    Match.when('network', () => ({
+      title: FAILED,
+      message: 'Network unreachable',
+    })),
+    Match.when('auth', () => ({
+      title: FAILED,
+      message: 'Re-authenticate to retry',
+    })),
+    Match.when('non-fast-forward', () => ({
+      title: REJECTED,
+      message: 'Remote moved on; pull or merge first',
+    })),
+    Match.when('validation', () => ({
+      title: REJECTED,
+      message: 'Server validation failed',
+    })),
+    Match.orElse(() => ({
+      title: FAILED,
+      message: 'Unexpected error',
+    }))
+  )

--- a/src/composables/useNotifications/push-failure-types.ts
+++ b/src/composables/useNotifications/push-failure-types.ts
@@ -1,0 +1,10 @@
+/**
+ * Reasons a push attempt may fail. Classification drives the
+ * notification copy and downstream retry policy in Epic 2.
+ */
+export type PushFailureReason =
+  | 'network'
+  | 'auth'
+  | 'non-fast-forward'
+  | 'validation'
+  | 'unknown'

--- a/src/composables/useNotifications/use-notification-persistence.ts
+++ b/src/composables/useNotifications/use-notification-persistence.ts
@@ -1,0 +1,45 @@
+import { storeToRefs } from 'pinia'
+import { watch } from 'vue'
+import {
+  type NotificationEntry,
+  useNotificationsStore,
+} from '@/stores/notifications'
+import { useNotificationsHistoryStore } from '@/stores/notifications-history'
+
+/**
+ * Strip non-cloneable fields (CTA actions are functions and IDB
+ * structured-clone rejects functions) before persisting. The CTA
+ * is dropped entirely — history entries are read-only records.
+ * @param entry Source queue entry.
+ * @returns IDB-safe history entry.
+ */
+const toPersistable = (entry: NotificationEntry): NotificationEntry => {
+  const { cta: _cta, ...rest } = entry
+  return rest
+}
+
+/**
+ * Wire the transient notifications queue to the persistent history
+ * store: hydrate from IDB on mount, append every new entry as it
+ * is added to the queue. Call once at app boot — typically inside
+ * a setup-only component such as `App.vue`.
+ * @returns void
+ */
+export const useNotificationsPersistence = (): void => {
+  const queue = useNotificationsStore()
+  const history = useNotificationsHistoryStore()
+  const { entries } = storeToRefs(queue)
+  void history.hydrate()
+  watch(
+    entries,
+    (next, prev) => {
+      const seen = new Set((prev ?? []).map(entry => entry.id))
+      next
+        .filter(entry => !seen.has(entry.id))
+        .forEach(entry => {
+          void history.appendEntry(toPersistable(entry))
+        })
+    },
+    { flush: 'post' }
+  )
+}

--- a/src/composables/useNotifications/use-notifications.test.ts
+++ b/src/composables/useNotifications/use-notifications.test.ts
@@ -1,0 +1,38 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { isRef } from 'vue'
+import { useNotifications } from './use-notifications'
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns a reactive entries ref and bound actions', () => {
+    const api = useNotifications()
+    expect(isRef(api.entries)).toBe(true)
+    expect(api.entries.value).toEqual([])
+    expect(typeof api.notify).toBe('function')
+    expect(typeof api.dismiss).toBe('function')
+    expect(typeof api.clear).toBe('function')
+  })
+
+  it('mutations through the composable propagate to entries', () => {
+    const { entries, notify, dismiss, clear } = useNotifications()
+    const id = notify({ kind: 'info', title: 'hi' })
+    expect(entries.value).toHaveLength(1)
+    dismiss(id)
+    expect(entries.value).toHaveLength(0)
+    notify({ kind: 'warn', title: 'a' })
+    notify({ kind: 'warn', title: 'b' })
+    clear()
+    expect(entries.value).toEqual([])
+  })
+
+  it('two consumers share the same store', () => {
+    const a = useNotifications()
+    const b = useNotifications()
+    a.notify({ kind: 'info', title: 'shared' })
+    expect(b.entries.value).toHaveLength(1)
+  })
+})

--- a/src/composables/useNotifications/use-notifications.ts
+++ b/src/composables/useNotifications/use-notifications.ts
@@ -1,0 +1,19 @@
+import { storeToRefs } from 'pinia'
+import { useNotificationsStore } from '@/stores/notifications'
+
+/**
+ * Reactive notifications API. Returns a readonly view of the queue
+ * plus bound notify/dismiss/clear actions, suitable for direct use
+ * in `<script setup>` and helper composables alike.
+ * @returns Readonly entries ref + bound store actions.
+ */
+export const useNotifications = () => {
+  const store = useNotificationsStore()
+  const { entries } = storeToRefs(store)
+  return {
+    entries,
+    notify: store.notify,
+    dismiss: store.dismiss,
+    clear: store.clear,
+  }
+}

--- a/src/stores/README.md
+++ b/src/stores/README.md
@@ -7,3 +7,4 @@ Pinia state management stores. Each store is decomposed: the `defineStore` file 
 - `auth` -- user authentication state, token sync to SW, login/logout actions
 - `content` -- global content item cache, loaded once on auth, filtered by type
 - `settings` -- application language settings, loaded from `languages.json` in the content repo
+- `notifications` -- in-memory queue of typed notifications (`info` / `warn` / `error` / `conflict` / `network`); consumed via the `useNotifications` composable. Persistence and UI come in later increments of the offline-first initiative.

--- a/src/stores/notifications-add.ts
+++ b/src/stores/notifications-add.ts
@@ -1,0 +1,26 @@
+import type { Ref } from 'vue'
+import { generateNotificationId } from './notifications-id'
+import type {
+  NotificationEntry,
+  NotificationInput,
+} from './notifications-types'
+
+/**
+ * Build the `notify` action. Appends a new entry built from the
+ * caller input plus a fresh id and timestamp, and returns the id
+ * so that the caller can later dismiss it programmatically.
+ * @param items Reactive ref backing the queue.
+ * @returns Function that pushes an entry and returns its id.
+ */
+export const createNotifyAction =
+  (items: Ref<readonly NotificationEntry[]>) =>
+  (input: NotificationInput): string => {
+    const id = generateNotificationId()
+    const entry: NotificationEntry = {
+      id,
+      createdAt: Date.now(),
+      ...input,
+    }
+    items.value = [...items.value, entry]
+    return id
+  }

--- a/src/stores/notifications-dismiss.ts
+++ b/src/stores/notifications-dismiss.ts
@@ -1,0 +1,15 @@
+import type { Ref } from 'vue'
+import type { NotificationEntry } from './notifications-types'
+
+/**
+ * Build the `dismiss` action. Removes the entry whose id matches;
+ * returns silently when the id is unknown so call sites can fire
+ * a dismiss without first reading the queue.
+ * @param items Reactive ref backing the queue.
+ * @returns Function that removes one entry by id.
+ */
+export const createDismissAction =
+  (items: Ref<readonly NotificationEntry[]>) =>
+  (id: string): void => {
+    items.value = items.value.filter(entry => entry.id !== id)
+  }

--- a/src/stores/notifications-history-actions.ts
+++ b/src/stores/notifications-history-actions.ts
@@ -1,0 +1,41 @@
+import type { Ref } from 'vue'
+import { listAll } from './notifications-history-idb'
+import {
+  append,
+  clearAll as dbClearAll,
+  markAllRead as dbMarkAllRead,
+  removeOne,
+} from './notifications-history-idb-write'
+import type { HistoryEntry } from './notifications-history-types'
+
+/**
+ * Build the async history actions bound to the supplied entries
+ * ref. Each action writes through to IDB and refreshes the ref.
+ * @param items Reactive entries ref backing the store.
+ * @returns Object exposing `refresh`, `appendEntry`, `markAllRead`,
+ *          `removeEntry`, and `clear` actions.
+ */
+export const createHistoryActions = (items: Ref<readonly HistoryEntry[]>) => {
+  const refresh = async (): Promise<void> => {
+    items.value = await listAll()
+  }
+  return {
+    refresh,
+    appendEntry: async (entry: HistoryEntry): Promise<void> => {
+      await append(entry)
+      await refresh()
+    },
+    markAllRead: async (): Promise<void> => {
+      await dbMarkAllRead()
+      await refresh()
+    },
+    removeEntry: async (id: string): Promise<void> => {
+      await removeOne(id)
+      await refresh()
+    },
+    clear: async (): Promise<void> => {
+      await dbClearAll()
+      await refresh()
+    },
+  }
+}

--- a/src/stores/notifications-history-idb-write.ts
+++ b/src/stores/notifications-history-idb-write.ts
@@ -1,0 +1,65 @@
+import {
+  fromRequest,
+  listAll,
+  MAX_HISTORY,
+  txStore,
+} from './notifications-history-idb'
+import type { HistoryEntry } from './notifications-history-types'
+
+const evictOverflow = async (): Promise<void> => {
+  const all = await listAll()
+  const overflow = all.length - MAX_HISTORY
+  const toRemove = overflow > 0 ? all.slice(0, overflow) : []
+  await Promise.all(
+    toRemove.map(async entry => {
+      const store = await txStore('readwrite')
+      await fromRequest(store.delete(entry.id))
+    })
+  )
+}
+
+/**
+ * Append a new history entry, evicting the oldest entries when the
+ * total exceeds the FIFO cap.
+ * @param entry Entry to append; id must already be assigned.
+ * @returns Resolves once write + eviction complete.
+ */
+export const append = async (entry: HistoryEntry): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.put(entry))
+  await evictOverflow()
+}
+
+/**
+ * Stamp every unread entry as read with the current timestamp.
+ * @returns Resolves once all writes complete.
+ */
+export const markAllRead = async (): Promise<void> => {
+  const all = await listAll()
+  const stamp = Date.now()
+  await Promise.all(
+    all.map(async entry => {
+      const store = await txStore('readwrite')
+      await fromRequest(store.put({ ...entry, readAt: stamp }))
+    })
+  )
+}
+
+/**
+ * Remove a single entry by id.
+ * @param id Entry id; missing ids are silently ignored.
+ * @returns Resolves once the delete completes.
+ */
+export const removeOne = async (id: string): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.delete(id))
+}
+
+/**
+ * Wipe all persisted history entries.
+ * @returns Resolves once the store is empty.
+ */
+export const clearAll = async (): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.clear())
+}

--- a/src/stores/notifications-history-idb.test.ts
+++ b/src/stores/notifications-history-idb.test.ts
@@ -1,0 +1,70 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { listAll, MAX_HISTORY } from './notifications-history-idb'
+import {
+  append,
+  clearAll,
+  markAllRead,
+  removeOne,
+} from './notifications-history-idb-write'
+import type { HistoryEntry } from './notifications-history-types'
+
+const entry = (id: string, createdAt: number): HistoryEntry => ({
+  id,
+  kind: 'info',
+  title: `t-${id}`,
+  createdAt,
+})
+
+describe('notifications history idb', () => {
+  beforeEach(async () => {
+    await clearAll()
+  })
+  afterEach(async () => {
+    await clearAll()
+  })
+
+  it('append + listAll round-trip preserves order by createdAt', async () => {
+    await append(entry('a', 200))
+    await append(entry('b', 100))
+    await append(entry('c', 300))
+    const all = await listAll()
+    expect(all.map(e => e.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('FIFO eviction trims oldest above MAX_HISTORY', async () => {
+    const total = MAX_HISTORY + 5
+    for (let i = 0; i < total; i += 1) {
+      await append(entry(`e${i}`, i))
+    }
+    const all = await listAll()
+    expect(all).toHaveLength(MAX_HISTORY)
+    expect(all[0]?.id).toBe('e5')
+    expect(all[all.length - 1]?.id).toBe(`e${total - 1}`)
+  })
+
+  it('markAllRead stamps readAt on every entry', async () => {
+    await append(entry('a', 1))
+    await append(entry('b', 2))
+    await markAllRead()
+    const all = await listAll()
+    for (const e of all) {
+      expect(e.readAt).toBeGreaterThan(0)
+    }
+  })
+
+  it('removeOne deletes only the requested id', async () => {
+    await append(entry('a', 1))
+    await append(entry('b', 2))
+    await removeOne('a')
+    const all = await listAll()
+    expect(all.map(e => e.id)).toEqual(['b'])
+  })
+
+  it('clearAll empties the store', async () => {
+    await append(entry('a', 1))
+    await append(entry('b', 2))
+    await clearAll()
+    expect(await listAll()).toEqual([])
+  })
+})

--- a/src/stores/notifications-history-idb.ts
+++ b/src/stores/notifications-history-idb.ts
@@ -1,0 +1,55 @@
+import type { HistoryEntry } from './notifications-history-types'
+
+const DB_NAME = 'admin-notifications'
+const STORE_NAME = 'history'
+const VERSION = 1
+
+/** Maximum entries retained in the persisted history. */
+export const MAX_HISTORY = 200
+
+/**
+ * Wrap an `IDBRequest` as a Promise that resolves with `result`
+ * on success and rejects with `error` on failure.
+ * @param request The IDB request to await.
+ * @returns Promise resolving with the request result.
+ */
+const promisify = <T>(request: IDBRequest<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    request.onsuccess = (): void => resolve(request.result)
+    request.onerror = (): void => reject(request.error)
+  })
+
+const openDb = (): Promise<IDBDatabase> => {
+  const req = globalThis.indexedDB.open(DB_NAME, VERSION)
+  req.onupgradeneeded = (): void => {
+    req.result.createObjectStore(STORE_NAME, { keyPath: 'id' })
+  }
+  return promisify(req)
+}
+
+/**
+ * Acquire a fresh transactional object store. Each public action
+ * opens its own transaction so async awaits never span an
+ * already-completed IDB transaction.
+ * @param mode Transaction mode.
+ * @returns Object store handle inside a fresh transaction.
+ */
+export const txStore = async (
+  mode: IDBTransactionMode
+): Promise<IDBObjectStore> => {
+  const db = await openDb()
+  return db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)
+}
+
+/** Wrap an IDBRequest as a Promise; resolves with `result`. */
+export const fromRequest = promisify
+
+/**
+ * Read every persisted history entry sorted oldest-first.
+ * @returns Frozen array of all entries.
+ */
+export const listAll = async (): Promise<readonly HistoryEntry[]> => {
+  const store = await txStore('readonly')
+  const all: readonly HistoryEntry[] = await fromRequest(store.getAll())
+  return [...all].sort((a, b) => a.createdAt - b.createdAt)
+}

--- a/src/stores/notifications-history-state.ts
+++ b/src/stores/notifications-history-state.ts
@@ -1,0 +1,34 @@
+import { ref } from 'vue'
+import { createHistoryActions } from './notifications-history-actions'
+import type { HistoryEntry } from './notifications-history-types'
+import {
+  createHistoryViews,
+  type HistoryFilter,
+} from './notifications-history-views'
+
+/**
+ * Build the reactive state and async actions for the notifications
+ * history store. Hydration is lazy — call `hydrate()` once at app
+ * boot to populate the entries ref from IDB.
+ * @returns Refs (entries, hydrated, filter) plus computed views
+ *          (visible, unreadCount) plus async actions.
+ */
+export const createNotificationsHistoryState = () => {
+  const items = ref<readonly HistoryEntry[]>([])
+  const hydrated = ref(false)
+  const filter = ref<HistoryFilter>('all')
+  const actions = createHistoryActions(items)
+  const views = createHistoryViews(items, filter)
+  const hydrate = async (): Promise<void> => {
+    await actions.refresh()
+    hydrated.value = true
+  }
+  return {
+    entries: items,
+    hydrated,
+    filter,
+    ...views,
+    hydrate,
+    ...actions,
+  }
+}

--- a/src/stores/notifications-history-types.ts
+++ b/src/stores/notifications-history-types.ts
@@ -1,0 +1,7 @@
+import type { NotificationEntry } from './notifications-types'
+
+/** Persisted history entry — same shape as a queue entry plus a
+ * read timestamp that turns "unread" into "read" in the drawer. */
+export type HistoryEntry = NotificationEntry & {
+  readonly readAt?: number
+}

--- a/src/stores/notifications-history-views.ts
+++ b/src/stores/notifications-history-views.ts
@@ -1,0 +1,27 @@
+import { computed, type Ref } from 'vue'
+import type { HistoryEntry } from './notifications-history-types'
+import type { NotificationKind } from './notifications-types'
+
+/** Filter chip selection used by the drawer. */
+export type HistoryFilter = NotificationKind | 'all'
+
+/**
+ * Build the derived state computeds for the history store: a
+ * filtered `visible` view plus an `unreadCount` for the indicator.
+ * @param items Reactive entries ref backing the store.
+ * @param filter Reactive filter chip selection.
+ * @returns Object exposing `visible` and `unreadCount` computeds.
+ */
+export const createHistoryViews = (
+  items: Ref<readonly HistoryEntry[]>,
+  filter: Ref<HistoryFilter>
+) => ({
+  visible: computed(() =>
+    filter.value === 'all'
+      ? items.value
+      : items.value.filter(e => e.kind === filter.value)
+  ),
+  unreadCount: computed(
+    () => items.value.filter(e => e.readAt === undefined).length
+  ),
+})

--- a/src/stores/notifications-history.ts
+++ b/src/stores/notifications-history.ts
@@ -1,0 +1,10 @@
+import { defineStore } from 'pinia'
+import { createNotificationsHistoryState } from './notifications-history-state'
+
+export type { HistoryEntry } from './notifications-history-types'
+
+/** Pinia store backing the persistent notifications history drawer. */
+export const useNotificationsHistoryStore = defineStore(
+  'notifications-history',
+  () => createNotificationsHistoryState()
+)

--- a/src/stores/notifications-id.ts
+++ b/src/stores/notifications-id.ts
@@ -1,0 +1,10 @@
+/**
+ * Build a stable identifier for a notification entry. Uses
+ * `crypto.randomUUID` when available; otherwise falls back to a
+ * timestamp + random base-36 fragment which is unique enough for
+ * the in-memory queue lifecycle.
+ * @returns Opaque unique identifier.
+ */
+export const generateNotificationId = (): string =>
+  globalThis.crypto?.randomUUID?.() ??
+  `n-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`

--- a/src/stores/notifications-state.ts
+++ b/src/stores/notifications-state.ts
@@ -1,0 +1,23 @@
+import { ref } from 'vue'
+import { createNotifyAction } from './notifications-add'
+import { createDismissAction } from './notifications-dismiss'
+import type { NotificationEntry } from './notifications-types'
+
+/**
+ * Build the reactive state and actions for the notifications store.
+ * Kept separate from the Pinia wrapper so the same factory can be
+ * exercised in unit tests without spinning up a full app.
+ * @returns Bound state ref plus notify/dismiss/clear actions.
+ */
+export const createNotificationsState = () => {
+  const items = ref<readonly NotificationEntry[]>([])
+  const clear = (): void => {
+    items.value = []
+  }
+  return {
+    entries: items,
+    notify: createNotifyAction(items),
+    dismiss: createDismissAction(items),
+    clear,
+  }
+}

--- a/src/stores/notifications-types.ts
+++ b/src/stores/notifications-types.ts
@@ -1,0 +1,26 @@
+/** Category of a notification — drives styling, icon, and stickiness. */
+export type NotificationKind =
+  | 'info'
+  | 'warn'
+  | 'error'
+  | 'conflict'
+  | 'network'
+
+/** Optional call-to-action attached to a notification entry. */
+export type NotificationCta = {
+  readonly label: string
+  readonly action: () => void
+}
+
+/** A single entry stored in the notifications queue. */
+export type NotificationEntry = {
+  readonly id: string
+  readonly kind: NotificationKind
+  readonly title: string
+  readonly message?: string
+  readonly createdAt: number
+  readonly cta?: NotificationCta
+}
+
+/** Caller-supplied shape — id and createdAt are assigned by the store. */
+export type NotificationInput = Omit<NotificationEntry, 'id' | 'createdAt'>

--- a/src/stores/notifications.test.ts
+++ b/src/stores/notifications.test.ts
@@ -1,0 +1,95 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNotificationsStore } from './notifications'
+
+describe('notifications store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('starts with empty entries', () => {
+    const store = useNotificationsStore()
+    expect(store.entries).toEqual([])
+  })
+
+  it('notify pushes an entry and returns its id', () => {
+    const store = useNotificationsStore()
+    const id = store.notify({ kind: 'info', title: 'hello' })
+    expect(id).toMatch(/.+/)
+    expect(store.entries).toHaveLength(1)
+    const entry = store.entries[0]
+    expect(entry?.id).toBe(id)
+    expect(entry?.kind).toBe('info')
+    expect(entry?.title).toBe('hello')
+  })
+
+  it('notify assigns unique ids', () => {
+    const store = useNotificationsStore()
+    const a = store.notify({ kind: 'info', title: 'a' })
+    const b = store.notify({ kind: 'info', title: 'b' })
+    expect(a).not.toBe(b)
+  })
+
+  it('notify stamps createdAt to a current timestamp', () => {
+    const before = Date.now()
+    const store = useNotificationsStore()
+    store.notify({ kind: 'warn', title: 'tick' })
+    const ts = store.entries[0]?.createdAt ?? 0
+    expect(ts).toBeGreaterThanOrEqual(before)
+    expect(ts).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('notify preserves an attached cta', () => {
+    const store = useNotificationsStore()
+    const action = (): void => undefined
+    store.notify({
+      kind: 'network',
+      title: 'down',
+      cta: { label: 'Retry', action },
+    })
+    const entry = store.entries[0]
+    expect(entry?.cta?.label).toBe('Retry')
+    expect(entry?.cta?.action).toBe(action)
+  })
+
+  it('notify accepts every category without type errors', () => {
+    const store = useNotificationsStore()
+    const kinds = ['info', 'warn', 'error', 'conflict', 'network'] as const
+    for (const kind of kinds) {
+      store.notify({ kind, title: kind })
+    }
+    expect(store.entries.map(e => e.kind)).toEqual([...kinds])
+  })
+
+  it('dismiss removes the entry with the given id', () => {
+    const store = useNotificationsStore()
+    const id = store.notify({ kind: 'info', title: 'x' })
+    store.notify({ kind: 'error', title: 'y' })
+    store.dismiss(id)
+    expect(store.entries).toHaveLength(1)
+    expect(store.entries[0]?.title).toBe('y')
+  })
+
+  it('dismiss with an unknown id is a no-op', () => {
+    const store = useNotificationsStore()
+    store.notify({ kind: 'info', title: 'x' })
+    store.dismiss('does-not-exist')
+    expect(store.entries).toHaveLength(1)
+  })
+
+  it('clear empties all entries', () => {
+    const store = useNotificationsStore()
+    store.notify({ kind: 'info', title: 'x' })
+    store.notify({ kind: 'info', title: 'y' })
+    store.clear()
+    expect(store.entries).toEqual([])
+  })
+
+  it('exposes entries as a frozen view of the queue', () => {
+    const store = useNotificationsStore()
+    store.notify({ kind: 'info', title: 'x' })
+    const snapshot = store.entries
+    store.notify({ kind: 'info', title: 'y' })
+    expect(snapshot).not.toBe(store.entries)
+  })
+})

--- a/src/stores/notifications.ts
+++ b/src/stores/notifications.ts
@@ -1,0 +1,14 @@
+import { defineStore } from 'pinia'
+import { createNotificationsState } from './notifications-state'
+
+export type {
+  NotificationCta,
+  NotificationEntry,
+  NotificationInput,
+  NotificationKind,
+} from './notifications-types'
+
+/** Pinia store backing the in-memory notifications queue. */
+export const useNotificationsStore = defineStore('notifications', () =>
+  createNotificationsState()
+)


### PR DESCRIPTION
## Summary
Phase A / Epic 1 of the offline-first initiative complete. Notifications now have a typed in-memory queue, visual toasts, header indicator, persistent history drawer, and typed factories for the producers Epics 2–4 will introduce.

## What's in this release
- **1.1 #79 / #95** — Pinia `notifications` store + `useNotifications` composable (5 typed kinds: info / warn / error / conflict / network).
- **1.2 #80 / #96** — `<NotificationToastStack>` bottom-right + `<NotificationIndicator>` in `<AppHeader>`. Auto-dismiss for transient kinds; sticky for failure kinds. AAA-compliant.
- **1.3 #81 / #98** — `<NotificationDrawer>` slide-in panel with filter chips, mark-all-read, clear-all. IDB persistence (200-entry FIFO); CTA stripped at the persistence boundary.
- **1.4 #82 / #97** — Typed factories (`notifyPushFailure`, `notifyConflictDetected`, `notifyValidationError`, `notifyNetworkDown`, `notifyInfo`) with CTA rendering in toast.

## Coverage
- Unit: 444/444 green (incl. 13 store, 12 toast/indicator, 5 IDB-history with `fake-indexeddb`).
- E2E: 10/10 green on chromium (5 toast + 5 drawer specs); chromium full suite 228/228.
- Validate: biome, oxlint sonar, jsdoc, vue-depth, css all clean.

## Test plan post-deploy
- [ ] dev-admin loads without console errors
- [ ] Bell indicator visible in header
- [ ] (optional) drawer opens on bell click — gated by `VITE_MOCK_AUTH=false` so no dev-trigger; smoke-only

## Notes
- Bell badge currently tracks live queue size, not persisted-unread count. Follow-up if product wants persisted-unread.
- `<NotificationDevTrigger>` is gated by `VITE_MOCK_AUTH=true` and does NOT ship in production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)