### PR TITLE
feat(tracing): in-memory span ring buffer (#119)

### DIFF
--- a/src/composables/useTracing/index.ts
+++ b/src/composables/useTracing/index.ts
@@ -1,4 +1,13 @@
-/** W3C trace-context generation + propagation helpers. */
+/** W3C trace-context + span recording helpers. */
+export type { Span, SpanStatus } from './span-types'
+export {
+  clearSpans,
+  currentSpan,
+  finishSpan,
+  listAllSpans,
+  MAX_SPANS,
+  startSpan,
+} from './spans-store'
 export {
   childOf,
   newRootTraceparent,

--- a/src/composables/useTracing/span-builder.ts
+++ b/src/composables/useTracing/span-builder.ts
@@ -1,0 +1,27 @@
+import { randomHex } from './random-hex'
+import type { Span } from './span-types'
+import { newRootTraceparent } from './traceparent'
+
+/**
+ * Build a fresh started span. Reused by the spans-store start
+ * action — extracted so the store stays under the max-lines
+ * budget and the helper can be unit-tested in isolation.
+ * @param name Operation name (e.g. `git.push`).
+ * @param parent Enclosing span, or undefined for a new trace root.
+ * @param attributes Attribute map shipped with the span.
+ * @returns Started span with `finishedAt` undefined.
+ */
+export const buildStartedSpan = (
+  name: string,
+  parent: Span | undefined,
+  attributes: Readonly<Record<string, string>>
+): Span => ({
+  id: randomHex(8),
+  traceId: parent?.traceId ?? newRootTraceparent().traceId,
+  parentId: parent?.id,
+  name,
+  startedAt: Date.now(),
+  finishedAt: undefined,
+  attributes,
+  status: 'unset',
+})

--- a/src/composables/useTracing/span-types.ts
+++ b/src/composables/useTracing/span-types.ts
@@ -1,0 +1,19 @@
+/** Outcome status carried on a finished span. */
+export type SpanStatus = 'ok' | 'error' | 'unset'
+
+/**
+ * Single recorded span. Trace-id is shared across all spans in a
+ * trace; parentId points at the enclosing span (undefined for the
+ * root span). Attributes are an arbitrary string→string map so
+ * the exporter (Epic 7) can ship them as OTLP attributes.
+ */
+export type Span = {
+  readonly id: string
+  readonly traceId: string
+  readonly parentId: string | undefined
+  readonly name: string
+  readonly startedAt: number
+  readonly finishedAt: number | undefined
+  readonly attributes: Readonly<Record<string, string>>
+  readonly status: SpanStatus
+}

--- a/src/composables/useTracing/spans-store.test.ts
+++ b/src/composables/useTracing/spans-store.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearSpans,
+  currentSpan,
+  finishSpan,
+  listAllSpans,
+  MAX_SPANS,
+  startSpan,
+} from './spans-store'
+
+describe('spans store', () => {
+  beforeEach(clearSpans)
+  afterEach(clearSpans)
+
+  it('start + finish round-trips with monotonic timestamps', () => {
+    const s = startSpan('op')
+    const finished = finishSpan(s.id)
+    expect(finished?.id).toBe(s.id)
+    expect(finished?.finishedAt).toBeGreaterThanOrEqual(s.startedAt)
+    expect(finished?.status).toBe('ok')
+  })
+
+  it('listAll returns oldest-first', () => {
+    const a = startSpan('a')
+    finishSpan(a.id)
+    const b = startSpan('b')
+    finishSpan(b.id)
+    expect(listAllSpans().map(s => s.name)).toEqual(['a', 'b'])
+  })
+
+  it('nested spans pick the correct parent via the active stack', () => {
+    const root = startSpan('root')
+    const child = startSpan('child', currentSpan())
+    expect(child.traceId).toBe(root.traceId)
+    expect(child.parentId).toBe(root.id)
+    finishSpan(child.id)
+    finishSpan(root.id)
+  })
+
+  it('eviction caps completed spans at MAX_SPANS', () => {
+    const total = MAX_SPANS + 100
+    for (let i = 0; i < total; i += 1) {
+      const s = startSpan(`op-${i}`)
+      finishSpan(s.id)
+    }
+    expect(listAllSpans()).toHaveLength(MAX_SPANS)
+    expect(listAllSpans()[0]?.name).toBe(`op-${total - MAX_SPANS}`)
+  })
+
+  it('finish status carries through', () => {
+    const s = startSpan('x')
+    finishSpan(s.id, 'error')
+    expect(listAllSpans()[0]?.status).toBe('error')
+  })
+
+  it('currentSpan returns undefined when nothing is active', () => {
+    expect(currentSpan()).toBeUndefined()
+    const s = startSpan('a')
+    expect(currentSpan()?.id).toBe(s.id)
+    finishSpan(s.id)
+    expect(currentSpan()).toBeUndefined()
+  })
+
+  it('finishSpan with an unknown id returns undefined', () => {
+    expect(finishSpan('does-not-exist')).toBeUndefined()
+    expect(listAllSpans()).toEqual([])
+  })
+
+  it('attributes propagate to the finished span', () => {
+    const s = startSpan('a', undefined, { foo: 'bar' })
+    finishSpan(s.id)
+    expect(listAllSpans()[0]?.attributes).toEqual({ foo: 'bar' })
+  })
+})

--- a/src/composables/useTracing/spans-store.ts
+++ b/src/composables/useTracing/spans-store.ts
@@ -1,0 +1,72 @@
+import { buildStartedSpan } from './span-builder'
+import type { Span, SpanStatus } from './span-types'
+
+/** Maximum spans retained in the in-memory ring. */
+export const MAX_SPANS = 500
+
+let active: Span[] = []
+let completed: Span[] = []
+
+const evictOldest = (): void => {
+  completed = completed.slice(Math.max(0, completed.length - MAX_SPANS))
+}
+
+/**
+ * Start a new span. Pushes onto the active stack so `currentSpan`
+ * returns it; root spans get a fresh trace-id, child spans inherit.
+ * @param name Operation name (e.g. `git.push`).
+ * @param parent Enclosing span, or undefined for a new trace root.
+ * @param attributes Attribute map shipped with the span.
+ * @returns The freshly started span.
+ */
+export const startSpan = (
+  name: string,
+  parent?: Span,
+  attributes: Readonly<Record<string, string>> = {}
+): Span => {
+  const span = buildStartedSpan(name, parent, attributes)
+  active = [...active, span]
+  return span
+}
+
+/**
+ * Finish a previously-started span. Removes it from the active
+ * stack and appends to the completed ring (FIFO eviction).
+ * @param id Span id returned by `startSpan`.
+ * @param status Final status, defaults to `ok`.
+ * @returns Finished span, or undefined when the id is unknown.
+ */
+export const finishSpan = (
+  id: string,
+  status: SpanStatus = 'ok'
+): Span | undefined => {
+  const found = active.find(s => s.id === id)
+  active = active.filter(s => s.id !== id)
+  const finished =
+    found === undefined
+      ? undefined
+      : { ...found, finishedAt: Date.now(), status }
+  completed = finished === undefined ? completed : [...completed, finished]
+  evictOldest()
+  return finished
+}
+
+/**
+ * Top of the active stack — most recent span that has not yet
+ * finished. Returns undefined when no span is active.
+ * @returns Active span at the top of the stack.
+ */
+export const currentSpan = (): Span | undefined => active[active.length - 1]
+
+/**
+ * Snapshot of completed spans, oldest-first. Used by the dev
+ * overlay (5.4) and the future exporter (Epic 7).
+ * @returns Frozen array of finished spans.
+ */
+export const listAllSpans = (): readonly Span[] => [...completed]
+
+/** Clear every recorded span. Used by tests and the dev overlay. */
+export const clearSpans = (): void => {
+  active = []
+  completed = []
+}


### PR DESCRIPTION
Phase B / Epic 5 increment 5.3. Span type + 500-entry FIFO ring. 8/8 unit. Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)