### PR TITLE
feat(tracing): dev-only trace overlay (Ctrl+Shift+T) (#120)

### DIFF
--- a/e2e/tracing/overlay.spec.ts
+++ b/e2e/tracing/overlay.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('trace overlay (5.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible', timeout: 15_000 })
+  })
+
+  test('Ctrl+Shift+T toggles the overlay', async ({ page }) => {
+    const overlay = page.locator('[data-testid="trace-overlay"]')
+    await expect(overlay).toBeHidden()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeVisible()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeHidden()
+  })
+
+  test('close button hides the overlay', async ({ page }) => {
+    await page.keyboard.press('Control+Shift+T')
+    const overlay = page.locator('[data-testid="trace-overlay"]')
+    await expect(overlay).toBeVisible()
+    await page.locator('[data-testid="trace-overlay-close"]').click()
+    await expect(overlay).toBeHidden()
+  })
+
+  test('shows empty state when no spans recorded', async ({ page }) => {
+    await page.keyboard.press('Control+Shift+T')
+    await expect(
+      page.locator('[data-testid="trace-overlay-empty"]')
+    ).toBeVisible()
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,5 +46,6 @@ watch(
   <NotificationToastStack />
   <NotificationDrawer />
   <NotificationDevTrigger />
+  <TraceOverlay />
   <SWDebugPanel />
 </template>

--- a/src/components/TraceOverlay/OverlayHeader.vue
+++ b/src/components/TraceOverlay/OverlayHeader.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+defineEmits<{ readonly close: [] }>()
+</script>
+
+<template>
+  <header class="head">
+    <strong>Traces</strong>
+    <button
+      type="button"
+      :data-testid="TRACE_OVERLAY_TEST_IDS.close"
+      aria-label="Close trace overlay"
+      @click="$emit('close')"
+    >
+      ×
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #1a2230;
+}
+
+.head button {
+  background: transparent;
+  border: 0;
+  color: #ddd;
+  font-size: 16px;
+  cursor: pointer;
+}
+</style>

--- a/src/components/TraceOverlay/SpanBar.vue
+++ b/src/components/TraceOverlay/SpanBar.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { Span } from '@/composables/useTracing'
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+defineProps<{
+  readonly span: Span
+  readonly offset: string
+  readonly width: string
+}>()
+</script>
+
+<template>
+  <li
+    class="row"
+    :data-testid="TRACE_OVERLAY_TEST_IDS.spanRow"
+    :data-status="span.status"
+  >
+    <span class="name">{{ span.name }}</span>
+    <span class="bar" :style="{ marginLeft: offset, width }" />
+  </li>
+</template>
+
+<style scoped>
+.row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  align-items: center;
+  font-size: 11px;
+  font-family: monospace;
+}
+
+.name {
+  color: #ddd;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bar {
+  height: 12px;
+  background: #4fc3f7;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.row[data-status='error'] .bar {
+  background: #e57373;
+}
+</style>

--- a/src/components/TraceOverlay/TraceList.vue
+++ b/src/components/TraceOverlay/TraceList.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import type { TraceGroup } from './group-by-trace'
+import TraceRow from './TraceRow.vue'
+
+defineProps<{
+  readonly groups: ReadonlyArray<TraceGroup>
+  readonly activeId: string | undefined
+}>()
+defineEmits<{
+  readonly select: [traceId: string]
+}>()
+</script>
+
+<template>
+  <ul class="list">
+    <TraceRow
+      v-for="group in groups"
+      :key="group.traceId"
+      :group="group"
+      :active="group.traceId === activeId"
+      @select="$emit('select', $event)"
+    />
+  </ul>
+</template>
+
+<style scoped>
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+</style>

--- a/src/components/TraceOverlay/TraceOverlay.vue
+++ b/src/components/TraceOverlay/TraceOverlay.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { listAllSpans } from '@/composables/useTracing'
+import { groupByTrace } from './group-by-trace'
+import OverlayHeader from './OverlayHeader.vue'
+import TraceList from './TraceList.vue'
+import TraceWaterfall from './TraceWaterfall.vue'
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+const visible = ref(false)
+const tick = ref(0)
+const activeTraceId = ref<string | undefined>(undefined)
+
+const groups = computed(() => {
+  void tick.value
+  return groupByTrace(listAllSpans())
+})
+const activeSpans = computed(
+  () =>
+    groups.value.find(g => g.traceId === activeTraceId.value)?.spans ??
+    groups.value[0]?.spans ??
+    []
+)
+
+const onKey = (e: KeyboardEvent): void => {
+  const match = e.ctrlKey && e.shiftKey && e.key === 'T'
+  const fire = match
+    ? () => {
+        e.preventDefault()
+        visible.value = !visible.value
+        tick.value += 1
+      }
+    : (): void => undefined
+  fire()
+}
+
+const onSelect = (id: string): void => {
+  activeTraceId.value = id
+}
+const close = (): void => {
+  visible.value = false
+}
+
+onMounted(() => {
+  globalThis.addEventListener('keydown', onKey)
+})
+onUnmounted(() => {
+  globalThis.removeEventListener('keydown', onKey)
+})
+</script>
+
+<template>
+  <aside
+    v-if="visible"
+    class="overlay"
+    :data-testid="TRACE_OVERLAY_TEST_IDS.root"
+    role="dialog"
+    aria-modal="false"
+    aria-label="Local trace overlay"
+  >
+    <OverlayHeader @close="close" />
+    <p
+      v-if="groups.length === 0"
+      class="empty"
+      :data-testid="TRACE_OVERLAY_TEST_IDS.empty"
+    >
+      No traces recorded yet.
+    </p>
+    <TraceList
+      v-else
+      :groups="groups"
+      :active-id="activeTraceId"
+      @select="onSelect"
+    />
+    <TraceWaterfall v-if="groups.length > 0" :spans="activeSpans" />
+  </aside>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  width: min(520px, 100vw);
+  height: 320px;
+  z-index: 9997;
+  background: #0d1520;
+  color: #ddd;
+  border-top: 2px solid #4fc3f7;
+  border-left: 2px solid #4fc3f7;
+  border-top-left-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.empty {
+  color: #888;
+  font-size: 12px;
+  padding: 12px;
+  text-align: center;
+}
+</style>

--- a/src/components/TraceOverlay/TraceRow.vue
+++ b/src/components/TraceOverlay/TraceRow.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { TraceGroup } from './group-by-trace'
+import TraceRowButton from './TraceRowButton.vue'
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+defineProps<{
+  readonly group: TraceGroup
+  readonly active: boolean
+}>()
+defineEmits<{ readonly select: [traceId: string] }>()
+</script>
+
+<template>
+  <li
+    class="row"
+    :data-testid="TRACE_OVERLAY_TEST_IDS.traceRow"
+    :data-active="String(active)"
+  >
+    <TraceRowButton
+      :group="group"
+      @select="$emit('select', $event)"
+    />
+  </li>
+</template>
+
+<style scoped>
+.row[data-active='true'] :deep(.trace-btn) {
+  background: #1c2a3a;
+}
+</style>

--- a/src/components/TraceOverlay/TraceRowButton.vue
+++ b/src/components/TraceOverlay/TraceRowButton.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { TraceGroup } from './group-by-trace'
+
+defineProps<{
+  readonly group: TraceGroup
+}>()
+defineEmits<{ readonly select: [traceId: string] }>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="trace-btn"
+    @click="$emit('select', group.traceId)"
+  >
+    <code class="id">{{ group.traceId.slice(0, 8) }}</code>
+    <span class="count">{{ group.spans.length }}</span>
+  </button>
+</template>
+
+<style scoped>
+.trace-btn {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  background: transparent;
+  border: 0;
+  color: #ddd;
+  font-family: monospace;
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.trace-btn:hover {
+  background: #1a2230;
+}
+
+.id {
+  color: #4fc3f7;
+}
+
+.count {
+  color: #888;
+  font-size: 11px;
+}
+</style>

--- a/src/components/TraceOverlay/TraceWaterfall.vue
+++ b/src/components/TraceOverlay/TraceWaterfall.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Span } from '@/composables/useTracing'
+import SpanBar from './SpanBar.vue'
+
+const props = defineProps<{
+  readonly spans: ReadonlyArray<Span>
+}>()
+
+const range = computed(() => {
+  const starts = props.spans.map(s => s.startedAt)
+  const ends = props.spans.map(s => s.finishedAt ?? s.startedAt)
+  const min = Math.min(...starts, 0)
+  const max = Math.max(...ends, min + 1)
+  return { min, span: max - min }
+})
+
+const widthOf = (s: Span): string => {
+  const dur = (s.finishedAt ?? s.startedAt) - s.startedAt
+  const pct = (dur / Math.max(range.value.span, 1)) * 100
+  return `${Math.max(2, pct)}%`
+}
+
+const offsetOf = (s: Span): string => {
+  const off = s.startedAt - range.value.min
+  const pct = (off / Math.max(range.value.span, 1)) * 100
+  return `${pct}%`
+}
+</script>
+
+<template>
+  <ol class="waterfall">
+    <SpanBar
+      v-for="s in spans"
+      :key="s.id"
+      :span="s"
+      :offset="offsetOf(s)"
+      :width="widthOf(s)"
+    />
+  </ol>
+</template>
+
+<style scoped>
+.waterfall {
+  list-style: none;
+  margin: 0;
+  padding: 6px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+</style>

--- a/src/components/TraceOverlay/group-by-trace.test.ts
+++ b/src/components/TraceOverlay/group-by-trace.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { Span } from '@/composables/useTracing'
+import { groupByTrace } from './group-by-trace'
+
+const span = (traceId: string, id: string, startedAt: number): Span => ({
+  id,
+  traceId,
+  parentId: undefined,
+  name: id,
+  startedAt,
+  finishedAt: startedAt + 1,
+  attributes: {},
+  status: 'ok',
+})
+
+describe('groupByTrace', () => {
+  it('returns each trace as its own group', () => {
+    const groups = groupByTrace([span('t1', 'a', 100), span('t2', 'b', 200)])
+    expect(groups.map(g => g.traceId)).toEqual(['t2', 't1'])
+  })
+
+  it('sorts spans within a trace oldest-first', () => {
+    const groups = groupByTrace([
+      span('t1', 'late', 200),
+      span('t1', 'early', 100),
+    ])
+    expect(groups[0]?.spans.map(s => s.id)).toEqual(['early', 'late'])
+  })
+
+  it('sorts traces newest-first by their first span', () => {
+    const groups = groupByTrace([span('old', 'a', 50), span('new', 'b', 500)])
+    expect(groups.map(g => g.traceId)).toEqual(['new', 'old'])
+  })
+
+  it('returns an empty list for empty input', () => {
+    expect(groupByTrace([])).toEqual([])
+  })
+})

--- a/src/components/TraceOverlay/group-by-trace.ts
+++ b/src/components/TraceOverlay/group-by-trace.ts
@@ -1,0 +1,32 @@
+import type { Span } from '@/composables/useTracing'
+
+/** A trace plus the spans recorded under it. */
+export type TraceGroup = {
+  readonly traceId: string
+  readonly spans: ReadonlyArray<Span>
+  readonly startedAt: number
+}
+
+/**
+ * Group recorded spans by trace-id and sort each group oldest-
+ * first internally. The outer list is sorted newest-trace-first
+ * so the most recent activity surfaces at the top of the overlay.
+ * @param spans Recorded spans (any order).
+ * @returns Frozen array of trace groups.
+ */
+export const groupByTrace = (
+  spans: ReadonlyArray<Span>
+): ReadonlyArray<TraceGroup> => {
+  const map = new Map<string, Span[]>()
+  for (const span of spans) {
+    const list = map.get(span.traceId) ?? []
+    list.push(span)
+    map.set(span.traceId, list)
+  }
+  const groups = [...map.entries()].map(([traceId, spans]) => ({
+    traceId,
+    spans: spans.slice().sort((a, b) => a.startedAt - b.startedAt),
+    startedAt: spans[0]?.startedAt ?? 0,
+  }))
+  return groups.sort((a, b) => b.startedAt - a.startedAt)
+}

--- a/src/components/TraceOverlay/test-ids.ts
+++ b/src/components/TraceOverlay/test-ids.ts
@@ -1,0 +1,8 @@
+/** Test IDs used by the dev trace overlay. */
+export const TRACE_OVERLAY_TEST_IDS = {
+  root: 'trace-overlay',
+  traceRow: 'trace-overlay-trace',
+  spanRow: 'trace-overlay-span',
+  empty: 'trace-overlay-empty',
+  close: 'trace-overlay-close',
+} as const


### PR DESCRIPTION
Phase B / Epic 5 increment 5.4 — closes Epic 5. <TraceOverlay> + waterfall renderer, groupByTrace helper. 3/3 e2e + 4/4 unit. Closes #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)