### PR TITLE
fix(ci): biome format drift on Phase A test files

### DIFF
--- a/e2e/notifications/visual-merge.spec.ts
+++ b/e2e/notifications/visual-merge.spec.ts
@@ -1,8 +1,6 @@
 import { expect, test } from '@playwright/test'
 
-const broadcastConflict = (
-  files: ReadonlyArray<string>
-): string => `
+const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
 ch.postMessage({
   sha: 'fa11',
@@ -23,9 +21,7 @@ globalThis.__visualMergeChannel = ch
 test.describe('visual merge editor (4.4)', () => {
   test.beforeEach(async ({ page }) => {
     await page
-      .evaluate(() =>
-        globalThis.localStorage?.removeItem('admin-conflicts')
-      )
+      .evaluate(() => globalThis.localStorage?.removeItem('admin-conflicts'))
       .catch(() => undefined)
     await page.goto('/')
     await page.waitForLoadState('networkidle')
@@ -38,31 +34,23 @@ test.describe('visual merge editor (4.4)', () => {
   test('visual merge link routes to the editor', async ({ page }) => {
     await page.evaluate(broadcastConflict(['blog/sample/index.en.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await page
-      .locator('[data-testid="conflicts-item-visual-merge"]')
-      .click()
+    await page.locator('[data-testid="conflicts-item-visual-merge"]').click()
     await expect(page).toHaveURL(/\/conflicts\/merge\//)
     await expect(
       page.locator('[data-testid="visual-merge-view"]')
     ).toBeVisible()
   })
 
-  test('cancel returns to /conflicts without writing', async ({
-    page,
-  }) => {
+  test('cancel returns to /conflicts without writing', async ({ page }) => {
     await page.evaluate(broadcastConflict(['x.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await page
-      .locator('[data-testid="conflicts-item-visual-merge"]')
-      .click()
+    await page.locator('[data-testid="conflicts-item-visual-merge"]').click()
     await page.locator('[data-testid="visual-merge-cancel"]').click()
     await expect(page).toHaveURL(/\/conflicts$/)
     const messages = await page.evaluate<readonly { type: string }[]>(
       () => globalThis.__visualMergeMessages ?? []
     )
-    expect(
-      messages.some(m => m.type === 'resolve-file-content')
-    ).toBe(false)
+    expect(messages.some(m => m.type === 'resolve-file-content')).toBe(false)
   })
 
   test('save posts resolve-file-content + flips row to resolved', async ({
@@ -70,9 +58,7 @@ test.describe('visual merge editor (4.4)', () => {
   }) => {
     await page.evaluate(broadcastConflict(['y.md']))
     await page.locator('[data-testid="notification-toast-cta"]').click()
-    await page
-      .locator('[data-testid="conflicts-item-visual-merge"]')
-      .click()
+    await page.locator('[data-testid="conflicts-item-visual-merge"]').click()
     await page.locator('[data-testid="visual-merge-save"]').click()
     await expect(page).toHaveURL(/\/conflicts$/)
     await expect(
@@ -81,8 +67,6 @@ test.describe('visual merge editor (4.4)', () => {
     const messages = await page.evaluate<readonly { type: string }[]>(
       () => globalThis.__visualMergeMessages ?? []
     )
-    expect(
-      messages.some(m => m.type === 'resolve-file-content')
-    ).toBe(true)
+    expect(messages.some(m => m.type === 'resolve-file-content')).toBe(true)
   })
 })

--- a/src/views/VisualMergeView/parse-three-ways.test.ts
+++ b/src/views/VisualMergeView/parse-three-ways.test.ts
@@ -14,11 +14,7 @@ const sample = [
 describe('parseThreeWays', () => {
   it('returns ours / theirs / merged from a marker file', () => {
     const split = parseThreeWays(sample)
-    expect(split.ours.split('\n')).toEqual([
-      'header',
-      'mine line',
-      'footer',
-    ])
+    expect(split.ours.split('\n')).toEqual(['header', 'mine line', 'footer'])
     expect(split.theirs.split('\n')).toEqual([
       'header',
       'theirs line',


### PR DESCRIPTION
Hotfix — 2 Phase A test files drifted past biome ci expectation. Local validate passed but CI strict check failed. Reapplied formatter, validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)