### PR TITLE
feat(tracing): W3C trace-context generation + parsing (#117)

### DIFF
--- a/src/composables/useTracing/index.ts
+++ b/src/composables/useTracing/index.ts
@@ -1,0 +1,8 @@
+/** W3C trace-context generation + propagation helpers. */
+export {
+  childOf,
+  newRootTraceparent,
+  parse as parseTraceparent,
+  serialise as serialiseTraceparent,
+} from './traceparent'
+export type { Traceparent } from './traceparent-types'

--- a/src/composables/useTracing/random-hex.ts
+++ b/src/composables/useTracing/random-hex.ts
@@ -1,0 +1,13 @@
+/**
+ * Generate a lower-case hex string of the requested byte length
+ * using `crypto.getRandomValues`. Throws when crypto is missing —
+ * intentionally fail loud rather than silently emit predictable
+ * trace ids that would mask outages later.
+ * @param bytes Number of random bytes to encode.
+ * @returns Hex string of length `bytes * 2`.
+ */
+export const randomHex = (bytes: number): string => {
+  const buf = new Uint8Array(bytes)
+  globalThis.crypto.getRandomValues(buf)
+  return Array.from(buf, b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/src/composables/useTracing/traceparent-types.ts
+++ b/src/composables/useTracing/traceparent-types.ts
@@ -1,0 +1,14 @@
+/**
+ * Decomposed W3C traceparent value. The `version` is fixed at
+ * `'00'` for the foreseeable future per the W3C spec.
+ */
+export type Traceparent = {
+  readonly version: '00'
+  readonly traceId: string
+  readonly parentId: string
+  readonly sampled: boolean
+}
+
+/** Validation regex for the serialised W3C traceparent string. */
+export const TRACEPARENT_RE =
+  /^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/

--- a/src/composables/useTracing/traceparent.test.ts
+++ b/src/composables/useTracing/traceparent.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { childOf, newRootTraceparent, parse, serialise } from './traceparent'
+import { TRACEPARENT_RE } from './traceparent-types'
+
+describe('newRootTraceparent', () => {
+  it('produces a string matching the W3C wire format', () => {
+    const tp = newRootTraceparent()
+    expect(serialise(tp)).toMatch(TRACEPARENT_RE)
+  })
+
+  it('produces distinct trace-ids on consecutive calls', () => {
+    const a = newRootTraceparent()
+    const b = newRootTraceparent()
+    expect(a.traceId).not.toBe(b.traceId)
+    expect(a.parentId).not.toBe(b.parentId)
+  })
+
+  it('honours the sampled flag', () => {
+    expect(serialise(newRootTraceparent(true))).toMatch(/-01$/)
+    expect(serialise(newRootTraceparent(false))).toMatch(/-00$/)
+  })
+})
+
+describe('childOf', () => {
+  it('keeps the trace-id and replaces the parent-id', () => {
+    const root = newRootTraceparent()
+    const child = childOf(root)
+    expect(child.traceId).toBe(root.traceId)
+    expect(child.parentId).not.toBe(root.parentId)
+  })
+})
+
+describe('parse', () => {
+  it('round-trips a serialised traceparent', () => {
+    const root = newRootTraceparent()
+    const back = parse(serialise(root))
+    expect(back).toEqual(root)
+  })
+
+  it('returns undefined for malformed input', () => {
+    expect(parse('garbage')).toBeUndefined()
+    expect(parse('00-not-hex-thanks-01')).toBeUndefined()
+    expect(parse('')).toBeUndefined()
+  })
+
+  it('rejects unsupported version bytes', () => {
+    const tp = newRootTraceparent()
+    const wire = serialise(tp).replace(/^00/, 'ff')
+    expect(parse(wire)).toBeUndefined()
+  })
+})

--- a/src/composables/useTracing/traceparent.ts
+++ b/src/composables/useTracing/traceparent.ts
@@ -1,0 +1,60 @@
+import { randomHex } from './random-hex'
+import { TRACEPARENT_RE, type Traceparent } from './traceparent-types'
+
+const flagOf = (sampled: boolean): string => (sampled ? '01' : '00')
+
+/**
+ * Build a fresh root traceparent (new traceId + parentId). Sampled
+ * by default — the upstream collector applies head-based sampling
+ * later, so all locally generated traces are eligible to ship.
+ * @param sampled Whether the trace should carry the sampled flag.
+ * @returns Decomposed traceparent ready to serialise.
+ */
+export const newRootTraceparent = (sampled = true): Traceparent => ({
+  version: '00',
+  traceId: randomHex(16),
+  parentId: randomHex(8),
+  sampled,
+})
+
+/**
+ * Build a child traceparent that inherits the trace-id from the
+ * parent and gets a fresh span-id. Used when continuing a trace
+ * across boundaries (client → SW → fetch).
+ * @param parent Existing parent traceparent.
+ * @returns Child traceparent with a new parentId.
+ */
+export const childOf = (parent: Traceparent): Traceparent => ({
+  ...parent,
+  parentId: randomHex(8),
+})
+
+/**
+ * Serialise a decomposed traceparent into the W3C wire format
+ * `version-traceId-parentId-flags` so it can be set as a request
+ * header or BroadcastChannel envelope field.
+ * @param tp Decomposed traceparent.
+ * @returns Wire-format string.
+ */
+export const serialise = (tp: Traceparent): string =>
+  `${tp.version}-${tp.traceId}-${tp.parentId}-${flagOf(tp.sampled)}`
+
+/**
+ * Parse a W3C traceparent string back into the decomposed form.
+ * Returns undefined for malformed input so callers can fall back
+ * to a fresh root rather than crash.
+ * @param raw Wire-format string.
+ * @returns Decomposed traceparent, or undefined when invalid.
+ */
+export const parse = (raw: string): Traceparent | undefined => {
+  const match = TRACEPARENT_RE.test(raw)
+  const parts = match ? raw.split('-') : []
+  return parts.length === 4 && parts[0] === '00'
+    ? {
+        version: '00',
+        traceId: parts[1] ?? '',
+        parentId: parts[2] ?? '',
+        sampled: parts[3] === '01',
+      }
+    : undefined
+}


### PR DESCRIPTION
Phase B / Epic 5 increment 5.1. Pure helpers — newRootTraceparent / childOf / serialise / parse. 7/7 unit. Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)