### PR TITLE
feat(connectivity): drain on reconnect + sync summary toast (#89)

### DIFF
--- a/e2e/notifications/push-summary.spec.ts
+++ b/e2e/notifications/push-summary.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastSummary = (synced: number): string => `
+const ch = new BroadcastChannel('sw-push-summary')
+ch.postMessage({ synced: ${synced}, at: ${Date.now()} })
+ch.close()
+`
+
+test.describe('drain summary bridge (3.3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('summary event surfaces an info toast naming the count', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastSummary(3))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'info')
+    await expect(toast).toContainText('3')
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@ import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entri
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
 import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-watcher'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
+import { usePushSummaryBridge } from '@/composables/useNotifications/use-push-summary-bridge'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
@@ -20,6 +21,7 @@ const contentStore = useContentStore()
 useNotificationsPersistence()
 usePushErrorBridge()
 useOfflineWatcher()
+usePushSummaryBridge()
 
 const poll = useDeployPolling()
 const mergedEntries = useMergedEntries(poll.entries)

--- a/src/composables/useNotifications/use-push-summary-bridge.ts
+++ b/src/composables/useNotifications/use-push-summary-bridge.ts
@@ -1,0 +1,28 @@
+import { onUnmounted } from 'vue'
+import {
+  type PushSummaryEvent,
+  SW_PUSH_SUMMARY_CHANNEL,
+} from '@/sw/protocol/push-summary'
+import { notifyInfo } from './notify-info'
+
+const subscribe = (channel: BroadcastChannel): void => {
+  channel.onmessage = (event: MessageEvent<PushSummaryEvent>): void => {
+    notifyInfo(`Synced ${event.data.synced} change(s)`)
+  }
+}
+
+/**
+ * Subscribe to SW-broadcast drain summaries and dispatch a
+ * transient info notification per event. Mount once near the app
+ * root.
+ * @returns void
+ */
+export const usePushSummaryBridge = (): void => {
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_SUMMARY_CHANNEL)
+    : undefined
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => subscribe(channel))()
+  onUnmounted(() => channel?.close())
+}

--- a/src/sw/connectivity/sw-connectivity-state.ts
+++ b/src/sw/connectivity/sw-connectivity-state.ts
@@ -4,6 +4,7 @@ import {
 } from '../protocol/connectivity'
 
 let online = true
+let wasOffline = false
 let channel: BroadcastChannel | undefined
 
 const channelOf = (): BroadcastChannel => {
@@ -18,12 +19,40 @@ const channelOf = (): BroadcastChannel => {
 export const isOnlineInSw = (): boolean => online
 
 /**
+ * True when the SW saw an offline transition since the last
+ * successful drain. Used to gate the "Synced N changes" toast so
+ * routine drains do not announce themselves.
+ * @returns Cached "was offline since last drain" flag.
+ */
+export const wasOfflineSinceDrain = (): boolean => wasOffline
+
+/** Reset the offline-since-drain flag. Call after a drain summary fires. */
+export const acknowledgeOfflineDrain = (): void => {
+  wasOffline = false
+}
+
+const handleTransition = async (next: boolean): Promise<void> => {
+  const becameOnline = !online && next
+  online = next
+  wasOffline = wasOffline || !next
+  await (becameOnline
+    ? (async (): Promise<void> => {
+        const { resetAttempts } = await import('../push-queue/reset-attempts')
+        const { drainPushes } = await import('../push-queue/drain')
+        await resetAttempts()
+        await drainPushes()
+      })()
+    : Promise.resolve())
+}
+
+/**
  * Wire the SW to consume connectivity events broadcast by the
- * client. Called once at SW boot.
+ * client. On every offline → online transition, reset retry
+ * counters and trigger an immediate drain.
  * @returns void
  */
 export const registerConnectivityListener = (): void => {
   channelOf().onmessage = (event: MessageEvent<ConnectivityEvent>): void => {
-    online = event.data.online
+    void handleTransition(event.data.online)
   }
 }

--- a/src/sw/protocol/push-summary.ts
+++ b/src/sw/protocol/push-summary.ts
@@ -1,0 +1,8 @@
+/** BroadcastChannel name for SW→client drain summary events. */
+export const SW_PUSH_SUMMARY_CHANNEL = 'sw-push-summary'
+
+/** Emitted after a successful drain that began while offline. */
+export type PushSummaryEvent = {
+  readonly synced: number
+  readonly at: number
+}

--- a/src/sw/push-queue/drain-summary.ts
+++ b/src/sw/push-queue/drain-summary.ts
@@ -1,0 +1,29 @@
+import {
+  acknowledgeOfflineDrain,
+  wasOfflineSinceDrain,
+} from '../connectivity/sw-connectivity-state'
+import { listPending } from './idb'
+import { publishPushSummary } from './summary-broadcast'
+
+/**
+ * After a drain completes, compare the queue length before and
+ * after to count successful pushes. When the SW saw an offline
+ * transition since the previous drain, broadcast a "Synced N
+ * change(s)" summary so the UI can confirm recovery.
+ * @param initial Pending count captured before the drain ran.
+ * @returns Resolves once the summary has been emitted (if any).
+ */
+export const announceDrainSummary = async (
+  initial: number
+): Promise<void> => {
+  const final = (await listPending()).length
+  const synced = Math.max(0, initial - final)
+  const announce = synced > 0 && wasOfflineSinceDrain()
+  const fire = announce
+    ? () => {
+        publishPushSummary(synced)
+        acknowledgeOfflineDrain()
+      }
+    : (): void => undefined
+  fire()
+}

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -2,6 +2,7 @@ import { Option } from 'effect'
 import { isOnlineInSw } from '../connectivity/sw-connectivity-state'
 import { workerState } from '../state/state'
 import { publishPushState } from './broadcast'
+import { announceDrainSummary } from './drain-summary'
 import { listPending } from './idb'
 import { processNext } from './process-next'
 
@@ -26,8 +27,10 @@ const processPending = async (): Promise<void> => {
 
 const runOnce = async (): Promise<void> => {
   inFlight = true
+  const initial = (await listPending()).length
   try {
     await processPending()
+    await announceDrainSummary(initial)
   } finally {
     inFlight = false
   }

--- a/src/sw/push-queue/reset-attempts.ts
+++ b/src/sw/push-queue/reset-attempts.ts
@@ -1,0 +1,17 @@
+import { fromRequest, listPending, txStore } from './idb'
+
+/**
+ * Clear the `attempt` counter on every queued entry. Called when
+ * connectivity is restored so prior backoff schedules do not delay
+ * the drain after the user is back online.
+ * @returns Resolves once the rewrite completes.
+ */
+export const resetAttempts = async (): Promise<void> => {
+  const all = await listPending()
+  await Promise.all(
+    all.map(async entry => {
+      const store = await txStore('readwrite')
+      await fromRequest(store.put({ ...entry, attempt: 1 }))
+    })
+  )
+}

--- a/src/sw/push-queue/summary-broadcast.ts
+++ b/src/sw/push-queue/summary-broadcast.ts
@@ -1,0 +1,22 @@
+import {
+  type PushSummaryEvent,
+  SW_PUSH_SUMMARY_CHANNEL,
+} from '../protocol/push-summary'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_SUMMARY_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast a drain summary so the client can surface a "Synced N
+ * changes" toast. Suppressed when no entries actually drained.
+ * @param synced Number of successful pushes in the just-finished drain.
+ * @returns void
+ */
+export const publishPushSummary = (synced: number): void => {
+  const event: PushSummaryEvent = { synced, at: Date.now() }
+  channelOf().postMessage(event)
+}


### PR DESCRIPTION
## Summary
Phase A / Epic 3 increment 3.3 — auto-drain on reconnect plus a confirmation toast for previously-offline users.

- SW connectivity listener: offline → online transition resets attempt counters (`reset-attempts.ts`) and triggers `drainPushes()`.
- New `sw-push-summary` channel: SW emits `{ synced, at }` only when at least one entry drained AND the SW saw an offline transition since the last drain.
- `usePushSummaryBridge` mounted in App.vue dispatches `notifyInfo("Synced N change(s)")` per event.

## Test plan
- [x] 1/1 e2e (`push-summary.spec.ts`)
- [x] Validate clean

Closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)