### PR TITLE
feat(settings): disable GH-only ops while offline (#90)

### DIFF
--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('settings offline gate (3.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/settings')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="members-section"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('offline disables invite + shows banner', async ({
+    page,
+    context,
+  }) => {
+    const banner = page.locator(
+      '[data-testid="members-offline-banner"]'
+    )
+    await expect(banner).toBeHidden()
+    await context.setOffline(true)
+    await expect(banner).toBeVisible()
+    const invite = page.locator('[data-testid="invite-open"]')
+    await expect(invite).toBeDisabled()
+  })
+
+  test('reconnect re-enables actions', async ({ page, context }) => {
+    await context.setOffline(true)
+    const invite = page.locator('[data-testid="invite-open"]')
+    await expect(invite).toBeDisabled()
+    await context.setOffline(false)
+    await expect(invite).toBeEnabled()
+  })
+})

--- a/src/views/SettingsView/MembersSection.vue
+++ b/src/views/SettingsView/MembersSection.vue
@@ -16,12 +16,26 @@ const s = useMembersSection()
         type="button"
         class="btn-invite"
         data-testid="invite-open"
-        :disabled="s.busy.value"
+        :disabled="s.busy.value || s.offline.value"
+        :aria-disabled="s.disabled.value"
+        :title="
+          s.offline.value
+            ? 'Offline: invitations require network'
+            : undefined
+        "
         @click="s.openDialog"
       >
         + Invite
       </button>
     </header>
+    <p
+      v-if="s.offline.value"
+      class="offline-banner"
+      data-testid="members-offline-banner"
+      role="status"
+    >
+      Working offline — member changes are paused until reconnect.
+    </p>
     <p v-if="s.loading.value" class="hint">Loading organisation members…</p>
     <InviteList
       v-if="s.invitations.value.length > 0"

--- a/src/views/SettingsView/members-public-state.ts
+++ b/src/views/SettingsView/members-public-state.ts
@@ -28,6 +28,7 @@ export const projectMembersPublic = <A extends Record<string, unknown>>(
   busy: s.busy,
   error: s.error,
   disabled: s.disabled,
+  offline: s.offline,
   canEditSettings: s.canEditSettings,
   openDialog: ctl.openDialog,
   closeDialog: ctl.closeDialog,

--- a/src/views/SettingsView/members-section-state.ts
+++ b/src/views/SettingsView/members-section-state.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { isOnline } from '@/composables/useConnectivity'
 import { usePermissions } from '@/composables/usePermissions'
 import type { OrgMember } from './roles-api-types'
 import { useOrgMembers } from './useOrgMembers'
@@ -26,7 +27,10 @@ export const buildMembersState = () => {
   const busy = ref(false)
   const error = ref<string | undefined>(undefined)
   const sorted = computed(() => sortByRank(members.value))
-  const disabled = computed(() => busy.value || !canEditSettings.value)
+  const offline = computed(() => !isOnline.value)
+  const disabled = computed(
+    () => busy.value || !canEditSettings.value || offline.value
+  )
   return {
     members,
     invitations,
@@ -38,5 +42,6 @@ export const buildMembersState = () => {
     error,
     sorted,
     disabled,
+    offline,
   }
 }


### PR DESCRIPTION
Phase A / Epic 3 increment 3.4 — closes Epic 3.

Members section now folds  into  so Invite + role selects + revoke action all gate together. Offline banner above the list (role=status). Invite button gets a tooltip when offline. 2/2 e2e green.

Closes #90. Closes Epic 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)