### PR TITLE
feat(sw): classify push errors + bridge to notifications (#85)

### DIFF
--- a/e2e/notifications/push-error-bridge.spec.ts
+++ b/e2e/notifications/push-error-bridge.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastError = (
+  reason: 'network' | 'auth' | 'non-fast-forward' | 'validation' | 'unknown',
+  target = 'origin/develop'
+): string => `
+const ch = new BroadcastChannel('sw-push-error')
+ch.postMessage({
+  reason: '${reason}',
+  sha: 'abc123',
+  target: '${target}',
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+test.describe('push error bridge → notification (2.3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('network error fires a sticky notification with target', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastError('network'))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'error')
+    await expect(toast).toContainText('origin/develop')
+  })
+
+  test('non-fast-forward emits distinct copy', async ({ page }) => {
+    await page.evaluate(broadcastError('non-fast-forward'))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toContainText(/rejected|remote/i)
+  })
+
+  test('every reason produces a unique toast', async ({ page }) => {
+    const reasons: ReadonlyArray<
+      'network' | 'auth' | 'non-fast-forward' | 'validation' | 'unknown'
+    > = ['network', 'auth', 'non-fast-forward', 'validation', 'unknown']
+    for (const reason of reasons) {
+      await page.evaluate(broadcastError(reason))
+    }
+    const toasts = page.locator('[data-testid="notification-toast"]')
+    await expect(toasts).toHaveCount(3)
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,20 +1,15 @@
 <script setup lang="ts">
-import { computed, provide, watch } from 'vue'
+import { provide, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import {
   DEPLOY_ENTRIES_KEY,
   DEPLOY_LOADING_KEY,
   DEPLOY_TRACK_KEY,
 } from '@/composables/useDeployStatus/deploy-context'
-import {
-  clearPendingDeploy,
-  isPendingMatched,
-  pendingDeploy,
-  pendingToDeployBuild,
-} from '@/composables/useDeployStatus/pending-deploy'
 import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polling'
-import type { DeployBuild } from '@/composables/useDeployStatus/workflow-types'
+import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entries'
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
+import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
@@ -22,34 +17,10 @@ const route = useRoute()
 const authStore = useAuthStore()
 const contentStore = useContentStore()
 useNotificationsPersistence()
+usePushErrorBridge()
 
-// Single app-wide poller. Pauses automatically once every visible
-// run is terminal; resumes when a save hits `requestPoll` via
-// DEPLOY_TRACK_KEY or when the tab regains focus with an active
-// deploy still in flight.
 const poll = useDeployPolling()
-
-// Merge the optimistic pending entry (set by the save flow) into the
-// real entries so the home list shows the user's action instantly.
-// The pending entry is dropped automatically once a real run with a
-// matching commit message lands.
-const PENDING_TTL_MS = 5 * 60 * 1000
-
-const mergedEntries = computed<ReadonlyArray<DeployBuild>>(() => {
-  const real = poll.entries.value
-  const pending = pendingDeploy.value
-  if (!pending) return real
-  const age = Date.now() - Date.parse(pending.createdAt)
-  if (age > PENDING_TTL_MS) {
-    clearPendingDeploy()
-    return real
-  }
-  if (isPendingMatched(pending, real)) {
-    clearPendingDeploy()
-    return real
-  }
-  return [pendingToDeployBuild(pending), ...real]
-})
+const mergedEntries = useMergedEntries(poll.entries)
 
 provide(DEPLOY_TRACK_KEY, poll.requestPoll)
 provide(DEPLOY_ENTRIES_KEY, mergedEntries)

--- a/src/composables/useDeployStatus/use-merged-entries.ts
+++ b/src/composables/useDeployStatus/use-merged-entries.ts
@@ -1,0 +1,48 @@
+import { Option } from 'effect'
+import { type ComputedRef, computed, type Ref } from 'vue'
+import {
+  clearPendingDeploy,
+  isPendingMatched,
+  type PendingDeploy,
+  pendingDeploy,
+  pendingToDeployBuild,
+} from './pending-deploy'
+import type { DeployBuild } from './workflow-types'
+
+const PENDING_TTL_MS = 5 * 60 * 1000
+
+const dropAndReturn = (
+  list: ReadonlyArray<DeployBuild>
+): ReadonlyArray<DeployBuild> => {
+  clearPendingDeploy()
+  return list
+}
+
+const mergeWithPending = (
+  realList: ReadonlyArray<DeployBuild>,
+  pending: PendingDeploy
+): ReadonlyArray<DeployBuild> => {
+  const expired = Date.now() - Date.parse(pending.createdAt) > PENDING_TTL_MS
+  const matched = isPendingMatched(pending, realList)
+  return expired || matched
+    ? dropAndReturn(realList)
+    : [pendingToDeployBuild(pending), ...realList]
+}
+
+/**
+ * Merge the optimistic pending deploy entry with the real list so
+ * the home view shows the user's most recent action instantly.
+ * The pending entry is dropped once a real run with a matching
+ * commit message arrives or after the TTL expires.
+ * @param real Reactive ref of real polled deploy builds.
+ * @returns Computed ref containing the merged list.
+ */
+export const useMergedEntries = (
+  real: Ref<readonly DeployBuild[]>
+): ComputedRef<ReadonlyArray<DeployBuild>> =>
+  computed<ReadonlyArray<DeployBuild>>(() =>
+    Option.match(Option.fromNullable(pendingDeploy.value), {
+      onNone: () => real.value,
+      onSome: pending => mergeWithPending(real.value, pending),
+    })
+  )

--- a/src/composables/useNotifications/push-failure-types.ts
+++ b/src/composables/useNotifications/push-failure-types.ts
@@ -1,10 +1,1 @@
-/**
- * Reasons a push attempt may fail. Classification drives the
- * notification copy and downstream retry policy in Epic 2.
- */
-export type PushFailureReason =
-  | 'network'
-  | 'auth'
-  | 'non-fast-forward'
-  | 'validation'
-  | 'unknown'
+export type { PushFailureReason } from '@/sw/protocol/push-error'

--- a/src/composables/useNotifications/use-push-error-bridge.ts
+++ b/src/composables/useNotifications/use-push-error-bridge.ts
@@ -1,0 +1,30 @@
+import { onUnmounted } from 'vue'
+import {
+  type PushErrorEvent,
+  SW_PUSH_ERROR_CHANNEL,
+} from '@/sw/protocol/push-error'
+import { notifyPushFailure } from './notify-push-failure'
+
+const subscribe = (channel: BroadcastChannel): void => {
+  channel.onmessage = (event: MessageEvent<PushErrorEvent>): void => {
+    const data = event.data
+    notifyPushFailure(data.reason, data.target)
+  }
+}
+
+/**
+ * Subscribe to SW-broadcast push errors and dispatch a typed
+ * notification per event. Mount once near the app root so every
+ * push failure surfaces to the user without coupling the SW to
+ * the client store.
+ * @returns void
+ */
+export const usePushErrorBridge = (): void => {
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_ERROR_CHANNEL)
+    : undefined
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => subscribe(channel))()
+  onUnmounted(() => channel?.close())
+}

--- a/src/sw/protocol/push-error.ts
+++ b/src/sw/protocol/push-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Reasons a push attempt may fail. Classification drives the
+ * notification copy and the downstream retry policy.
+ */
+export type PushFailureReason =
+  | 'network'
+  | 'auth'
+  | 'non-fast-forward'
+  | 'validation'
+  | 'unknown'
+
+/** BroadcastChannel name carrying classified push error events. */
+export const SW_PUSH_ERROR_CHANNEL = 'sw-push-error'
+
+/** Single push failure event broadcast to the client. */
+export type PushErrorEvent = {
+  readonly reason: PushFailureReason
+  readonly sha: string
+  readonly target: string
+  readonly at: number
+}

--- a/src/sw/push-queue/classify-error.test.ts
+++ b/src/sw/push-queue/classify-error.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { classifyPushError } from './classify-error'
+
+describe('classifyPushError', () => {
+  it('detects fast-forward rejection', () => {
+    expect(classifyPushError(new Error('not a fast-forward'))).toBe(
+      'non-fast-forward'
+    )
+    expect(classifyPushError(new Error('fetch first'))).toBe(
+      'non-fast-forward'
+    )
+  })
+
+  it('detects auth failures', () => {
+    expect(classifyPushError(new Error('401 Unauthorized'))).toBe('auth')
+    expect(classifyPushError(new Error('403 Forbidden'))).toBe('auth')
+    expect(classifyPushError(new Error('Bad credentials'))).toBe('auth')
+  })
+
+  it('detects validation failures', () => {
+    expect(classifyPushError(new Error('422 Unprocessable Entity'))).toBe(
+      'validation'
+    )
+    expect(classifyPushError(new Error('validation failed'))).toBe(
+      'validation'
+    )
+  })
+
+  it('detects network failures', () => {
+    expect(classifyPushError(new Error('Failed to fetch'))).toBe('network')
+    expect(classifyPushError(new Error('NetworkError'))).toBe('network')
+    expect(classifyPushError(new Error('ENOTFOUND'))).toBe('network')
+  })
+
+  it('falls back to unknown', () => {
+    expect(classifyPushError(new Error('something weird'))).toBe('unknown')
+    expect(classifyPushError('not even an error')).toBe('unknown')
+    expect(classifyPushError(undefined)).toBe('unknown')
+  })
+
+  it('precedence: fast-forward beats auth when both match', () => {
+    expect(
+      classifyPushError(new Error('non-fast-forward — 403 Forbidden'))
+    ).toBe('non-fast-forward')
+  })
+})

--- a/src/sw/push-queue/classify-error.ts
+++ b/src/sw/push-queue/classify-error.ts
@@ -1,0 +1,57 @@
+import type { PushFailureReason } from '../protocol/push-error'
+
+const NETWORK_PATTERNS: ReadonlyArray<RegExp> = [
+  /failed to fetch/i,
+  /networkerror/i,
+  /load failed/i,
+  /err_network/i,
+  /enotfound/i,
+  /econnreset/i,
+]
+
+const AUTH_PATTERNS: ReadonlyArray<RegExp> = [
+  /401/,
+  /403/,
+  /unauthorized/i,
+  /forbidden/i,
+  /bad credentials/i,
+]
+
+const FF_PATTERNS: ReadonlyArray<RegExp> = [
+  /not a fast-?forward/i,
+  /fetch first/i,
+  /non-fast-forward/i,
+  /push declined.*non-fast/i,
+]
+
+const VALIDATION_PATTERNS: ReadonlyArray<RegExp> = [
+  /422/,
+  /unprocessable/i,
+  /validation failed/i,
+]
+
+const matches = (source: string, patterns: ReadonlyArray<RegExp>): boolean =>
+  patterns.some(re => re.test(source))
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+/**
+ * Classify a push failure into one of the typed reasons that the
+ * notification factory understands. Falls back to `unknown` so
+ * callers always get a reason and can surface a generic copy.
+ * @param error Raw error thrown by the push pipeline.
+ * @returns Classified reason.
+ */
+export const classifyPushError = (error: unknown): PushFailureReason => {
+  const msg = messageOf(error)
+  return matches(msg, FF_PATTERNS)
+    ? 'non-fast-forward'
+    : matches(msg, AUTH_PATTERNS)
+      ? 'auth'
+      : matches(msg, VALIDATION_PATTERNS)
+        ? 'validation'
+        : matches(msg, NETWORK_PATTERNS)
+          ? 'network'
+          : 'unknown'
+}

--- a/src/sw/push-queue/error-broadcast.ts
+++ b/src/sw/push-queue/error-broadcast.ts
@@ -1,0 +1,34 @@
+import {
+  type PushErrorEvent,
+  SW_PUSH_ERROR_CHANNEL,
+} from '../protocol/push-error'
+import { classifyPushError } from './classify-error'
+import type { PushQueueEntry } from './types'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_ERROR_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast a classified push failure event so the client can
+ * surface a typed notification. The reason is derived from the
+ * raw error via `classifyPushError`.
+ * @param entry Queue entry whose push failed.
+ * @param error Raw error from the push pipeline.
+ * @returns void
+ */
+export const publishPushError = (
+  entry: PushQueueEntry,
+  error: unknown
+): void => {
+  const event: PushErrorEvent = {
+    reason: classifyPushError(error),
+    sha: entry.sha,
+    target: entry.branch,
+    at: Date.now(),
+  }
+  channelOf().postMessage(event)
+}

--- a/src/sw/push-queue/process-next.ts
+++ b/src/sw/push-queue/process-next.ts
@@ -1,28 +1,25 @@
 import { Option } from 'effect'
 import type { workerState } from '../state/state'
 import { publishPushState } from './broadcast'
-import { dequeue } from './enqueue'
+import { publishPushError } from './error-broadcast'
+import { pushOnce } from './push-once'
 import type { PushQueueEntry } from './types'
 
-const tryPush = async (
+const haltOnFailure = (
   entry: PushQueueEntry,
-  config: NonNullable<typeof workerState.config>
-): Promise<boolean> => {
-  const { pushToRemote } = await import('../git/remote/push-to-remote')
-  await pushToRemote(config)
-  await dequeue(entry.sha)
-  return true
-}
-
-const haltOnFailure = (remaining: number): Promise<void> => {
+  remaining: number,
+  error: unknown
+): Promise<void> => {
   publishPushState({ status: 'error', pending: remaining })
+  publishPushError(entry, error)
   return Promise.resolve()
 }
 
 /**
  * Recursively push the queue starting at `index`. Stops on the
- * first failure and emits an error state covering the entries
- * that remain unprocessed.
+ * first failure, emits an error state covering the unprocessed
+ * entries, and broadcasts a classified `PushErrorEvent` so the
+ * client can surface a typed notification.
  * @param pending Entries to process (oldest-first).
  * @param index Current position in `pending`.
  * @param config SW git configuration.
@@ -36,9 +33,9 @@ export const processNext = (
   Option.match(Option.fromNullable(pending[index]), {
     onNone: () => Promise.resolve(),
     onSome: async entry => {
-      const ok = await tryPush(entry, config).catch(() => false)
-      return ok
+      const result = await pushOnce(entry, config)
+      return result.ok
         ? processNext(pending, index + 1, config)
-        : haltOnFailure(pending.length - index)
+        : haltOnFailure(entry, pending.length - index, result.error)
     },
   })

--- a/src/sw/push-queue/push-once.ts
+++ b/src/sw/push-queue/push-once.ts
@@ -1,0 +1,30 @@
+import type { workerState } from '../state/state'
+import { dequeue } from './enqueue'
+import type { PushQueueEntry } from './types'
+
+/** Discriminated outcome of a single push attempt. */
+export type PushOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: unknown }
+
+/**
+ * Attempt to push and dequeue a single queued entry. Returns a
+ * discriminated result so the caller can react to the underlying
+ * error without losing it to a `.catch(() => false)`.
+ * @param entry Queued entry to push and remove on success.
+ * @param config SW git configuration with token + remote.
+ * @returns `{ ok: true }` on success, `{ ok: false, error }` on failure.
+ */
+export const pushOnce = async (
+  entry: PushQueueEntry,
+  config: NonNullable<typeof workerState.config>
+): Promise<PushOutcome> => {
+  try {
+    const { pushToRemote } = await import('../git/remote/push-to-remote')
+    await pushToRemote(config)
+    await dequeue(entry.sha)
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error }
+  }
+}


### PR DESCRIPTION
## Summary
Phase A / Epic 2 increment 2.3 — push failures surface as typed notifications.

- SW classifies the underlying error into one of five reasons (`network` / `auth` / `non-fast-forward` / `validation` / `unknown`) and broadcasts a `PushErrorEvent` on `SW_PUSH_ERROR_CHANNEL`.
- Client `usePushErrorBridge` subscribes and dispatches `notifyPushFailure(reason, target)` from Epic 1.4.
- Type centralised in `src/sw/protocol/push-error.ts`; client `useNotifications/push-failure-types` re-exports.
- Side effect: `App.vue` shrunk past the 50-line budget — pending-deploy merge logic extracted into `useMergedEntries`, original `if`-chain rewritten with `Option.match`.

## Test plan
- [x] 6/6 classifier unit (table-driven incl. precedence)
- [x] 3/3 e2e (`push-error-bridge.spec.ts`) — broadcast fake events, toast appears with kind=error, target embedded
- [x] 450/450 unit total
- [x] `bun run validate` clean

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)