### PR TITLE
feat(sw): decouple commit from push via IDB queue (#83)

### DIFF
--- a/src/sw/git/remote/real-commit.ts
+++ b/src/sw/git/remote/real-commit.ts
@@ -1,19 +1,19 @@
 import { Effect } from 'effect'
 import { log } from '../../logging/logger'
 import { recordOp } from '../../logging/metrics'
+import { drainPushes, enqueue } from '../../push-queue'
 import { workerState } from '../../state/state'
 import { fs, REPO_DIR } from '../fs'
 import { loadGit } from '../load-git'
 
 type SWGitConfig = NonNullable<typeof workerState.config>
 
-const runCommit = async (
+const commitLocally = async (
   config: SWGitConfig,
   message: string
 ): Promise<string> => {
-  const start = Date.now()
   const git = await loadGit()
-  const sha = await git.commit({
+  return git.commit({
     fs,
     dir: REPO_DIR,
     message,
@@ -22,11 +22,24 @@ const runCommit = async (
       email: config.authorEmail ?? 'admin@prometheus.org',
     },
   })
+}
+
+const runCommitAndQueue = async (
+  config: SWGitConfig,
+  message: string
+): Promise<string> => {
+  const start = Date.now()
+  const sha = await commitLocally(config, message)
   log('info', 'git', `committed ${sha.slice(0, 7)}`)
-  const { pushToRemote } = await import('./push-to-remote')
-  await pushToRemote(config)
   workerState.commitSha = sha
-  recordOp('commitAndPush', Date.now() - start)
+  recordOp('commit', Date.now() - start)
+  await enqueue({
+    sha,
+    branch: config.branch,
+    message,
+    enqueuedAt: Date.now(),
+  })
+  void drainPushes()
   return sha
 }
 
@@ -35,22 +48,23 @@ const runCommit = async (
  * generic UnknownError whose `.message` reads "An unknown error
  * occurred in Effect.tryPromise". The handler at /api/github/commit
  * then bubbles that opaque text up to the user. We need the
- * underlying isomorphic-git reason ("not a fast-forward",
- * "401 Unauthorized", "RPC failed with HTTP 422", etc.) so failed
- * saves are diagnosable. Coerce non-Error throws so callers always
- * get a string-bearing Error.
+ * underlying isomorphic-git reason so failed saves are diagnosable.
+ * Coerce non-Error throws so callers always get a string-bearing
+ * Error.
  */
 const preserveError = (e: unknown): Error =>
   e instanceof Error ? e : new Error(String(e))
 
 /**
- * Execute real git commit + push to remote.
- * @param config - Validated SW git configuration
- * @param message - Commit message
- * @returns Effect yielding the commit SHA
+ * Run a real git commit, enqueue the push, return the commit sha
+ * to the caller without waiting for the network. The push is
+ * processed by the background drain in `push-queue/drain.ts`.
+ * @param config Validated SW git configuration.
+ * @param message Commit message.
+ * @returns Effect yielding the commit sha.
  */
 export const realCommit = (config: SWGitConfig, message: string) =>
   Effect.tryPromise({
-    try: () => runCommit(config, message),
+    try: () => runCommitAndQueue(config, message),
     catch: preserveError,
   })

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -1,0 +1,60 @@
+import { Option } from 'effect'
+import { workerState } from '../state/state'
+import { dequeue } from './enqueue'
+import { listPending } from './idb'
+import type { PushQueueEntry } from './types'
+
+let inFlight = false
+
+const tryPush = async (
+  entry: PushQueueEntry,
+  config: NonNullable<typeof workerState.config>
+): Promise<boolean> => {
+  const { pushToRemote } = await import('../git/remote/push-to-remote')
+  await pushToRemote(config)
+  await dequeue(entry.sha)
+  return true
+}
+
+const processNext = (
+  pending: readonly PushQueueEntry[],
+  index: number,
+  config: NonNullable<typeof workerState.config>
+): Promise<void> =>
+  Option.match(Option.fromNullable(pending[index]), {
+    onNone: () => Promise.resolve(),
+    onSome: async entry => {
+      const ok = await tryPush(entry, config).catch(() => false)
+      return ok ? processNext(pending, index + 1, config) : Promise.resolve()
+    },
+  })
+
+const processPending = async (): Promise<void> =>
+  Option.match(Option.fromNullable(workerState.config), {
+    onNone: () => Promise.resolve(),
+    onSome: async config => {
+      const pending = await listPending()
+      await processNext(pending, 0, config)
+    },
+  })
+
+const runOnce = async (): Promise<void> => {
+  inFlight = true
+  try {
+    await processPending()
+  } finally {
+    inFlight = false
+  }
+}
+
+/**
+ * Process queued push entries oldest-first. Each successful push
+ * dequeues its entry; the first failure stops the drain so the
+ * queue stays ordered for the next retry. Reentrant drain calls
+ * coalesce — only one walk runs at a time.
+ * @returns Resolves once the walk has finished or yielded.
+ */
+export const drainPushes = async (): Promise<void> => {
+  const acquired = !inFlight
+  await (acquired ? runOnce() : Promise.resolve())
+}

--- a/src/sw/push-queue/enqueue.ts
+++ b/src/sw/push-queue/enqueue.ts
@@ -1,0 +1,47 @@
+import { fromRequest, txStore } from './idb'
+import type { PushQueueEntry } from './types'
+
+const writeIfFresh = async (
+  entry: PushQueueEntry,
+  duplicate: boolean
+): Promise<boolean> => {
+  const fresh = !duplicate
+  await (fresh
+    ? txStore('readwrite').then(s => fromRequest(s.put(entry)))
+    : Promise.resolve())
+  return fresh
+}
+
+/**
+ * Persist a push queue entry. Idempotent on `sha` — re-enqueueing
+ * the same commit is a no-op. Returns whether the entry was newly
+ * added so callers can decide whether to trigger a drain.
+ * @param entry Entry to append; `sha` must be unique per commit.
+ * @returns True if the entry was new, false if a duplicate.
+ */
+export const enqueue = async (entry: PushQueueEntry): Promise<boolean> => {
+  const store = await txStore('readonly')
+  const existing = await fromRequest(store.get(entry.sha))
+  return writeIfFresh(entry, existing !== undefined)
+}
+
+/**
+ * Remove a queue entry by `sha`. Used after a successful push so
+ * the entry is no longer retried.
+ * @param sha Commit sha of the entry to remove.
+ * @returns Resolves once the delete completes.
+ */
+export const dequeue = async (sha: string): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.delete(sha))
+}
+
+/**
+ * Wipe every persisted entry. Used by tests and the future
+ * "Reset queue" recovery action.
+ * @returns Resolves once the store is empty.
+ */
+export const clearQueue = async (): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.clear())
+}

--- a/src/sw/push-queue/idb.ts
+++ b/src/sw/push-queue/idb.ts
@@ -1,0 +1,52 @@
+import type { PushQueueEntry } from './types'
+
+const DB_NAME = 'admin-push-queue'
+const STORE_NAME = 'queue'
+const VERSION = 1
+
+/**
+ * Wrap an `IDBRequest` as a Promise that resolves with `result`
+ * on success and rejects with `error` on failure.
+ * @param request The IDB request to await.
+ * @returns Promise resolving with the request result.
+ */
+const promisify = <T>(request: IDBRequest<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    request.onsuccess = (): void => resolve(request.result)
+    request.onerror = (): void => reject(request.error)
+  })
+
+const openDb = (): Promise<IDBDatabase> => {
+  const req = globalThis.indexedDB.open(DB_NAME, VERSION)
+  req.onupgradeneeded = (): void => {
+    req.result.createObjectStore(STORE_NAME, { keyPath: 'sha' })
+  }
+  return promisify(req)
+}
+
+/**
+ * Acquire a fresh transactional object store. Each public action
+ * opens its own transaction so async awaits never span an
+ * already-completed IDB transaction.
+ * @param mode Transaction mode.
+ * @returns Object store handle inside a fresh transaction.
+ */
+export const txStore = async (
+  mode: IDBTransactionMode
+): Promise<IDBObjectStore> => {
+  const db = await openDb()
+  return db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)
+}
+
+/** Wrap an IDBRequest as a Promise; resolves with `result`. */
+export const fromRequest = promisify
+
+/**
+ * List every persisted queue entry sorted oldest-first.
+ * @returns Frozen array of all queued entries.
+ */
+export const listPending = async (): Promise<readonly PushQueueEntry[]> => {
+  const store = await txStore('readonly')
+  const all: readonly PushQueueEntry[] = await fromRequest(store.getAll())
+  return [...all].sort((a, b) => a.enqueuedAt - b.enqueuedAt)
+}

--- a/src/sw/push-queue/index.ts
+++ b/src/sw/push-queue/index.ts
@@ -1,0 +1,5 @@
+/** SW push queue: decouples local commit from remote push. */
+export { drainPushes } from './drain'
+export { clearQueue, dequeue, enqueue } from './enqueue'
+export { listPending } from './idb'
+export type { PushQueueEntry } from './types'

--- a/src/sw/push-queue/queue.test.ts
+++ b/src/sw/push-queue/queue.test.ts
@@ -1,0 +1,60 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearQueue, dequeue, enqueue } from './enqueue'
+import { listPending } from './idb'
+import type { PushQueueEntry } from './types'
+
+const entry = (sha: string, ts: number): PushQueueEntry => ({
+  sha,
+  branch: 'develop',
+  message: `commit ${sha}`,
+  enqueuedAt: ts,
+})
+
+describe('push queue', () => {
+  beforeEach(async () => {
+    await clearQueue()
+  })
+  afterEach(async () => {
+    await clearQueue()
+  })
+
+  it('enqueue persists an entry visible via listPending', async () => {
+    await enqueue(entry('a1', 100))
+    const all = await listPending()
+    expect(all).toHaveLength(1)
+    expect(all[0]?.sha).toBe('a1')
+  })
+
+  it('listPending returns entries oldest-first', async () => {
+    await enqueue(entry('c', 300))
+    await enqueue(entry('a', 100))
+    await enqueue(entry('b', 200))
+    const all = await listPending()
+    expect(all.map(e => e.sha)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('enqueue is idempotent on sha', async () => {
+    const first = await enqueue(entry('a', 100))
+    const second = await enqueue(entry('a', 200))
+    expect(first).toBe(true)
+    expect(second).toBe(false)
+    const all = await listPending()
+    expect(all).toHaveLength(1)
+    expect(all[0]?.enqueuedAt).toBe(100)
+  })
+
+  it('dequeue removes a single entry', async () => {
+    await enqueue(entry('a', 100))
+    await enqueue(entry('b', 200))
+    await dequeue('a')
+    const all = await listPending()
+    expect(all.map(e => e.sha)).toEqual(['b'])
+  })
+
+  it('dequeue with unknown sha is a no-op', async () => {
+    await enqueue(entry('a', 100))
+    await dequeue('does-not-exist')
+    expect(await listPending()).toHaveLength(1)
+  })
+})

--- a/src/sw/push-queue/types.ts
+++ b/src/sw/push-queue/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Single entry in the SW push queue. Identified by `sha` so the
+ * queue can be re-enqueued idempotently (same commit = same id).
+ */
+export type PushQueueEntry = {
+  readonly sha: string
+  readonly branch: string
+  readonly message: string
+  readonly enqueuedAt: number
+}


### PR DESCRIPTION
## Summary
Phase A / Epic 2 increment 2.1 — UI no longer blocks on network for save. Commit returns to the caller after the local commit is staged; the push is enqueued in IDB and processed by a background drain inside the SW.

## What changed
- New `src/sw/push-queue/` module:
  - **idb.ts** — `globalThis.indexedDB` open + `txStore` + `listPending` (oldest-first by `enqueuedAt`)
  - **enqueue.ts** — idempotent `enqueue` (no-op when same `sha` already present), `dequeue`, `clearQueue`
  - **drain.ts** — reentrant `drainPushes()` walks the queue oldest-first, stops on the first failure to preserve order. Reentry guard coalesces concurrent calls.
  - **types.ts**, **index.ts** — barrel + `PushQueueEntry`
- `realCommit` now commits locally, persists the queue entry, fires `drainPushes()` without awaiting, and returns the sha. The prior synchronous push path is gone — push is strictly background.

## Out of scope (later increments)
- Push state events → indicator (#84 / 2.2)
- Error classification → notifications (#85 / 2.3)
- Exp-backoff retry + manual retry (#86 / 2.4)

## Test plan
- [x] `bun run test:unit -- run` — 444/444 green (incl. 5 new queue specs against `fake-indexeddb`)
- [x] `bun run test:e2e -- e2e/notifications/ --project=chromium` — 10/10 green
- [x] `bun run test:e2e -- e2e/content/preview-flow.spec.ts e2e/content/cmd-undo.spec.ts --project=chromium` — 9/9 green (save flow regression check)
- [x] `bun run validate` — biome / oxlint sonar / jsdoc / vue-depth / css all clean

Mock mode is untouched (only `realCommit` path was changed). End-to-end real-mode verification will land with #84 once state events are observable in the UI.

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)