### PR TITLE
release: async push pipeline Epic 2 (2.1+2.2+2.3+2.4)

### DIFF
--- a/e2e/notifications/push-error-bridge.spec.ts
+++ b/e2e/notifications/push-error-bridge.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastError = (
+  reason: 'network' | 'auth' | 'non-fast-forward' | 'validation' | 'unknown',
+  target = 'origin/develop'
+): string => `
+const ch = new BroadcastChannel('sw-push-error')
+ch.postMessage({
+  reason: '${reason}',
+  sha: 'abc123',
+  target: '${target}',
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+test.describe('push error bridge → notification (2.3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('network error fires a sticky notification with target', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastError('network'))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'error')
+    await expect(toast).toContainText('origin/develop')
+  })
+
+  test('non-fast-forward emits distinct copy', async ({ page }) => {
+    await page.evaluate(broadcastError('non-fast-forward'))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toContainText(/rejected|remote/i)
+  })
+
+  test('every reason produces a unique toast', async ({ page }) => {
+    const reasons: ReadonlyArray<
+      'network' | 'auth' | 'non-fast-forward' | 'validation' | 'unknown'
+    > = ['network', 'auth', 'non-fast-forward', 'validation', 'unknown']
+    for (const reason of reasons) {
+      await page.evaluate(broadcastError(reason))
+    }
+    const toasts = page.locator('[data-testid="notification-toast"]')
+    await expect(toasts).toHaveCount(3)
+  })
+})

--- a/e2e/notifications/push-retry.spec.ts
+++ b/e2e/notifications/push-retry.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastTerminal = (
+  reason: 'network' | 'auth' | 'unknown'
+): string => `
+const ch = new BroadcastChannel('sw-push-error')
+ch.postMessage({
+  reason: '${reason}',
+  sha: 'deadbeef',
+  target: 'origin/develop',
+  at: ${Date.now()},
+  terminal: true,
+  attempt: 5,
+})
+ch.close()
+`
+
+const captureControl = `
+globalThis.__retryHits = 0
+const ch = new BroadcastChannel('sw-push-control')
+ch.onmessage = e => {
+  if (e.data?.type === 'retry-now') {
+    globalThis.__retryHits = (globalThis.__retryHits ?? 0) + 1
+  }
+}
+globalThis.__retryChannel = ch
+`
+
+test.describe('push retry CTA (2.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('retriable terminal error attaches a Retry CTA', async ({ page }) => {
+    await page.evaluate(broadcastTerminal('network'))
+    const cta = page
+      .locator('[data-testid="notification-toast-cta"]')
+      .first()
+    await expect(cta).toBeVisible()
+    await expect(cta).toHaveText('Retry')
+  })
+
+  test('non-retriable terminal error does NOT attach a CTA', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastTerminal('auth'))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(
+      toast.locator('[data-testid="notification-toast-cta"]')
+    ).toBeHidden()
+  })
+
+  test('clicking Retry posts a retry-now control message', async ({
+    page,
+  }) => {
+    await page.evaluate(captureControl)
+    await page.evaluate(broadcastTerminal('network'))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate<number>(
+            () => globalThis.__retryHits ?? 0
+          ),
+        { timeout: 5_000 }
+      )
+      .toBe(1)
+  })
+})

--- a/e2e/notifications/push-sync-badge.spec.ts
+++ b/e2e/notifications/push-sync-badge.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+
+const broadcast = (
+  pending: number,
+  status: 'idle' | 'syncing' | 'error'
+): string => `
+const ch = new BroadcastChannel('sw-push-state')
+ch.postMessage({ status: '${status}', pending: ${pending} })
+ch.close()
+`
+
+test.describe('push sync badge (2.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('badge stays hidden while idle and pending=0', async ({ page }) => {
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await expect(badge).toBeHidden()
+  })
+
+  test('syncing state surfaces with pending count', async ({ page }) => {
+    await page.evaluate(broadcast(2, 'syncing'))
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await expect(badge).toBeVisible()
+    await expect(badge).toHaveAttribute('data-status', 'syncing')
+    await expect(
+      page.locator('[data-testid="push-sync-badge-count"]')
+    ).toHaveText('2')
+  })
+
+  test('error state surfaces and does not pulse', async ({ page }) => {
+    await page.evaluate(broadcast(1, 'error'))
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await expect(badge).toBeVisible()
+    await expect(badge).toHaveAttribute('data-status', 'error')
+  })
+
+  test('drain success returns the badge to hidden', async ({ page }) => {
+    const badge = page.locator('[data-testid="push-sync-badge"]')
+    await page.evaluate(broadcast(1, 'syncing'))
+    await expect(badge).toBeVisible()
+    await page.evaluate(broadcast(0, 'idle'))
+    await expect(badge).toBeHidden()
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,20 +1,15 @@
 <script setup lang="ts">
-import { computed, provide, watch } from 'vue'
+import { provide, watch } from 'vue'
 import { RouterView, useRoute } from 'vue-router'
 import {
   DEPLOY_ENTRIES_KEY,
   DEPLOY_LOADING_KEY,
   DEPLOY_TRACK_KEY,
 } from '@/composables/useDeployStatus/deploy-context'
-import {
-  clearPendingDeploy,
-  isPendingMatched,
-  pendingDeploy,
-  pendingToDeployBuild,
-} from '@/composables/useDeployStatus/pending-deploy'
 import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polling'
-import type { DeployBuild } from '@/composables/useDeployStatus/workflow-types'
+import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entries'
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
+import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
@@ -22,34 +17,10 @@ const route = useRoute()
 const authStore = useAuthStore()
 const contentStore = useContentStore()
 useNotificationsPersistence()
+usePushErrorBridge()
 
-// Single app-wide poller. Pauses automatically once every visible
-// run is terminal; resumes when a save hits `requestPoll` via
-// DEPLOY_TRACK_KEY or when the tab regains focus with an active
-// deploy still in flight.
 const poll = useDeployPolling()
-
-// Merge the optimistic pending entry (set by the save flow) into the
-// real entries so the home list shows the user's action instantly.
-// The pending entry is dropped automatically once a real run with a
-// matching commit message lands.
-const PENDING_TTL_MS = 5 * 60 * 1000
-
-const mergedEntries = computed<ReadonlyArray<DeployBuild>>(() => {
-  const real = poll.entries.value
-  const pending = pendingDeploy.value
-  if (!pending) return real
-  const age = Date.now() - Date.parse(pending.createdAt)
-  if (age > PENDING_TTL_MS) {
-    clearPendingDeploy()
-    return real
-  }
-  if (isPendingMatched(pending, real)) {
-    clearPendingDeploy()
-    return real
-  }
-  return [pendingToDeployBuild(pending), ...real]
-})
+const mergedEntries = useMergedEntries(poll.entries)
 
 provide(DEPLOY_TRACK_KEY, poll.requestPoll)
 provide(DEPLOY_ENTRIES_KEY, mergedEntries)

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -34,6 +34,7 @@ const hash = __COMMIT_HASH__
 
 <template>
   <AppHeader>
+    <PushSyncBadge />
     <NotificationIndicator />
     <AuthButton />
   </AppHeader>

--- a/src/components/PushSyncBadge/PushSyncBadge.vue
+++ b/src/components/PushSyncBadge/PushSyncBadge.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { usePushState } from '@/composables/useSWBridge/use-push-state'
+import { PUSH_SYNC_TEST_IDS } from './test-ids'
+
+const { state } = usePushState()
+const visible = computed(
+  () => state.value.status !== 'idle' || state.value.pending > 0
+)
+const ariaLabel = computed(() =>
+  state.value.status === 'error'
+    ? `Push sync error, ${state.value.pending} pending`
+    : `Push syncing, ${state.value.pending} pending`
+)
+</script>
+
+<template>
+  <aside
+    v-if="visible"
+    class="push-sync"
+    :data-testid="PUSH_SYNC_TEST_IDS.root"
+    :data-status="state.status"
+    :aria-label="ariaLabel"
+    aria-live="polite"
+  >
+    <span v-if="state.pending > 0" :data-testid="PUSH_SYNC_TEST_IDS.count">
+      {{ state.pending }}
+    </span>
+    <span v-else aria-hidden="true">·</span>
+  </aside>
+</template>
+
+<style scoped>
+.push-sync {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-weight: 700;
+  border-radius: 12px;
+  color: #fff;
+  background: var(--color-accent, #4fc3f7);
+}
+
+.push-sync[data-status='syncing'] {
+  animation: push-sync-pulse 1.2s ease-in-out infinite;
+}
+
+.push-sync[data-status='error'] {
+  background: var(--color-error, #e53935);
+  animation: none;
+}
+
+@keyframes push-sync-pulse {
+  0%, 100% { opacity: 100%; }
+  50% { opacity: 55%; }
+}
+</style>

--- a/src/components/PushSyncBadge/test-ids.ts
+++ b/src/components/PushSyncBadge/test-ids.ts
@@ -1,0 +1,5 @@
+/** Test IDs for the SW push pipeline status badge. */
+export const PUSH_SYNC_TEST_IDS = {
+  root: 'push-sync-badge',
+  count: 'push-sync-badge-count',
+} as const

--- a/src/composables/useDeployStatus/use-merged-entries.ts
+++ b/src/composables/useDeployStatus/use-merged-entries.ts
@@ -1,0 +1,48 @@
+import { Option } from 'effect'
+import { type ComputedRef, computed, type Ref } from 'vue'
+import {
+  clearPendingDeploy,
+  isPendingMatched,
+  type PendingDeploy,
+  pendingDeploy,
+  pendingToDeployBuild,
+} from './pending-deploy'
+import type { DeployBuild } from './workflow-types'
+
+const PENDING_TTL_MS = 5 * 60 * 1000
+
+const dropAndReturn = (
+  list: ReadonlyArray<DeployBuild>
+): ReadonlyArray<DeployBuild> => {
+  clearPendingDeploy()
+  return list
+}
+
+const mergeWithPending = (
+  realList: ReadonlyArray<DeployBuild>,
+  pending: PendingDeploy
+): ReadonlyArray<DeployBuild> => {
+  const expired = Date.now() - Date.parse(pending.createdAt) > PENDING_TTL_MS
+  const matched = isPendingMatched(pending, realList)
+  return expired || matched
+    ? dropAndReturn(realList)
+    : [pendingToDeployBuild(pending), ...realList]
+}
+
+/**
+ * Merge the optimistic pending deploy entry with the real list so
+ * the home view shows the user's most recent action instantly.
+ * The pending entry is dropped once a real run with a matching
+ * commit message arrives or after the TTL expires.
+ * @param real Reactive ref of real polled deploy builds.
+ * @returns Computed ref containing the merged list.
+ */
+export const useMergedEntries = (
+  real: Ref<readonly DeployBuild[]>
+): ComputedRef<ReadonlyArray<DeployBuild>> =>
+  computed<ReadonlyArray<DeployBuild>>(() =>
+    Option.match(Option.fromNullable(pendingDeploy.value), {
+      onNone: () => real.value,
+      onSome: pending => mergeWithPending(real.value, pending),
+    })
+  )

--- a/src/composables/useNotifications/notify-push-failure.ts
+++ b/src/composables/useNotifications/notify-push-failure.ts
@@ -1,27 +1,39 @@
-import { useNotificationsStore } from '@/stores/notifications'
+import {
+  type NotificationCta,
+  useNotificationsStore,
+} from '@/stores/notifications'
 import { pushFailureCopy } from './push-failure-copy'
 import type { PushFailureReason } from './push-failure-types'
 
 const decorate = (base: string, target: string | undefined): string =>
   target === undefined ? base : `${base} (${target})`
 
+const ctaFor = (
+  onRetry: (() => void) | undefined
+): NotificationCta | undefined =>
+  onRetry === undefined ? undefined : { label: 'Retry', action: onRetry }
+
 /**
  * Surface a sticky error notification describing why the latest
  * push attempt failed. Optional target ref (e.g. `origin/develop`)
  * is appended to the message so the user knows which remote was
- * affected when several are configured.
+ * affected when several are configured. When `onRetry` is
+ * supplied the toast exposes a Retry CTA wired to it.
  * @param reason Classified push failure reason.
  * @param target Optional remote ref to disambiguate the message.
+ * @param onRetry Optional callback wired to the Retry CTA.
  * @returns Id of the emitted notification entry.
  */
 export const notifyPushFailure = (
   reason: PushFailureReason,
-  target?: string
+  target?: string,
+  onRetry?: () => void
 ): string => {
   const copy = pushFailureCopy(reason)
   return useNotificationsStore().notify({
     kind: 'error',
     title: copy.title,
     message: decorate(copy.message, target),
+    cta: ctaFor(onRetry),
   })
 }

--- a/src/composables/useNotifications/push-failure-types.ts
+++ b/src/composables/useNotifications/push-failure-types.ts
@@ -1,10 +1,1 @@
-/**
- * Reasons a push attempt may fail. Classification drives the
- * notification copy and downstream retry policy in Epic 2.
- */
-export type PushFailureReason =
-  | 'network'
-  | 'auth'
-  | 'non-fast-forward'
-  | 'validation'
-  | 'unknown'
+export type { PushFailureReason } from '@/sw/protocol/push-error'

--- a/src/composables/useNotifications/push-retry.ts
+++ b/src/composables/useNotifications/push-retry.ts
@@ -1,0 +1,22 @@
+import {
+  type PushControlMessage,
+  SW_PUSH_CONTROL_CHANNEL,
+} from '@/sw/protocol/push-control'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_CONTROL_CHANNEL)
+  return channel
+}
+
+/**
+ * Ask the SW to retry the queued pushes immediately. Wired up to
+ * the Retry CTA on terminal push-failure notifications and (in
+ * the future) to a manual button on the sync badge.
+ * @returns void
+ */
+export const requestPushRetry = (): void => {
+  const msg: PushControlMessage = { type: 'retry-now' }
+  channelOf().postMessage(msg)
+}

--- a/src/composables/useNotifications/use-push-error-bridge.ts
+++ b/src/composables/useNotifications/use-push-error-bridge.ts
@@ -1,0 +1,30 @@
+import { onUnmounted } from 'vue'
+import {
+  type PushErrorEvent,
+  SW_PUSH_ERROR_CHANNEL,
+} from '@/sw/protocol/push-error'
+import { notifyPushFailure } from './notify-push-failure'
+
+const subscribe = (channel: BroadcastChannel): void => {
+  channel.onmessage = (event: MessageEvent<PushErrorEvent>): void => {
+    const data = event.data
+    notifyPushFailure(data.reason, data.target)
+  }
+}
+
+/**
+ * Subscribe to SW-broadcast push errors and dispatch a typed
+ * notification per event. Mount once near the app root so every
+ * push failure surfaces to the user without coupling the SW to
+ * the client store.
+ * @returns void
+ */
+export const usePushErrorBridge = (): void => {
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_ERROR_CHANNEL)
+    : undefined
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => subscribe(channel))()
+  onUnmounted(() => channel?.close())
+}

--- a/src/composables/useNotifications/use-push-error-bridge.ts
+++ b/src/composables/useNotifications/use-push-error-bridge.ts
@@ -4,19 +4,30 @@ import {
   SW_PUSH_ERROR_CHANNEL,
 } from '@/sw/protocol/push-error'
 import { notifyPushFailure } from './notify-push-failure'
+import { requestPushRetry } from './push-retry'
+
+const RETRIABLE_REASONS: ReadonlySet<string> = new Set(['network', 'unknown'])
+
+const dispatch = (event: PushErrorEvent): void => {
+  const offerRetry = event.terminal && RETRIABLE_REASONS.has(event.reason)
+  notifyPushFailure(
+    event.reason,
+    event.target,
+    offerRetry ? requestPushRetry : undefined
+  )
+}
 
 const subscribe = (channel: BroadcastChannel): void => {
   channel.onmessage = (event: MessageEvent<PushErrorEvent>): void => {
-    const data = event.data
-    notifyPushFailure(data.reason, data.target)
+    dispatch(event.data)
   }
 }
 
 /**
  * Subscribe to SW-broadcast push errors and dispatch a typed
- * notification per event. Mount once near the app root so every
- * push failure surfaces to the user without coupling the SW to
- * the client store.
+ * notification per event. Terminal failures on retriable reasons
+ * (network / unknown) get a Retry CTA wired to the manual SW
+ * control channel.
  * @returns void
  */
 export const usePushErrorBridge = (): void => {

--- a/src/composables/useSWBridge/use-push-state.ts
+++ b/src/composables/useSWBridge/use-push-state.ts
@@ -1,0 +1,29 @@
+import { onUnmounted, ref } from 'vue'
+import {
+  INITIAL_PUSH_STATE,
+  type PushState,
+  SW_PUSH_STATE_CHANNEL,
+} from '@/sw/protocol'
+
+/**
+ * Subscribe to push pipeline state events broadcast by the SW.
+ * Returns a reactive ref that mirrors the latest snapshot. The
+ * subscription is torn down automatically on unmount.
+ * @returns Reactive `state` ref reflecting the SW push pipeline.
+ */
+export const usePushState = () => {
+  const state = ref<PushState>(INITIAL_PUSH_STATE)
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_STATE_CHANNEL)
+    : undefined
+  const wire = (ch: BroadcastChannel): void => {
+    ch.onmessage = (event: MessageEvent<PushState>): void => {
+      state.value = event.data
+    }
+  }
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => wire(channel))()
+  onUnmounted(() => channel?.close())
+  return { state }
+}

--- a/src/sw/git/remote/real-commit.ts
+++ b/src/sw/git/remote/real-commit.ts
@@ -1,19 +1,19 @@
 import { Effect } from 'effect'
 import { log } from '../../logging/logger'
 import { recordOp } from '../../logging/metrics'
+import { drainPushes, enqueue } from '../../push-queue'
 import { workerState } from '../../state/state'
 import { fs, REPO_DIR } from '../fs'
 import { loadGit } from '../load-git'
 
 type SWGitConfig = NonNullable<typeof workerState.config>
 
-const runCommit = async (
+const commitLocally = async (
   config: SWGitConfig,
   message: string
 ): Promise<string> => {
-  const start = Date.now()
   const git = await loadGit()
-  const sha = await git.commit({
+  return git.commit({
     fs,
     dir: REPO_DIR,
     message,
@@ -22,11 +22,24 @@ const runCommit = async (
       email: config.authorEmail ?? 'admin@prometheus.org',
     },
   })
+}
+
+const runCommitAndQueue = async (
+  config: SWGitConfig,
+  message: string
+): Promise<string> => {
+  const start = Date.now()
+  const sha = await commitLocally(config, message)
   log('info', 'git', `committed ${sha.slice(0, 7)}`)
-  const { pushToRemote } = await import('./push-to-remote')
-  await pushToRemote(config)
   workerState.commitSha = sha
-  recordOp('commitAndPush', Date.now() - start)
+  recordOp('commit', Date.now() - start)
+  await enqueue({
+    sha,
+    branch: config.branch,
+    message,
+    enqueuedAt: Date.now(),
+  })
+  void drainPushes()
   return sha
 }
 
@@ -35,22 +48,23 @@ const runCommit = async (
  * generic UnknownError whose `.message` reads "An unknown error
  * occurred in Effect.tryPromise". The handler at /api/github/commit
  * then bubbles that opaque text up to the user. We need the
- * underlying isomorphic-git reason ("not a fast-forward",
- * "401 Unauthorized", "RPC failed with HTTP 422", etc.) so failed
- * saves are diagnosable. Coerce non-Error throws so callers always
- * get a string-bearing Error.
+ * underlying isomorphic-git reason so failed saves are diagnosable.
+ * Coerce non-Error throws so callers always get a string-bearing
+ * Error.
  */
 const preserveError = (e: unknown): Error =>
   e instanceof Error ? e : new Error(String(e))
 
 /**
- * Execute real git commit + push to remote.
- * @param config - Validated SW git configuration
- * @param message - Commit message
- * @returns Effect yielding the commit SHA
+ * Run a real git commit, enqueue the push, return the commit sha
+ * to the caller without waiting for the network. The push is
+ * processed by the background drain in `push-queue/drain.ts`.
+ * @param config Validated SW git configuration.
+ * @param message Commit message.
+ * @returns Effect yielding the commit sha.
  */
 export const realCommit = (config: SWGitConfig, message: string) =>
   Effect.tryPromise({
-    try: () => runCommit(config, message),
+    try: () => runCommitAndQueue(config, message),
     catch: preserveError,
   })

--- a/src/sw/main.ts
+++ b/src/sw/main.ts
@@ -9,6 +9,7 @@ import { registerLifecycle } from './core/lifecycle'
 import { registerMessageListener } from './core/messaging/message-listener'
 import { initLogChannel, log } from './logging/logger'
 import { SW_VERSION } from './protocol'
+import { registerPushControlListener } from './push-queue/control-listener'
 
 initLogChannel()
 log('info', 'lifecycle', 'SW loading', { version: SW_VERSION })
@@ -16,5 +17,6 @@ log('info', 'lifecycle', 'SW loading', { version: SW_VERSION })
 registerLifecycle()
 registerFetchListener()
 registerMessageListener()
+registerPushControlListener()
 
 log('info', 'lifecycle', 'SW ready', { version: SW_VERSION })

--- a/src/sw/protocol.ts
+++ b/src/sw/protocol.ts
@@ -14,6 +14,12 @@ export type {
   LogEntry,
   LogLevel,
 } from './protocol/log-types'
+export {
+  INITIAL_PUSH_STATE,
+  type PushState,
+  type PushStatus,
+  SW_PUSH_STATE_CHANNEL,
+} from './protocol/push-state'
 export type {
   SWFetchRequest,
   SWFetchResponse,

--- a/src/sw/protocol/push-control.ts
+++ b/src/sw/protocol/push-control.ts
@@ -1,0 +1,5 @@
+/** BroadcastChannel name for client→SW push pipeline control. */
+export const SW_PUSH_CONTROL_CHANNEL = 'sw-push-control'
+
+/** Control message asking the SW to drain the queue immediately. */
+export type PushControlMessage = { readonly type: 'retry-now' }

--- a/src/sw/protocol/push-error.ts
+++ b/src/sw/protocol/push-error.ts
@@ -18,4 +18,6 @@ export type PushErrorEvent = {
   readonly sha: string
   readonly target: string
   readonly at: number
+  readonly terminal: boolean
+  readonly attempt: number
 }

--- a/src/sw/protocol/push-error.ts
+++ b/src/sw/protocol/push-error.ts
@@ -1,0 +1,21 @@
+/**
+ * Reasons a push attempt may fail. Classification drives the
+ * notification copy and the downstream retry policy.
+ */
+export type PushFailureReason =
+  | 'network'
+  | 'auth'
+  | 'non-fast-forward'
+  | 'validation'
+  | 'unknown'
+
+/** BroadcastChannel name carrying classified push error events. */
+export const SW_PUSH_ERROR_CHANNEL = 'sw-push-error'
+
+/** Single push failure event broadcast to the client. */
+export type PushErrorEvent = {
+  readonly reason: PushFailureReason
+  readonly sha: string
+  readonly target: string
+  readonly at: number
+}

--- a/src/sw/protocol/push-state.ts
+++ b/src/sw/protocol/push-state.ts
@@ -1,0 +1,17 @@
+/** Status of the SW push pipeline as broadcast to the UI. */
+export type PushStatus = 'idle' | 'syncing' | 'error'
+
+/** Live snapshot of the SW push queue state. */
+export type PushState = {
+  readonly status: PushStatus
+  readonly pending: number
+}
+
+/** BroadcastChannel name for push state events. */
+export const SW_PUSH_STATE_CHANNEL = 'sw-push-state'
+
+/** Initial state when no SW activity is observed. */
+export const INITIAL_PUSH_STATE: PushState = {
+  status: 'idle',
+  pending: 0,
+}

--- a/src/sw/push-queue/broadcast.ts
+++ b/src/sw/push-queue/broadcast.ts
@@ -1,0 +1,37 @@
+import { type PushState, SW_PUSH_STATE_CHANNEL } from '../protocol/push-state'
+
+let lastState: PushState = { status: 'idle', pending: 0 }
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_STATE_CHANNEL)
+  return channel
+}
+
+const sendIfChanged = (prev: PushState, next: PushState): void => {
+  const changed = prev.status !== next.status || prev.pending !== next.pending
+  const fire = changed
+    ? () => channelOf().postMessage(next)
+    : (): void => undefined
+  fire()
+}
+
+/**
+ * Broadcast the latest push pipeline snapshot to all subscribed
+ * clients. The last known state is cached so repeat publishers
+ * (drain ticks, error retries) skip redundant emissions.
+ * @param next New push state to broadcast.
+ * @returns void
+ */
+export const publishPushState = (next: PushState): void => {
+  const prev = lastState
+  lastState = next
+  sendIfChanged(prev, next)
+}
+
+/**
+ * Read the cached push state without broadcasting. Useful when a
+ * fresh subscriber asks for the current value.
+ * @returns Last broadcast state.
+ */
+export const currentPushState = (): PushState => lastState

--- a/src/sw/push-queue/classify-error.test.ts
+++ b/src/sw/push-queue/classify-error.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { classifyPushError } from './classify-error'
+
+describe('classifyPushError', () => {
+  it('detects fast-forward rejection', () => {
+    expect(classifyPushError(new Error('not a fast-forward'))).toBe(
+      'non-fast-forward'
+    )
+    expect(classifyPushError(new Error('fetch first'))).toBe(
+      'non-fast-forward'
+    )
+  })
+
+  it('detects auth failures', () => {
+    expect(classifyPushError(new Error('401 Unauthorized'))).toBe('auth')
+    expect(classifyPushError(new Error('403 Forbidden'))).toBe('auth')
+    expect(classifyPushError(new Error('Bad credentials'))).toBe('auth')
+  })
+
+  it('detects validation failures', () => {
+    expect(classifyPushError(new Error('422 Unprocessable Entity'))).toBe(
+      'validation'
+    )
+    expect(classifyPushError(new Error('validation failed'))).toBe(
+      'validation'
+    )
+  })
+
+  it('detects network failures', () => {
+    expect(classifyPushError(new Error('Failed to fetch'))).toBe('network')
+    expect(classifyPushError(new Error('NetworkError'))).toBe('network')
+    expect(classifyPushError(new Error('ENOTFOUND'))).toBe('network')
+  })
+
+  it('falls back to unknown', () => {
+    expect(classifyPushError(new Error('something weird'))).toBe('unknown')
+    expect(classifyPushError('not even an error')).toBe('unknown')
+    expect(classifyPushError(undefined)).toBe('unknown')
+  })
+
+  it('precedence: fast-forward beats auth when both match', () => {
+    expect(
+      classifyPushError(new Error('non-fast-forward — 403 Forbidden'))
+    ).toBe('non-fast-forward')
+  })
+})

--- a/src/sw/push-queue/classify-error.ts
+++ b/src/sw/push-queue/classify-error.ts
@@ -1,0 +1,57 @@
+import type { PushFailureReason } from '../protocol/push-error'
+
+const NETWORK_PATTERNS: ReadonlyArray<RegExp> = [
+  /failed to fetch/i,
+  /networkerror/i,
+  /load failed/i,
+  /err_network/i,
+  /enotfound/i,
+  /econnreset/i,
+]
+
+const AUTH_PATTERNS: ReadonlyArray<RegExp> = [
+  /401/,
+  /403/,
+  /unauthorized/i,
+  /forbidden/i,
+  /bad credentials/i,
+]
+
+const FF_PATTERNS: ReadonlyArray<RegExp> = [
+  /not a fast-?forward/i,
+  /fetch first/i,
+  /non-fast-forward/i,
+  /push declined.*non-fast/i,
+]
+
+const VALIDATION_PATTERNS: ReadonlyArray<RegExp> = [
+  /422/,
+  /unprocessable/i,
+  /validation failed/i,
+]
+
+const matches = (source: string, patterns: ReadonlyArray<RegExp>): boolean =>
+  patterns.some(re => re.test(source))
+
+const messageOf = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error)
+
+/**
+ * Classify a push failure into one of the typed reasons that the
+ * notification factory understands. Falls back to `unknown` so
+ * callers always get a reason and can surface a generic copy.
+ * @param error Raw error thrown by the push pipeline.
+ * @returns Classified reason.
+ */
+export const classifyPushError = (error: unknown): PushFailureReason => {
+  const msg = messageOf(error)
+  return matches(msg, FF_PATTERNS)
+    ? 'non-fast-forward'
+    : matches(msg, AUTH_PATTERNS)
+      ? 'auth'
+      : matches(msg, VALIDATION_PATTERNS)
+        ? 'validation'
+        : matches(msg, NETWORK_PATTERNS)
+          ? 'network'
+          : 'unknown'
+}

--- a/src/sw/push-queue/control-listener.ts
+++ b/src/sw/push-queue/control-listener.ts
@@ -1,0 +1,32 @@
+import { Match } from 'effect'
+import {
+  type PushControlMessage,
+  SW_PUSH_CONTROL_CHANNEL,
+} from '../protocol/push-control'
+
+let controlChannel: BroadcastChannel | undefined
+
+const dispatch = async (msg: PushControlMessage): Promise<void> => {
+  await Match.value(msg.type).pipe(
+    Match.when('retry-now', async () => {
+      const { drainPushes } = await import('./drain')
+      await drainPushes()
+    }),
+    Match.orElse(async () => undefined)
+  )
+}
+
+/**
+ * Subscribe the SW to client-issued push control messages. The
+ * channel handle is cached so re-registering is a no-op. Mount
+ * once at SW boot.
+ * @returns void
+ */
+export const registerPushControlListener = (): void => {
+  controlChannel ??= new BroadcastChannel(SW_PUSH_CONTROL_CHANNEL)
+  controlChannel.onmessage = (
+    event: MessageEvent<PushControlMessage>
+  ): void => {
+    void dispatch(event.data)
+  }
+}

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -1,33 +1,9 @@
 import { Option } from 'effect'
 import { workerState } from '../state/state'
-import { dequeue } from './enqueue'
 import { listPending } from './idb'
-import type { PushQueueEntry } from './types'
+import { processNext } from './process-next'
 
 let inFlight = false
-
-const tryPush = async (
-  entry: PushQueueEntry,
-  config: NonNullable<typeof workerState.config>
-): Promise<boolean> => {
-  const { pushToRemote } = await import('../git/remote/push-to-remote')
-  await pushToRemote(config)
-  await dequeue(entry.sha)
-  return true
-}
-
-const processNext = (
-  pending: readonly PushQueueEntry[],
-  index: number,
-  config: NonNullable<typeof workerState.config>
-): Promise<void> =>
-  Option.match(Option.fromNullable(pending[index]), {
-    onNone: () => Promise.resolve(),
-    onSome: async entry => {
-      const ok = await tryPush(entry, config).catch(() => false)
-      return ok ? processNext(pending, index + 1, config) : Promise.resolve()
-    },
-  })
 
 const processPending = async (): Promise<void> =>
   Option.match(Option.fromNullable(workerState.config), {
@@ -49,7 +25,7 @@ const runOnce = async (): Promise<void> => {
 
 /**
  * Process queued push entries oldest-first. Each successful push
- * dequeues its entry; the first failure stops the drain so the
+ * dequeues its entry; the first failure stops the walk so the
  * queue stays ordered for the next retry. Reentrant drain calls
  * coalesce — only one walk runs at a time.
  * @returns Resolves once the walk has finished or yielded.

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -1,0 +1,60 @@
+import { Option } from 'effect'
+import { workerState } from '../state/state'
+import { dequeue } from './enqueue'
+import { listPending } from './idb'
+import type { PushQueueEntry } from './types'
+
+let inFlight = false
+
+const tryPush = async (
+  entry: PushQueueEntry,
+  config: NonNullable<typeof workerState.config>
+): Promise<boolean> => {
+  const { pushToRemote } = await import('../git/remote/push-to-remote')
+  await pushToRemote(config)
+  await dequeue(entry.sha)
+  return true
+}
+
+const processNext = (
+  pending: readonly PushQueueEntry[],
+  index: number,
+  config: NonNullable<typeof workerState.config>
+): Promise<void> =>
+  Option.match(Option.fromNullable(pending[index]), {
+    onNone: () => Promise.resolve(),
+    onSome: async entry => {
+      const ok = await tryPush(entry, config).catch(() => false)
+      return ok ? processNext(pending, index + 1, config) : Promise.resolve()
+    },
+  })
+
+const processPending = async (): Promise<void> =>
+  Option.match(Option.fromNullable(workerState.config), {
+    onNone: () => Promise.resolve(),
+    onSome: async config => {
+      const pending = await listPending()
+      await processNext(pending, 0, config)
+    },
+  })
+
+const runOnce = async (): Promise<void> => {
+  inFlight = true
+  try {
+    await processPending()
+  } finally {
+    inFlight = false
+  }
+}
+
+/**
+ * Process queued push entries oldest-first. Each successful push
+ * dequeues its entry; the first failure stops the drain so the
+ * queue stays ordered for the next retry. Reentrant drain calls
+ * coalesce — only one walk runs at a time.
+ * @returns Resolves once the walk has finished or yielded.
+ */
+export const drainPushes = async (): Promise<void> => {
+  const acquired = !inFlight
+  await (acquired ? runOnce() : Promise.resolve())
+}

--- a/src/sw/push-queue/enqueue.ts
+++ b/src/sw/push-queue/enqueue.ts
@@ -1,0 +1,47 @@
+import { fromRequest, txStore } from './idb'
+import type { PushQueueEntry } from './types'
+
+const writeIfFresh = async (
+  entry: PushQueueEntry,
+  duplicate: boolean
+): Promise<boolean> => {
+  const fresh = !duplicate
+  await (fresh
+    ? txStore('readwrite').then(s => fromRequest(s.put(entry)))
+    : Promise.resolve())
+  return fresh
+}
+
+/**
+ * Persist a push queue entry. Idempotent on `sha` — re-enqueueing
+ * the same commit is a no-op. Returns whether the entry was newly
+ * added so callers can decide whether to trigger a drain.
+ * @param entry Entry to append; `sha` must be unique per commit.
+ * @returns True if the entry was new, false if a duplicate.
+ */
+export const enqueue = async (entry: PushQueueEntry): Promise<boolean> => {
+  const store = await txStore('readonly')
+  const existing = await fromRequest(store.get(entry.sha))
+  return writeIfFresh(entry, existing !== undefined)
+}
+
+/**
+ * Remove a queue entry by `sha`. Used after a successful push so
+ * the entry is no longer retried.
+ * @param sha Commit sha of the entry to remove.
+ * @returns Resolves once the delete completes.
+ */
+export const dequeue = async (sha: string): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.delete(sha))
+}
+
+/**
+ * Wipe every persisted entry. Used by tests and the future
+ * "Reset queue" recovery action.
+ * @returns Resolves once the store is empty.
+ */
+export const clearQueue = async (): Promise<void> => {
+  const store = await txStore('readwrite')
+  await fromRequest(store.clear())
+}

--- a/src/sw/push-queue/enqueue.ts
+++ b/src/sw/push-queue/enqueue.ts
@@ -1,4 +1,5 @@
-import { fromRequest, txStore } from './idb'
+import { publishPushState } from './broadcast'
+import { fromRequest, listPending, txStore } from './idb'
 import type { PushQueueEntry } from './types'
 
 const writeIfFresh = async (
@@ -12,6 +13,13 @@ const writeIfFresh = async (
   return fresh
 }
 
+const refreshPendingCount = async (
+  status: 'idle' | 'syncing' | 'error'
+): Promise<void> => {
+  const pending = (await listPending()).length
+  publishPushState({ status, pending })
+}
+
 /**
  * Persist a push queue entry. Idempotent on `sha` — re-enqueueing
  * the same commit is a no-op. Returns whether the entry was newly
@@ -22,7 +30,9 @@ const writeIfFresh = async (
 export const enqueue = async (entry: PushQueueEntry): Promise<boolean> => {
   const store = await txStore('readonly')
   const existing = await fromRequest(store.get(entry.sha))
-  return writeIfFresh(entry, existing !== undefined)
+  const fresh = await writeIfFresh(entry, existing !== undefined)
+  await (fresh ? refreshPendingCount('syncing') : Promise.resolve())
+  return fresh
 }
 
 /**
@@ -34,6 +44,11 @@ export const enqueue = async (entry: PushQueueEntry): Promise<boolean> => {
 export const dequeue = async (sha: string): Promise<void> => {
   const store = await txStore('readwrite')
   await fromRequest(store.delete(sha))
+  const remaining = (await listPending()).length
+  publishPushState({
+    status: remaining === 0 ? 'idle' : 'syncing',
+    pending: remaining,
+  })
 }
 
 /**
@@ -44,4 +59,5 @@ export const dequeue = async (sha: string): Promise<void> => {
 export const clearQueue = async (): Promise<void> => {
   const store = await txStore('readwrite')
   await fromRequest(store.clear())
+  publishPushState({ status: 'idle', pending: 0 })
 }

--- a/src/sw/push-queue/error-broadcast.ts
+++ b/src/sw/push-queue/error-broadcast.ts
@@ -1,0 +1,34 @@
+import {
+  type PushErrorEvent,
+  SW_PUSH_ERROR_CHANNEL,
+} from '../protocol/push-error'
+import { classifyPushError } from './classify-error'
+import type { PushQueueEntry } from './types'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_ERROR_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast a classified push failure event so the client can
+ * surface a typed notification. The reason is derived from the
+ * raw error via `classifyPushError`.
+ * @param entry Queue entry whose push failed.
+ * @param error Raw error from the push pipeline.
+ * @returns void
+ */
+export const publishPushError = (
+  entry: PushQueueEntry,
+  error: unknown
+): void => {
+  const event: PushErrorEvent = {
+    reason: classifyPushError(error),
+    sha: entry.sha,
+    target: entry.branch,
+    at: Date.now(),
+  }
+  channelOf().postMessage(event)
+}

--- a/src/sw/push-queue/error-broadcast.ts
+++ b/src/sw/push-queue/error-broadcast.ts
@@ -1,8 +1,8 @@
 import {
   type PushErrorEvent,
+  type PushFailureReason,
   SW_PUSH_ERROR_CHANNEL,
 } from '../protocol/push-error'
-import { classifyPushError } from './classify-error'
 import type { PushQueueEntry } from './types'
 
 let channel: BroadcastChannel | undefined
@@ -14,21 +14,26 @@ const channelOf = (): BroadcastChannel => {
 
 /**
  * Broadcast a classified push failure event so the client can
- * surface a typed notification. The reason is derived from the
- * raw error via `classifyPushError`.
+ * surface a typed notification. The `terminal` flag tells the UI
+ * whether retries are exhausted or the failure is non-retriable
+ * — only terminal events surface a Retry CTA.
  * @param entry Queue entry whose push failed.
- * @param error Raw error from the push pipeline.
+ * @param reason Classified failure reason.
+ * @param terminal True when no further retries are scheduled.
  * @returns void
  */
 export const publishPushError = (
   entry: PushQueueEntry,
-  error: unknown
+  reason: PushFailureReason,
+  terminal: boolean
 ): void => {
   const event: PushErrorEvent = {
-    reason: classifyPushError(error),
+    reason,
     sha: entry.sha,
     target: entry.branch,
     at: Date.now(),
+    terminal,
+    attempt: entry.attempt ?? 1,
   }
   channelOf().postMessage(event)
 }

--- a/src/sw/push-queue/handle-failure.ts
+++ b/src/sw/push-queue/handle-failure.ts
@@ -1,0 +1,38 @@
+import { publishPushState } from './broadcast'
+import { classifyPushError } from './classify-error'
+import { publishPushError } from './error-broadcast'
+import { shouldRetry } from './retry-policy'
+import { scheduleRetry } from './schedule-retry'
+import type { PushQueueEntry } from './types'
+import { bumpAttempt } from './update-attempt'
+
+/**
+ * React to a failed push attempt. Retriable failures bump the
+ * attempt counter, schedule the next drain, and surface a
+ * non-terminal error event. Terminal failures (auth /
+ * non-fast-forward / validation / retry-cap) leave the entry in
+ * place and surface a terminal event so the UI can offer a Retry
+ * CTA on user action.
+ * @param entry Failed queue entry.
+ * @param remaining Pending count covering the entry and everything after.
+ * @param error Raw error from the push pipeline.
+ * @returns Resolves once side effects (broadcast, schedule) are queued.
+ */
+export const handleFailure = async (
+  entry: PushQueueEntry,
+  remaining: number,
+  error: unknown
+): Promise<void> => {
+  const reason = classifyPushError(error)
+  const attempt = entry.attempt ?? 1
+  const retry = shouldRetry(reason, attempt)
+  publishPushState({ status: 'error', pending: remaining })
+  publishPushError(entry, reason, !retry)
+  const schedule = retry
+    ? async (): Promise<void> => {
+        await bumpAttempt(entry)
+        scheduleRetry(attempt)
+      }
+    : async (): Promise<void> => undefined
+  await schedule()
+}

--- a/src/sw/push-queue/idb.ts
+++ b/src/sw/push-queue/idb.ts
@@ -1,0 +1,52 @@
+import type { PushQueueEntry } from './types'
+
+const DB_NAME = 'admin-push-queue'
+const STORE_NAME = 'queue'
+const VERSION = 1
+
+/**
+ * Wrap an `IDBRequest` as a Promise that resolves with `result`
+ * on success and rejects with `error` on failure.
+ * @param request The IDB request to await.
+ * @returns Promise resolving with the request result.
+ */
+const promisify = <T>(request: IDBRequest<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    request.onsuccess = (): void => resolve(request.result)
+    request.onerror = (): void => reject(request.error)
+  })
+
+const openDb = (): Promise<IDBDatabase> => {
+  const req = globalThis.indexedDB.open(DB_NAME, VERSION)
+  req.onupgradeneeded = (): void => {
+    req.result.createObjectStore(STORE_NAME, { keyPath: 'sha' })
+  }
+  return promisify(req)
+}
+
+/**
+ * Acquire a fresh transactional object store. Each public action
+ * opens its own transaction so async awaits never span an
+ * already-completed IDB transaction.
+ * @param mode Transaction mode.
+ * @returns Object store handle inside a fresh transaction.
+ */
+export const txStore = async (
+  mode: IDBTransactionMode
+): Promise<IDBObjectStore> => {
+  const db = await openDb()
+  return db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)
+}
+
+/** Wrap an IDBRequest as a Promise; resolves with `result`. */
+export const fromRequest = promisify
+
+/**
+ * List every persisted queue entry sorted oldest-first.
+ * @returns Frozen array of all queued entries.
+ */
+export const listPending = async (): Promise<readonly PushQueueEntry[]> => {
+  const store = await txStore('readonly')
+  const all: readonly PushQueueEntry[] = await fromRequest(store.getAll())
+  return [...all].sort((a, b) => a.enqueuedAt - b.enqueuedAt)
+}

--- a/src/sw/push-queue/index.ts
+++ b/src/sw/push-queue/index.ts
@@ -1,0 +1,5 @@
+/** SW push queue: decouples local commit from remote push. */
+export { drainPushes } from './drain'
+export { clearQueue, dequeue, enqueue } from './enqueue'
+export { listPending } from './idb'
+export type { PushQueueEntry } from './types'

--- a/src/sw/push-queue/process-next.ts
+++ b/src/sw/push-queue/process-next.ts
@@ -1,28 +1,25 @@
 import { Option } from 'effect'
 import type { workerState } from '../state/state'
 import { publishPushState } from './broadcast'
-import { dequeue } from './enqueue'
+import { publishPushError } from './error-broadcast'
+import { pushOnce } from './push-once'
 import type { PushQueueEntry } from './types'
 
-const tryPush = async (
+const haltOnFailure = (
   entry: PushQueueEntry,
-  config: NonNullable<typeof workerState.config>
-): Promise<boolean> => {
-  const { pushToRemote } = await import('../git/remote/push-to-remote')
-  await pushToRemote(config)
-  await dequeue(entry.sha)
-  return true
-}
-
-const haltOnFailure = (remaining: number): Promise<void> => {
+  remaining: number,
+  error: unknown
+): Promise<void> => {
   publishPushState({ status: 'error', pending: remaining })
+  publishPushError(entry, error)
   return Promise.resolve()
 }
 
 /**
  * Recursively push the queue starting at `index`. Stops on the
- * first failure and emits an error state covering the entries
- * that remain unprocessed.
+ * first failure, emits an error state covering the unprocessed
+ * entries, and broadcasts a classified `PushErrorEvent` so the
+ * client can surface a typed notification.
  * @param pending Entries to process (oldest-first).
  * @param index Current position in `pending`.
  * @param config SW git configuration.
@@ -36,9 +33,9 @@ export const processNext = (
   Option.match(Option.fromNullable(pending[index]), {
     onNone: () => Promise.resolve(),
     onSome: async entry => {
-      const ok = await tryPush(entry, config).catch(() => false)
-      return ok
+      const result = await pushOnce(entry, config)
+      return result.ok
         ? processNext(pending, index + 1, config)
-        : haltOnFailure(pending.length - index)
+        : haltOnFailure(entry, pending.length - index, result.error)
     },
   })

--- a/src/sw/push-queue/process-next.ts
+++ b/src/sw/push-queue/process-next.ts
@@ -1,0 +1,44 @@
+import { Option } from 'effect'
+import type { workerState } from '../state/state'
+import { publishPushState } from './broadcast'
+import { dequeue } from './enqueue'
+import type { PushQueueEntry } from './types'
+
+const tryPush = async (
+  entry: PushQueueEntry,
+  config: NonNullable<typeof workerState.config>
+): Promise<boolean> => {
+  const { pushToRemote } = await import('../git/remote/push-to-remote')
+  await pushToRemote(config)
+  await dequeue(entry.sha)
+  return true
+}
+
+const haltOnFailure = (remaining: number): Promise<void> => {
+  publishPushState({ status: 'error', pending: remaining })
+  return Promise.resolve()
+}
+
+/**
+ * Recursively push the queue starting at `index`. Stops on the
+ * first failure and emits an error state covering the entries
+ * that remain unprocessed.
+ * @param pending Entries to process (oldest-first).
+ * @param index Current position in `pending`.
+ * @param config SW git configuration.
+ * @returns Resolves once the walk has finished or yielded.
+ */
+export const processNext = (
+  pending: readonly PushQueueEntry[],
+  index: number,
+  config: NonNullable<typeof workerState.config>
+): Promise<void> =>
+  Option.match(Option.fromNullable(pending[index]), {
+    onNone: () => Promise.resolve(),
+    onSome: async entry => {
+      const ok = await tryPush(entry, config).catch(() => false)
+      return ok
+        ? processNext(pending, index + 1, config)
+        : haltOnFailure(pending.length - index)
+    },
+  })

--- a/src/sw/push-queue/process-next.ts
+++ b/src/sw/push-queue/process-next.ts
@@ -1,25 +1,13 @@
 import { Option } from 'effect'
 import type { workerState } from '../state/state'
-import { publishPushState } from './broadcast'
-import { publishPushError } from './error-broadcast'
+import { handleFailure } from './handle-failure'
 import { pushOnce } from './push-once'
 import type { PushQueueEntry } from './types'
 
-const haltOnFailure = (
-  entry: PushQueueEntry,
-  remaining: number,
-  error: unknown
-): Promise<void> => {
-  publishPushState({ status: 'error', pending: remaining })
-  publishPushError(entry, error)
-  return Promise.resolve()
-}
-
 /**
  * Recursively push the queue starting at `index`. Stops on the
- * first failure, emits an error state covering the unprocessed
- * entries, and broadcasts a classified `PushErrorEvent` so the
- * client can surface a typed notification.
+ * first failure, delegating retry policy + broadcasting to
+ * `handleFailure`. Successful pushes advance to the next entry.
  * @param pending Entries to process (oldest-first).
  * @param index Current position in `pending`.
  * @param config SW git configuration.
@@ -36,6 +24,6 @@ export const processNext = (
       const result = await pushOnce(entry, config)
       return result.ok
         ? processNext(pending, index + 1, config)
-        : haltOnFailure(entry, pending.length - index, result.error)
+        : handleFailure(entry, pending.length - index, result.error)
     },
   })

--- a/src/sw/push-queue/push-once.ts
+++ b/src/sw/push-queue/push-once.ts
@@ -1,0 +1,30 @@
+import type { workerState } from '../state/state'
+import { dequeue } from './enqueue'
+import type { PushQueueEntry } from './types'
+
+/** Discriminated outcome of a single push attempt. */
+export type PushOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: unknown }
+
+/**
+ * Attempt to push and dequeue a single queued entry. Returns a
+ * discriminated result so the caller can react to the underlying
+ * error without losing it to a `.catch(() => false)`.
+ * @param entry Queued entry to push and remove on success.
+ * @param config SW git configuration with token + remote.
+ * @returns `{ ok: true }` on success, `{ ok: false, error }` on failure.
+ */
+export const pushOnce = async (
+  entry: PushQueueEntry,
+  config: NonNullable<typeof workerState.config>
+): Promise<PushOutcome> => {
+  try {
+    const { pushToRemote } = await import('../git/remote/push-to-remote')
+    await pushToRemote(config)
+    await dequeue(entry.sha)
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error }
+  }
+}

--- a/src/sw/push-queue/queue.test.ts
+++ b/src/sw/push-queue/queue.test.ts
@@ -1,0 +1,60 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { clearQueue, dequeue, enqueue } from './enqueue'
+import { listPending } from './idb'
+import type { PushQueueEntry } from './types'
+
+const entry = (sha: string, ts: number): PushQueueEntry => ({
+  sha,
+  branch: 'develop',
+  message: `commit ${sha}`,
+  enqueuedAt: ts,
+})
+
+describe('push queue', () => {
+  beforeEach(async () => {
+    await clearQueue()
+  })
+  afterEach(async () => {
+    await clearQueue()
+  })
+
+  it('enqueue persists an entry visible via listPending', async () => {
+    await enqueue(entry('a1', 100))
+    const all = await listPending()
+    expect(all).toHaveLength(1)
+    expect(all[0]?.sha).toBe('a1')
+  })
+
+  it('listPending returns entries oldest-first', async () => {
+    await enqueue(entry('c', 300))
+    await enqueue(entry('a', 100))
+    await enqueue(entry('b', 200))
+    const all = await listPending()
+    expect(all.map(e => e.sha)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('enqueue is idempotent on sha', async () => {
+    const first = await enqueue(entry('a', 100))
+    const second = await enqueue(entry('a', 200))
+    expect(first).toBe(true)
+    expect(second).toBe(false)
+    const all = await listPending()
+    expect(all).toHaveLength(1)
+    expect(all[0]?.enqueuedAt).toBe(100)
+  })
+
+  it('dequeue removes a single entry', async () => {
+    await enqueue(entry('a', 100))
+    await enqueue(entry('b', 200))
+    await dequeue('a')
+    const all = await listPending()
+    expect(all.map(e => e.sha)).toEqual(['b'])
+  })
+
+  it('dequeue with unknown sha is a no-op', async () => {
+    await enqueue(entry('a', 100))
+    await dequeue('does-not-exist')
+    expect(await listPending()).toHaveLength(1)
+  })
+})

--- a/src/sw/push-queue/retry-policy.test.ts
+++ b/src/sw/push-queue/retry-policy.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { backoffMs, MAX_ATTEMPTS, shouldRetry } from './retry-policy'
+
+describe('shouldRetry', () => {
+  it('returns true for retriable reasons under the cap', () => {
+    expect(shouldRetry('network', 0)).toBe(true)
+    expect(shouldRetry('network', MAX_ATTEMPTS - 1)).toBe(true)
+    expect(shouldRetry('unknown', 1)).toBe(true)
+  })
+
+  it('returns false at or beyond the cap', () => {
+    expect(shouldRetry('network', MAX_ATTEMPTS)).toBe(false)
+    expect(shouldRetry('network', MAX_ATTEMPTS + 5)).toBe(false)
+  })
+
+  it('returns false for non-retriable reasons', () => {
+    expect(shouldRetry('auth', 0)).toBe(false)
+    expect(shouldRetry('non-fast-forward', 0)).toBe(false)
+    expect(shouldRetry('validation', 0)).toBe(false)
+  })
+})
+
+describe('backoffMs', () => {
+  it('returns the configured delay per attempt', () => {
+    expect(backoffMs(1)).toBe(2_000)
+    expect(backoffMs(2)).toBe(4_000)
+    expect(backoffMs(3)).toBe(8_000)
+    expect(backoffMs(4)).toBe(16_000)
+    expect(backoffMs(5)).toBe(32_000)
+  })
+
+  it('clamps to the largest delay for unexpected attempts', () => {
+    expect(backoffMs(0)).toBe(2_000)
+    expect(backoffMs(99)).toBe(32_000)
+  })
+})

--- a/src/sw/push-queue/retry-policy.ts
+++ b/src/sw/push-queue/retry-policy.ts
@@ -1,0 +1,39 @@
+import type { PushFailureReason } from '../protocol/push-error'
+
+/** Maximum retry attempts (including the original try). */
+export const MAX_ATTEMPTS = 5
+
+/** Backoff schedule (ms) per attempt index 1..MAX_ATTEMPTS-1. */
+const BACKOFF_MS: ReadonlyArray<number> = [
+  2_000, 4_000, 8_000, 16_000, 32_000,
+]
+
+const RETRIABLE: ReadonlySet<PushFailureReason> = new Set([
+  'network',
+  'unknown',
+])
+
+/**
+ * Decide whether a classified failure should retry given the
+ * current attempt count. Auth / non-fast-forward / validation are
+ * never retried automatically — they require user action.
+ * @param reason Classified failure reason.
+ * @param attempt Number of attempts already made (1-indexed).
+ * @returns True if a further retry is permitted.
+ */
+export const shouldRetry = (
+  reason: PushFailureReason,
+  attempt: number
+): boolean => RETRIABLE.has(reason) && attempt < MAX_ATTEMPTS
+
+const clampIndex = (attempt: number): number =>
+  Math.max(0, Math.min(BACKOFF_MS.length - 1, attempt - 1))
+
+/**
+ * Lookup the backoff delay (ms) for the given attempt index.
+ * Clamps to the first/last configured delay outside the table.
+ * @param attempt 1-indexed attempt count just completed.
+ * @returns Delay before the next attempt.
+ */
+export const backoffMs = (attempt: number): number =>
+  BACKOFF_MS[clampIndex(attempt)] ?? 32_000

--- a/src/sw/push-queue/schedule-retry.ts
+++ b/src/sw/push-queue/schedule-retry.ts
@@ -1,0 +1,25 @@
+import { backoffMs } from './retry-policy'
+
+/**
+ * Schedule a deferred drain attempt. Returns immediately so the
+ * caller does not block the SW message dispatch loop. Real
+ * delivery is best-effort — if the SW is suspended before the
+ * timer fires, the next user activity wakes it and the queue is
+ * picked up on the next drain trigger.
+ * @param attempt 1-indexed attempt count just completed.
+ * @returns Cancel handle; call to cancel the scheduled drain.
+ */
+export const scheduleRetry = (attempt: number): (() => void) => {
+  const delay = backoffMs(attempt)
+  const handle = globalThis.setTimeout(() => {
+    void runDrain()
+  }, delay)
+  return (): void => {
+    globalThis.clearTimeout(handle)
+  }
+}
+
+const runDrain = async (): Promise<void> => {
+  const { drainPushes } = await import('./drain')
+  await drainPushes()
+}

--- a/src/sw/push-queue/types.ts
+++ b/src/sw/push-queue/types.ts
@@ -1,0 +1,10 @@
+/**
+ * Single entry in the SW push queue. Identified by `sha` so the
+ * queue can be re-enqueued idempotently (same commit = same id).
+ */
+export type PushQueueEntry = {
+  readonly sha: string
+  readonly branch: string
+  readonly message: string
+  readonly enqueuedAt: number
+}

--- a/src/sw/push-queue/types.ts
+++ b/src/sw/push-queue/types.ts
@@ -7,4 +7,5 @@ export type PushQueueEntry = {
   readonly branch: string
   readonly message: string
   readonly enqueuedAt: number
+  readonly attempt?: number
 }

--- a/src/sw/push-queue/update-attempt.ts
+++ b/src/sw/push-queue/update-attempt.ts
@@ -1,0 +1,18 @@
+import { fromRequest, txStore } from './idb'
+import type { PushQueueEntry } from './types'
+
+/**
+ * Persist an incremented attempt count on an existing queue
+ * entry. Used by the retry path so the next failure picks up the
+ * correct backoff slot.
+ * @param entry Source entry; attempt is bumped by one.
+ * @returns Resolves once the rewrite completes.
+ */
+export const bumpAttempt = async (entry: PushQueueEntry): Promise<void> => {
+  const next: PushQueueEntry = {
+    ...entry,
+    attempt: (entry.attempt ?? 1) + 1,
+  }
+  const store = await txStore('readwrite')
+  await fromRequest(store.put(next))
+}


### PR DESCRIPTION
## Summary
Phase A / Epic 2 — async push pipeline complete. Saves no longer block on the network: commit returns to the UI as soon as the local commit is staged and the push is processed by a background drain inside the SW. Failures classify into typed reasons, surface as notifications, retry transient errors with exponential backoff, and offer a manual Retry CTA on terminal failures.

## What's in this release
- **2.1 #83 / #100** — IDB-backed FIFO queue in SW, idempotent on commit sha; `realCommit` enqueues + fires drain without awaiting; mock mode untouched.
- **2.2 #84 / #101** — `sw-push-state` channel + `<PushSyncBadge>` in `<AppHeader>`. Pulses while syncing, red on error, hidden idle.
- **2.3 #85 / #102** — Push-error classifier (network / auth / non-fast-forward / validation / unknown) + `usePushErrorBridge` dispatching `notifyPushFailure(reason, target)`.
- **2.4 #86 / #103** — Retry policy `[2,4,8,16,32]s` × 5 for retriable reasons; terminal failures surface a Retry CTA wired to the new `sw-push-control` channel.

## Coverage
- Unit: 455/455 green (incl. queue, classifier, retry-policy)
- E2E (chromium): all notifications specs green (toast, drawer, push-sync-badge, push-error-bridge, push-retry)
- `bun run validate` clean

## Verification post-deploy
- [ ] dev-admin loads without console errors
- [ ] Save flow returns instantly (commit-then-push decoupled)
- [ ] Push sync badge surfaces in header during real save

## Notes
- Auto-retry uses `setTimeout` inside the SW — best-effort; surviving SW termination requires a future Periodic Background Sync hook.
- Mock mode is intentionally untouched; the queue path runs only with real GH config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)