### PR TITLE
feat(sw): push state events surface as header sync badge (#84)

### DIFF
--- a/e2e/notifications/push-sync-badge.spec.ts
+++ b/e2e/notifications/push-sync-badge.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+
+const broadcast = (
+  pending: number,
+  status: 'idle' | 'syncing' | 'error'
+): string => `
+const ch = new BroadcastChannel('sw-push-state')
+ch.postMessage({ status: '${status}', pending: ${pending} })
+ch.close()
+`
+
+test.describe('push sync badge (2.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('badge stays hidden while idle and pending=0', async ({ page }) => {
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await expect(badge).toBeHidden()
+  })
+
+  test('syncing state surfaces with pending count', async ({ page }) => {
+    await page.evaluate(broadcast(2, 'syncing'))
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await expect(badge).toBeVisible()
+    await expect(badge).toHaveAttribute('data-status', 'syncing')
+    await expect(
+      page.locator('[data-testid="push-sync-badge-count"]')
+    ).toHaveText('2')
+  })
+
+  test('error state surfaces and does not pulse', async ({ page }) => {
+    await page.evaluate(broadcast(1, 'error'))
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await expect(badge).toBeVisible()
+    await expect(badge).toHaveAttribute('data-status', 'error')
+  })
+
+  test('drain success returns the badge to hidden', async ({ page }) => {
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await page.evaluate(broadcast(1, 'syncing'))
+    await expect(badge).toBeVisible()
+    await page.evaluate(broadcast(0, 'idle'))
+    await expect(badge).toBeHidden()
+  })
+})

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -34,6 +34,7 @@ const hash = __COMMIT_HASH__
 
 <template>
   <AppHeader>
+    <PushSyncBadge />
     <NotificationIndicator />
     <AuthButton />
   </AppHeader>

--- a/src/components/PushSyncBadge/PushSyncBadge.vue
+++ b/src/components/PushSyncBadge/PushSyncBadge.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { usePushState } from '@/composables/useSWBridge/use-push-state'
+import { PUSH_SYNC_TEST_IDS } from './test-ids'
+
+const { state } = usePushState()
+const visible = computed(
+  () => state.value.status !== 'idle' || state.value.pending > 0
+)
+const ariaLabel = computed(() =>
+  state.value.status === 'error'
+    ? `Push sync error, ${state.value.pending} pending`
+    : `Push syncing, ${state.value.pending} pending`
+)
+</script>
+
+<template>
+  <aside
+    v-if="visible"
+    class="push-sync"
+    :data-testid="PUSH_SYNC_TEST_IDS.root"
+    :data-status="state.status"
+    :aria-label="ariaLabel"
+    aria-live="polite"
+  >
+    <span v-if="state.pending > 0" :data-testid="PUSH_SYNC_TEST_IDS.count">
+      {{ state.pending }}
+    </span>
+    <span v-else aria-hidden="true">·</span>
+  </aside>
+</template>
+
+<style scoped>
+.push-sync {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 12px;
+  color: #fff;
+  background: var(--color-accent, #4fc3f7);
+}
+
+.push-sync[data-status='syncing'] {
+  animation: push-sync-pulse 1.2s ease-in-out infinite;
+}
+
+.push-sync[data-status='error'] {
+  background: var(--color-error, #e53935);
+  animation: none;
+}
+
+@keyframes push-sync-pulse {
+  0%, 100% { opacity: 100%; }
+  50% { opacity: 55%; }
+}
+</style>

--- a/src/components/PushSyncBadge/test-ids.ts
+++ b/src/components/PushSyncBadge/test-ids.ts
@@ -1,0 +1,5 @@
+/** Test IDs for the SW push pipeline status badge. */
+export const PUSH_SYNC_TEST_IDS = {
+  root: 'push-sync-badge',
+  count: 'push-sync-badge-count',
+} as const

--- a/src/composables/useSWBridge/use-push-state.ts
+++ b/src/composables/useSWBridge/use-push-state.ts
@@ -1,0 +1,29 @@
+import { onUnmounted, ref } from 'vue'
+import {
+  INITIAL_PUSH_STATE,
+  type PushState,
+  SW_PUSH_STATE_CHANNEL,
+} from '@/sw/protocol'
+
+/**
+ * Subscribe to push pipeline state events broadcast by the SW.
+ * Returns a reactive ref that mirrors the latest snapshot. The
+ * subscription is torn down automatically on unmount.
+ * @returns Reactive `state` ref reflecting the SW push pipeline.
+ */
+export const usePushState = () => {
+  const state = ref<PushState>(INITIAL_PUSH_STATE)
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_STATE_CHANNEL)
+    : undefined
+  const wire = (ch: BroadcastChannel): void => {
+    ch.onmessage = (event: MessageEvent<PushState>): void => {
+      state.value = event.data
+    }
+  }
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => wire(channel))()
+  onUnmounted(() => channel?.close())
+  return { state }
+}

--- a/src/sw/protocol.ts
+++ b/src/sw/protocol.ts
@@ -14,6 +14,12 @@ export type {
   LogEntry,
   LogLevel,
 } from './protocol/log-types'
+export {
+  INITIAL_PUSH_STATE,
+  type PushState,
+  type PushStatus,
+  SW_PUSH_STATE_CHANNEL,
+} from './protocol/push-state'
 export type {
   SWFetchRequest,
   SWFetchResponse,

--- a/src/sw/protocol/push-state.ts
+++ b/src/sw/protocol/push-state.ts
@@ -1,0 +1,17 @@
+/** Status of the SW push pipeline as broadcast to the UI. */
+export type PushStatus = 'idle' | 'syncing' | 'error'
+
+/** Live snapshot of the SW push queue state. */
+export type PushState = {
+  readonly status: PushStatus
+  readonly pending: number
+}
+
+/** BroadcastChannel name for push state events. */
+export const SW_PUSH_STATE_CHANNEL = 'sw-push-state'
+
+/** Initial state when no SW activity is observed. */
+export const INITIAL_PUSH_STATE: PushState = {
+  status: 'idle',
+  pending: 0,
+}

--- a/src/sw/push-queue/broadcast.ts
+++ b/src/sw/push-queue/broadcast.ts
@@ -1,0 +1,37 @@
+import { type PushState, SW_PUSH_STATE_CHANNEL } from '../protocol/push-state'
+
+let lastState: PushState = { status: 'idle', pending: 0 }
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_STATE_CHANNEL)
+  return channel
+}
+
+const sendIfChanged = (prev: PushState, next: PushState): void => {
+  const changed = prev.status !== next.status || prev.pending !== next.pending
+  const fire = changed
+    ? () => channelOf().postMessage(next)
+    : (): void => undefined
+  fire()
+}
+
+/**
+ * Broadcast the latest push pipeline snapshot to all subscribed
+ * clients. The last known state is cached so repeat publishers
+ * (drain ticks, error retries) skip redundant emissions.
+ * @param next New push state to broadcast.
+ * @returns void
+ */
+export const publishPushState = (next: PushState): void => {
+  const prev = lastState
+  lastState = next
+  sendIfChanged(prev, next)
+}
+
+/**
+ * Read the cached push state without broadcasting. Useful when a
+ * fresh subscriber asks for the current value.
+ * @returns Last broadcast state.
+ */
+export const currentPushState = (): PushState => lastState

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -1,33 +1,9 @@
 import { Option } from 'effect'
 import { workerState } from '../state/state'
-import { dequeue } from './enqueue'
 import { listPending } from './idb'
-import type { PushQueueEntry } from './types'
+import { processNext } from './process-next'
 
 let inFlight = false
-
-const tryPush = async (
-  entry: PushQueueEntry,
-  config: NonNullable<typeof workerState.config>
-): Promise<boolean> => {
-  const { pushToRemote } = await import('../git/remote/push-to-remote')
-  await pushToRemote(config)
-  await dequeue(entry.sha)
-  return true
-}
-
-const processNext = (
-  pending: readonly PushQueueEntry[],
-  index: number,
-  config: NonNullable<typeof workerState.config>
-): Promise<void> =>
-  Option.match(Option.fromNullable(pending[index]), {
-    onNone: () => Promise.resolve(),
-    onSome: async entry => {
-      const ok = await tryPush(entry, config).catch(() => false)
-      return ok ? processNext(pending, index + 1, config) : Promise.resolve()
-    },
-  })
 
 const processPending = async (): Promise<void> =>
   Option.match(Option.fromNullable(workerState.config), {
@@ -49,7 +25,7 @@ const runOnce = async (): Promise<void> => {
 
 /**
  * Process queued push entries oldest-first. Each successful push
- * dequeues its entry; the first failure stops the drain so the
+ * dequeues its entry; the first failure stops the walk so the
  * queue stays ordered for the next retry. Reentrant drain calls
  * coalesce — only one walk runs at a time.
  * @returns Resolves once the walk has finished or yielded.

--- a/src/sw/push-queue/enqueue.ts
+++ b/src/sw/push-queue/enqueue.ts
@@ -1,4 +1,5 @@
-import { fromRequest, txStore } from './idb'
+import { publishPushState } from './broadcast'
+import { fromRequest, listPending, txStore } from './idb'
 import type { PushQueueEntry } from './types'
 
 const writeIfFresh = async (
@@ -12,6 +13,13 @@ const writeIfFresh = async (
   return fresh
 }
 
+const refreshPendingCount = async (
+  status: 'idle' | 'syncing' | 'error'
+): Promise<void> => {
+  const pending = (await listPending()).length
+  publishPushState({ status, pending })
+}
+
 /**
  * Persist a push queue entry. Idempotent on `sha` — re-enqueueing
  * the same commit is a no-op. Returns whether the entry was newly
@@ -22,7 +30,9 @@ const writeIfFresh = async (
 export const enqueue = async (entry: PushQueueEntry): Promise<boolean> => {
   const store = await txStore('readonly')
   const existing = await fromRequest(store.get(entry.sha))
-  return writeIfFresh(entry, existing !== undefined)
+  const fresh = await writeIfFresh(entry, existing !== undefined)
+  await (fresh ? refreshPendingCount('syncing') : Promise.resolve())
+  return fresh
 }
 
 /**
@@ -34,6 +44,11 @@ export const enqueue = async (entry: PushQueueEntry): Promise<boolean> => {
 export const dequeue = async (sha: string): Promise<void> => {
   const store = await txStore('readwrite')
   await fromRequest(store.delete(sha))
+  const remaining = (await listPending()).length
+  publishPushState({
+    status: remaining === 0 ? 'idle' : 'syncing',
+    pending: remaining,
+  })
 }
 
 /**
@@ -44,4 +59,5 @@ export const dequeue = async (sha: string): Promise<void> => {
 export const clearQueue = async (): Promise<void> => {
   const store = await txStore('readwrite')
   await fromRequest(store.clear())
+  publishPushState({ status: 'idle', pending: 0 })
 }

--- a/src/sw/push-queue/process-next.ts
+++ b/src/sw/push-queue/process-next.ts
@@ -1,0 +1,44 @@
+import { Option } from 'effect'
+import type { workerState } from '../state/state'
+import { publishPushState } from './broadcast'
+import { dequeue } from './enqueue'
+import type { PushQueueEntry } from './types'
+
+const tryPush = async (
+  entry: PushQueueEntry,
+  config: NonNullable<typeof workerState.config>
+): Promise<boolean> => {
+  const { pushToRemote } = await import('../git/remote/push-to-remote')
+  await pushToRemote(config)
+  await dequeue(entry.sha)
+  return true
+}
+
+const haltOnFailure = (remaining: number): Promise<void> => {
+  publishPushState({ status: 'error', pending: remaining })
+  return Promise.resolve()
+}
+
+/**
+ * Recursively push the queue starting at `index`. Stops on the
+ * first failure and emits an error state covering the entries
+ * that remain unprocessed.
+ * @param pending Entries to process (oldest-first).
+ * @param index Current position in `pending`.
+ * @param config SW git configuration.
+ * @returns Resolves once the walk has finished or yielded.
+ */
+export const processNext = (
+  pending: readonly PushQueueEntry[],
+  index: number,
+  config: NonNullable<typeof workerState.config>
+): Promise<void> =>
+  Option.match(Option.fromNullable(pending[index]), {
+    onNone: () => Promise.resolve(),
+    onSome: async entry => {
+      const ok = await tryPush(entry, config).catch(() => false)
+      return ok
+        ? processNext(pending, index + 1, config)
+        : haltOnFailure(pending.length - index)
+    },
+  })


### PR DESCRIPTION
## Summary
Phase A / Epic 2 increment 2.2 — SW broadcasts push state, header surfaces it.

- `PushState`/`PushStatus` types + `SW_PUSH_STATE_CHANNEL` in the protocol barrel.
- `publishPushState()` caches last state and emits only on change. Wired into `enqueue` (status → syncing), `dequeue` (drain → idle when empty), `clearQueue` (force idle), and `processNext` (push failure → error).
- `usePushState` composable subscribes to the channel.
- `<PushSyncBadge>` mounted next to the notification bell. Hidden while idle + pending=0; pulses while syncing; red on error.

## Test plan
- [x] 4/4 e2e (`push-sync-badge.spec.ts`) on chromium — broadcast fake states via `page.evaluate`, badge reacts as expected
- [x] 444/444 unit
- [x] `bun run validate` clean

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)