### PR TITLE
release: offline mode Epic 3 (3.1+3.2+3.3+3.4)

### DIFF
--- a/e2e/notifications/offline-watch.spec.ts
+++ b/e2e/notifications/offline-watch.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('offline watcher (3.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('going offline surfaces a network notification', async ({
+    page,
+    context,
+  }) => {
+    await context.setOffline(true)
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'network')
+    await expect(toast).toContainText(/offline|network/i)
+  })
+
+  test('online → offline → online does not double-fire', async ({
+    page,
+    context,
+  }) => {
+    await context.setOffline(true)
+    await expect(
+      page.locator('[data-testid="notification-toast"]')
+    ).toHaveCount(1)
+    await context.setOffline(false)
+    await context.setOffline(true)
+    await expect(
+      page.locator('[data-testid="notification-toast"]')
+    ).toHaveCount(2)
+  })
+})

--- a/e2e/notifications/push-retry.spec.ts
+++ b/e2e/notifications/push-retry.spec.ts
@@ -37,9 +37,7 @@ test.describe('push retry CTA (2.4)', () => {
 
   test('retriable terminal error attaches a Retry CTA', async ({ page }) => {
     await page.evaluate(broadcastTerminal('network'))
-    const cta = page
-      .locator('[data-testid="notification-toast-cta"]')
-      .first()
+    const cta = page.locator('[data-testid="notification-toast-cta"]').first()
     await expect(cta).toBeVisible()
     await expect(cta).toHaveText('Retry')
   })
@@ -64,9 +62,7 @@ test.describe('push retry CTA (2.4)', () => {
     await expect
       .poll(
         async () =>
-          await page.evaluate<number>(
-            () => globalThis.__retryHits ?? 0
-          ),
+          await page.evaluate<number>(() => globalThis.__retryHits ?? 0),
         { timeout: 5_000 }
       )
       .toBe(1)

--- a/e2e/notifications/push-summary.spec.ts
+++ b/e2e/notifications/push-summary.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastSummary = (synced: number): string => `
+const ch = new BroadcastChannel('sw-push-summary')
+ch.postMessage({ synced: ${synced}, at: ${Date.now()} })
+ch.close()
+`
+
+test.describe('drain summary bridge (3.3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('summary event surfaces an info toast naming the count', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastSummary(3))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'info')
+    await expect(toast).toContainText('3')
+  })
+})

--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('settings offline gate (3.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/settings')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="members-section"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('offline disables invite + shows banner', async ({
+    page,
+    context,
+  }) => {
+    const banner = page.locator(
+      '[data-testid="members-offline-banner"]'
+    )
+    await expect(banner).toBeHidden()
+    await context.setOffline(true)
+    await expect(banner).toBeVisible()
+    const invite = page.locator('[data-testid="invite-open"]')
+    await expect(invite).toBeDisabled()
+  })
+
+  test('reconnect re-enables actions', async ({ page, context }) => {
+    await context.setOffline(true)
+    const invite = page.locator('[data-testid="invite-open"]')
+    await expect(invite).toBeDisabled()
+    await context.setOffline(false)
+    await expect(invite).toBeEnabled()
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@ import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entri
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
 import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-watcher'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
+import { usePushSummaryBridge } from '@/composables/useNotifications/use-push-summary-bridge'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
@@ -20,6 +21,7 @@ const contentStore = useContentStore()
 useNotificationsPersistence()
 usePushErrorBridge()
 useOfflineWatcher()
+usePushSummaryBridge()
 
 const poll = useDeployPolling()
 const mergedEntries = useMergedEntries(poll.entries)

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import {
 import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polling'
 import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entries'
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
+import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-watcher'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
@@ -18,6 +19,7 @@ const authStore = useAuthStore()
 const contentStore = useContentStore()
 useNotificationsPersistence()
 usePushErrorBridge()
+useOfflineWatcher()
 
 const poll = useDeployPolling()
 const mergedEntries = useMergedEntries(poll.entries)

--- a/src/components/PushSyncBadge/PushSyncBadge.vue
+++ b/src/components/PushSyncBadge/PushSyncBadge.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { isOnline } from '@/composables/useConnectivity'
 import { usePushState } from '@/composables/useSWBridge/use-push-state'
 import { PUSH_SYNC_TEST_IDS } from './test-ids'
 
 const { state } = usePushState()
+const offline = computed(() => !isOnline.value)
 const visible = computed(
-  () => state.value.status !== 'idle' || state.value.pending > 0
+  () =>
+    state.value.status !== 'idle' ||
+    state.value.pending > 0 ||
+    offline.value
 )
 const ariaLabel = computed(() =>
-  state.value.status === 'error'
-    ? `Push sync error, ${state.value.pending} pending`
-    : `Push syncing, ${state.value.pending} pending`
+  offline.value
+    ? `Working offline, ${state.value.pending} pending`
+    : state.value.status === 'error'
+      ? `Push sync error, ${state.value.pending} pending`
+      : `Push syncing, ${state.value.pending} pending`
 )
 </script>
 
@@ -20,6 +27,7 @@ const ariaLabel = computed(() =>
     class="push-sync"
     :data-testid="PUSH_SYNC_TEST_IDS.root"
     :data-status="state.status"
+    :data-offline="String(offline)"
     :aria-label="ariaLabel"
     aria-live="polite"
   >
@@ -51,6 +59,11 @@ const ariaLabel = computed(() =>
 
 .push-sync[data-status='error'] {
   background: var(--color-error, #e53935);
+  animation: none;
+}
+
+.push-sync[data-offline='true'] {
+  background: var(--color-text-muted, #888);
   animation: none;
 }
 

--- a/src/composables/useConnectivity/broadcast.ts
+++ b/src/composables/useConnectivity/broadcast.ts
@@ -1,0 +1,23 @@
+import {
+  type ConnectivityEvent,
+  SW_CONNECTIVITY_CHANNEL,
+} from '@/sw/protocol/connectivity'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_CONNECTIVITY_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast the current online state to the SW so the push queue
+ * can decide whether to drain or hold. Clients call this whenever
+ * the local `isOnline` ref flips.
+ * @param online True when the network is reachable.
+ * @returns void
+ */
+export const broadcastConnectivity = (online: boolean): void => {
+  const event: ConnectivityEvent = { online, at: Date.now() }
+  channelOf().postMessage(event)
+}

--- a/src/composables/useConnectivity/connectivity-state.ts
+++ b/src/composables/useConnectivity/connectivity-state.ts
@@ -1,0 +1,9 @@
+import { ref } from 'vue'
+
+const initialOnline =
+  typeof navigator === 'undefined' ? true : navigator.onLine
+
+/** Module-shared connectivity ref. True when the app considers
+ * itself reachable; flipped by both `navigator.onLine` events and
+ * the periodic heartbeat probe. */
+export const isOnline = ref<boolean>(initialOnline)

--- a/src/composables/useConnectivity/heartbeat.ts
+++ b/src/composables/useConnectivity/heartbeat.ts
@@ -1,0 +1,28 @@
+/** Minimum interval between heartbeat probes (ms). */
+export const HEARTBEAT_INTERVAL_MS = 30_000
+
+const HEARTBEAT_URL = 'https://api.github.com/user'
+
+/**
+ * Probe network reachability with a single short-timeout fetch.
+ * Resolves true when the request returns 2xx or 4xx (server is
+ * up, regardless of auth state); resolves false on network
+ * failure or 5xx so callers can flip into offline mode.
+ * @param controller AbortController owning the request lifecycle.
+ * @returns True when the network appears reachable.
+ */
+export const probeReachability = async (
+  controller: AbortController
+): Promise<boolean> => {
+  try {
+    const response = await fetch(HEARTBEAT_URL, {
+      method: 'HEAD',
+      signal: controller.signal,
+      cache: 'no-store',
+      mode: 'cors',
+    })
+    return response.status < 500
+  } catch {
+    return false
+  }
+}

--- a/src/composables/useConnectivity/index.ts
+++ b/src/composables/useConnectivity/index.ts
@@ -1,0 +1,3 @@
+/** Connectivity heartbeat composable. */
+export { isOnline } from './connectivity-state'
+export { useConnectivity } from './use-connectivity'

--- a/src/composables/useConnectivity/page-visibility.ts
+++ b/src/composables/useConnectivity/page-visibility.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue'
+
+const initialVisible =
+  typeof document === 'undefined' ? true : !document.hidden
+
+/** Module-shared visibility ref. True when the tab is visible. */
+export const isPageVisible = ref<boolean>(initialVisible)
+
+const supported = typeof document !== 'undefined'
+
+const wire = (): void => {
+  document.addEventListener('visibilitychange', () => {
+    isPageVisible.value = !document.hidden
+  })
+}
+
+const noop = (): void => undefined
+;(supported ? wire : noop)()

--- a/src/composables/useConnectivity/use-connectivity.ts
+++ b/src/composables/useConnectivity/use-connectivity.ts
@@ -1,4 +1,5 @@
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
+import { broadcastConnectivity } from './broadcast'
 import { isOnline } from './connectivity-state'
 import { HEARTBEAT_INTERVAL_MS, probeReachability } from './heartbeat'
 import { isPageVisible } from './page-visibility'
@@ -25,25 +26,27 @@ const handleOffline = (): void => {
   isOnline.value = false
 }
 
+const wireListeners = (): void => {
+  globalThis.addEventListener('online', handleOnline)
+  globalThis.addEventListener('offline', handleOffline)
+  setInterval(() => {
+    void tick()
+  }, HEARTBEAT_INTERVAL_MS)
+  watch(isOnline, next => broadcastConnectivity(next), { immediate: true })
+}
+
 const ensureRegistered = (): void => {
   const already = registered
   registered = true
-  const wire = (): void => {
-    globalThis.addEventListener('online', handleOnline)
-    globalThis.addEventListener('offline', handleOffline)
-    setInterval(() => {
-      void tick()
-    }, HEARTBEAT_INTERVAL_MS)
-  }
   const noop = (): void => undefined
-  ;(already ? noop : wire)()
+  ;(already ? noop : wireListeners)()
 }
 
 /**
  * Reactive connectivity probe. Returns the shared `isOnline` ref
- * and registers `online`/`offline` listeners plus a 30s heartbeat
- * when called for the first time. The heartbeat skips ticks while
- * the tab is hidden so background tabs don't generate traffic.
+ * and registers `online`/`offline` listeners + a 30 s heartbeat
+ * + an SW broadcast on the first call. Heartbeat skips ticks
+ * while the tab is hidden so background tabs are silent.
  * @returns Object exposing the reactive `isOnline` ref.
  */
 export const useConnectivity = () => {

--- a/src/composables/useConnectivity/use-connectivity.ts
+++ b/src/composables/useConnectivity/use-connectivity.ts
@@ -1,0 +1,55 @@
+import { onMounted, onUnmounted } from 'vue'
+import { isOnline } from './connectivity-state'
+import { HEARTBEAT_INTERVAL_MS, probeReachability } from './heartbeat'
+import { isPageVisible } from './page-visibility'
+
+let registered = false
+
+const tick = async (): Promise<void> => {
+  const visible = isPageVisible.value
+  const skip = !visible
+  await (skip
+    ? Promise.resolve()
+    : (async (): Promise<void> => {
+        const ctrl = new AbortController()
+        const reachable = await probeReachability(ctrl)
+        isOnline.value = reachable
+      })())
+}
+
+const handleOnline = (): void => {
+  isOnline.value = true
+}
+
+const handleOffline = (): void => {
+  isOnline.value = false
+}
+
+const ensureRegistered = (): void => {
+  const already = registered
+  registered = true
+  const wire = (): void => {
+    globalThis.addEventListener('online', handleOnline)
+    globalThis.addEventListener('offline', handleOffline)
+    setInterval(() => {
+      void tick()
+    }, HEARTBEAT_INTERVAL_MS)
+  }
+  const noop = (): void => undefined
+  ;(already ? noop : wire)()
+}
+
+/**
+ * Reactive connectivity probe. Returns the shared `isOnline` ref
+ * and registers `online`/`offline` listeners plus a 30s heartbeat
+ * when called for the first time. The heartbeat skips ticks while
+ * the tab is hidden so background tabs don't generate traffic.
+ * @returns Object exposing the reactive `isOnline` ref.
+ */
+export const useConnectivity = () => {
+  onMounted(() => {
+    ensureRegistered()
+  })
+  onUnmounted(() => undefined)
+  return { isOnline }
+}

--- a/src/composables/useNotifications/use-offline-watcher.ts
+++ b/src/composables/useNotifications/use-offline-watcher.ts
@@ -1,0 +1,27 @@
+import { watch } from 'vue'
+import { isOnline, useConnectivity } from '@/composables/useConnectivity'
+import { notifyNetworkDown } from './notify-network-down'
+import { requestPushRetry } from './push-retry'
+
+/**
+ * Surface a sticky network notification on every offline
+ * transition and ensure the connectivity heartbeat is registered.
+ * Notification CTA is wired to the manual retry control message
+ * so the user can probe a recovery without waiting on the next
+ * heartbeat tick.
+ * @returns void
+ */
+export const useOfflineWatcher = (): void => {
+  useConnectivity()
+  watch(
+    isOnline,
+    (next, prev) => {
+      const transitionedOffline = prev !== false && next === false
+      const fire = transitionedOffline
+        ? () => notifyNetworkDown(requestPushRetry)
+        : (): void => undefined
+      fire()
+    },
+    { immediate: false }
+  )
+}

--- a/src/composables/useNotifications/use-push-summary-bridge.ts
+++ b/src/composables/useNotifications/use-push-summary-bridge.ts
@@ -1,0 +1,28 @@
+import { onUnmounted } from 'vue'
+import {
+  type PushSummaryEvent,
+  SW_PUSH_SUMMARY_CHANNEL,
+} from '@/sw/protocol/push-summary'
+import { notifyInfo } from './notify-info'
+
+const subscribe = (channel: BroadcastChannel): void => {
+  channel.onmessage = (event: MessageEvent<PushSummaryEvent>): void => {
+    notifyInfo(`Synced ${event.data.synced} change(s)`)
+  }
+}
+
+/**
+ * Subscribe to SW-broadcast drain summaries and dispatch a
+ * transient info notification per event. Mount once near the app
+ * root.
+ * @returns void
+ */
+export const usePushSummaryBridge = (): void => {
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_SUMMARY_CHANNEL)
+    : undefined
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => subscribe(channel))()
+  onUnmounted(() => channel?.close())
+}

--- a/src/sw/connectivity/sw-connectivity-state.ts
+++ b/src/sw/connectivity/sw-connectivity-state.ts
@@ -1,0 +1,29 @@
+import {
+  type ConnectivityEvent,
+  SW_CONNECTIVITY_CHANNEL,
+} from '../protocol/connectivity'
+
+let online = true
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_CONNECTIVITY_CHANNEL)
+  return channel
+}
+
+/**
+ * True when the client most recently reported the network is up.
+ * @returns Cached online state.
+ */
+export const isOnlineInSw = (): boolean => online
+
+/**
+ * Wire the SW to consume connectivity events broadcast by the
+ * client. Called once at SW boot.
+ * @returns void
+ */
+export const registerConnectivityListener = (): void => {
+  channelOf().onmessage = (event: MessageEvent<ConnectivityEvent>): void => {
+    online = event.data.online
+  }
+}

--- a/src/sw/connectivity/sw-connectivity-state.ts
+++ b/src/sw/connectivity/sw-connectivity-state.ts
@@ -4,6 +4,7 @@ import {
 } from '../protocol/connectivity'
 
 let online = true
+let wasOffline = false
 let channel: BroadcastChannel | undefined
 
 const channelOf = (): BroadcastChannel => {
@@ -18,12 +19,40 @@ const channelOf = (): BroadcastChannel => {
 export const isOnlineInSw = (): boolean => online
 
 /**
+ * True when the SW saw an offline transition since the last
+ * successful drain. Used to gate the "Synced N changes" toast so
+ * routine drains do not announce themselves.
+ * @returns Cached "was offline since last drain" flag.
+ */
+export const wasOfflineSinceDrain = (): boolean => wasOffline
+
+/** Reset the offline-since-drain flag. Call after a drain summary fires. */
+export const acknowledgeOfflineDrain = (): void => {
+  wasOffline = false
+}
+
+const handleTransition = async (next: boolean): Promise<void> => {
+  const becameOnline = !online && next
+  online = next
+  wasOffline = wasOffline || !next
+  await (becameOnline
+    ? (async (): Promise<void> => {
+        const { resetAttempts } = await import('../push-queue/reset-attempts')
+        const { drainPushes } = await import('../push-queue/drain')
+        await resetAttempts()
+        await drainPushes()
+      })()
+    : Promise.resolve())
+}
+
+/**
  * Wire the SW to consume connectivity events broadcast by the
- * client. Called once at SW boot.
+ * client. On every offline → online transition, reset retry
+ * counters and trigger an immediate drain.
  * @returns void
  */
 export const registerConnectivityListener = (): void => {
   channelOf().onmessage = (event: MessageEvent<ConnectivityEvent>): void => {
-    online = event.data.online
+    void handleTransition(event.data.online)
   }
 }

--- a/src/sw/main.ts
+++ b/src/sw/main.ts
@@ -4,6 +4,7 @@
  * via load-git.ts to enable code-splitting. This keeps
  * the main SW chunk small for fast installation.
  */
+import { registerConnectivityListener } from './connectivity/sw-connectivity-state'
 import { registerFetchListener } from './core/fetch-listener'
 import { registerLifecycle } from './core/lifecycle'
 import { registerMessageListener } from './core/messaging/message-listener'
@@ -18,5 +19,6 @@ registerLifecycle()
 registerFetchListener()
 registerMessageListener()
 registerPushControlListener()
+registerConnectivityListener()
 
 log('info', 'lifecycle', 'SW ready', { version: SW_VERSION })

--- a/src/sw/protocol/connectivity.ts
+++ b/src/sw/protocol/connectivity.ts
@@ -1,0 +1,8 @@
+/** BroadcastChannel name for client→SW connectivity state. */
+export const SW_CONNECTIVITY_CHANNEL = 'sw-connectivity'
+
+/** Connectivity broadcast payload. */
+export type ConnectivityEvent = {
+  readonly online: boolean
+  readonly at: number
+}

--- a/src/sw/protocol/push-summary.ts
+++ b/src/sw/protocol/push-summary.ts
@@ -1,0 +1,8 @@
+/** BroadcastChannel name for SW→client drain summary events. */
+export const SW_PUSH_SUMMARY_CHANNEL = 'sw-push-summary'
+
+/** Emitted after a successful drain that began while offline. */
+export type PushSummaryEvent = {
+  readonly synced: number
+  readonly at: number
+}

--- a/src/sw/push-queue/drain-summary.ts
+++ b/src/sw/push-queue/drain-summary.ts
@@ -1,0 +1,29 @@
+import {
+  acknowledgeOfflineDrain,
+  wasOfflineSinceDrain,
+} from '../connectivity/sw-connectivity-state'
+import { listPending } from './idb'
+import { publishPushSummary } from './summary-broadcast'
+
+/**
+ * After a drain completes, compare the queue length before and
+ * after to count successful pushes. When the SW saw an offline
+ * transition since the previous drain, broadcast a "Synced N
+ * change(s)" summary so the UI can confirm recovery.
+ * @param initial Pending count captured before the drain ran.
+ * @returns Resolves once the summary has been emitted (if any).
+ */
+export const announceDrainSummary = async (
+  initial: number
+): Promise<void> => {
+  const final = (await listPending()).length
+  const synced = Math.max(0, initial - final)
+  const announce = synced > 0 && wasOfflineSinceDrain()
+  const fire = announce
+    ? () => {
+        publishPushSummary(synced)
+        acknowledgeOfflineDrain()
+      }
+    : (): void => undefined
+  fire()
+}

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -1,18 +1,28 @@
 import { Option } from 'effect'
+import { isOnlineInSw } from '../connectivity/sw-connectivity-state'
 import { workerState } from '../state/state'
+import { publishPushState } from './broadcast'
 import { listPending } from './idb'
 import { processNext } from './process-next'
 
 let inFlight = false
 
-const processPending = async (): Promise<void> =>
-  Option.match(Option.fromNullable(workerState.config), {
-    onNone: () => Promise.resolve(),
-    onSome: async config => {
-      const pending = await listPending()
-      await processNext(pending, 0, config)
-    },
-  })
+const surfaceOfflineHold = async (): Promise<void> => {
+  const pending = (await listPending()).length
+  publishPushState({ status: 'syncing', pending })
+}
+
+const processPending = async (): Promise<void> => {
+  await (isOnlineInSw()
+    ? Option.match(Option.fromNullable(workerState.config), {
+        onNone: () => Promise.resolve(),
+        onSome: async config => {
+          const pending = await listPending()
+          await processNext(pending, 0, config)
+        },
+      })
+    : surfaceOfflineHold())
+}
 
 const runOnce = async (): Promise<void> => {
   inFlight = true

--- a/src/sw/push-queue/drain.ts
+++ b/src/sw/push-queue/drain.ts
@@ -2,6 +2,7 @@ import { Option } from 'effect'
 import { isOnlineInSw } from '../connectivity/sw-connectivity-state'
 import { workerState } from '../state/state'
 import { publishPushState } from './broadcast'
+import { announceDrainSummary } from './drain-summary'
 import { listPending } from './idb'
 import { processNext } from './process-next'
 
@@ -26,8 +27,10 @@ const processPending = async (): Promise<void> => {
 
 const runOnce = async (): Promise<void> => {
   inFlight = true
+  const initial = (await listPending()).length
   try {
     await processPending()
+    await announceDrainSummary(initial)
   } finally {
     inFlight = false
   }

--- a/src/sw/push-queue/reset-attempts.ts
+++ b/src/sw/push-queue/reset-attempts.ts
@@ -1,0 +1,17 @@
+import { fromRequest, listPending, txStore } from './idb'
+
+/**
+ * Clear the `attempt` counter on every queued entry. Called when
+ * connectivity is restored so prior backoff schedules do not delay
+ * the drain after the user is back online.
+ * @returns Resolves once the rewrite completes.
+ */
+export const resetAttempts = async (): Promise<void> => {
+  const all = await listPending()
+  await Promise.all(
+    all.map(async entry => {
+      const store = await txStore('readwrite')
+      await fromRequest(store.put({ ...entry, attempt: 1 }))
+    })
+  )
+}

--- a/src/sw/push-queue/summary-broadcast.ts
+++ b/src/sw/push-queue/summary-broadcast.ts
@@ -1,0 +1,22 @@
+import {
+  type PushSummaryEvent,
+  SW_PUSH_SUMMARY_CHANNEL,
+} from '../protocol/push-summary'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_SUMMARY_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast a drain summary so the client can surface a "Synced N
+ * changes" toast. Suppressed when no entries actually drained.
+ * @param synced Number of successful pushes in the just-finished drain.
+ * @returns void
+ */
+export const publishPushSummary = (synced: number): void => {
+  const event: PushSummaryEvent = { synced, at: Date.now() }
+  channelOf().postMessage(event)
+}

--- a/src/views/SettingsView/MembersSection.vue
+++ b/src/views/SettingsView/MembersSection.vue
@@ -16,12 +16,26 @@ const s = useMembersSection()
         type="button"
         class="btn-invite"
         data-testid="invite-open"
-        :disabled="s.busy.value"
+        :disabled="s.busy.value || s.offline.value"
+        :aria-disabled="s.disabled.value"
+        :title="
+          s.offline.value
+            ? 'Offline: invitations require network'
+            : undefined
+        "
         @click="s.openDialog"
       >
         + Invite
       </button>
     </header>
+    <p
+      v-if="s.offline.value"
+      class="offline-banner"
+      data-testid="members-offline-banner"
+      role="status"
+    >
+      Working offline — member changes are paused until reconnect.
+    </p>
     <p v-if="s.loading.value" class="hint">Loading organisation members…</p>
     <InviteList
       v-if="s.invitations.value.length > 0"

--- a/src/views/SettingsView/members-public-state.ts
+++ b/src/views/SettingsView/members-public-state.ts
@@ -28,6 +28,7 @@ export const projectMembersPublic = <A extends Record<string, unknown>>(
   busy: s.busy,
   error: s.error,
   disabled: s.disabled,
+  offline: s.offline,
   canEditSettings: s.canEditSettings,
   openDialog: ctl.openDialog,
   closeDialog: ctl.closeDialog,

--- a/src/views/SettingsView/members-section-state.ts
+++ b/src/views/SettingsView/members-section-state.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { isOnline } from '@/composables/useConnectivity'
 import { usePermissions } from '@/composables/usePermissions'
 import type { OrgMember } from './roles-api-types'
 import { useOrgMembers } from './useOrgMembers'
@@ -26,7 +27,10 @@ export const buildMembersState = () => {
   const busy = ref(false)
   const error = ref<string | undefined>(undefined)
   const sorted = computed(() => sortByRank(members.value))
-  const disabled = computed(() => busy.value || !canEditSettings.value)
+  const offline = computed(() => !isOnline.value)
+  const disabled = computed(
+    () => busy.value || !canEditSettings.value || offline.value
+  )
   return {
     members,
     invitations,
@@ -38,5 +42,6 @@ export const buildMembersState = () => {
     error,
     sorted,
     disabled,
+    offline,
   }
 }


### PR DESCRIPTION
## Summary
Phase A / Epic 3 — offline mode. The push pipeline now stops trying when the network is down, queues up commits, drains automatically on reconnect, and surfaces every state change to the user.

## What's in this release
- **3.1 #87 / #105** — `useConnectivity` composable: navigator.onLine + 30 s heartbeat probe (skipped while tab hidden), reactive shared `isOnline` ref.
- **3.2 #88 / #106** — Hold pushes when offline. SW gates drain on cached online flag, surfaces pending count, fires offline notification on transition. PushSyncBadge tints gray while offline.
- **3.3 #89 / #107** — Auto-drain on reconnect. Resets attempt counters, triggers immediate drain, emits "Synced N change(s)" info toast when a previously-offline drain succeeds.
- **3.4 #90 / #108** — Members section disables Invite/role-change/revoke while offline; offline banner with role=status; tooltip on Invite explains why.

## Coverage
- Unit: 455/455 green
- E2E (chromium): 26/26 notifications + settings green
- `bun run validate` clean

## Verification post-deploy
- [ ] dev-admin loads without console errors
- [ ] Triggering DevTools "Offline" surfaces network notification + sync badge tint
- [ ] Settings → Members shows banner + disabled Invite button while offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)