### PR TITLE
feat(connectivity): online/offline detection with heartbeat (#87)

### DIFF
--- a/e2e/notifications/push-retry.spec.ts
+++ b/e2e/notifications/push-retry.spec.ts
@@ -37,9 +37,7 @@ test.describe('push retry CTA (2.4)', () => {
 
   test('retriable terminal error attaches a Retry CTA', async ({ page }) => {
     await page.evaluate(broadcastTerminal('network'))
-    const cta = page
-      .locator('[data-testid="notification-toast-cta"]')
-      .first()
+    const cta = page.locator('[data-testid="notification-toast-cta"]').first()
     await expect(cta).toBeVisible()
     await expect(cta).toHaveText('Retry')
   })
@@ -64,9 +62,7 @@ test.describe('push retry CTA (2.4)', () => {
     await expect
       .poll(
         async () =>
-          await page.evaluate<number>(
-            () => globalThis.__retryHits ?? 0
-          ),
+          await page.evaluate<number>(() => globalThis.__retryHits ?? 0),
         { timeout: 5_000 }
       )
       .toBe(1)

--- a/src/composables/useConnectivity/connectivity-state.ts
+++ b/src/composables/useConnectivity/connectivity-state.ts
@@ -1,0 +1,9 @@
+import { ref } from 'vue'
+
+const initialOnline =
+  typeof navigator === 'undefined' ? true : navigator.onLine
+
+/** Module-shared connectivity ref. True when the app considers
+ * itself reachable; flipped by both `navigator.onLine` events and
+ * the periodic heartbeat probe. */
+export const isOnline = ref<boolean>(initialOnline)

--- a/src/composables/useConnectivity/heartbeat.ts
+++ b/src/composables/useConnectivity/heartbeat.ts
@@ -1,0 +1,28 @@
+/** Minimum interval between heartbeat probes (ms). */
+export const HEARTBEAT_INTERVAL_MS = 30_000
+
+const HEARTBEAT_URL = 'https://api.github.com/user'
+
+/**
+ * Probe network reachability with a single short-timeout fetch.
+ * Resolves true when the request returns 2xx or 4xx (server is
+ * up, regardless of auth state); resolves false on network
+ * failure or 5xx so callers can flip into offline mode.
+ * @param controller AbortController owning the request lifecycle.
+ * @returns True when the network appears reachable.
+ */
+export const probeReachability = async (
+  controller: AbortController
+): Promise<boolean> => {
+  try {
+    const response = await fetch(HEARTBEAT_URL, {
+      method: 'HEAD',
+      signal: controller.signal,
+      cache: 'no-store',
+      mode: 'cors',
+    })
+    return response.status < 500
+  } catch {
+    return false
+  }
+}

--- a/src/composables/useConnectivity/index.ts
+++ b/src/composables/useConnectivity/index.ts
@@ -1,0 +1,3 @@
+/** Connectivity heartbeat composable. */
+export { isOnline } from './connectivity-state'
+export { useConnectivity } from './use-connectivity'

--- a/src/composables/useConnectivity/page-visibility.ts
+++ b/src/composables/useConnectivity/page-visibility.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue'
+
+const initialVisible =
+  typeof document === 'undefined' ? true : !document.hidden
+
+/** Module-shared visibility ref. True when the tab is visible. */
+export const isPageVisible = ref<boolean>(initialVisible)
+
+const supported = typeof document !== 'undefined'
+
+const wire = (): void => {
+  document.addEventListener('visibilitychange', () => {
+    isPageVisible.value = !document.hidden
+  })
+}
+
+const noop = (): void => undefined
+;(supported ? wire : noop)()

--- a/src/composables/useConnectivity/use-connectivity.ts
+++ b/src/composables/useConnectivity/use-connectivity.ts
@@ -1,0 +1,55 @@
+import { onMounted, onUnmounted } from 'vue'
+import { isOnline } from './connectivity-state'
+import { HEARTBEAT_INTERVAL_MS, probeReachability } from './heartbeat'
+import { isPageVisible } from './page-visibility'
+
+let registered = false
+
+const tick = async (): Promise<void> => {
+  const visible = isPageVisible.value
+  const skip = !visible
+  await (skip
+    ? Promise.resolve()
+    : (async (): Promise<void> => {
+        const ctrl = new AbortController()
+        const reachable = await probeReachability(ctrl)
+        isOnline.value = reachable
+      })())
+}
+
+const handleOnline = (): void => {
+  isOnline.value = true
+}
+
+const handleOffline = (): void => {
+  isOnline.value = false
+}
+
+const ensureRegistered = (): void => {
+  const already = registered
+  registered = true
+  const wire = (): void => {
+    globalThis.addEventListener('online', handleOnline)
+    globalThis.addEventListener('offline', handleOffline)
+    setInterval(() => {
+      void tick()
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+  const noop = (): void => undefined
+  ;(already ? noop : wire)()
+}
+
+/**
+ * Reactive connectivity probe. Returns the shared `isOnline` ref
+ * and registers `online`/`offline` listeners plus a 30s heartbeat
+ * when called for the first time. The heartbeat skips ticks while
+ * the tab is hidden so background tabs don't generate traffic.
+ * @returns Object exposing the reactive `isOnline` ref.
+ */
+export const useConnectivity = () => {
+  onMounted(() => {
+    ensureRegistered()
+  })
+  onUnmounted(() => undefined)
+  return { isOnline }
+}


### PR DESCRIPTION
## Summary
Phase A / Epic 3 increment 3.1 — `isOnline` signal for the rest of the offline epic.

- `useConnectivity` composable returning the shared reactive `isOnline` ref. Initial value seeded from `navigator.onLine`.
- 30-second heartbeat (`HEAD https://api.github.com/user`) flips the ref based on reachability; skipped while the tab is hidden so background tabs are silent.
- `online` / `offline` window events flip the ref synchronously without waiting for the next heartbeat cycle.

## Out of scope (later increments)
- Consume `isOnline` in the push queue (#88 / 3.2)
- Drain on reconnect (#89 / 3.3)
- Settings ops gate (#90 / 3.4)

## Test plan
- [x] 455/455 unit
- [x] `bun run validate` clean
- [ ] Real online/offline e2e validation deferred to 3.2 where the badge gives an observable surface

Closes #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)