### PR TITLE
feat(sw): retry policy with backoff + manual retry CTA (#86)

### DIFF
--- a/e2e/notifications/push-retry.spec.ts
+++ b/e2e/notifications/push-retry.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastTerminal = (
+  reason: 'network' | 'auth' | 'unknown'
+): string => `
+const ch = new BroadcastChannel('sw-push-error')
+ch.postMessage({
+  reason: '${reason}',
+  sha: 'deadbeef',
+  target: 'origin/develop',
+  at: ${Date.now()},
+  terminal: true,
+  attempt: 5,
+})
+ch.close()
+`
+
+const captureControl = `
+globalThis.__retryHits = 0
+const ch = new BroadcastChannel('sw-push-control')
+ch.onmessage = e => {
+  if (e.data?.type === 'retry-now') {
+    globalThis.__retryHits = (globalThis.__retryHits ?? 0) + 1
+  }
+}
+globalThis.__retryChannel = ch
+`
+
+test.describe('push retry CTA (2.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('retriable terminal error attaches a Retry CTA', async ({ page }) => {
+    await page.evaluate(broadcastTerminal('network'))
+    const cta = page
+      .locator('[data-testid="notification-toast-cta"]')
+      .first()
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveText('Retry')
+  })
+
+  test('non-retriable terminal error does NOT attach a CTA', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastTerminal('auth'))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(
+      toast.locator('[data-testid="notification-toast-cta"]')
+    ).toBeHidden()
+  })
+
+  test('clicking Retry posts a retry-now control message', async ({
+    page,
+  }) => {
+    await page.evaluate(captureControl)
+    await page.evaluate(broadcastTerminal('network'))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate<number>(
+            () => globalThis.__retryHits ?? 0
+          ),
+        { timeout: 5_000 }
+      )
+      .toBe(1)
+  })
+})

--- a/src/composables/useNotifications/notify-push-failure.ts
+++ b/src/composables/useNotifications/notify-push-failure.ts
@@ -1,27 +1,39 @@
-import { useNotificationsStore } from '@/stores/notifications'
+import {
+  type NotificationCta,
+  useNotificationsStore,
+} from '@/stores/notifications'
 import { pushFailureCopy } from './push-failure-copy'
 import type { PushFailureReason } from './push-failure-types'
 
 const decorate = (base: string, target: string | undefined): string =>
   target === undefined ? base : `${base} (${target})`
 
+const ctaFor = (
+  onRetry: (() => void) | undefined
+): NotificationCta | undefined =>
+  onRetry === undefined ? undefined : { label: 'Retry', action: onRetry }
+
 /**
  * Surface a sticky error notification describing why the latest
  * push attempt failed. Optional target ref (e.g. `origin/develop`)
  * is appended to the message so the user knows which remote was
- * affected when several are configured.
+ * affected when several are configured. When `onRetry` is
+ * supplied the toast exposes a Retry CTA wired to it.
  * @param reason Classified push failure reason.
  * @param target Optional remote ref to disambiguate the message.
+ * @param onRetry Optional callback wired to the Retry CTA.
  * @returns Id of the emitted notification entry.
  */
 export const notifyPushFailure = (
   reason: PushFailureReason,
-  target?: string
+  target?: string,
+  onRetry?: () => void
 ): string => {
   const copy = pushFailureCopy(reason)
   return useNotificationsStore().notify({
     kind: 'error',
     title: copy.title,
     message: decorate(copy.message, target),
+    cta: ctaFor(onRetry),
   })
 }

--- a/src/composables/useNotifications/push-retry.ts
+++ b/src/composables/useNotifications/push-retry.ts
@@ -1,0 +1,22 @@
+import {
+  type PushControlMessage,
+  SW_PUSH_CONTROL_CHANNEL,
+} from '@/sw/protocol/push-control'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_CONTROL_CHANNEL)
+  return channel
+}
+
+/**
+ * Ask the SW to retry the queued pushes immediately. Wired up to
+ * the Retry CTA on terminal push-failure notifications and (in
+ * the future) to a manual button on the sync badge.
+ * @returns void
+ */
+export const requestPushRetry = (): void => {
+  const msg: PushControlMessage = { type: 'retry-now' }
+  channelOf().postMessage(msg)
+}

--- a/src/composables/useNotifications/use-push-error-bridge.ts
+++ b/src/composables/useNotifications/use-push-error-bridge.ts
@@ -4,19 +4,30 @@ import {
   SW_PUSH_ERROR_CHANNEL,
 } from '@/sw/protocol/push-error'
 import { notifyPushFailure } from './notify-push-failure'
+import { requestPushRetry } from './push-retry'
+
+const RETRIABLE_REASONS: ReadonlySet<string> = new Set(['network', 'unknown'])
+
+const dispatch = (event: PushErrorEvent): void => {
+  const offerRetry = event.terminal && RETRIABLE_REASONS.has(event.reason)
+  notifyPushFailure(
+    event.reason,
+    event.target,
+    offerRetry ? requestPushRetry : undefined
+  )
+}
 
 const subscribe = (channel: BroadcastChannel): void => {
   channel.onmessage = (event: MessageEvent<PushErrorEvent>): void => {
-    const data = event.data
-    notifyPushFailure(data.reason, data.target)
+    dispatch(event.data)
   }
 }
 
 /**
  * Subscribe to SW-broadcast push errors and dispatch a typed
- * notification per event. Mount once near the app root so every
- * push failure surfaces to the user without coupling the SW to
- * the client store.
+ * notification per event. Terminal failures on retriable reasons
+ * (network / unknown) get a Retry CTA wired to the manual SW
+ * control channel.
  * @returns void
  */
 export const usePushErrorBridge = (): void => {

--- a/src/sw/main.ts
+++ b/src/sw/main.ts
@@ -9,6 +9,7 @@ import { registerLifecycle } from './core/lifecycle'
 import { registerMessageListener } from './core/messaging/message-listener'
 import { initLogChannel, log } from './logging/logger'
 import { SW_VERSION } from './protocol'
+import { registerPushControlListener } from './push-queue/control-listener'
 
 initLogChannel()
 log('info', 'lifecycle', 'SW loading', { version: SW_VERSION })
@@ -16,5 +17,6 @@ log('info', 'lifecycle', 'SW loading', { version: SW_VERSION })
 registerLifecycle()
 registerFetchListener()
 registerMessageListener()
+registerPushControlListener()
 
 log('info', 'lifecycle', 'SW ready', { version: SW_VERSION })

--- a/src/sw/protocol/push-control.ts
+++ b/src/sw/protocol/push-control.ts
@@ -1,0 +1,5 @@
+/** BroadcastChannel name for client→SW push pipeline control. */
+export const SW_PUSH_CONTROL_CHANNEL = 'sw-push-control'
+
+/** Control message asking the SW to drain the queue immediately. */
+export type PushControlMessage = { readonly type: 'retry-now' }

--- a/src/sw/protocol/push-error.ts
+++ b/src/sw/protocol/push-error.ts
@@ -18,4 +18,6 @@ export type PushErrorEvent = {
   readonly sha: string
   readonly target: string
   readonly at: number
+  readonly terminal: boolean
+  readonly attempt: number
 }

--- a/src/sw/push-queue/control-listener.ts
+++ b/src/sw/push-queue/control-listener.ts
@@ -1,0 +1,32 @@
+import { Match } from 'effect'
+import {
+  type PushControlMessage,
+  SW_PUSH_CONTROL_CHANNEL,
+} from '../protocol/push-control'
+
+let controlChannel: BroadcastChannel | undefined
+
+const dispatch = async (msg: PushControlMessage): Promise<void> => {
+  await Match.value(msg.type).pipe(
+    Match.when('retry-now', async () => {
+      const { drainPushes } = await import('./drain')
+      await drainPushes()
+    }),
+    Match.orElse(async () => undefined)
+  )
+}
+
+/**
+ * Subscribe the SW to client-issued push control messages. The
+ * channel handle is cached so re-registering is a no-op. Mount
+ * once at SW boot.
+ * @returns void
+ */
+export const registerPushControlListener = (): void => {
+  controlChannel ??= new BroadcastChannel(SW_PUSH_CONTROL_CHANNEL)
+  controlChannel.onmessage = (
+    event: MessageEvent<PushControlMessage>
+  ): void => {
+    void dispatch(event.data)
+  }
+}

--- a/src/sw/push-queue/error-broadcast.ts
+++ b/src/sw/push-queue/error-broadcast.ts
@@ -1,8 +1,8 @@
 import {
   type PushErrorEvent,
+  type PushFailureReason,
   SW_PUSH_ERROR_CHANNEL,
 } from '../protocol/push-error'
-import { classifyPushError } from './classify-error'
 import type { PushQueueEntry } from './types'
 
 let channel: BroadcastChannel | undefined
@@ -14,21 +14,26 @@ const channelOf = (): BroadcastChannel => {
 
 /**
  * Broadcast a classified push failure event so the client can
- * surface a typed notification. The reason is derived from the
- * raw error via `classifyPushError`.
+ * surface a typed notification. The `terminal` flag tells the UI
+ * whether retries are exhausted or the failure is non-retriable
+ * — only terminal events surface a Retry CTA.
  * @param entry Queue entry whose push failed.
- * @param error Raw error from the push pipeline.
+ * @param reason Classified failure reason.
+ * @param terminal True when no further retries are scheduled.
  * @returns void
  */
 export const publishPushError = (
   entry: PushQueueEntry,
-  error: unknown
+  reason: PushFailureReason,
+  terminal: boolean
 ): void => {
   const event: PushErrorEvent = {
-    reason: classifyPushError(error),
+    reason,
     sha: entry.sha,
     target: entry.branch,
     at: Date.now(),
+    terminal,
+    attempt: entry.attempt ?? 1,
   }
   channelOf().postMessage(event)
 }

--- a/src/sw/push-queue/handle-failure.ts
+++ b/src/sw/push-queue/handle-failure.ts
@@ -1,0 +1,38 @@
+import { publishPushState } from './broadcast'
+import { classifyPushError } from './classify-error'
+import { publishPushError } from './error-broadcast'
+import { shouldRetry } from './retry-policy'
+import { scheduleRetry } from './schedule-retry'
+import type { PushQueueEntry } from './types'
+import { bumpAttempt } from './update-attempt'
+
+/**
+ * React to a failed push attempt. Retriable failures bump the
+ * attempt counter, schedule the next drain, and surface a
+ * non-terminal error event. Terminal failures (auth /
+ * non-fast-forward / validation / retry-cap) leave the entry in
+ * place and surface a terminal event so the UI can offer a Retry
+ * CTA on user action.
+ * @param entry Failed queue entry.
+ * @param remaining Pending count covering the entry and everything after.
+ * @param error Raw error from the push pipeline.
+ * @returns Resolves once side effects (broadcast, schedule) are queued.
+ */
+export const handleFailure = async (
+  entry: PushQueueEntry,
+  remaining: number,
+  error: unknown
+): Promise<void> => {
+  const reason = classifyPushError(error)
+  const attempt = entry.attempt ?? 1
+  const retry = shouldRetry(reason, attempt)
+  publishPushState({ status: 'error', pending: remaining })
+  publishPushError(entry, reason, !retry)
+  const schedule = retry
+    ? async (): Promise<void> => {
+        await bumpAttempt(entry)
+        scheduleRetry(attempt)
+      }
+    : async (): Promise<void> => undefined
+  await schedule()
+}

--- a/src/sw/push-queue/process-next.ts
+++ b/src/sw/push-queue/process-next.ts
@@ -1,25 +1,13 @@
 import { Option } from 'effect'
 import type { workerState } from '../state/state'
-import { publishPushState } from './broadcast'
-import { publishPushError } from './error-broadcast'
+import { handleFailure } from './handle-failure'
 import { pushOnce } from './push-once'
 import type { PushQueueEntry } from './types'
 
-const haltOnFailure = (
-  entry: PushQueueEntry,
-  remaining: number,
-  error: unknown
-): Promise<void> => {
-  publishPushState({ status: 'error', pending: remaining })
-  publishPushError(entry, error)
-  return Promise.resolve()
-}
-
 /**
  * Recursively push the queue starting at `index`. Stops on the
- * first failure, emits an error state covering the unprocessed
- * entries, and broadcasts a classified `PushErrorEvent` so the
- * client can surface a typed notification.
+ * first failure, delegating retry policy + broadcasting to
+ * `handleFailure`. Successful pushes advance to the next entry.
  * @param pending Entries to process (oldest-first).
  * @param index Current position in `pending`.
  * @param config SW git configuration.
@@ -36,6 +24,6 @@ export const processNext = (
       const result = await pushOnce(entry, config)
       return result.ok
         ? processNext(pending, index + 1, config)
-        : haltOnFailure(entry, pending.length - index, result.error)
+        : handleFailure(entry, pending.length - index, result.error)
     },
   })

--- a/src/sw/push-queue/retry-policy.test.ts
+++ b/src/sw/push-queue/retry-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { backoffMs, MAX_ATTEMPTS, shouldRetry } from './retry-policy'
+
+describe('shouldRetry', () => {
+  it('returns true for retriable reasons under the cap', () => {
+    expect(shouldRetry('network', 0)).toBe(true)
+    expect(shouldRetry('network', MAX_ATTEMPTS - 1)).toBe(true)
+    expect(shouldRetry('unknown', 1)).toBe(true)
+  })
+
+  it('returns false at or beyond the cap', () => {
+    expect(shouldRetry('network', MAX_ATTEMPTS)).toBe(false)
+    expect(shouldRetry('network', MAX_ATTEMPTS + 5)).toBe(false)
+  })
+
+  it('returns false for non-retriable reasons', () => {
+    expect(shouldRetry('auth', 0)).toBe(false)
+    expect(shouldRetry('non-fast-forward', 0)).toBe(false)
+    expect(shouldRetry('validation', 0)).toBe(false)
+  })
+})
+
+describe('backoffMs', () => {
+  it('returns the configured delay per attempt', () => {
+    expect(backoffMs(1)).toBe(2_000)
+    expect(backoffMs(2)).toBe(4_000)
+    expect(backoffMs(3)).toBe(8_000)
+    expect(backoffMs(4)).toBe(16_000)
+    expect(backoffMs(5)).toBe(32_000)
+  })
+
+  it('clamps to the largest delay for unexpected attempts', () => {
+    expect(backoffMs(0)).toBe(2_000)
+    expect(backoffMs(99)).toBe(32_000)
+  })
+})

--- a/src/sw/push-queue/retry-policy.ts
+++ b/src/sw/push-queue/retry-policy.ts
@@ -1,0 +1,39 @@
+import type { PushFailureReason } from '../protocol/push-error'
+
+/** Maximum retry attempts (including the original try). */
+export const MAX_ATTEMPTS = 5
+
+/** Backoff schedule (ms) per attempt index 1..MAX_ATTEMPTS-1. */
+const BACKOFF_MS: ReadonlyArray<number> = [
+  2_000, 4_000, 8_000, 16_000, 32_000,
+]
+
+const RETRIABLE: ReadonlySet<PushFailureReason> = new Set([
+  'network',
+  'unknown',
+])
+
+/**
+ * Decide whether a classified failure should retry given the
+ * current attempt count. Auth / non-fast-forward / validation are
+ * never retried automatically — they require user action.
+ * @param reason Classified failure reason.
+ * @param attempt Number of attempts already made (1-indexed).
+ * @returns True if a further retry is permitted.
+ */
+export const shouldRetry = (
+  reason: PushFailureReason,
+  attempt: number
+): boolean => RETRIABLE.has(reason) && attempt < MAX_ATTEMPTS
+
+const clampIndex = (attempt: number): number =>
+  Math.max(0, Math.min(BACKOFF_MS.length - 1, attempt - 1))
+
+/**
+ * Lookup the backoff delay (ms) for the given attempt index.
+ * Clamps to the first/last configured delay outside the table.
+ * @param attempt 1-indexed attempt count just completed.
+ * @returns Delay before the next attempt.
+ */
+export const backoffMs = (attempt: number): number =>
+  BACKOFF_MS[clampIndex(attempt)] ?? 32_000

--- a/src/sw/push-queue/schedule-retry.ts
+++ b/src/sw/push-queue/schedule-retry.ts
@@ -1,0 +1,25 @@
+import { backoffMs } from './retry-policy'
+
+/**
+ * Schedule a deferred drain attempt. Returns immediately so the
+ * caller does not block the SW message dispatch loop. Real
+ * delivery is best-effort — if the SW is suspended before the
+ * timer fires, the next user activity wakes it and the queue is
+ * picked up on the next drain trigger.
+ * @param attempt 1-indexed attempt count just completed.
+ * @returns Cancel handle; call to cancel the scheduled drain.
+ */
+export const scheduleRetry = (attempt: number): (() => void) => {
+  const delay = backoffMs(attempt)
+  const handle = globalThis.setTimeout(() => {
+    void runDrain()
+  }, delay)
+  return (): void => {
+    globalThis.clearTimeout(handle)
+  }
+}
+
+const runDrain = async (): Promise<void> => {
+  const { drainPushes } = await import('./drain')
+  await drainPushes()
+}

--- a/src/sw/push-queue/types.ts
+++ b/src/sw/push-queue/types.ts
@@ -7,4 +7,5 @@ export type PushQueueEntry = {
   readonly branch: string
   readonly message: string
   readonly enqueuedAt: number
+  readonly attempt?: number
 }

--- a/src/sw/push-queue/update-attempt.ts
+++ b/src/sw/push-queue/update-attempt.ts
@@ -1,0 +1,18 @@
+import { fromRequest, txStore } from './idb'
+import type { PushQueueEntry } from './types'
+
+/**
+ * Persist an incremented attempt count on an existing queue
+ * entry. Used by the retry path so the next failure picks up the
+ * correct backoff slot.
+ * @param entry Source entry; attempt is bumped by one.
+ * @returns Resolves once the rewrite completes.
+ */
+export const bumpAttempt = async (entry: PushQueueEntry): Promise<void> => {
+  const next: PushQueueEntry = {
+    ...entry,
+    attempt: (entry.attempt ?? 1) + 1,
+  }
+  const store = await txStore('readwrite')
+  await fromRequest(store.put(next))
+}


### PR DESCRIPTION
## Summary
Phase A / Epic 2 increment 2.4 — closes Epic 2. Push pipeline now self-heals from transient failures and exposes a manual escape hatch.

- Retry policy: `[2,4,8,16,32]s` backoff schedule, max 5 attempts. `network` + `unknown` retry; `auth` / `non-fast-forward` / `validation` never retry.
- `handle-failure.ts` is the single decision point — classify, broadcast (with `terminal` flag), then either `bumpAttempt + scheduleRetry` or stop.
- `bumpAttempt` rewrites the queue entry with the incremented counter. Backoff timer is best-effort (SW may be killed); next user activity drains the persisted queue.
- New `sw-push-control` channel: client → SW `retry-now`. `registerPushControlListener()` mounted in `sw/main.ts`.
- Client `requestPushRetry()` + extended `notifyPushFailure(reason, target, onRetry)`: terminal failures on retriable reasons surface a Retry CTA wired to the manual control message.

## Test plan
- [x] 5/5 retry-policy unit
- [x] 3/3 retry e2e (`push-retry.spec.ts`) — CTA shows for retriable terminal, hidden for auth, click posts `retry-now`
- [x] 455/455 unit total
- [x] `bun run validate` clean

Closes #86. Closes Epic 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)