### PR TITLE
release: conflict resolution Epic 4 (4.1+4.2+4.3+4.4) — Phase A complete

### DIFF
--- a/e2e/notifications/conflicts-resolve.spec.ts
+++ b/e2e/notifications/conflicts-resolve.spec.ts
@@ -1,0 +1,93 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastConflict = (
+  files: ReadonlyArray<string>
+): string => `
+const ch = new BroadcastChannel('sw-push-conflict')
+ch.postMessage({
+  sha: 'def456',
+  target: 'origin/develop',
+  files: ${JSON.stringify(files)},
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+const captureControl = `
+globalThis.__resolveMessages = []
+const ch = new BroadcastChannel('sw-push-control')
+ch.onmessage = e => globalThis.__resolveMessages.push(e.data)
+globalThis.__resolveChannel = ch
+`
+
+test.describe('per-file conflict resolution (4.3)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page
+      .evaluate(() =>
+        globalThis.localStorage?.removeItem('admin-conflicts')
+      )
+      .catch(() => undefined)
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+    await page.evaluate(captureControl)
+  })
+
+  test('keep mine flips the row to resolved + posts message', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['a.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-keep-mine"]')
+      .click()
+    await expect(
+      page.locator('[data-testid="conflicts-item-resolved"]')
+    ).toContainText('mine')
+    const messages = await page.evaluate<readonly { type: string }[]>(
+      () => globalThis.__resolveMessages ?? []
+    )
+    expect(messages.some(m => m.type === 'resolve-file')).toBe(true)
+  })
+
+  test('finalize appears once every file is resolved', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['a.md', 'b.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    const finalize = page.locator('[data-testid="conflicts-finalize"]')
+    await expect(finalize).toBeHidden()
+    await page
+      .locator('[data-testid="conflicts-item-keep-mine"]')
+      .first()
+      .click()
+    await expect(finalize).toBeHidden()
+    await page
+      .locator('[data-testid="conflicts-item-take-theirs"]')
+      .first()
+      .click()
+    await expect(finalize).toBeVisible()
+  })
+
+  test('finalize click posts finalize-resolution + clears list', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['a.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-force-mine"]')
+      .click()
+    await page.locator('[data-testid="conflicts-finalize"]').click()
+    await expect(
+      page.locator('[data-testid="conflicts-empty"]')
+    ).toBeVisible()
+    const messages = await page.evaluate<readonly { type: string }[]>(
+      () => globalThis.__resolveMessages ?? []
+    )
+    expect(
+      messages.some(m => m.type === 'finalize-resolution')
+    ).toBe(true)
+  })
+})

--- a/e2e/notifications/conflicts-resolve.spec.ts
+++ b/e2e/notifications/conflicts-resolve.spec.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-const broadcastConflict = (
-  files: ReadonlyArray<string>
-): string => `
+const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
 ch.postMessage({
   sha: 'def456',
@@ -23,9 +21,7 @@ globalThis.__resolveChannel = ch
 test.describe('per-file conflict resolution (4.3)', () => {
   test.beforeEach(async ({ page }) => {
     await page
-      .evaluate(() =>
-        globalThis.localStorage?.removeItem('admin-conflicts')
-      )
+      .evaluate(() => globalThis.localStorage?.removeItem('admin-conflicts'))
       .catch(() => undefined)
     await page.goto('/')
     await page.waitForLoadState('networkidle')
@@ -40,9 +36,7 @@ test.describe('per-file conflict resolution (4.3)', () => {
   }) => {
     await page.evaluate(broadcastConflict(['a.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await page
-      .locator('[data-testid="conflicts-item-keep-mine"]')
-      .click()
+    await page.locator('[data-testid="conflicts-item-keep-mine"]').click()
     await expect(
       page.locator('[data-testid="conflicts-item-resolved"]')
     ).toContainText('mine')
@@ -52,9 +46,7 @@ test.describe('per-file conflict resolution (4.3)', () => {
     expect(messages.some(m => m.type === 'resolve-file')).toBe(true)
   })
 
-  test('finalize appears once every file is resolved', async ({
-    page,
-  }) => {
+  test('finalize appears once every file is resolved', async ({ page }) => {
     await page.evaluate(broadcastConflict(['a.md', 'b.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
     const finalize = page.locator('[data-testid="conflicts-finalize"]')
@@ -76,9 +68,7 @@ test.describe('per-file conflict resolution (4.3)', () => {
   }) => {
     await page.evaluate(broadcastConflict(['a.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await page
-      .locator('[data-testid="conflicts-item-force-mine"]')
-      .click()
+    await page.locator('[data-testid="conflicts-item-force-mine"]').click()
     await page.locator('[data-testid="conflicts-finalize"]').click()
     await expect(
       page.locator('[data-testid="conflicts-empty"]')
@@ -86,8 +76,6 @@ test.describe('per-file conflict resolution (4.3)', () => {
     const messages = await page.evaluate<readonly { type: string }[]>(
       () => globalThis.__resolveMessages ?? []
     )
-    expect(
-      messages.some(m => m.type === 'finalize-resolution')
-    ).toBe(true)
+    expect(messages.some(m => m.type === 'finalize-resolution')).toBe(true)
   })
 })

--- a/e2e/notifications/conflicts-view.spec.ts
+++ b/e2e/notifications/conflicts-view.spec.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-const broadcastConflict = (
-  files: ReadonlyArray<string>
-): string => `
+const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
 ch.postMessage({
   sha: 'abc123',
@@ -15,9 +13,9 @@ ch.close()
 
 test.describe('conflicts view (4.2)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.evaluate(() =>
-      globalThis.localStorage?.removeItem('admin-conflicts')
-    ).catch(() => undefined)
+    await page
+      .evaluate(() => globalThis.localStorage?.removeItem('admin-conflicts'))
+      .catch(() => undefined)
     await page.goto('/')
     await page.waitForLoadState('networkidle')
     await page
@@ -38,22 +36,22 @@ test.describe('conflicts view (4.2)', () => {
   test('reload preserves the conflict list', async ({ page }) => {
     await page.evaluate(broadcastConflict(['c.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await expect(
-      page.locator('[data-testid="conflicts-item"]')
-    ).toHaveCount(1)
+    await expect(page.locator('[data-testid="conflicts-item"]')).toHaveCount(
+      1
+    )
     await page.reload()
     await page.waitForLoadState('networkidle')
-    await expect(
-      page.locator('[data-testid="conflicts-item"]')
-    ).toHaveCount(1)
+    await expect(page.locator('[data-testid="conflicts-item"]')).toHaveCount(
+      1
+    )
   })
 
   test('mark all resolved empties the list', async ({ page }) => {
     await page.evaluate(broadcastConflict(['x.md', 'y.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await expect(
-      page.locator('[data-testid="conflicts-item"]')
-    ).toHaveCount(2)
+    await expect(page.locator('[data-testid="conflicts-item"]')).toHaveCount(
+      2
+    )
     await page.locator('[data-testid="conflicts-resolve-all"]').click()
     await expect(
       page.locator('[data-testid="conflicts-empty"]')

--- a/e2e/notifications/conflicts-view.spec.ts
+++ b/e2e/notifications/conflicts-view.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastConflict = (
+  files: ReadonlyArray<string>
+): string => `
+const ch = new BroadcastChannel('sw-push-conflict')
+ch.postMessage({
+  sha: 'abc123',
+  target: 'origin/develop',
+  files: ${JSON.stringify(files)},
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+test.describe('conflicts view (4.2)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.evaluate(() =>
+      globalThis.localStorage?.removeItem('admin-conflicts')
+    ).catch(() => undefined)
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('toast Resolve CTA navigates to /conflicts and lists files', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['blog/a/index.en.md', 'b.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await expect(page).toHaveURL(/\/conflicts$/)
+    const items = page.locator('[data-testid="conflicts-item"]')
+    await expect(items).toHaveCount(2)
+  })
+
+  test('reload preserves the conflict list', async ({ page }) => {
+    await page.evaluate(broadcastConflict(['c.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await expect(
+      page.locator('[data-testid="conflicts-item"]')
+    ).toHaveCount(1)
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+    await expect(
+      page.locator('[data-testid="conflicts-item"]')
+    ).toHaveCount(1)
+  })
+
+  test('mark all resolved empties the list', async ({ page }) => {
+    await page.evaluate(broadcastConflict(['x.md', 'y.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await expect(
+      page.locator('[data-testid="conflicts-item"]')
+    ).toHaveCount(2)
+    await page.locator('[data-testid="conflicts-resolve-all"]').click()
+    await expect(
+      page.locator('[data-testid="conflicts-empty"]')
+    ).toBeVisible()
+  })
+})

--- a/e2e/notifications/push-conflict.spec.ts
+++ b/e2e/notifications/push-conflict.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastConflict = (files: ReadonlyArray<string>): string => `
+const ch = new BroadcastChannel('sw-push-conflict')
+ch.postMessage({
+  sha: 'beefcafe',
+  target: 'origin/develop',
+  files: ${JSON.stringify(files)},
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+test.describe('push conflict bridge (4.1)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+  })
+
+  test('conflict event surfaces a sticky conflict toast', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['blog/a/index.en.md']))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toHaveAttribute('data-kind', 'conflict')
+    await expect(toast).toHaveAttribute('data-sticky', 'true')
+    await expect(toast).toContainText('1')
+  })
+
+  test('multi-file conflict reports the count', async ({ page }) => {
+    await page.evaluate(broadcastConflict(['a.md', 'b.md', 'c.md']))
+    const toast = page.locator('[data-testid="notification-toast"]').first()
+    await expect(toast).toBeVisible()
+    await expect(toast).toContainText('3')
+  })
+})

--- a/e2e/notifications/visual-merge.spec.ts
+++ b/e2e/notifications/visual-merge.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test'
+
+const broadcastConflict = (
+  files: ReadonlyArray<string>
+): string => `
+const ch = new BroadcastChannel('sw-push-conflict')
+ch.postMessage({
+  sha: 'fa11',
+  target: 'origin/develop',
+  files: ${JSON.stringify(files)},
+  at: ${Date.now()},
+})
+ch.close()
+`
+
+const captureControl = `
+globalThis.__visualMergeMessages = []
+const ch = new BroadcastChannel('sw-push-control')
+ch.onmessage = e => globalThis.__visualMergeMessages.push(e.data)
+globalThis.__visualMergeChannel = ch
+`
+
+test.describe('visual merge editor (4.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page
+      .evaluate(() =>
+        globalThis.localStorage?.removeItem('admin-conflicts')
+      )
+      .catch(() => undefined)
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible' })
+    await page.evaluate(captureControl)
+  })
+
+  test('visual merge link routes to the editor', async ({ page }) => {
+    await page.evaluate(broadcastConflict(['blog/sample/index.en.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-visual-merge"]')
+      .click()
+    await expect(page).toHaveURL(/\/conflicts\/merge\//)
+    await expect(
+      page.locator('[data-testid="visual-merge-view"]')
+    ).toBeVisible()
+  })
+
+  test('cancel returns to /conflicts without writing', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['x.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-visual-merge"]')
+      .click()
+    await page.locator('[data-testid="visual-merge-cancel"]').click()
+    await expect(page).toHaveURL(/\/conflicts$/)
+    const messages = await page.evaluate<readonly { type: string }[]>(
+      () => globalThis.__visualMergeMessages ?? []
+    )
+    expect(
+      messages.some(m => m.type === 'resolve-file-content')
+    ).toBe(false)
+  })
+
+  test('save posts resolve-file-content + flips row to resolved', async ({
+    page,
+  }) => {
+    await page.evaluate(broadcastConflict(['y.md']))
+    await page.locator('[data-testid="notification-toast-cta"]').click()
+    await page
+      .locator('[data-testid="conflicts-item-visual-merge"]')
+      .click()
+    await page.locator('[data-testid="visual-merge-save"]').click()
+    await expect(page).toHaveURL(/\/conflicts$/)
+    await expect(
+      page.locator('[data-testid="conflicts-item-resolved"]')
+    ).toContainText('mine')
+    const messages = await page.evaluate<readonly { type: string }[]>(
+      () => globalThis.__visualMergeMessages ?? []
+    )
+    expect(
+      messages.some(m => m.type === 'resolve-file-content')
+    ).toBe(true)
+  })
+})

--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -13,9 +13,7 @@ test.describe('settings offline gate (3.4)', () => {
     page,
     context,
   }) => {
-    const banner = page.locator(
-      '[data-testid="members-offline-banner"]'
-    )
+    const banner = page.locator('[data-testid="members-offline-banner"]')
     await expect(banner).toBeHidden()
     await context.setOffline(true)
     await expect(banner).toBeVisible()

--- a/src/App.vue
+++ b/src/App.vue
@@ -10,6 +10,7 @@ import { useDeployPolling } from '@/composables/useDeployStatus/use-deploy-polli
 import { useMergedEntries } from '@/composables/useDeployStatus/use-merged-entries'
 import { useNotificationsPersistence } from '@/composables/useNotifications/use-notification-persistence'
 import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-watcher'
+import { usePushConflictBridge } from '@/composables/useNotifications/use-push-conflict-bridge'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { usePushSummaryBridge } from '@/composables/useNotifications/use-push-summary-bridge'
 import { useAuthStore } from '@/stores/auth'
@@ -22,6 +23,7 @@ useNotificationsPersistence()
 usePushErrorBridge()
 useOfflineWatcher()
 usePushSummaryBridge()
+usePushConflictBridge()
 
 const poll = useDeployPolling()
 const mergedEntries = useMergedEntries(poll.entries)

--- a/src/composables/useNotifications/push-control.ts
+++ b/src/composables/useNotifications/push-control.ts
@@ -1,0 +1,50 @@
+import {
+  type PushControlMessage,
+  type ResolveStrategy,
+  SW_PUSH_CONTROL_CHANNEL,
+} from '@/sw/protocol/push-control'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_CONTROL_CHANNEL)
+  return channel
+}
+
+const send = (msg: PushControlMessage): void => {
+  channelOf().postMessage(msg)
+}
+
+/**
+ * Ask the SW to retry the queued pushes immediately. Wired up to
+ * the Retry CTA on terminal push-failure notifications.
+ * @returns void
+ */
+export const requestPushRetry = (): void => {
+  send({ type: 'retry-now' })
+}
+
+/**
+ * Ask the SW to apply a resolution strategy to a single
+ * conflicted file. The SW rewrites the working tree, stages the
+ * file, and remembers the strategy for the finalize step.
+ * @param file Path of the conflicted file relative to repo root.
+ * @param strategy User-chosen resolution strategy.
+ * @returns void
+ */
+export const requestResolveFile = (
+  file: string,
+  strategy: ResolveStrategy
+): void => {
+  send({ type: 'resolve-file', file, strategy })
+}
+
+/**
+ * Ask the SW to finalize the conflict resolution: commit the
+ * staged files and push the merge commit (force-with-lease when
+ * any file used `force-mine`).
+ * @returns void
+ */
+export const requestFinalizeResolution = (): void => {
+  send({ type: 'finalize-resolution' })
+}

--- a/src/composables/useNotifications/push-control.ts
+++ b/src/composables/useNotifications/push-control.ts
@@ -40,6 +40,21 @@ export const requestResolveFile = (
 }
 
 /**
+ * Ask the SW to write a manually-merged content to a conflicted
+ * file and stage it. Used by the visual merge editor when the
+ * user has edited the merged result themselves.
+ * @param file Path of the conflicted file relative to repo root.
+ * @param content Resolved text the user produced in the editor.
+ * @returns void
+ */
+export const requestResolveFileContent = (
+  file: string,
+  content: string
+): void => {
+  send({ type: 'resolve-file-content', file, content })
+}
+
+/**
  * Ask the SW to finalize the conflict resolution: commit the
  * staged files and push the merge commit (force-with-lease when
  * any file used `force-mine`).

--- a/src/composables/useNotifications/push-retry.ts
+++ b/src/composables/useNotifications/push-retry.ts
@@ -1,22 +1,5 @@
-import {
-  type PushControlMessage,
-  SW_PUSH_CONTROL_CHANNEL,
-} from '@/sw/protocol/push-control'
-
-let channel: BroadcastChannel | undefined
-
-const channelOf = (): BroadcastChannel => {
-  channel ??= new BroadcastChannel(SW_PUSH_CONTROL_CHANNEL)
-  return channel
-}
-
-/**
- * Ask the SW to retry the queued pushes immediately. Wired up to
- * the Retry CTA on terminal push-failure notifications and (in
- * the future) to a manual button on the sync badge.
- * @returns void
- */
-export const requestPushRetry = (): void => {
-  const msg: PushControlMessage = { type: 'retry-now' }
-  channelOf().postMessage(msg)
-}
+export {
+  requestFinalizeResolution,
+  requestPushRetry,
+  requestResolveFile,
+} from './push-control'

--- a/src/composables/useNotifications/use-push-conflict-bridge.ts
+++ b/src/composables/useNotifications/use-push-conflict-bridge.ts
@@ -1,36 +1,27 @@
 import { onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { useConflictsStore } from '@/stores/conflicts'
 import {
   type PushConflictEvent,
   SW_PUSH_CONFLICT_CHANNEL,
 } from '@/sw/protocol/push-conflict'
 import { notifyConflictDetected } from './notify-conflict-detected'
 
-let pendingConflict: PushConflictEvent | undefined
-
-/**
- * Read the most recent conflict event seen by the bridge. Used by
- * the conflict view to render the file list without re-listening
- * on the channel.
- * @returns Last conflict event, or undefined when none yet.
- */
-export const lastConflictEvent = (): PushConflictEvent | undefined =>
-  pendingConflict
-
-const dispatch = (event: PushConflictEvent): void => {
-  pendingConflict = event
-  notifyConflictDetected(event.files)
-}
-
-const subscribe = (channel: BroadcastChannel): void => {
+const subscribe = (
+  channel: BroadcastChannel,
+  store: ReturnType<typeof useConflictsStore>,
+  goToConflicts: () => void
+): void => {
   channel.onmessage = (event: MessageEvent<PushConflictEvent>): void => {
-    dispatch(event.data)
+    store.record({ ...event.data })
+    notifyConflictDetected(event.data.files, goToConflicts)
   }
 }
 
 /**
- * Subscribe to SW-broadcast merge conflict events and dispatch a
- * sticky notification per occurrence. The most recent event is
- * cached for later inspection by the conflict view (4.2+).
+ * Subscribe to SW-broadcast merge conflict events. Each event is
+ * persisted into the conflicts store and surfaces a sticky toast
+ * with a "Resolve" CTA that navigates to `/conflicts`.
  * @returns void
  */
 export const usePushConflictBridge = (): void => {
@@ -38,7 +29,14 @@ export const usePushConflictBridge = (): void => {
   const channel = supported
     ? new BroadcastChannel(SW_PUSH_CONFLICT_CHANNEL)
     : undefined
+  const store = useConflictsStore()
+  const router = useRouter()
+  const goToConflicts = (): void => {
+    void router.push('/conflicts')
+  }
   const noop = (): void => undefined
-  ;(channel === undefined ? noop : () => subscribe(channel))()
+  ;(channel === undefined
+    ? noop
+    : () => subscribe(channel, store, goToConflicts))()
   onUnmounted(() => channel?.close())
 }

--- a/src/composables/useNotifications/use-push-conflict-bridge.ts
+++ b/src/composables/useNotifications/use-push-conflict-bridge.ts
@@ -1,0 +1,44 @@
+import { onUnmounted } from 'vue'
+import {
+  type PushConflictEvent,
+  SW_PUSH_CONFLICT_CHANNEL,
+} from '@/sw/protocol/push-conflict'
+import { notifyConflictDetected } from './notify-conflict-detected'
+
+let pendingConflict: PushConflictEvent | undefined
+
+/**
+ * Read the most recent conflict event seen by the bridge. Used by
+ * the conflict view to render the file list without re-listening
+ * on the channel.
+ * @returns Last conflict event, or undefined when none yet.
+ */
+export const lastConflictEvent = (): PushConflictEvent | undefined =>
+  pendingConflict
+
+const dispatch = (event: PushConflictEvent): void => {
+  pendingConflict = event
+  notifyConflictDetected(event.files)
+}
+
+const subscribe = (channel: BroadcastChannel): void => {
+  channel.onmessage = (event: MessageEvent<PushConflictEvent>): void => {
+    dispatch(event.data)
+  }
+}
+
+/**
+ * Subscribe to SW-broadcast merge conflict events and dispatch a
+ * sticky notification per occurrence. The most recent event is
+ * cached for later inspection by the conflict view (4.2+).
+ * @returns void
+ */
+export const usePushConflictBridge = (): void => {
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported
+    ? new BroadcastChannel(SW_PUSH_CONFLICT_CHANNEL)
+    : undefined
+  const noop = (): void => undefined
+  ;(channel === undefined ? noop : () => subscribe(channel))()
+  onUnmounted(() => channel?.close())
+}

--- a/src/router/content-routes.ts
+++ b/src/router/content-routes.ts
@@ -35,6 +35,12 @@ export const contentRoutes: RouteRecordRaw[] = [
     component: () => import('../views/SettingsView/SettingsView.vue'),
   },
   {
+    path: '/conflicts',
+    name: 'conflicts',
+    meta: { requiresAuth: true },
+    component: () => import('../views/ConflictsView/ConflictsView.vue'),
+  },
+  {
     path: '/content/:type/edit/:slug',
     name: 'content-edit',
     meta: { requiresAuth: true },

--- a/src/router/content-routes.ts
+++ b/src/router/content-routes.ts
@@ -1,5 +1,6 @@
 import type { RouteRecordRaw } from 'vue-router'
 import type { ContentType } from '@/types/content'
+import { nonContentRoutes } from './non-content-routes'
 
 const CONTENT_SECTIONS: readonly ContentType[] = [
   'blog',
@@ -19,32 +20,17 @@ const sectionRoutes: RouteRecordRaw[] = CONTENT_SECTIONS.map(type => ({
   props: { contentType: type },
 }))
 
+const editRoute: RouteRecordRaw = {
+  path: '/content/:type/edit/:slug',
+  name: 'content-edit',
+  meta: { requiresAuth: true },
+  component: () => import('../views/ContentEditView.vue'),
+  props: true,
+}
+
 /** Routes for content management (require authentication) */
 export const contentRoutes: RouteRecordRaw[] = [
   ...sectionRoutes,
-  {
-    path: '/tickets',
-    name: 'tickets',
-    meta: { requiresAuth: true },
-    component: () => import('../views/TicketsView/TicketsView.vue'),
-  },
-  {
-    path: '/settings',
-    name: 'settings',
-    meta: { requiresAuth: true },
-    component: () => import('../views/SettingsView/SettingsView.vue'),
-  },
-  {
-    path: '/conflicts',
-    name: 'conflicts',
-    meta: { requiresAuth: true },
-    component: () => import('../views/ConflictsView/ConflictsView.vue'),
-  },
-  {
-    path: '/content/:type/edit/:slug',
-    name: 'content-edit',
-    meta: { requiresAuth: true },
-    component: () => import('../views/ContentEditView.vue'),
-    props: true,
-  },
+  ...nonContentRoutes,
+  editRoute,
 ]

--- a/src/router/non-content-routes.ts
+++ b/src/router/non-content-routes.ts
@@ -1,0 +1,29 @@
+import type { RouteRecordRaw } from 'vue-router'
+
+/** Routes outside the content management section. */
+export const nonContentRoutes: RouteRecordRaw[] = [
+  {
+    path: '/tickets',
+    name: 'tickets',
+    meta: { requiresAuth: true },
+    component: () => import('../views/TicketsView/TicketsView.vue'),
+  },
+  {
+    path: '/settings',
+    name: 'settings',
+    meta: { requiresAuth: true },
+    component: () => import('../views/SettingsView/SettingsView.vue'),
+  },
+  {
+    path: '/conflicts',
+    name: 'conflicts',
+    meta: { requiresAuth: true },
+    component: () => import('../views/ConflictsView/ConflictsView.vue'),
+  },
+  {
+    path: '/conflicts/merge/:file(.+)',
+    name: 'conflicts-merge',
+    meta: { requiresAuth: true },
+    component: () => import('../views/VisualMergeView/VisualMergeView.vue'),
+  },
+]

--- a/src/stores/conflicts-actions.ts
+++ b/src/stores/conflicts-actions.ts
@@ -1,0 +1,33 @@
+import type { Ref } from 'vue'
+import type { ResolveStrategy } from '@/sw/protocol/push-control'
+import { clearConflict, saveConflict } from './conflicts-storage'
+import type { ConflictRecord } from './conflicts-types'
+
+/**
+ * Build the async actions bound to the conflicts store refs.
+ * Persists the conflict event to localStorage and tracks
+ * per-file resolution choices in memory until finalize.
+ * @param current Reactive ref of the current conflict record.
+ * @param resolutions Reactive ref of the resolutions map.
+ * @returns Object exposing record / setResolution / clear.
+ */
+export const createConflictActions = (
+  current: Ref<ConflictRecord | undefined>,
+  resolutions: Ref<Map<string, ResolveStrategy>>
+) => ({
+  record: (next: ConflictRecord): void => {
+    current.value = next
+    resolutions.value = new Map()
+    saveConflict(next)
+  },
+  setResolution: (file: string, strategy: ResolveStrategy): void => {
+    const map = new Map(resolutions.value)
+    map.set(file, strategy)
+    resolutions.value = map
+  },
+  clear: (): void => {
+    current.value = undefined
+    resolutions.value = new Map()
+    clearConflict()
+  },
+})

--- a/src/stores/conflicts-storage.ts
+++ b/src/stores/conflicts-storage.ts
@@ -1,0 +1,48 @@
+import type { ConflictRecord } from './conflicts-types'
+
+const STORAGE_KEY = 'admin-conflicts'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const parse = (raw: string | null): ConflictRecord | undefined => {
+  const parsed: unknown = raw === null ? undefined : JSON.parse(raw)
+  return isObject(parsed)
+    ? {
+        sha: String(parsed['sha'] ?? ''),
+        target: String(parsed['target'] ?? ''),
+        files: Array.isArray(parsed['files'])
+          ? parsed['files'].filter((f): f is string => typeof f === 'string')
+          : [],
+        at: Number(parsed['at'] ?? 0),
+      }
+    : undefined
+}
+
+/**
+ * Read the persisted conflict record from `localStorage`. Returns
+ * `undefined` when no record exists or the payload is malformed.
+ * @returns Last persisted conflict, or undefined.
+ */
+export const loadConflict = (): ConflictRecord | undefined => {
+  const raw = globalThis.localStorage?.getItem(STORAGE_KEY) ?? null
+  return parse(raw)
+}
+
+/**
+ * Persist the supplied conflict record so it survives reloads.
+ * @param record Latest conflict payload from the SW.
+ * @returns void
+ */
+export const saveConflict = (record: ConflictRecord): void => {
+  globalThis.localStorage?.setItem(STORAGE_KEY, JSON.stringify(record))
+}
+
+/**
+ * Clear the persisted conflict record. Called once the user
+ * resolves or dismisses the conflict.
+ * @returns void
+ */
+export const clearConflict = (): void => {
+  globalThis.localStorage?.removeItem(STORAGE_KEY)
+}

--- a/src/stores/conflicts-types.ts
+++ b/src/stores/conflicts-types.ts
@@ -1,0 +1,7 @@
+/** Persisted record of an unresolved auto-merge attempt. */
+export type ConflictRecord = {
+  readonly sha: string
+  readonly target: string
+  readonly files: ReadonlyArray<string>
+  readonly at: number
+}

--- a/src/stores/conflicts.ts
+++ b/src/stores/conflicts.ts
@@ -1,0 +1,37 @@
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+import {
+  clearConflict,
+  loadConflict,
+  saveConflict,
+} from './conflicts-storage'
+import type { ConflictRecord } from './conflicts-types'
+
+export type { ConflictRecord } from './conflicts-types'
+
+/**
+ * Build the reactive state for the conflicts store. Persists to
+ * `localStorage` so the conflict survives reload until resolved.
+ * @returns Bound state ref + actions.
+ */
+const createConflictsState = () => {
+  const current = ref<ConflictRecord | undefined>(loadConflict())
+  const hasConflict = computed(() => current.value !== undefined)
+  return {
+    current,
+    hasConflict,
+    record: (next: ConflictRecord): void => {
+      current.value = next
+      saveConflict(next)
+    },
+    clear: (): void => {
+      current.value = undefined
+      clearConflict()
+    },
+  }
+}
+
+/** Pinia store backing the persisted conflict record. */
+export const useConflictsStore = defineStore('conflicts', () =>
+  createConflictsState()
+)

--- a/src/stores/conflicts.ts
+++ b/src/stores/conflicts.ts
@@ -1,33 +1,34 @@
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
-import {
-  clearConflict,
-  loadConflict,
-  saveConflict,
-} from './conflicts-storage'
+import type { ResolveStrategy } from '@/sw/protocol/push-control'
+import { createConflictActions } from './conflicts-actions'
+import { loadConflict } from './conflicts-storage'
 import type { ConflictRecord } from './conflicts-types'
 
 export type { ConflictRecord } from './conflicts-types'
 
 /**
- * Build the reactive state for the conflicts store. Persists to
- * `localStorage` so the conflict survives reload until resolved.
+ * Build the reactive state for the conflicts store. Persists the
+ * conflict event to `localStorage` so it survives reload, and
+ * tracks per-file resolution choices in memory until the user
+ * finalizes them.
  * @returns Bound state ref + actions.
  */
 const createConflictsState = () => {
   const current = ref<ConflictRecord | undefined>(loadConflict())
+  const resolutions = ref(new Map<string, ResolveStrategy>())
   const hasConflict = computed(() => current.value !== undefined)
+  const allResolved = computed(() => {
+    const total = current.value?.files.length ?? 0
+    return total > 0 && resolutions.value.size === total
+  })
+  const actions = createConflictActions(current, resolutions)
   return {
     current,
+    resolutions,
     hasConflict,
-    record: (next: ConflictRecord): void => {
-      current.value = next
-      saveConflict(next)
-    },
-    clear: (): void => {
-      current.value = undefined
-      clearConflict()
-    },
+    allResolved,
+    ...actions,
   }
 }
 

--- a/src/sw/conflicts/finalize.ts
+++ b/src/sw/conflicts/finalize.ts
@@ -1,0 +1,50 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+import { buildAuthOpts } from '../git/remote/build-auth-opts'
+import { workerState } from '../state/state'
+import { clearForcePending, hasForcePending } from './resolve-file'
+
+const commitResolution = async (
+  config: NonNullable<typeof workerState.config>
+): Promise<void> => {
+  const git = await loadGit()
+  await git.commit({
+    fs,
+    dir: REPO_DIR,
+    message: 'Resolve merge conflicts',
+    author: {
+      name: config.authorName ?? 'Admin',
+      email: config.authorEmail ?? 'admin@prometheus.org',
+    },
+  })
+}
+
+const pushResolution = async (
+  config: NonNullable<typeof workerState.config>,
+  force: boolean
+): Promise<void> => {
+  const git = await loadGit()
+  const { default: http } = await import('isomorphic-git/http/web')
+  const opts = buildAuthOpts(config, http)
+  await git.push({ ...opts, force })
+}
+
+/**
+ * Commit every staged resolution and push the merge commit to
+ * the remote. Pushes with `force=true` (force-with-lease) when at
+ * least one file was resolved via the `force-mine` strategy.
+ * Returns the inferred force flag so the caller can audit.
+ * @returns True when a force push was issued.
+ */
+export const finalizeResolution = async (): Promise<boolean> => {
+  const config = workerState.config
+  const force = hasForcePending()
+  await (config === undefined
+    ? Promise.resolve()
+    : (async (): Promise<void> => {
+        await commitResolution(config)
+        await pushResolution(config, force)
+      })())
+  clearForcePending()
+  return force
+}

--- a/src/sw/conflicts/parse-markers.test.ts
+++ b/src/sw/conflicts/parse-markers.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { resolveByStrategy } from './parse-markers'
+
+const sample = [
+  'before',
+  '<<<<<<< HEAD',
+  'mine line 1',
+  'mine line 2',
+  '=======',
+  'theirs line 1',
+  '>>>>>>> origin/develop',
+  'after',
+].join('\n')
+
+describe('resolveByStrategy', () => {
+  it('keeps "mine" lines when strategy is mine', () => {
+    const out = resolveByStrategy(sample, 'mine')
+    expect(out.split('\n')).toEqual([
+      'before',
+      'mine line 1',
+      'mine line 2',
+      'after',
+    ])
+  })
+
+  it('keeps "theirs" lines when strategy is theirs', () => {
+    const out = resolveByStrategy(sample, 'theirs')
+    expect(out.split('\n')).toEqual(['before', 'theirs line 1', 'after'])
+  })
+
+  it('treats force-mine identically to mine', () => {
+    expect(resolveByStrategy(sample, 'force-mine')).toBe(
+      resolveByStrategy(sample, 'mine')
+    )
+  })
+
+  it('passes content without markers through unchanged', () => {
+    const plain = 'no markers here'
+    expect(resolveByStrategy(plain, 'mine')).toBe(plain)
+  })
+
+  it('handles multiple conflict blocks', () => {
+    const multi = [
+      'a',
+      '<<<<<<< HEAD',
+      'mine1',
+      '=======',
+      'theirs1',
+      '>>>>>>> r',
+      'b',
+      '<<<<<<< HEAD',
+      'mine2',
+      '=======',
+      'theirs2',
+      '>>>>>>> r',
+      'c',
+    ].join('\n')
+    expect(resolveByStrategy(multi, 'theirs').split('\n')).toEqual([
+      'a',
+      'theirs1',
+      'b',
+      'theirs2',
+      'c',
+    ])
+  })
+})

--- a/src/sw/conflicts/parse-markers.ts
+++ b/src/sw/conflicts/parse-markers.ts
@@ -1,0 +1,58 @@
+import type { ResolveStrategy } from '../protocol/push-control'
+
+const HEAD_MARKER = /^<{7} .*$/
+const SEP_MARKER = /^={7}$/
+const TAIL_MARKER = /^>{7} .*$/
+
+type Section = 'outside' | 'ours' | 'theirs'
+
+const nextSection = (line: string, prev: Section): Section =>
+  HEAD_MARKER.test(line)
+    ? 'ours'
+    : SEP_MARKER.test(line)
+      ? 'theirs'
+      : TAIL_MARKER.test(line)
+        ? 'outside'
+        : prev
+
+const isMarker = (line: string): boolean =>
+  HEAD_MARKER.test(line) || SEP_MARKER.test(line) || TAIL_MARKER.test(line)
+
+const shouldKeep = (
+  section: Section,
+  line: string,
+  keepOurs: boolean
+): boolean =>
+  !isMarker(line) &&
+  (section === 'outside' ||
+    (section === 'ours' && keepOurs) ||
+    (section === 'theirs' && !keepOurs))
+
+/**
+ * Strip merge conflict markers from a textual file according to
+ * the chosen resolution strategy. `mine` / `force-mine` keeps
+ * `<<<<<<<`-`=======` lines; `theirs` keeps `=======`-`>>>>>>>`.
+ * Lines outside any conflict block are kept verbatim.
+ * @param content Raw file content with conflict markers.
+ * @param strategy Resolution strategy chosen by the user.
+ * @returns Resolved file content with markers stripped.
+ */
+export const resolveByStrategy = (
+  content: string,
+  strategy: ResolveStrategy
+): string => {
+  const keepOurs = strategy !== 'theirs'
+  const lines = content.split('\n')
+  const result: string[] = []
+  let section: Section = 'outside'
+  for (const line of lines) {
+    section = nextSection(line, section)
+    const include = shouldKeep(section, line, keepOurs)
+    const noop = (): void => undefined
+    const push = (): void => {
+      result.push(line)
+    }
+    ;(include ? push : noop)()
+  }
+  return result.join('\n')
+}

--- a/src/sw/conflicts/resolve-file.ts
+++ b/src/sw/conflicts/resolve-file.ts
@@ -1,0 +1,46 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+import type { ResolveStrategy } from '../protocol/push-control'
+import { resolveByStrategy } from './parse-markers'
+
+const forceMineSet = new Set<string>()
+
+/**
+ * Apply the chosen strategy to a single conflicted file: rewrite
+ * the working tree without conflict markers and stage the result
+ * via `git.add`. Force-mine paths are remembered so the finalize
+ * step can decide whether to push with the force flag.
+ * @param file Path of the conflicted file (relative to repo root).
+ * @param strategy User-selected resolution strategy.
+ * @returns Resolves once the file is staged.
+ */
+export const resolveFile = async (
+  file: string,
+  strategy: ResolveStrategy
+): Promise<void> => {
+  const path = `${REPO_DIR}/${file}`
+  const raw = await fs.promises.readFile(path, 'utf8')
+  const content =
+    typeof raw === 'string' ? raw : new TextDecoder().decode(raw)
+  const next = resolveByStrategy(content, strategy)
+  await fs.promises.writeFile(path, next, 'utf8')
+  const git = await loadGit()
+  await git.add({ fs, dir: REPO_DIR, filepath: file })
+  const noop = (): void => undefined
+  const remember = (): void => {
+    forceMineSet.add(file)
+  }
+  ;(strategy === 'force-mine' ? remember : noop)()
+}
+
+/**
+ * Whether any resolved file was marked force-mine, telling the
+ * finalize step to issue a `git push --force-with-lease`.
+ * @returns True when at least one force-mine resolution is queued.
+ */
+export const hasForcePending = (): boolean => forceMineSet.size > 0
+
+/** Reset the force-mine accumulator. Called after finalize. */
+export const clearForcePending = (): void => {
+  forceMineSet.clear()
+}

--- a/src/sw/conflicts/write-resolved.ts
+++ b/src/sw/conflicts/write-resolved.ts
@@ -1,0 +1,20 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+
+/**
+ * Apply a manually-merged file content to the working tree and
+ * stage it. Used by the visual merge UI when the user has
+ * produced the final content themselves.
+ * @param file Path of the file relative to repo root.
+ * @param content Resolved text content to write.
+ * @returns Resolves once the file is staged.
+ */
+export const writeResolvedContent = async (
+  file: string,
+  content: string
+): Promise<void> => {
+  const path = `${REPO_DIR}/${file}`
+  await fs.promises.writeFile(path, content, 'utf8')
+  const git = await loadGit()
+  await git.add({ fs, dir: REPO_DIR, filepath: file })
+}

--- a/src/sw/protocol/push-conflict.ts
+++ b/src/sw/protocol/push-conflict.ts
@@ -1,0 +1,10 @@
+/** BroadcastChannel name for SW→client merge conflict events. */
+export const SW_PUSH_CONFLICT_CHANNEL = 'sw-push-conflict'
+
+/** Emitted when an auto-merge attempt leaves conflict markers. */
+export type PushConflictEvent = {
+  readonly sha: string
+  readonly target: string
+  readonly files: ReadonlyArray<string>
+  readonly at: number
+}

--- a/src/sw/protocol/push-control.ts
+++ b/src/sw/protocol/push-control.ts
@@ -1,5 +1,15 @@
 /** BroadcastChannel name for client→SW push pipeline control. */
 export const SW_PUSH_CONTROL_CHANNEL = 'sw-push-control'
 
-/** Control message asking the SW to drain the queue immediately. */
-export type PushControlMessage = { readonly type: 'retry-now' }
+/** Resolution strategies a user can apply per conflicted file. */
+export type ResolveStrategy = 'mine' | 'theirs' | 'force-mine'
+
+/** Control messages exchanged on the push-control channel. */
+export type PushControlMessage =
+  | { readonly type: 'retry-now' }
+  | {
+      readonly type: 'resolve-file'
+      readonly file: string
+      readonly strategy: ResolveStrategy
+    }
+  | { readonly type: 'finalize-resolution' }

--- a/src/sw/protocol/push-control.ts
+++ b/src/sw/protocol/push-control.ts
@@ -12,4 +12,9 @@ export type PushControlMessage =
       readonly file: string
       readonly strategy: ResolveStrategy
     }
+  | {
+      readonly type: 'resolve-file-content'
+      readonly file: string
+      readonly content: string
+    }
   | { readonly type: 'finalize-resolution' }

--- a/src/sw/push-queue/attempt-merge.ts
+++ b/src/sw/push-queue/attempt-merge.ts
@@ -1,0 +1,57 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+import { buildAuthOpts } from '../git/remote/build-auth-opts'
+import type { SWGitConfig } from '../protocol'
+import { filesFromError, filesFromStatus } from './merge-conflict-files'
+
+/** Outcome of a single auto-merge attempt. */
+export type MergeOutcome =
+  | { readonly kind: 'clean' }
+  | {
+      readonly kind: 'conflict'
+      readonly files: ReadonlyArray<string>
+    }
+  | { readonly kind: 'fail'; readonly error: unknown }
+
+const isMergeConflict = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'MergeConflictError'
+
+const collectConflictFiles = async (
+  error: unknown
+): Promise<ReadonlyArray<string>> => {
+  const fromError = filesFromError(error)
+  return fromError.length > 0 ? fromError : await filesFromStatus()
+}
+
+/**
+ * Attempt to fast-forward / auto-merge the local branch against
+ * the remote. Wraps `git.pull` so callers can react to the three
+ * outcomes without parsing error names themselves.
+ * @param config Validated SW git configuration.
+ * @returns Discriminated outcome (clean / conflict / fail).
+ */
+export const attemptMerge = async (
+  config: SWGitConfig
+): Promise<MergeOutcome> => {
+  const git = await loadGit()
+  const { default: http } = await import('isomorphic-git/http/web')
+  const opts = buildAuthOpts(config, http)
+  try {
+    await git.pull({
+      ...opts,
+      fs,
+      dir: REPO_DIR,
+      ref: config.branch,
+      singleBranch: true,
+      author: {
+        name: config.authorName ?? 'Admin',
+        email: config.authorEmail ?? 'admin@prometheus.org',
+      },
+    })
+    return { kind: 'clean' }
+  } catch (error) {
+    return isMergeConflict(error)
+      ? { kind: 'conflict', files: await collectConflictFiles(error) }
+      : { kind: 'fail', error }
+  }
+}

--- a/src/sw/push-queue/conflict-broadcast.ts
+++ b/src/sw/push-queue/conflict-broadcast.ts
@@ -1,0 +1,33 @@
+import {
+  type PushConflictEvent,
+  SW_PUSH_CONFLICT_CHANNEL,
+} from '../protocol/push-conflict'
+import type { PushQueueEntry } from './types'
+
+let channel: BroadcastChannel | undefined
+
+const channelOf = (): BroadcastChannel => {
+  channel ??= new BroadcastChannel(SW_PUSH_CONFLICT_CHANNEL)
+  return channel
+}
+
+/**
+ * Broadcast an unresolved-conflict event so the client can list
+ * affected files in the conflict view (4.2) and offer per-file
+ * resolution (4.3+).
+ * @param entry Queue entry whose push triggered the merge attempt.
+ * @param files Conflict file paths reported by isomorphic-git.
+ * @returns void
+ */
+export const publishPushConflict = (
+  entry: PushQueueEntry,
+  files: ReadonlyArray<string>
+): void => {
+  const event: PushConflictEvent = {
+    sha: entry.sha,
+    target: entry.branch,
+    files,
+    at: Date.now(),
+  }
+  channelOf().postMessage(event)
+}

--- a/src/sw/push-queue/control-listener.ts
+++ b/src/sw/push-queue/control-listener.ts
@@ -1,6 +1,7 @@
 import { Match } from 'effect'
 import { finalizeResolution } from '../conflicts/finalize'
 import { resolveFile } from '../conflicts/resolve-file'
+import { writeResolvedContent } from '../conflicts/write-resolved'
 import {
   type PushControlMessage,
   SW_PUSH_CONTROL_CHANNEL,
@@ -18,6 +19,9 @@ const dispatch = async (msg: PushControlMessage): Promise<void> => {
     Match.discriminator('type')('retry-now', () => handleRetry()),
     Match.discriminator('type')('resolve-file', ({ file, strategy }) =>
       resolveFile(file, strategy)
+    ),
+    Match.discriminator('type')('resolve-file-content', ({ file, content }) =>
+      writeResolvedContent(file, content)
     ),
     Match.discriminator('type')('finalize-resolution', () =>
       finalizeResolution().then(() => undefined)

--- a/src/sw/push-queue/control-listener.ts
+++ b/src/sw/push-queue/control-listener.ts
@@ -1,4 +1,6 @@
 import { Match } from 'effect'
+import { finalizeResolution } from '../conflicts/finalize'
+import { resolveFile } from '../conflicts/resolve-file'
 import {
   type PushControlMessage,
   SW_PUSH_CONTROL_CHANNEL,
@@ -6,13 +8,21 @@ import {
 
 let controlChannel: BroadcastChannel | undefined
 
+const handleRetry = async (): Promise<void> => {
+  const { drainPushes } = await import('./drain')
+  await drainPushes()
+}
+
 const dispatch = async (msg: PushControlMessage): Promise<void> => {
-  await Match.value(msg.type).pipe(
-    Match.when('retry-now', async () => {
-      const { drainPushes } = await import('./drain')
-      await drainPushes()
-    }),
-    Match.orElse(async () => undefined)
+  await Match.value(msg).pipe(
+    Match.discriminator('type')('retry-now', () => handleRetry()),
+    Match.discriminator('type')('resolve-file', ({ file, strategy }) =>
+      resolveFile(file, strategy)
+    ),
+    Match.discriminator('type')('finalize-resolution', () =>
+      finalizeResolution().then(() => undefined)
+    ),
+    Match.exhaustive
   )
 }
 

--- a/src/sw/push-queue/files-from-error.ts
+++ b/src/sw/push-queue/files-from-error.ts
@@ -1,0 +1,18 @@
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Inspect an isomorphic-git merge error and return the list of
+ * conflict file paths it carries on `error.data.filepaths`. Falls
+ * back to an empty array so callers always get a list. Pure —
+ * no fs / git dependencies — so unit tests don't need IDB shims.
+ * @param error Raw error from `git.pull` / `git.merge`.
+ * @returns Conflict file paths reported by the error payload.
+ */
+export const filesFromError = (error: unknown): ReadonlyArray<string> => {
+  const data = isObject(error) ? error['data'] : undefined
+  const filepaths = isObject(data) ? data['filepaths'] : undefined
+  return Array.isArray(filepaths)
+    ? filepaths.filter((p): p is string => typeof p === 'string')
+    : []
+}

--- a/src/sw/push-queue/handle-failure.ts
+++ b/src/sw/push-queue/handle-failure.ts
@@ -1,22 +1,52 @@
 import { publishPushState } from './broadcast'
 import { classifyPushError } from './classify-error'
 import { publishPushError } from './error-broadcast'
+import { tryMergeAfterNff } from './handle-nff'
 import { shouldRetry } from './retry-policy'
 import { scheduleRetry } from './schedule-retry'
 import type { PushQueueEntry } from './types'
 import { bumpAttempt } from './update-attempt'
 
+const scheduleAfterMerge = async (entry: PushQueueEntry): Promise<void> => {
+  await bumpAttempt(entry)
+  scheduleRetry(entry.attempt ?? 1)
+}
+
+const handleNonFastForward = async (
+  entry: PushQueueEntry,
+  remaining: number
+): Promise<void> => {
+  const outcome = await tryMergeAfterNff(entry)
+  const cleanMerge = outcome.kind === 'clean'
+  publishPushState({
+    status: cleanMerge ? 'syncing' : 'error',
+    pending: remaining,
+  })
+  publishPushError(entry, 'non-fast-forward', !cleanMerge)
+  await (cleanMerge ? scheduleAfterMerge(entry) : Promise.resolve())
+}
+
+const handleGenericFailure = async (
+  entry: PushQueueEntry,
+  remaining: number,
+  reason: ReturnType<typeof classifyPushError>,
+  retry: boolean
+): Promise<void> => {
+  publishPushState({ status: 'error', pending: remaining })
+  publishPushError(entry, reason, !retry)
+  await (retry ? scheduleAfterMerge(entry) : Promise.resolve())
+}
+
 /**
- * React to a failed push attempt. Retriable failures bump the
- * attempt counter, schedule the next drain, and surface a
- * non-terminal error event. Terminal failures (auth /
- * non-fast-forward / validation / retry-cap) leave the entry in
- * place and surface a terminal event so the UI can offer a Retry
- * CTA on user action.
+ * React to a failed push attempt. Non-fast-forward triggers an
+ * auto-merge — clean merges retry, conflicts surface via the
+ * conflict channel. Other transient errors bump the attempt
+ * counter and schedule a backoff retry. Terminal failures emit
+ * a terminal error event for the UI.
  * @param entry Failed queue entry.
  * @param remaining Pending count covering the entry and everything after.
  * @param error Raw error from the push pipeline.
- * @returns Resolves once side effects (broadcast, schedule) are queued.
+ * @returns Resolves once side effects are queued.
  */
 export const handleFailure = async (
   entry: PushQueueEntry,
@@ -26,13 +56,7 @@ export const handleFailure = async (
   const reason = classifyPushError(error)
   const attempt = entry.attempt ?? 1
   const retry = shouldRetry(reason, attempt)
-  publishPushState({ status: 'error', pending: remaining })
-  publishPushError(entry, reason, !retry)
-  const schedule = retry
-    ? async (): Promise<void> => {
-        await bumpAttempt(entry)
-        scheduleRetry(attempt)
-      }
-    : async (): Promise<void> => undefined
-  await schedule()
+  await (reason === 'non-fast-forward'
+    ? handleNonFastForward(entry, remaining)
+    : handleGenericFailure(entry, remaining, reason, retry))
 }

--- a/src/sw/push-queue/handle-nff.ts
+++ b/src/sw/push-queue/handle-nff.ts
@@ -1,0 +1,33 @@
+import { workerState } from '../state/state'
+import { attemptMerge, type MergeOutcome } from './attempt-merge'
+import { publishPushConflict } from './conflict-broadcast'
+import type { PushQueueEntry } from './types'
+
+const noConfigOutcome: MergeOutcome = {
+  kind: 'fail',
+  error: new Error('SW git config missing'),
+}
+
+/**
+ * Try to merge the remote branch in response to a non-fast-
+ * forward push rejection. Returns the merge outcome so the
+ * failure handler can decide whether to re-drain (clean), surface
+ * a conflict notification (conflict), or fall through to the
+ * generic terminal-error path (fail).
+ * @param entry Failed queue entry whose push triggered the merge.
+ * @returns Discriminated outcome (clean / conflict / fail).
+ */
+export const tryMergeAfterNff = async (
+  entry: PushQueueEntry
+): Promise<MergeOutcome> => {
+  const config = workerState.config
+  const outcome =
+    config === undefined ? noConfigOutcome : await attemptMerge(config)
+  const noop = (): void => undefined
+  const fire =
+    outcome.kind === 'conflict'
+      ? () => publishPushConflict(entry, outcome.files)
+      : noop
+  fire()
+  return outcome
+}

--- a/src/sw/push-queue/merge-conflict-files.test.ts
+++ b/src/sw/push-queue/merge-conflict-files.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { filesFromError } from './files-from-error'
+
+describe('filesFromError', () => {
+  it('returns the filepaths array carried on data', () => {
+    const error = { data: { filepaths: ['a.md', 'b.md'] } }
+    expect(filesFromError(error)).toEqual(['a.md', 'b.md'])
+  })
+
+  it('drops non-string entries', () => {
+    const error = { data: { filepaths: ['a.md', 42, undefined, 'b.md'] } }
+    expect(filesFromError(error)).toEqual(['a.md', 'b.md'])
+  })
+
+  it('returns [] when data is missing', () => {
+    expect(filesFromError(new Error('boom'))).toEqual([])
+    expect(filesFromError(undefined)).toEqual([])
+    expect(filesFromError({ no: 'data-here' })).toEqual([])
+  })
+
+  it('returns [] when filepaths is not an array', () => {
+    expect(filesFromError({ data: { filepaths: 'hello' } })).toEqual([])
+    expect(filesFromError({ data: 'hello' })).toEqual([])
+  })
+})

--- a/src/sw/push-queue/merge-conflict-files.ts
+++ b/src/sw/push-queue/merge-conflict-files.ts
@@ -1,0 +1,18 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+
+export { filesFromError } from './files-from-error'
+
+/**
+ * Inspect the working tree for entries with conflict markers
+ * (statusMatrix rows where head/workdir/stage diverge). Used as
+ * a fallback when the merge error omits the filepaths list.
+ * @returns Paths of files that currently carry conflict markers.
+ */
+export const filesFromStatus = async (): Promise<ReadonlyArray<string>> => {
+  const git = await loadGit()
+  const matrix = await git.statusMatrix({ fs, dir: REPO_DIR })
+  return matrix
+    .filter(row => row[1] !== row[2] && row[2] !== row[3])
+    .map(row => row[0])
+}

--- a/src/views/ConflictsView/ConflictItem.vue
+++ b/src/views/ConflictsView/ConflictItem.vue
@@ -1,19 +1,59 @@
 <script setup lang="ts">
+import type { ResolveStrategy } from '@/sw/protocol/push-control'
 import { CONFLICT_TEST_IDS } from './test-ids'
 
-defineProps<{ readonly path: string }>()
+defineProps<{
+  readonly path: string
+  readonly resolved: ResolveStrategy | undefined
+}>()
+defineEmits<{
+  readonly resolve: [strategy: ResolveStrategy]
+}>()
 </script>
 
 <template>
   <li
     class="conflict-item"
     :data-testid="CONFLICT_TEST_IDS.item"
+    :data-resolved="resolved ?? 'pending'"
   >
-    <code
-      class="path"
-      :data-testid="CONFLICT_TEST_IDS.filePath"
-    >{{ path }}</code>
-    <span class="status">conflict</span>
+    <code class="path" :data-testid="CONFLICT_TEST_IDS.filePath">{{
+      path
+    }}</code>
+    <span
+      v-if="resolved !== undefined"
+      class="status status-resolved"
+      :data-testid="CONFLICT_TEST_IDS.resolved"
+      >{{ resolved }}</span
+    >
+    <span v-else class="status">conflict</span>
+    <button
+      v-if="resolved === undefined"
+      type="button"
+      class="btn"
+      :data-testid="CONFLICT_TEST_IDS.keepMine"
+      @click="$emit('resolve', 'mine')"
+    >
+      keep mine
+    </button>
+    <button
+      v-if="resolved === undefined"
+      type="button"
+      class="btn"
+      :data-testid="CONFLICT_TEST_IDS.takeTheirs"
+      @click="$emit('resolve', 'theirs')"
+    >
+      take theirs
+    </button>
+    <button
+      v-if="resolved === undefined"
+      type="button"
+      class="btn force"
+      :data-testid="CONFLICT_TEST_IDS.forceMine"
+      @click="$emit('resolve', 'force-mine')"
+    >
+      force push mine
+    </button>
   </li>
 </template>
 
@@ -21,8 +61,8 @@ defineProps<{ readonly path: string }>()
 .conflict-item {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
+  flex-wrap: wrap;
+  gap: 8px;
   padding: 8px 12px;
   border: 1px solid var(--color-border, #ddd);
   border-left: 3px solid var(--color-error, #e53935);
@@ -30,15 +70,41 @@ defineProps<{ readonly path: string }>()
   background: var(--color-surface, #fff);
 }
 
+.conflict-item[data-resolved='mine'],
+.conflict-item[data-resolved='theirs'],
+.conflict-item[data-resolved='force-mine'] {
+  border-left-color: var(--color-success, #43a047);
+  opacity: 70%;
+}
+
 .path {
   font-size: 0.8125rem;
   font-family: monospace;
+  flex: 1 1 auto;
 }
 
 .status {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  color: var(--color-error, #e53935);
+}
+
+.status-resolved {
+  color: var(--color-success, #43a047);
+}
+
+.btn {
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  border: 1px solid var(--color-border, #ddd);
+  background: transparent;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.btn.force {
+  border-color: var(--color-error, #e53935);
   color: var(--color-error, #e53935);
 }
 </style>

--- a/src/views/ConflictsView/ConflictItem.vue
+++ b/src/views/ConflictsView/ConflictItem.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { CONFLICT_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly path: string }>()
+</script>
+
+<template>
+  <li
+    class="conflict-item"
+    :data-testid="CONFLICT_TEST_IDS.item"
+  >
+    <code
+      class="path"
+      :data-testid="CONFLICT_TEST_IDS.filePath"
+    >{{ path }}</code>
+    <span class="status">conflict</span>
+  </li>
+</template>
+
+<style scoped>
+.conflict-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border: 1px solid var(--color-border, #ddd);
+  border-left: 3px solid var(--color-error, #e53935);
+  border-radius: 4px;
+  background: var(--color-surface, #fff);
+}
+
+.path {
+  font-size: 0.8125rem;
+  font-family: monospace;
+}
+
+.status {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-error, #e53935);
+}
+</style>

--- a/src/views/ConflictsView/ConflictItem.vue
+++ b/src/views/ConflictsView/ConflictItem.vue
@@ -1,14 +1,20 @@
 <script setup lang="ts">
+import { useRouter } from 'vue-router'
 import type { ResolveStrategy } from '@/sw/protocol/push-control'
 import { CONFLICT_TEST_IDS } from './test-ids'
 
-defineProps<{
+const props = defineProps<{
   readonly path: string
   readonly resolved: ResolveStrategy | undefined
 }>()
 defineEmits<{
   readonly resolve: [strategy: ResolveStrategy]
 }>()
+
+const router = useRouter()
+const onVisualMerge = (): void => {
+  void router.push(`/conflicts/merge/${encodeURIComponent(props.path)}`)
+}
 </script>
 
 <template>
@@ -53,6 +59,15 @@ defineEmits<{
       @click="$emit('resolve', 'force-mine')"
     >
       force push mine
+    </button>
+    <button
+      v-if="resolved === undefined"
+      type="button"
+      class="btn merge"
+      :data-testid="CONFLICT_TEST_IDS.visualMerge"
+      @click="onVisualMerge"
+    >
+      visual merge
     </button>
   </li>
 </template>
@@ -106,5 +121,10 @@ defineEmits<{
 .btn.force {
   border-color: var(--color-error, #e53935);
   color: var(--color-error, #e53935);
+}
+
+.btn.merge {
+  border-color: var(--color-accent, #4fc3f7);
+  color: var(--color-accent, #4fc3f7);
 }
 </style>

--- a/src/views/ConflictsView/ConflictsBody.vue
+++ b/src/views/ConflictsView/ConflictsBody.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useConflictsStore } from '@/stores/conflicts'
+import ConflictsEmpty from './ConflictsEmpty.vue'
+import ConflictsHeader from './ConflictsHeader.vue'
+import ConflictsHint from './ConflictsHint.vue'
+import ConflictsList from './ConflictsList.vue'
+import { CONFLICT_TEST_IDS } from './test-ids'
+
+const store = useConflictsStore()
+const files = computed(() => store.current?.files ?? [])
+const target = computed(() => store.current?.target ?? '')
+const onResolveAll = (): void => {
+  store.clear()
+}
+</script>
+
+<template>
+  <section class="conflicts-view" :data-testid="CONFLICT_TEST_IDS.root">
+    <ConflictsHeader
+      :has-conflict="store.hasConflict"
+      @resolve-all="onResolveAll"
+    />
+    <ConflictsEmpty v-if="!store.hasConflict" />
+    <ConflictsHint v-else :target="target" />
+    <ConflictsList :files="files" />
+  </section>
+</template>
+
+<style scoped>
+.conflicts-view {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 720px;
+}
+</style>

--- a/src/views/ConflictsView/ConflictsBody.vue
+++ b/src/views/ConflictsView/ConflictsBody.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { notifyInfo } from '@/composables/useNotifications'
+import {
+  requestFinalizeResolution,
+  requestResolveFile,
+} from '@/composables/useNotifications/push-control'
 import { useConflictsStore } from '@/stores/conflicts'
+import type { ResolveStrategy } from '@/sw/protocol/push-control'
 import ConflictsEmpty from './ConflictsEmpty.vue'
+import ConflictsFinalize from './ConflictsFinalize.vue'
 import ConflictsHeader from './ConflictsHeader.vue'
 import ConflictsHint from './ConflictsHint.vue'
 import ConflictsList from './ConflictsList.vue'
@@ -11,6 +18,20 @@ const store = useConflictsStore()
 const files = computed(() => store.current?.files ?? [])
 const target = computed(() => store.current?.target ?? '')
 const onResolveAll = (): void => {
+  store.clear()
+}
+const onResolve = (file: string, strategy: ResolveStrategy): void => {
+  store.setResolution(file, strategy)
+  requestResolveFile(file, strategy)
+}
+const onFinalize = (): void => {
+  const usedForce = [...store.resolutions.values()].includes('force-mine')
+  requestFinalizeResolution()
+  notifyInfo(
+    usedForce
+      ? 'Force-pushed merge resolution to remote'
+      : 'Merge resolution committed and pushed'
+  )
   store.clear()
 }
 </script>
@@ -23,7 +44,15 @@ const onResolveAll = (): void => {
     />
     <ConflictsEmpty v-if="!store.hasConflict" />
     <ConflictsHint v-else :target="target" />
-    <ConflictsList :files="files" />
+    <ConflictsList
+      :files="files"
+      :resolutions="store.resolutions"
+      @resolve="onResolve"
+    />
+    <ConflictsFinalize
+      v-if="store.allResolved"
+      @finalize="onFinalize"
+    />
   </section>
 </template>
 

--- a/src/views/ConflictsView/ConflictsEmpty.vue
+++ b/src/views/ConflictsView/ConflictsEmpty.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { CONFLICT_TEST_IDS } from './test-ids'
+</script>
+
+<template>
+  <p class="empty" :data-testid="CONFLICT_TEST_IDS.empty">
+    No active conflicts.
+  </p>
+</template>
+
+<style scoped>
+.empty {
+  color: var(--color-text-muted, #888);
+}
+</style>

--- a/src/views/ConflictsView/ConflictsFinalize.vue
+++ b/src/views/ConflictsView/ConflictsFinalize.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { CONFLICT_TEST_IDS } from './test-ids'
+
+defineEmits<{ readonly finalize: [] }>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="finalize"
+    :data-testid="CONFLICT_TEST_IDS.finalize"
+    @click="$emit('finalize')"
+  >
+    Commit + push merged result
+  </button>
+</template>
+
+<style scoped>
+.finalize {
+  align-self: flex-start;
+  font-size: 0.875rem;
+  font-weight: 700;
+  padding: 8px 14px;
+  border: 0;
+  border-radius: 4px;
+  background: var(--color-accent, #4fc3f7);
+  color: #fff;
+  cursor: pointer;
+}
+</style>

--- a/src/views/ConflictsView/ConflictsHeader.vue
+++ b/src/views/ConflictsView/ConflictsHeader.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { CONFLICT_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly hasConflict: boolean }>()
+defineEmits<{ readonly resolveAll: [] }>()
+</script>
+
+<template>
+  <header class="head">
+    <strong class="title">Merge conflicts</strong>
+    <button
+      v-if="hasConflict"
+      type="button"
+      class="resolve-all"
+      :data-testid="CONFLICT_TEST_IDS.resolveAll"
+      @click="$emit('resolveAll')"
+    >
+      Mark all resolved
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.title {
+  font-size: 1.25rem;
+}
+
+.resolve-all {
+  font-size: 0.8125rem;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 4px;
+  cursor: pointer;
+}
+</style>

--- a/src/views/ConflictsView/ConflictsHint.vue
+++ b/src/views/ConflictsView/ConflictsHint.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+defineProps<{ readonly target: string }>()
+</script>
+
+<template>
+  <p class="hint">
+    Push to <code>{{ target }}</code> stalled — the following files
+    need manual resolution before sync can resume.
+  </p>
+</template>
+
+<style scoped>
+.hint {
+  font-size: 0.875rem;
+  color: var(--color-text, #444);
+}
+</style>

--- a/src/views/ConflictsView/ConflictsList.vue
+++ b/src/views/ConflictsView/ConflictsList.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
+import type { ResolveStrategy } from '@/sw/protocol/push-control'
 import ConflictItem from './ConflictItem.vue'
 import { CONFLICT_TEST_IDS } from './test-ids'
 
-defineProps<{ readonly files: ReadonlyArray<string> }>()
+defineProps<{
+  readonly files: ReadonlyArray<string>
+  readonly resolutions: ReadonlyMap<string, ResolveStrategy>
+}>()
+defineEmits<{
+  readonly resolve: [file: string, strategy: ResolveStrategy]
+}>()
 </script>
 
 <template>
@@ -11,6 +18,8 @@ defineProps<{ readonly files: ReadonlyArray<string> }>()
       v-for="file in files"
       :key="file"
       :path="file"
+      :resolved="resolutions.get(file)"
+      @resolve="strategy => $emit('resolve', file, strategy)"
     />
   </ul>
 </template>

--- a/src/views/ConflictsView/ConflictsList.vue
+++ b/src/views/ConflictsView/ConflictsList.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import ConflictItem from './ConflictItem.vue'
+import { CONFLICT_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly files: ReadonlyArray<string> }>()
+</script>
+
+<template>
+  <ul class="conflicts-list" :data-testid="CONFLICT_TEST_IDS.list">
+    <ConflictItem
+      v-for="file in files"
+      :key="file"
+      :path="file"
+    />
+  </ul>
+</template>
+
+<style scoped>
+.conflicts-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+</style>

--- a/src/views/ConflictsView/ConflictsView.vue
+++ b/src/views/ConflictsView/ConflictsView.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import AppLayout from '@/components/AppLayout.vue'
+import ConflictsBody from './ConflictsBody.vue'
+</script>
+
+<template>
+  <AppLayout>
+    <ConflictsBody />
+  </AppLayout>
+</template>

--- a/src/views/ConflictsView/test-ids.ts
+++ b/src/views/ConflictsView/test-ids.ts
@@ -1,0 +1,9 @@
+/** Test IDs used by the merge conflict view. */
+export const CONFLICT_TEST_IDS = {
+  root: 'conflicts-view',
+  empty: 'conflicts-empty',
+  list: 'conflicts-list',
+  item: 'conflicts-item',
+  filePath: 'conflicts-item-path',
+  resolveAll: 'conflicts-resolve-all',
+} as const

--- a/src/views/ConflictsView/test-ids.ts
+++ b/src/views/ConflictsView/test-ids.ts
@@ -6,4 +6,9 @@ export const CONFLICT_TEST_IDS = {
   item: 'conflicts-item',
   filePath: 'conflicts-item-path',
   resolveAll: 'conflicts-resolve-all',
+  finalize: 'conflicts-finalize',
+  keepMine: 'conflicts-item-keep-mine',
+  takeTheirs: 'conflicts-item-take-theirs',
+  forceMine: 'conflicts-item-force-mine',
+  resolved: 'conflicts-item-resolved',
 } as const

--- a/src/views/ConflictsView/test-ids.ts
+++ b/src/views/ConflictsView/test-ids.ts
@@ -11,4 +11,5 @@ export const CONFLICT_TEST_IDS = {
   takeTheirs: 'conflicts-item-take-theirs',
   forceMine: 'conflicts-item-force-mine',
   resolved: 'conflicts-item-resolved',
+  visualMerge: 'conflicts-item-visual-merge',
 } as const

--- a/src/views/VisualMergeView/MergeEditor.vue
+++ b/src/views/VisualMergeView/MergeEditor.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { VISUAL_MERGE_TEST_IDS } from './test-ids'
+
+const props = defineProps<{
+  readonly ours: string
+  readonly theirs: string
+  readonly merged: string
+}>()
+const emit = defineEmits<{ readonly update: [next: string] }>()
+
+const onInput = (event: Event): void => {
+  const target = event.target
+  const value =
+    target instanceof HTMLTextAreaElement ? target.value : props.merged
+  emit('update', value)
+}
+</script>
+
+<template>
+  <article class="merge-editor">
+    <pre
+      class="pane ours"
+      :data-testid="VISUAL_MERGE_TEST_IDS.ours"
+    >{{ ours }}</pre>
+    <textarea
+      class="pane merged"
+      :data-testid="VISUAL_MERGE_TEST_IDS.merged"
+      :value="merged"
+      spellcheck="false"
+      @input="onInput"
+    />
+    <pre
+      class="pane theirs"
+      :data-testid="VISUAL_MERGE_TEST_IDS.theirs"
+    >{{ theirs }}</pre>
+  </article>
+</template>
+
+<style scoped>
+.merge-editor {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  min-height: 320px;
+}
+
+.pane {
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 4px;
+  padding: 8px;
+  font-family: monospace;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  overflow: auto;
+  background: var(--color-surface, #fff);
+}
+
+.pane.ours {
+  border-left: 3px solid var(--color-accent, #4fc3f7);
+}
+
+.pane.theirs {
+  border-left: 3px solid var(--color-warning, #ffb74d);
+}
+
+.pane.merged {
+  border-left: 3px solid var(--color-success, #43a047);
+  resize: vertical;
+}
+</style>

--- a/src/views/VisualMergeView/VisualMergeBody.vue
+++ b/src/views/VisualMergeView/VisualMergeBody.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { requestResolveFileContent } from '@/composables/useNotifications/push-control'
+import { useConflictsStore } from '@/stores/conflicts'
+import { fetchFileContent } from './fetch-file-content'
+import MergeEditor from './MergeEditor.vue'
+import { parseThreeWays, type ThreeWaySplit } from './parse-three-ways'
+import { VISUAL_MERGE_TEST_IDS } from './test-ids'
+import VisualMergeHeader from './VisualMergeHeader.vue'
+
+const route = useRoute()
+const router = useRouter()
+const store = useConflictsStore()
+const file = String(route.params['file'] ?? '')
+const split = ref<ThreeWaySplit | undefined>(undefined)
+const merged = ref('')
+
+onMounted(async () => {
+  const content = (await fetchFileContent(file)) ?? ''
+  const next = parseThreeWays(content)
+  split.value = next
+  merged.value = next.merged
+})
+
+const onUpdate = (next: string): void => {
+  merged.value = next
+}
+const onSave = (): void => {
+  requestResolveFileContent(file, merged.value)
+  store.setResolution(file, 'mine')
+  void router.push('/conflicts')
+}
+const onCancel = (): void => {
+  void router.push('/conflicts')
+}
+</script>
+
+<template>
+  <section class="visual-merge" :data-testid="VISUAL_MERGE_TEST_IDS.root">
+    <VisualMergeHeader
+      :file="file"
+      @save="onSave"
+      @cancel="onCancel"
+    />
+    <p
+      v-if="split === undefined"
+      class="loading"
+      :data-testid="VISUAL_MERGE_TEST_IDS.loading"
+    >
+      Loading file…
+    </p>
+    <MergeEditor
+      v-else
+      :ours="split.ours"
+      :theirs="split.theirs"
+      :merged="merged"
+      @update="onUpdate"
+    />
+  </section>
+</template>
+
+<style scoped>
+.visual-merge {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.loading {
+  color: var(--color-text-muted, #888);
+}
+</style>

--- a/src/views/VisualMergeView/VisualMergeHeader.vue
+++ b/src/views/VisualMergeView/VisualMergeHeader.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { VISUAL_MERGE_TEST_IDS } from './test-ids'
+
+defineProps<{ readonly file: string }>()
+defineEmits<{
+  readonly save: []
+  readonly cancel: []
+}>()
+</script>
+
+<template>
+  <header class="head">
+    <strong class="title">Resolve {{ file }}</strong>
+    <button
+      type="button"
+      class="cancel"
+      :data-testid="VISUAL_MERGE_TEST_IDS.cancel"
+      @click="$emit('cancel')"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="save"
+      :data-testid="VISUAL_MERGE_TEST_IDS.save"
+      @click="$emit('save')"
+    >
+      Save merged
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.title {
+  font-size: 1rem;
+  margin-right: auto;
+  font-family: monospace;
+}
+
+.cancel,
+.save {
+  font-size: 0.8125rem;
+  padding: 6px 12px;
+  border: 1px solid var(--color-border, #ddd);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.save {
+  background: var(--color-accent, #4fc3f7);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 700;
+}
+</style>

--- a/src/views/VisualMergeView/VisualMergeView.vue
+++ b/src/views/VisualMergeView/VisualMergeView.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import AppLayout from '@/components/AppLayout.vue'
+import VisualMergeBody from './VisualMergeBody.vue'
+</script>
+
+<template>
+  <AppLayout>
+    <VisualMergeBody />
+  </AppLayout>
+</template>

--- a/src/views/VisualMergeView/fetch-file-content.ts
+++ b/src/views/VisualMergeView/fetch-file-content.ts
@@ -1,0 +1,24 @@
+import { swFetch } from '@/composables/useSWBridge/sw-fetch'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const extractContent = (body: unknown): string | undefined => {
+  const content = isObject(body) ? body['content'] : undefined
+  return typeof content === 'string' ? content : undefined
+}
+
+/**
+ * Read the current working-tree content of a file via the SW
+ * file API. Returns the raw text including any merge markers.
+ * @param path Repo-relative file path.
+ * @returns Raw file content, or undefined when the SW reports an error.
+ */
+export const fetchFileContent = async (
+  path: string
+): Promise<string | undefined> => {
+  const res = await swFetch(
+    `/api/github/file?path=${encodeURIComponent(path)}`
+  )
+  return res.ok ? extractContent(await res.json()) : undefined
+}

--- a/src/views/VisualMergeView/parse-three-ways.test.ts
+++ b/src/views/VisualMergeView/parse-three-ways.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { parseThreeWays } from './parse-three-ways'
+
+const sample = [
+  'header',
+  '<<<<<<< HEAD',
+  'mine line',
+  '=======',
+  'theirs line',
+  '>>>>>>> origin/develop',
+  'footer',
+].join('\n')
+
+describe('parseThreeWays', () => {
+  it('returns ours / theirs / merged from a marker file', () => {
+    const split = parseThreeWays(sample)
+    expect(split.ours.split('\n')).toEqual([
+      'header',
+      'mine line',
+      'footer',
+    ])
+    expect(split.theirs.split('\n')).toEqual([
+      'header',
+      'theirs line',
+      'footer',
+    ])
+    expect(split.merged).toBe(split.ours)
+  })
+
+  it('passes marker-free content through identically', () => {
+    const split = parseThreeWays('plain content')
+    expect(split.ours).toBe('plain content')
+    expect(split.theirs).toBe('plain content')
+    expect(split.merged).toBe('plain content')
+  })
+})

--- a/src/views/VisualMergeView/parse-three-ways.ts
+++ b/src/views/VisualMergeView/parse-three-ways.ts
@@ -1,0 +1,22 @@
+import { resolveByStrategy } from '@/sw/conflicts/parse-markers'
+
+/** Three-way split of a file containing conflict markers. */
+export type ThreeWaySplit = {
+  readonly ours: string
+  readonly theirs: string
+  readonly merged: string
+}
+
+/**
+ * Split a file with conflict markers into the three views the
+ * visual merge editor needs: the "ours" content, the "theirs"
+ * content, and a starting point for the merged pane (initialised
+ * from "ours" so the user only edits where they disagree).
+ * @param content Raw file content with conflict markers.
+ * @returns ours / theirs / merged seed strings.
+ */
+export const parseThreeWays = (content: string): ThreeWaySplit => ({
+  ours: resolveByStrategy(content, 'mine'),
+  theirs: resolveByStrategy(content, 'theirs'),
+  merged: resolveByStrategy(content, 'mine'),
+})

--- a/src/views/VisualMergeView/test-ids.ts
+++ b/src/views/VisualMergeView/test-ids.ts
@@ -1,0 +1,10 @@
+/** Test IDs used by the visual merge editor. */
+export const VISUAL_MERGE_TEST_IDS = {
+  root: 'visual-merge-view',
+  ours: 'visual-merge-ours',
+  theirs: 'visual-merge-theirs',
+  merged: 'visual-merge-merged',
+  save: 'visual-merge-save',
+  cancel: 'visual-merge-cancel',
+  loading: 'visual-merge-loading',
+} as const


### PR DESCRIPTION
## Summary
Phase A / Epic 4 — conflict resolution. Closes Phase A of the offline-first initiative.

## What's in this release
- **4.1 #91 / #110** — SW reacts to non-fast-forward push by attempting `git.pull`. Clean merges retry; conflicts broadcast on `sw-push-conflict`.
- **4.2 #92 / #111** — Persistent conflicts store (localStorage) + `/conflicts` route with file list; survives reload. CTA on the conflict toast routes here.
- **4.3 #93 / #112** — Per-file resolution actions (keep mine / take theirs / force push mine). SW marker parser strips conflict regions; finalize commits + pushes (force-with-lease when any file used force-mine).
- **4.4 #94 / #113** — Visual 3-pane merge editor at `/conflicts/merge/:file`. New `resolve-file-content` SW message accepts manually-merged content. Lazy-loaded route.

## Coverage
- Unit: 466/466 (incl. parser, three-way split, retry-policy, classifier, IDB)
- E2E (chromium): 30+ notifications/settings specs green (toast, drawer, push-sync-badge, push-error-bridge, push-retry, offline-watch, push-summary, push-conflict, conflicts-view, conflicts-resolve, visual-merge)
- `bun run validate` clean

## Verification post-deploy
- [ ] dev-admin loads without console errors
- [ ] /conflicts route renders empty state when no conflicts pending

## Notes / follow-ups
- Visual merge currently uses a textarea for the middle pane; upgrading to `@codemirror/merge` MergeView with per-hunk buttons is a polish increment that does not require any further protocol changes.
- Setting backoff timer in SW is best-effort across SW termination; surviving SW kill requires Periodic Background Sync (out-of-scope for Phase A).

## Phase A scoreboard (now in master)
- Epic 1 — notifications backbone (1.1–1.4)
- Epic 2 — async push pipeline (2.1–2.4)
- Epic 3 — offline mode (3.1–3.4)
- Epic 4 — conflict resolution (4.1–4.4)

Phase B (observability, Hono Worker collector, SSE traces) sits behind the architectural decisions agreed on 2026-04-30 — see `memory/project_offline_initiative.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)