### PR TITLE
feat(conflicts): visual 3-pane merge editor (#94)

### DIFF
--- a/e2e/notifications/conflicts-resolve.spec.ts
+++ b/e2e/notifications/conflicts-resolve.spec.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-const broadcastConflict = (
-  files: ReadonlyArray<string>
-): string => `
+const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
 ch.postMessage({
   sha: 'def456',
@@ -23,9 +21,7 @@ globalThis.__resolveChannel = ch
 test.describe('per-file conflict resolution (4.3)', () => {
   test.beforeEach(async ({ page }) => {
     await page
-      .evaluate(() =>
-        globalThis.localStorage?.removeItem('admin-conflicts')
-      )
+      .evaluate(() => globalThis.localStorage?.removeItem('admin-conflicts'))
       .catch(() => undefined)
     await page.goto('/')
     await page.waitForLoadState('networkidle')
@@ -40,9 +36,7 @@ test.describe('per-file conflict resolution (4.3)', () => {
   }) => {
     await page.evaluate(broadcastConflict(['a.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await page
-      .locator('[data-testid="conflicts-item-keep-mine"]')
-      .click()
+    await page.locator('[data-testid="conflicts-item-keep-mine"]').click()
     await expect(
       page.locator('[data-testid="conflicts-item-resolved"]')
     ).toContainText('mine')
@@ -52,9 +46,7 @@ test.describe('per-file conflict resolution (4.3)', () => {
     expect(messages.some(m => m.type === 'resolve-file')).toBe(true)
   })
 
-  test('finalize appears once every file is resolved', async ({
-    page,
-  }) => {
+  test('finalize appears once every file is resolved', async ({ page }) => {
     await page.evaluate(broadcastConflict(['a.md', 'b.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
     const finalize = page.locator('[data-testid="conflicts-finalize"]')
@@ -76,9 +68,7 @@ test.describe('per-file conflict resolution (4.3)', () => {
   }) => {
     await page.evaluate(broadcastConflict(['a.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await page
-      .locator('[data-testid="conflicts-item-force-mine"]')
-      .click()
+    await page.locator('[data-testid="conflicts-item-force-mine"]').click()
     await page.locator('[data-testid="conflicts-finalize"]').click()
     await expect(
       page.locator('[data-testid="conflicts-empty"]')
@@ -86,8 +76,6 @@ test.describe('per-file conflict resolution (4.3)', () => {
     const messages = await page.evaluate<readonly { type: string }[]>(
       () => globalThis.__resolveMessages ?? []
     )
-    expect(
-      messages.some(m => m.type === 'finalize-resolution')
-    ).toBe(true)
+    expect(messages.some(m => m.type === 'finalize-resolution')).toBe(true)
   })
 })

--- a/e2e/notifications/visual-merge.spec.ts
+++ b/e2e/notifications/visual-merge.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastConflict = (
+  files: ReadonlyArray<string>
+): string => `
+const ch = new BroadcastChannel('sw-push-conflict')
+ch.postMessage({
+  sha: 'fa11',
+  target: 'origin/develop',
+  files: ${JSON.stringify(files)},
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+const captureControl = `
+globalThis.__visualMergeMessages = []
+const ch = new BroadcastChannel('sw-push-control')
+ch.onmessage = e => globalThis.__visualMergeMessages.push(e.data)
+globalThis.__visualMergeChannel = ch
+`
+
+test.describe('visual merge editor (4.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page
+      .evaluate(() =>
+        globalThis.localStorage?.removeItem('admin-conflicts')
+      )
+      .catch(() => undefined)
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+    await page.evaluate(captureControl)
+  })
+
+  test('visual merge link routes to the editor', async ({ page }) => {
+    await page.evaluate(broadcastConflict(['blog/sample/index.en.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-visual-merge"]')
+      .click()
+    await expect(page).toHaveURL(/\/conflicts\/merge\//)
+    await expect(
+      page.locator('[data-testid="visual-merge-view"]')
+    ).toBeVisible()
+  })
+
+  test('cancel returns to /conflicts without writing', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['x.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-visual-merge"]')
+      .click()
+    await page.locator('[data-testid="visual-merge-cancel"]').click()
+    await expect(page).toHaveURL(/\/conflicts$/)
+    const messages = await page.evaluate<readonly { type: string }[]>(
+      () => globalThis.__visualMergeMessages ?? []
+    )
+    expect(
+      messages.some(m => m.type === 'resolve-file-content')
+    ).toBe(false)
+  })
+
+  test('save posts resolve-file-content + flips row to resolved', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['y.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-visual-merge"]')
+      .click()
+    await page.locator('[data-testid="visual-merge-save"]').click()
+    await expect(page).toHaveURL(/\/conflicts$/)
+    await expect(
+      page.locator('[data-testid="conflicts-item-resolved"]')
+    ).toContainText('mine')
+    const messages = await page.evaluate<readonly { type: string }[]>(
+      () => globalThis.__visualMergeMessages ?? []
+    )
+    expect(
+      messages.some(m => m.type === 'resolve-file-content')
+    ).toBe(true)
+  })
+})

--- a/src/composables/useNotifications/push-control.ts
+++ b/src/composables/useNotifications/push-control.ts
@@ -40,6 +40,21 @@ export const requestResolveFile = (
 }
 
 /**
+ * Ask the SW to write a manually-merged content to a conflicted
+ * file and stage it. Used by the visual merge editor when the
+ * user has edited the merged result themselves.
+ * @param file Path of the conflicted file relative to repo root.
+ * @param content Resolved text the user produced in the editor.
+ * @returns void
+ */
+export const requestResolveFileContent = (
+  file: string,
+  content: string
+): void => {
+  send({ type: 'resolve-file-content', file, content })
+}
+
+/**
  * Ask the SW to finalize the conflict resolution: commit the
  * staged files and push the merge commit (force-with-lease when
  * any file used `force-mine`).

--- a/src/router/content-routes.ts
+++ b/src/router/content-routes.ts
@@ -1,5 +1,6 @@
 import type { RouteRecordRaw } from 'vue-router'
 import type { ContentType } from '@/types/content'
+import { nonContentRoutes } from './non-content-routes'
 
 const CONTENT_SECTIONS: readonly ContentType[] = [
   'blog',
@@ -19,32 +20,17 @@ const sectionRoutes: RouteRecordRaw[] = CONTENT_SECTIONS.map(type => ({
   props: { contentType: type },
 }))
 
+const editRoute: RouteRecordRaw = {
+  path: '/content/:type/edit/:slug',
+  name: 'content-edit',
+  meta: { requiresAuth: true },
+  component: () => import('../views/ContentEditView.vue'),
+  props: true,
+}
+
 /** Routes for content management (require authentication) */
 export const contentRoutes: RouteRecordRaw[] = [
   ...sectionRoutes,
-  {
-    path: '/tickets',
-    name: 'tickets',
-    meta: { requiresAuth: true },
-    component: () => import('../views/TicketsView/TicketsView.vue'),
-  },
-  {
-    path: '/settings',
-    name: 'settings',
-    meta: { requiresAuth: true },
-    component: () => import('../views/SettingsView/SettingsView.vue'),
-  },
-  {
-    path: '/conflicts',
-    name: 'conflicts',
-    meta: { requiresAuth: true },
-    component: () => import('../views/ConflictsView/ConflictsView.vue'),
-  },
-  {
-    path: '/content/:type/edit/:slug',
-    name: 'content-edit',
-    meta: { requiresAuth: true },
-    component: () => import('../views/ContentEditView.vue'),
-    props: true,
-  },
+  ...nonContentRoutes,
+  editRoute,
 ]

--- a/src/router/non-content-routes.ts
+++ b/src/router/non-content-routes.ts
@@ -1,0 +1,29 @@
+import type { RouteRecordRaw } from 'vue-router'
+
+/** Routes outside the content management section. */
+export const nonContentRoutes: RouteRecordRaw[] = [
+  {
+    path: '/tickets',
+    name: 'tickets',
+    meta: { requiresAuth: true },
+    component: () => import('../views/TicketsView/TicketsView.vue'),
+  },
+  {
+    path: '/settings',
+    name: 'settings',
+    meta: { requiresAuth: true },
+    component: () => import('../views/SettingsView/SettingsView.vue'),
+  },
+  {
+    path: '/conflicts',
+    name: 'conflicts',
+    meta: { requiresAuth: true },
+    component: () => import('../views/ConflictsView/ConflictsView.vue'),
+  },
+  {
+    path: '/conflicts/merge/:file(.+)',
+    name: 'conflicts-merge',
+    meta: { requiresAuth: true },
+    component: () => import('../views/VisualMergeView/VisualMergeView.vue'),
+  },
+]

--- a/src/sw/conflicts/write-resolved.ts
+++ b/src/sw/conflicts/write-resolved.ts
@@ -1,0 +1,20 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+
+/**
+ * Apply a manually-merged file content to the working tree and
+ * stage it. Used by the visual merge UI when the user has
+ * produced the final content themselves.
+ * @param file Path of the file relative to repo root.
+ * @param content Resolved text content to write.
+ * @returns Resolves once the file is staged.
+ */
+export const writeResolvedContent = async (
+  file: string,
+  content: string
+): Promise<void> => {
+  const path = `${REPO_DIR}/${file}`
+  await fs.promises.writeFile(path, content, 'utf8')
+  const git = await loadGit()
+  await git.add({ fs, dir: REPO_DIR, filepath: file })
+}

--- a/src/sw/protocol/push-control.ts
+++ b/src/sw/protocol/push-control.ts
@@ -12,4 +12,9 @@ export type PushControlMessage =
       readonly file: string
       readonly strategy: ResolveStrategy
     }
+  | {
+      readonly type: 'resolve-file-content'
+      readonly file: string
+      readonly content: string
+    }
   | { readonly type: 'finalize-resolution' }

--- a/src/sw/push-queue/control-listener.ts
+++ b/src/sw/push-queue/control-listener.ts
@@ -1,6 +1,7 @@
 import { Match } from 'effect'
 import { finalizeResolution } from '../conflicts/finalize'
 import { resolveFile } from '../conflicts/resolve-file'
+import { writeResolvedContent } from '../conflicts/write-resolved'
 import {
   type PushControlMessage,
   SW_PUSH_CONTROL_CHANNEL,
@@ -18,6 +19,9 @@ const dispatch = async (msg: PushControlMessage): Promise<void> => {
     Match.discriminator('type')('retry-now', () => handleRetry()),
     Match.discriminator('type')('resolve-file', ({ file, strategy }) =>
       resolveFile(file, strategy)
+    ),
+    Match.discriminator('type')('resolve-file-content', ({ file, content }) =>
+      writeResolvedContent(file, content)
     ),
     Match.discriminator('type')('finalize-resolution', () =>
       finalizeResolution().then(() => undefined)

--- a/src/views/ConflictsView/ConflictItem.vue
+++ b/src/views/ConflictsView/ConflictItem.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
+import { useRouter } from 'vue-router'
 import type { ResolveStrategy } from '@/sw/protocol/push-control'
 import { CONFLICT_TEST_IDS } from './test-ids'
 
-defineProps<{
+const props = defineProps<{
   readonly path: string
   readonly resolved: ResolveStrategy | undefined
 }>()
 defineEmits<{
   readonly resolve: [strategy: ResolveStrategy]
 }>()
+
+const router = useRouter()
+const onVisualMerge = (): void => {
+  void router.push(`/conflicts/merge/${encodeURIComponent(props.path)}`)
+}
 </script>
 
 <template>
@@ -53,6 +59,15 @@ defineEmits<{
       @click="$emit('resolve', 'force-mine')"
     >
       force push mine
+    </button>
+    <button
+      v-if="resolved === undefined"
+      type="button"
+      class="btn merge"
+      :data-testid="CONFLICT_TEST_IDS.visualMerge"
+      @click="onVisualMerge"
+    >
+      visual merge
     </button>
   </li>
 </template>
@@ -106,5 +121,10 @@ defineEmits<{
 .btn.force {
   border-color: var(--color-error, #e53935);
   color: var(--color-error, #e53935);
+}
+
+.btn.merge {
+  border-color: var(--color-accent, #4fc3f7);
+  color: var(--color-accent, #4fc3f7);
 }
 </style>

--- a/src/views/ConflictsView/test-ids.ts
+++ b/src/views/ConflictsView/test-ids.ts
@@ -11,4 +11,5 @@ export const CONFLICT_TEST_IDS = {
   takeTheirs: 'conflicts-item-take-theirs',
   forceMine: 'conflicts-item-force-mine',
   resolved: 'conflicts-item-resolved',
+  visualMerge: 'conflicts-item-visual-merge',
 } as const

--- a/src/views/VisualMergeView/MergeEditor.vue
+++ b/src/views/VisualMergeView/MergeEditor.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { VISUAL_MERGE_TEST_IDS } from './test-ids'
+
+const props = defineProps<{
+  readonly ours: string
+  readonly theirs: string
+  readonly merged: string
+}>()
+const emit = defineEmits<{ readonly update: [next: string] }>()
+
+const onInput = (event: Event): void => {
+  const target = event.target
+  const value =
+    target instanceof HTMLTextAreaElement ? target.value : props.merged
+  emit('update', value)
+}
+</script>
+
+<template>
+  <article class="merge-editor">
+    <pre
+      class="pane ours"
+      :data-testid="VISUAL_MERGE_TEST_IDS.ours"
+    >{{ ours }}</pre>
+    <textarea
+      class="pane merged"
+      :data-testid="VISUAL_MERGE_TEST_IDS.merged"
+      :value="merged"
+      spellcheck="false"
+      @input="onInput"
+    />
+    <pre
+      class="pane theirs"
+      :data-testid="VISUAL_MERGE_TEST_IDS.theirs"
+    >{{ theirs }}</pre>
+  </article>
+</template>
+
+<style scoped>
+.merge-editor {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  min-height: 320px;
+}
+
+.pane {
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 4px;
+  padding: 8px;
+  font-family: monospace;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow: auto;
+  background: var(--color-surface, #fff);
+}
+
+.pane.ours {
+  border-left: 3px solid var(--color-accent, #4fc3f7);
+}
+
+.pane.theirs {
+  border-left: 3px solid var(--color-warning, #ffb74d);
+}
+
+.pane.merged {
+  border-left: 3px solid var(--color-success, #43a047);
+  resize: vertical;
+}
+</style>

--- a/src/views/VisualMergeView/VisualMergeBody.vue
+++ b/src/views/VisualMergeView/VisualMergeBody.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { requestResolveFileContent } from '@/composables/useNotifications/push-control'
+import { useConflictsStore } from '@/stores/conflicts'
+import { fetchFileContent } from './fetch-file-content'
+import MergeEditor from './MergeEditor.vue'
+import { parseThreeWays, type ThreeWaySplit } from './parse-three-ways'
+import { VISUAL_MERGE_TEST_IDS } from './test-ids'
+import VisualMergeHeader from './VisualMergeHeader.vue'
+
+const route = useRoute()
+const router = useRouter()
+const store = useConflictsStore()
+const file = String(route.params['file'] ?? '')
+const split = ref<ThreeWaySplit | undefined>(undefined)
+const merged = ref('')
+
+onMounted(async () => {
+  const content = (await fetchFileContent(file)) ?? ''
+  const next = parseThreeWays(content)
+  split.value = next
+  merged.value = next.merged
+})
+
+const onUpdate = (next: string): void => {
+  merged.value = next
+}
+const onSave = (): void => {
+  requestResolveFileContent(file, merged.value)
+  store.setResolution(file, 'mine')
+  void router.push('/conflicts')
+}
+const onCancel = (): void => {
+  void router.push('/conflicts')
+}
+</script>
+
+<template>
+  <section class="visual-merge" :data-testid="VISUAL_MERGE_TEST_IDS.root">
+    <VisualMergeHeader
+      :file="file"
+      @save="onSave"
+      @cancel="onCancel"
+    />
+    <p
+      v-if="split === undefined"
+      class="loading"
+      :data-testid="VISUAL_MERGE_TEST_IDS.loading"
+    >
+      Loading file…
+    </p>
+    <MergeEditor
+      v-else
+      :ours="split.ours"
+      :theirs="split.theirs"
+      :merged="merged"
+      @update="onUpdate"
+    />
+  </section>
+</template>
+
+<style scoped>
+.visual-merge {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.loading {
+  color: var(--color-text-muted, #888);
+}
+</style>

--- a/src/views/VisualMergeView/VisualMergeHeader.vue
+++ b/src/views/VisualMergeView/VisualMergeHeader.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { VISUAL_MERGE_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly file: string }>()
+defineEmits<{
+  readonly save: []
+  readonly cancel: []
+}>()
+</script>
+
+<template>
+  <header class="head">
+    <strong class="title">Resolve {{ file }}</strong>
+    <button
+      type="button"
+      class="cancel"
+      :data-testid="VISUAL_MERGE_TEST_IDS.cancel"
+      @click="$emit('cancel')"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="save"
+      :data-testid="VISUAL_MERGE_TEST_IDS.save"
+      @click="$emit('save')"
+    >
+      Save merged
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.title {
+  font-size: 1rem;
+  margin-right: auto;
+  font-family: monospace;
+}
+
+.cancel,
+.save {
+  font-size: 0.8125rem;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.save {
+  background: var(--color-accent, #4fc3f7);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 700;
+}
+</style>

--- a/src/views/VisualMergeView/VisualMergeView.vue
+++ b/src/views/VisualMergeView/VisualMergeView.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import AppLayout from '@/components/AppLayout.vue'
+import VisualMergeBody from './VisualMergeBody.vue'
+</script>
+
+<template>
+  <AppLayout>
+    <VisualMergeBody />
+  </AppLayout>
+</template>

--- a/src/views/VisualMergeView/fetch-file-content.ts
+++ b/src/views/VisualMergeView/fetch-file-content.ts
@@ -1,0 +1,24 @@
+import { swFetch } from '@/composables/useSWBridge/sw-fetch'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const extractContent = (body: unknown): string | undefined => {
+  const content = isObject(body) ? body['content'] : undefined
+  return typeof content === 'string' ? content : undefined
+}
+
+/**
+ * Read the current working-tree content of a file via the SW
+ * file API. Returns the raw text including any merge markers.
+ * @param path Repo-relative file path.
+ * @returns Raw file content, or undefined when the SW reports an error.
+ */
+export const fetchFileContent = async (
+  path: string
+): Promise<string | undefined> => {
+  const res = await swFetch(
+    `/api/github/file?path=${encodeURIComponent(path)}`
+  )
+  return res.ok ? extractContent(await res.json()) : undefined
+}

--- a/src/views/VisualMergeView/parse-three-ways.test.ts
+++ b/src/views/VisualMergeView/parse-three-ways.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { parseThreeWays } from './parse-three-ways'
+
+const sample = [
+  'header',
+  '<<<<<<< HEAD',
+  'mine line',
+  '=======',
+  'theirs line',
+  '>>>>>>> origin/develop',
+  'footer',
+].join('\n')
+
+describe('parseThreeWays', () => {
+  it('returns ours / theirs / merged from a marker file', () => {
+    const split = parseThreeWays(sample)
+    expect(split.ours.split('\n')).toEqual([
+      'header',
+      'mine line',
+      'footer',
+    ])
+    expect(split.theirs.split('\n')).toEqual([
+      'header',
+      'theirs line',
+      'footer',
+    ])
+    expect(split.merged).toBe(split.ours)
+  })
+
+  it('passes marker-free content through identically', () => {
+    const split = parseThreeWays('plain content')
+    expect(split.ours).toBe('plain content')
+    expect(split.theirs).toBe('plain content')
+    expect(split.merged).toBe('plain content')
+  })
+})

--- a/src/views/VisualMergeView/parse-three-ways.ts
+++ b/src/views/VisualMergeView/parse-three-ways.ts
@@ -1,0 +1,22 @@
+import { resolveByStrategy } from '@/sw/conflicts/parse-markers'
+
+/** Three-way split of a file containing conflict markers. */
+export type ThreeWaySplit = {
+  readonly ours: string
+  readonly theirs: string
+  readonly merged: string
+}
+
+/**
+ * Split a file with conflict markers into the three views the
+ * visual merge editor needs: the "ours" content, the "theirs"
+ * content, and a starting point for the merged pane (initialised
+ * from "ours" so the user only edits where they disagree).
+ * @param content Raw file content with conflict markers.
+ * @returns ours / theirs / merged seed strings.
+ */
+export const parseThreeWays = (content: string): ThreeWaySplit => ({
+  ours: resolveByStrategy(content, 'mine'),
+  theirs: resolveByStrategy(content, 'theirs'),
+  merged: resolveByStrategy(content, 'mine'),
+})

--- a/src/views/VisualMergeView/test-ids.ts
+++ b/src/views/VisualMergeView/test-ids.ts
@@ -1,0 +1,10 @@
+/** Test IDs used by the visual merge editor. */
+export const VISUAL_MERGE_TEST_IDS = {
+  root: 'visual-merge-view',
+  ours: 'visual-merge-ours',
+  theirs: 'visual-merge-theirs',
+  merged: 'visual-merge-merged',
+  save: 'visual-merge-save',
+  cancel: 'visual-merge-cancel',
+  loading: 'visual-merge-loading',
+} as const


### PR DESCRIPTION
Phase A / Epic 4 increment 4.4 — closes Epic 4 and Phase A. /conflicts/merge/:file route hosts an ours / merged / theirs editor; save posts resolve-file-content to SW which writes + stages. 3/3 e2e + 2/2 parser unit green. Closes #94. Closes Epic 4. Closes Phase A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)