### PR TITLE
feat(sw): auto-merge on non-fast-forward + conflict broadcast (#91)

### DIFF
--- a/e2e/notifications/push-conflict.spec.ts
+++ b/e2e/notifications/push-conflict.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastConflict = (files: ReadonlyArray<string>): string => `
+const ch = new BroadcastChannel('sw-push-conflict')
+ch.postMessage({
+  sha: 'beefcafe',
+  target: 'origin/develop',
+  files: ${JSON.stringify(files)},
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+test.describe('push conflict bridge (4.1)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('conflict event surfaces a sticky conflict toast', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['blog/a/index.en.md']))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'conflict')
+    await expect(toast).toHaveAttribute('data-sticky', 'true')
+    await expect(toast).toContainText('1')
+  })
+
+  test('multi-file conflict reports the count', async ({ page }) => {
+    await page.evaluate(broadcastConflict(['a.md', 'b.md', 'c.md']))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toContainText('3')
+  })
+})

--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -13,9 +13,7 @@ test.describe('settings offline gate (3.4)', () => {
     page,
     context,
   }) => {
-    const banner = page.locator(
-      '[data-testid="members-offline-banner"]'
-    )
+    const banner = page.locator('[data-testid="members-offline-banner"]')
     await expect(banner).toBeHidden()
     await context.setOffline(true)
     await expect(banner).toBeVisible()

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polli
 import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entries'
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
 import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-watcher'
+import { usePushConflictBridge } from '@/composables/useNotifications/use-push-conflict-bridge'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { usePushSummaryBridge } from '@/composables/useNotifications/use-push-summary-bridge'
 import { useAuthStore } from '@/stores/auth'
@@ -22,6 +23,7 @@ useNotificationsPersistence()
 usePushErrorBridge()
 useOfflineWatcher()
 usePushSummaryBridge()
+usePushConflictBridge()
 
 const poll = useDeployPolling()
 const mergedEntries = useMergedEntries(poll.entries)

--- a/src/composables/useNotifications/use-push-conflict-bridge.ts
+++ b/src/composables/useNotifications/use-push-conflict-bridge.ts
@@ -1,0 +1,44 @@
+import { onUnmounted } from 'vue'
+import {
+  type PushConflictEvent,
+  SW_PUSH_CONFLICT_CHANNEL,
+} from '@/sw/protocol/push-conflict'
+import { notifyConflictDetected } from './notify-conflict-detected'
+
+let pendingConflict: PushConflictEvent | undefined
+
+/**
+ * Read the most recent conflict event seen by the bridge. Used by
+ * the conflict view to render the file list without re-listening
+ * on the channel.
+ * @returns Last conflict event, or undefined when none yet.
+ */
+export const lastConflictEvent = (): PushConflictEvent | undefined =>
+  pendingConflict
+
+const dispatch = (event: PushConflictEvent): void => {
+  pendingConflict = event
+  notifyConflictDetected(event.files)
+}
+
+const subscribe = (channel: BroadcastChannel): void => {
+  channel.onmessage = (event: MessageEvent<PushConflictEvent>): void => {
+    dispatch(event.data)
+  }
+}
+
+/**
+ * Subscribe to SW-broadcast merge conflict events and dispatch a
+ * sticky notification per occurrence. The most recent event is
+ * cached for later inspection by the conflict view (4.2+).
+ * @returns void
+ */
+export const usePushConflictBridge = (): void => {
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_CONFLICT_CHANNEL)
+    : undefined
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => subscribe(channel))()
+  onUnmounted(() => channel?.close())
+}

--- a/src/sw/protocol/push-conflict.ts
+++ b/src/sw/protocol/push-conflict.ts
@@ -1,0 +1,10 @@
+/** BroadcastChannel name for SW→client merge conflict events. */
+export const SW_PUSH_CONFLICT_CHANNEL = 'sw-push-conflict'
+
+/** Emitted when an auto-merge attempt leaves conflict markers. */
+export type PushConflictEvent = {
+  readonly sha: string
+  readonly target: string
+  readonly files: ReadonlyArray<string>
+  readonly at: number
+}

--- a/src/sw/push-queue/attempt-merge.ts
+++ b/src/sw/push-queue/attempt-merge.ts
@@ -1,0 +1,57 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+import { buildAuthOpts } from '../git/remote/build-auth-opts'
+import type { SWGitConfig } from '../protocol'
+import { filesFromError, filesFromStatus } from './merge-conflict-files'
+
+/** Outcome of a single auto-merge attempt. */
+export type MergeOutcome =
+  | { readonly kind: 'clean' }
+  | {
+      readonly kind: 'conflict'
+      readonly files: ReadonlyArray<string>
+    }
+  | { readonly kind: 'fail'; readonly error: unknown }
+
+const isMergeConflict = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'MergeConflictError'
+
+const collectConflictFiles = async (
+  error: unknown
+): Promise<ReadonlyArray<string>> => {
+  const fromError = filesFromError(error)
+  return fromError.length > 0 ? fromError : await filesFromStatus()
+}
+
+/**
+ * Attempt to fast-forward / auto-merge the local branch against
+ * the remote. Wraps `git.pull` so callers can react to the three
+ * outcomes without parsing error names themselves.
+ * @param config Validated SW git configuration.
+ * @returns Discriminated outcome (clean / conflict / fail).
+ */
+export const attemptMerge = async (
+  config: SWGitConfig
+): Promise<MergeOutcome> => {
+  const git = await loadGit()
+  const { default: http } = await import('isomorphic-git/http/web')
+  const opts = buildAuthOpts(config, http)
+  try {
+    await git.pull({
+      ...opts,
+      fs,
+      dir: REPO_DIR,
+      ref: config.branch,
+      singleBranch: true,
+      author: {
+        name: config.authorName ?? 'Admin',
+        email: config.authorEmail ?? 'admin@prometheus.org',
+      },
+    })
+    return { kind: 'clean' }
+  } catch (error) {
+    return isMergeConflict(error)
+      ? { kind: 'conflict', files: await collectConflictFiles(error) }
+      : { kind: 'fail', error }
+  }
+}

--- a/src/sw/push-queue/conflict-broadcast.ts
+++ b/src/sw/push-queue/conflict-broadcast.ts
@@ -1,0 +1,33 @@
+import {
+  type PushConflictEvent,
+  SW_PUSH_CONFLICT_CHANNEL,
+} from '../protocol/push-conflict'
+import type { PushQueueEntry } from './types'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_CONFLICT_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast an unresolved-conflict event so the client can list
+ * affected files in the conflict view (4.2) and offer per-file
+ * resolution (4.3+).
+ * @param entry Queue entry whose push triggered the merge attempt.
+ * @param files Conflict file paths reported by isomorphic-git.
+ * @returns void
+ */
+export const publishPushConflict = (
+  entry: PushQueueEntry,
+  files: ReadonlyArray<string>
+): void => {
+  const event: PushConflictEvent = {
+    sha: entry.sha,
+    target: entry.branch,
+    files,
+    at: Date.now(),
+  }
+  channelOf().postMessage(event)
+}

--- a/src/sw/push-queue/files-from-error.ts
+++ b/src/sw/push-queue/files-from-error.ts
@@ -1,0 +1,18 @@
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Inspect an isomorphic-git merge error and return the list of
+ * conflict file paths it carries on `error.data.filepaths`. Falls
+ * back to an empty array so callers always get a list. Pure —
+ * no fs / git dependencies — so unit tests don't need IDB shims.
+ * @param error Raw error from `git.pull` / `git.merge`.
+ * @returns Conflict file paths reported by the error payload.
+ */
+export const filesFromError = (error: unknown): ReadonlyArray<string> => {
+  const data = isObject(error) ? error['data'] : undefined
+  const filepaths = isObject(data) ? data['filepaths'] : undefined
+  return Array.isArray(filepaths)
+    ? filepaths.filter((p): p is string => typeof p === 'string')
+    : []
+}

--- a/src/sw/push-queue/handle-failure.ts
+++ b/src/sw/push-queue/handle-failure.ts
@@ -1,22 +1,52 @@
 import { publishPushState } from './broadcast'
 import { classifyPushError } from './classify-error'
 import { publishPushError } from './error-broadcast'
+import { tryMergeAfterNff } from './handle-nff'
 import { shouldRetry } from './retry-policy'
 import { scheduleRetry } from './schedule-retry'
 import type { PushQueueEntry } from './types'
 import { bumpAttempt } from './update-attempt'
 
+const scheduleAfterMerge = async (entry: PushQueueEntry): Promise<void> => {
+  await bumpAttempt(entry)
+  scheduleRetry(entry.attempt ?? 1)
+}
+
+const handleNonFastForward = async (
+  entry: PushQueueEntry,
+  remaining: number
+): Promise<void> => {
+  const outcome = await tryMergeAfterNff(entry)
+  const cleanMerge = outcome.kind === 'clean'
+  publishPushState({
+    status: cleanMerge ? 'syncing' : 'error',
+    pending: remaining,
+  })
+  publishPushError(entry, 'non-fast-forward', !cleanMerge)
+  await (cleanMerge ? scheduleAfterMerge(entry) : Promise.resolve())
+}
+
+const handleGenericFailure = async (
+  entry: PushQueueEntry,
+  remaining: number,
+  reason: ReturnType<typeof classifyPushError>,
+  retry: boolean
+): Promise<void> => {
+  publishPushState({ status: 'error', pending: remaining })
+  publishPushError(entry, reason, !retry)
+  await (retry ? scheduleAfterMerge(entry) : Promise.resolve())
+}
+
 /**
- * React to a failed push attempt. Retriable failures bump the
- * attempt counter, schedule the next drain, and surface a
- * non-terminal error event. Terminal failures (auth /
- * non-fast-forward / validation / retry-cap) leave the entry in
- * place and surface a terminal event so the UI can offer a Retry
- * CTA on user action.
+ * React to a failed push attempt. Non-fast-forward triggers an
+ * auto-merge — clean merges retry, conflicts surface via the
+ * conflict channel. Other transient errors bump the attempt
+ * counter and schedule a backoff retry. Terminal failures emit
+ * a terminal error event for the UI.
  * @param entry Failed queue entry.
  * @param remaining Pending count covering the entry and everything after.
  * @param error Raw error from the push pipeline.
- * @returns Resolves once side effects (broadcast, schedule) are queued.
+ * @returns Resolves once side effects are queued.
  */
 export const handleFailure = async (
   entry: PushQueueEntry,
@@ -26,13 +56,7 @@ export const handleFailure = async (
   const reason = classifyPushError(error)
   const attempt = entry.attempt ?? 1
   const retry = shouldRetry(reason, attempt)
-  publishPushState({ status: 'error', pending: remaining })
-  publishPushError(entry, reason, !retry)
-  const schedule = retry
-    ? async (): Promise<void> => {
-        await bumpAttempt(entry)
-        scheduleRetry(attempt)
-      }
-    : async (): Promise<void> => undefined
-  await schedule()
+  await (reason === 'non-fast-forward'
+    ? handleNonFastForward(entry, remaining)
+    : handleGenericFailure(entry, remaining, reason, retry))
 }

--- a/src/sw/push-queue/handle-nff.ts
+++ b/src/sw/push-queue/handle-nff.ts
@@ -1,0 +1,33 @@
+import { workerState } from '../state/state'
+import { attemptMerge, type MergeOutcome } from './attempt-merge'
+import { publishPushConflict } from './conflict-broadcast'
+import type { PushQueueEntry } from './types'
+
+const noConfigOutcome: MergeOutcome = {
+  kind: 'fail',
+  error: new Error('SW git config missing'),
+}
+
+/**
+ * Try to merge the remote branch in response to a non-fast-
+ * forward push rejection. Returns the merge outcome so the
+ * failure handler can decide whether to re-drain (clean), surface
+ * a conflict notification (conflict), or fall through to the
+ * generic terminal-error path (fail).
+ * @param entry Failed queue entry whose push triggered the merge.
+ * @returns Discriminated outcome (clean / conflict / fail).
+ */
+export const tryMergeAfterNff = async (
+  entry: PushQueueEntry
+): Promise<MergeOutcome> => {
+  const config = workerState.config
+  const outcome =
+    config === undefined ? noConfigOutcome : await attemptMerge(config)
+  const noop = (): void => undefined
+  const fire =
+    outcome.kind === 'conflict'
+      ? () => publishPushConflict(entry, outcome.files)
+      : noop
+  fire()
+  return outcome
+}

--- a/src/sw/push-queue/merge-conflict-files.test.ts
+++ b/src/sw/push-queue/merge-conflict-files.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { filesFromError } from './files-from-error'
+
+describe('filesFromError', () => {
+  it('returns the filepaths array carried on data', () => {
+    const error = { data: { filepaths: ['a.md', 'b.md'] } }
+    expect(filesFromError(error)).toEqual(['a.md', 'b.md'])
+  })
+
+  it('drops non-string entries', () => {
+    const error = { data: { filepaths: ['a.md', 42, undefined, 'b.md'] } }
+    expect(filesFromError(error)).toEqual(['a.md', 'b.md'])
+  })
+
+  it('returns [] when data is missing', () => {
+    expect(filesFromError(new Error('boom'))).toEqual([])
+    expect(filesFromError(undefined)).toEqual([])
+    expect(filesFromError({ no: 'data-here' })).toEqual([])
+  })
+
+  it('returns [] when filepaths is not an array', () => {
+    expect(filesFromError({ data: { filepaths: 'hello' } })).toEqual([])
+    expect(filesFromError({ data: 'hello' })).toEqual([])
+  })
+})

--- a/src/sw/push-queue/merge-conflict-files.ts
+++ b/src/sw/push-queue/merge-conflict-files.ts
@@ -1,0 +1,18 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+
+export { filesFromError } from './files-from-error'
+
+/**
+ * Inspect the working tree for entries with conflict markers
+ * (statusMatrix rows where head/workdir/stage diverge). Used as
+ * a fallback when the merge error omits the filepaths list.
+ * @returns Paths of files that currently carry conflict markers.
+ */
+export const filesFromStatus = async (): Promise<ReadonlyArray<string>> => {
+  const git = await loadGit()
+  const matrix = await git.statusMatrix({ fs, dir: REPO_DIR })
+  return matrix
+    .filter(row => row[1] !== row[2] && row[2] !== row[3])
+    .map(row => row[0])
+}


### PR DESCRIPTION
Phase A / Epic 4 increment 4.1.

SW now reacts to non-fast-forward push by attempting auto-merge via isomorphic-git's pull. Clean merges retry; conflicts broadcast on the new sw-push-conflict channel and surface a sticky conflict toast.

- attempt-merge.ts (clean / conflict / fail outcomes)
- files-from-error.ts (pure, IDB-free) extracted for test
- sw-push-conflict channel + bridge → notifyConflictDetected
- handle-failure.ts special-cases non-fast-forward

Unit: 4/4. E2E: 2/2. Validate clean. Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)