### PR TITLE
feat(connectivity): hold pushes offline + offline notification (#88)

### DIFF
--- a/e2e/notifications/offline-watch.spec.ts
+++ b/e2e/notifications/offline-watch.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('offline watcher (3.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('going offline surfaces a network notification', async ({
+    page,
+    context,
+  }) => {
+    await context.setOffline(true)
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'network')
+    await expect(toast).toContainText(/offline|network/i)
+  })
+
+  test('online → offline → online does not double-fire', async ({
+    page,
+    context,
+  }) => {
+    await context.setOffline(true)
+    await expect(
+      page.locator('[data-testid="notification-toast"]')
+    ).toHaveCount(1)
+    await context.setOffline(false)
+    await context.setOffline(true)
+    await expect(
+      page.locator('[data-testid="notification-toast"]')
+    ).toHaveCount(2)
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import {
 import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polling'
 import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entries'
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
+import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-watcher'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
@@ -18,6 +19,7 @@ const authStore = useAuthStore()
 const contentStore = useContentStore()
 useNotificationsPersistence()
 usePushErrorBridge()
+useOfflineWatcher()
 
 const poll = useDeployPolling()
 const mergedEntries = useMergedEntries(poll.entries)

--- a/src/components/PushSyncBadge/PushSyncBadge.vue
+++ b/src/components/PushSyncBadge/PushSyncBadge.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { isOnline } from '@/composables/useConnectivity'
 import { usePushState } from '@/composables/useSWBridge/use-push-state'
 import { PUSH_SYNC_TEST_IDS } from './test-ids'
 
 const { state } = usePushState()
+const offline = computed(() => !isOnline.value)
 const visible = computed(
-  () => state.value.status !== 'idle' || state.value.pending > 0
+  () =>
+    state.value.status !== 'idle' ||
+    state.value.pending > 0 ||
+    offline.value
 )
 const ariaLabel = computed(() =>
-  state.value.status === 'error'
-    ? `Push sync error, ${state.value.pending} pending`
-    : `Push syncing, ${state.value.pending} pending`
+  offline.value
+    ? `Working offline, ${state.value.pending} pending`
+    : state.value.status === 'error'
+      ? `Push sync error, ${state.value.pending} pending`
+      : `Push syncing, ${state.value.pending} pending`
 )
 </script>
 
@@ -20,6 +27,7 @@ const ariaLabel = computed(() =>
     class="push-sync"
     :data-testid="PUSH_SYNC_TEST_IDS.root"
     :data-status="state.status"
+    :data-offline="String(offline)"
     :aria-label="ariaLabel"
     aria-live="polite"
   >
@@ -51,6 +59,11 @@ const ariaLabel = computed(() =>
 
 .push-sync[data-status='error'] {
   background: var(--color-error, #e53935);
+  animation: none;
+}
+
+.push-sync[data-offline='true'] {
+  background: var(--color-text-muted, #888);
   animation: none;
 }
 

--- a/src/composables/useConnectivity/broadcast.ts
+++ b/src/composables/useConnectivity/broadcast.ts
@@ -1,0 +1,23 @@
+import {
+  type ConnectivityEvent,
+  SW_CONNECTIVITY_CHANNEL,
+} from '@/sw/protocol/connectivity'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_CONNECTIVITY_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast the current online state to the SW so the push queue
+ * can decide whether to drain or hold. Clients call this whenever
+ * the local `isOnline` ref flips.
+ * @param online True when the network is reachable.
+ * @returns void
+ */
+export const broadcastConnectivity = (online: boolean): void => {
+  const event: ConnectivityEvent = { online, at: Date.now() }
+  channelOf().postMessage(event)
+}

--- a/src/composables/useConnectivity/use-connectivity.ts
+++ b/src/composables/useConnectivity/use-connectivity.ts
@@ -1,4 +1,5 @@
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
+import { broadcastConnectivity } from './broadcast'
 import { isOnline } from './connectivity-state'
 import { HEARTBEAT_INTERVAL_MS, probeReachability } from './heartbeat'
 import { isPageVisible } from './page-visibility'
@@ -25,25 +26,27 @@ const handleOffline = (): void => {
   isOnline.value = false
 }
 
+const wireListeners = (): void => {
+  globalThis.addEventListener('online', handleOnline)
+  globalThis.addEventListener('offline', handleOffline)
+  setInterval(() => {
+    void tick()
+  }, HEARTBEAT_INTERVAL_MS)
+  watch(isOnline, next => broadcastConnectivity(next), { immediate: true })
+}
+
 const ensureRegistered = (): void => {
   const already = registered
   registered = true
-  const wire = (): void => {
-    globalThis.addEventListener('online', handleOnline)
-    globalThis.addEventListener('offline', handleOffline)
-    setInterval(() => {
-      void tick()
-    }, HEARTBEAT_INTERVAL_MS)
-  }
   const noop = (): void => undefined
-  ;(already ? noop : wire)()
+  ;(already ? noop : wireListeners)()
 }
 
 /**
  * Reactive connectivity probe. Returns the shared `isOnline` ref
- * and registers `online`/`offline` listeners plus a 30s heartbeat
- * when called for the first time. The heartbeat skips ticks while
- * the tab is hidden so background tabs don't generate traffic.
+ * and registers `online`/`offline` listeners + a 30 s heartbeat
+ * + an SW broadcast on the first call. Heartbeat skips ticks
+ * while the tab is hidden so background tabs are silent.
  * @returns Object exposing the reactive `isOnline` ref.
  */
 export const useConnectivity = () => {

--- a/src/composables/useNotifications/use-offline-watcher.ts
+++ b/src/composables/useNotifications/use-offline-watcher.ts
@@ -1,0 +1,27 @@
+import { watch } from 'vue'
+import { isOnline, useConnectivity } from '@/composables/useConnectivity'
+import { notifyNetworkDown } from './notify-network-down'
+import { requestPushRetry } from './push-retry'
+
+/**
+ * Surface a sticky network notification on every offline
+ * transition and ensure the connectivity heartbeat is registered.
+ * Notification CTA is wired to the manual retry control message
+ * so the user can probe a recovery without waiting on the next
+ * heartbeat tick.
+ * @returns void
+ */
+export const useOfflineWatcher = (): void => {
+  useConnectivity()
+  watch(
+    isOnline,
+    (next, prev) => {
+      const transitionedOffline = prev !== false && next === false
+      const fire = transitionedOffline
+        ? () => notifyNetworkDown(requestPushRetry)
+        : (): void => undefined
+      fire()
+    },
+    { immediate: false }
+  )
+}

--- a/src/sw/connectivity/sw-connectivity-state.ts
+++ b/src/sw/connectivity/sw-connectivity-state.ts
@@ -1,0 +1,29 @@
+import {
+  type ConnectivityEvent,
+  SW_CONNECTIVITY_CHANNEL,
+} from '../protocol/connectivity'
+
+let online = true
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_CONNECTIVITY_CHANNEL)
+  return channel
+}
+
+/**
+ * True when the client most recently reported the network is up.
+ * @returns Cached online state.
+ */
+export const isOnlineInSw = (): boolean => online
+
+/**
+ * Wire the SW to consume connectivity events broadcast by the
+ * client. Called once at SW boot.
+ * @returns void
+ */
+export const registerConnectivityListener = (): void => {
+  channelOf().onmessage = (event: MessageEvent<ConnectivityEvent>): void => {
+    online = event.data.online
+  }
+}

--- a/src/sw/main.ts
+++ b/src/sw/main.ts
@@ -4,6 +4,7 @@
  * via load-git.ts to enable code-splitting. This keeps
  * the main SW chunk small for fast installation.
  */
+import { registerConnectivityListener } from './connectivity/sw-connectivity-state'
 import { registerFetchListener } from './core/fetch-listener'
 import { registerLifecycle } from './core/lifecycle'
 import { registerMessageListener } from './core/messaging/message-listener'
@@ -18,5 +19,6 @@ registerLifecycle()
 registerFetchListener()
 registerMessageListener()
 registerPushControlListener()
+registerConnectivityListener()
 
 log('info', 'lifecycle', 'SW ready', { version: SW_VERSION })

--- a/src/sw/protocol/connectivity.ts
+++ b/src/sw/protocol/connectivity.ts
@@ -1,0 +1,8 @@
+/** BroadcastChannel name for client→SW connectivity state. */
+export const SW_CONNECTIVITY_CHANNEL = 'sw-connectivity'
+
+/** Connectivity broadcast payload. */
+export type ConnectivityEvent = {
+  readonly online: boolean
+  readonly at: number
+}

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -1,18 +1,28 @@
 import { Option } from 'effect'
+import { isOnlineInSw } from '../connectivity/sw-connectivity-state'
 import { workerState } from '../state/state'
+import { publishPushState } from './broadcast'
 import { listPending } from './idb'
 import { processNext } from './process-next'
 
 let inFlight = false
 
-const processPending = async (): Promise<void> =>
-  Option.match(Option.fromNullable(workerState.config), {
-    onNone: () => Promise.resolve(),
-    onSome: async config => {
-      const pending = await listPending()
-      await processNext(pending, 0, config)
-    },
-  })
+const surfaceOfflineHold = async (): Promise<void> => {
+  const pending = (await listPending()).length
+  publishPushState({ status: 'syncing', pending })
+}
+
+const processPending = async (): Promise<void> => {
+  await (isOnlineInSw()
+    ? Option.match(Option.fromNullable(workerState.config), {
+        onNone: () => Promise.resolve(),
+        onSome: async config => {
+          const pending = await listPending()
+          await processNext(pending, 0, config)
+        },
+      })
+    : surfaceOfflineHold())
+}
 
 const runOnce = async (): Promise<void> => {
   inFlight = true


### PR DESCRIPTION
## Summary
Phase A / Epic 3 increment 3.2 — push queue stops attempting fetch while offline; user gets a notification + visual badge.

- SW caches client-broadcast online state via new `sw-connectivity` channel.
- Drain gates on `isOnlineInSw()` — surfaces `syncing` state with pending count and skips network when offline.
- `useOfflineWatcher` mounted in App.vue fires `notifyNetworkDown(requestPushRetry)` on every offline transition.
- `<PushSyncBadge>` becomes visible while offline (gray tint).

## Test plan
- [x] 2/2 e2e (`offline-watch.spec.ts`) — `context.setOffline(true)` triggers toast; no double-fire across cycles
- [x] 22/22 notifications e2e total
- [x] 455/455 unit
- [x] `bun run validate` clean

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)