### PR TITLE
release: client tracing Epic 5 (5.1+5.3+5.4)

### DIFF
--- a/e2e/tracing/overlay.spec.ts
+++ b/e2e/tracing/overlay.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('trace overlay (5.4)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page
+      .locator('[data-testid="notification-indicator"]')
+      .waitFor({ state: 'visible', timeout: 15_000 })
+  })
+
+  test('Ctrl+Shift+T toggles the overlay', async ({ page }) => {
+    const overlay = page.locator('[data-testid="trace-overlay"]')
+    await expect(overlay).toBeHidden()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeVisible()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeHidden()
+  })
+
+  test('close button hides the overlay', async ({ page }) => {
+    await page.keyboard.press('Control+Shift+T')
+    const overlay = page.locator('[data-testid="trace-overlay"]')
+    await expect(overlay).toBeVisible()
+    await page.locator('[data-testid="trace-overlay-close"]').click()
+    await expect(overlay).toBeHidden()
+  })
+
+  test('shows empty state when no spans recorded', async ({ page }) => {
+    await page.keyboard.press('Control+Shift+T')
+    await expect(
+      page.locator('[data-testid="trace-overlay-empty"]')
+    ).toBeVisible()
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,5 +46,6 @@ watch(
   <NotificationToastStack />
   <NotificationDrawer />
   <NotificationDevTrigger />
+  <TraceOverlay />
   <SWDebugPanel />
 </template>

--- a/src/components/TraceOverlay/OverlayHeader.vue
+++ b/src/components/TraceOverlay/OverlayHeader.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+defineEmits<{ readonly close: [] }>()
+</script>
+
+<template>
+  <header class="head">
+    <strong>Traces</strong>
+    <button
+      type="button"
+      :data-testid="TRACE_OVERLAY_TEST_IDS.close"
+      aria-label="Close trace overlay"
+      @click="$emit('close')"
+    >
+      ×
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #1a2230;
+}
+
+.head button {
+  background: transparent;
+  border: 0;
+  color: #ddd;
+  font-size: 16px;
+  cursor: pointer;
+}
+</style>

--- a/src/components/TraceOverlay/SpanBar.vue
+++ b/src/components/TraceOverlay/SpanBar.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { Span } from '@/composables/useTracing'
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+defineProps<{
+  readonly span: Span
+  readonly offset: string
+  readonly width: string
+}>()
+</script>
+
+<template>
+  <li
+    class="row"
+    :data-testid="TRACE_OVERLAY_TEST_IDS.spanRow"
+    :data-status="span.status"
+  >
+    <span class="name">{{ span.name }}</span>
+    <span class="bar" :style="{ marginLeft: offset, width }" />
+  </li>
+</template>
+
+<style scoped>
+.row {
+  display: grid;
+  grid-template-columns: 160px 1fr;
+  align-items: center;
+  font-size: 11px;
+  font-family: monospace;
+}
+
+.name {
+  color: #ddd;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bar {
+  height: 12px;
+  background: #4fc3f7;
+  border-radius: 2px;
+  display: inline-block;
+}
+
+.row[data-status='error'] .bar {
+  background: #e57373;
+}
+</style>

--- a/src/components/TraceOverlay/TraceList.vue
+++ b/src/components/TraceOverlay/TraceList.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import type { TraceGroup } from './group-by-trace'
+import TraceRow from './TraceRow.vue'
+
+defineProps<{
+  readonly groups: ReadonlyArray<TraceGroup>
+  readonly activeId: string | undefined
+}>()
+defineEmits<{
+  readonly select: [traceId: string]
+}>()
+</script>
+
+<template>
+  <ul class="list">
+    <TraceRow
+      v-for="group in groups"
+      :key="group.traceId"
+      :group="group"
+      :active="group.traceId === activeId"
+      @select="$emit('select', $event)"
+    />
+  </ul>
+</template>
+
+<style scoped>
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+</style>

--- a/src/components/TraceOverlay/TraceOverlay.vue
+++ b/src/components/TraceOverlay/TraceOverlay.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { listAllSpans } from '@/composables/useTracing'
+import { groupByTrace } from './group-by-trace'
+import OverlayHeader from './OverlayHeader.vue'
+import TraceList from './TraceList.vue'
+import TraceWaterfall from './TraceWaterfall.vue'
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+const visible = ref(false)
+const tick = ref(0)
+const activeTraceId = ref<string | undefined>(undefined)
+
+const groups = computed(() => {
+  void tick.value
+  return groupByTrace(listAllSpans())
+})
+const activeSpans = computed(
+  () =>
+    groups.value.find(g => g.traceId === activeTraceId.value)?.spans ??
+    groups.value[0]?.spans ??
+    []
+)
+
+const onKey = (e: KeyboardEvent): void => {
+  const match = e.ctrlKey && e.shiftKey && e.key === 'T'
+  const fire = match
+    ? () => {
+        e.preventDefault()
+        visible.value = !visible.value
+        tick.value += 1
+      }
+    : (): void => undefined
+  fire()
+}
+
+const onSelect = (id: string): void => {
+  activeTraceId.value = id
+}
+const close = (): void => {
+  visible.value = false
+}
+
+onMounted(() => {
+  globalThis.addEventListener('keydown', onKey)
+})
+onUnmounted(() => {
+  globalThis.removeEventListener('keydown', onKey)
+})
+</script>
+
+<template>
+  <aside
+    v-if="visible"
+    class="overlay"
+    :data-testid="TRACE_OVERLAY_TEST_IDS.root"
+    role="dialog"
+    aria-modal="false"
+    aria-label="Local trace overlay"
+  >
+    <OverlayHeader @close="close" />
+    <p
+      v-if="groups.length === 0"
+      class="empty"
+      :data-testid="TRACE_OVERLAY_TEST_IDS.empty"
+    >
+      No traces recorded yet.
+    </p>
+    <TraceList
+      v-else
+      :groups="groups"
+      :active-id="activeTraceId"
+      @select="onSelect"
+    />
+    <TraceWaterfall v-if="groups.length > 0" :spans="activeSpans" />
+  </aside>
+</template>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  width: min(520px, 100vw);
+  height: 320px;
+  z-index: 9997;
+  background: #0d1520;
+  color: #ddd;
+  border-top: 2px solid #4fc3f7;
+  border-left: 2px solid #4fc3f7;
+  border-top-left-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.empty {
+  color: #888;
+  font-size: 12px;
+  padding: 12px;
+  text-align: center;
+}
+</style>

--- a/src/components/TraceOverlay/TraceRow.vue
+++ b/src/components/TraceOverlay/TraceRow.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { TraceGroup } from './group-by-trace'
+import TraceRowButton from './TraceRowButton.vue'
+import { TRACE_OVERLAY_TEST_IDS } from './test-ids'
+
+defineProps<{
+  readonly group: TraceGroup
+  readonly active: boolean
+}>()
+defineEmits<{ readonly select: [traceId: string] }>()
+</script>
+
+<template>
+  <li
+    class="row"
+    :data-testid="TRACE_OVERLAY_TEST_IDS.traceRow"
+    :data-active="String(active)"
+  >
+    <TraceRowButton
+      :group="group"
+      @select="$emit('select', $event)"
+    />
+  </li>
+</template>
+
+<style scoped>
+.row[data-active='true'] :deep(.trace-btn) {
+  background: #1c2a3a;
+}
+</style>

--- a/src/components/TraceOverlay/TraceRowButton.vue
+++ b/src/components/TraceOverlay/TraceRowButton.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { TraceGroup } from './group-by-trace'
+
+defineProps<{
+  readonly group: TraceGroup
+}>()
+defineEmits<{ readonly select: [traceId: string] }>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="trace-btn"
+    @click="$emit('select', group.traceId)"
+  >
+    <code class="id">{{ group.traceId.slice(0, 8) }}</code>
+    <span class="count">{{ group.spans.length }}</span>
+  </button>
+</template>
+
+<style scoped>
+.trace-btn {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  background: transparent;
+  border: 0;
+  color: #ddd;
+  font-family: monospace;
+  font-size: 12px;
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.trace-btn:hover {
+  background: #1a2230;
+}
+
+.id {
+  color: #4fc3f7;
+}
+
+.count {
+  color: #888;
+  font-size: 11px;
+}
+</style>

--- a/src/components/TraceOverlay/TraceWaterfall.vue
+++ b/src/components/TraceOverlay/TraceWaterfall.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Span } from '@/composables/useTracing'
+import SpanBar from './SpanBar.vue'
+
+const props = defineProps<{
+  readonly spans: ReadonlyArray<Span>
+}>()
+
+const range = computed(() => {
+  const starts = props.spans.map(s => s.startedAt)
+  const ends = props.spans.map(s => s.finishedAt ?? s.startedAt)
+  const min = Math.min(...starts, 0)
+  const max = Math.max(...ends, min + 1)
+  return { min, span: max - min }
+})
+
+const widthOf = (s: Span): string => {
+  const dur = (s.finishedAt ?? s.startedAt) - s.startedAt
+  const pct = (dur / Math.max(range.value.span, 1)) * 100
+  return `${Math.max(2, pct)}%`
+}
+
+const offsetOf = (s: Span): string => {
+  const off = s.startedAt - range.value.min
+  const pct = (off / Math.max(range.value.span, 1)) * 100
+  return `${pct}%`
+}
+</script>
+
+<template>
+  <ol class="waterfall">
+    <SpanBar
+      v-for="s in spans"
+      :key="s.id"
+      :span="s"
+      :offset="offsetOf(s)"
+      :width="widthOf(s)"
+    />
+  </ol>
+</template>
+
+<style scoped>
+.waterfall {
+  list-style: none;
+  margin: 0;
+  padding: 6px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+</style>

--- a/src/components/TraceOverlay/group-by-trace.test.ts
+++ b/src/components/TraceOverlay/group-by-trace.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { Span } from '@/composables/useTracing'
+import { groupByTrace } from './group-by-trace'
+
+const span = (traceId: string, id: string, startedAt: number): Span => ({
+  id,
+  traceId,
+  parentId: undefined,
+  name: id,
+  startedAt,
+  finishedAt: startedAt + 1,
+  attributes: {},
+  status: 'ok',
+})
+
+describe('groupByTrace', () => {
+  it('returns each trace as its own group', () => {
+    const groups = groupByTrace([span('t1', 'a', 100), span('t2', 'b', 200)])
+    expect(groups.map(g => g.traceId)).toEqual(['t2', 't1'])
+  })
+
+  it('sorts spans within a trace oldest-first', () => {
+    const groups = groupByTrace([
+      span('t1', 'late', 200),
+      span('t1', 'early', 100),
+    ])
+    expect(groups[0]?.spans.map(s => s.id)).toEqual(['early', 'late'])
+  })
+
+  it('sorts traces newest-first by their first span', () => {
+    const groups = groupByTrace([span('old', 'a', 50), span('new', 'b', 500)])
+    expect(groups.map(g => g.traceId)).toEqual(['new', 'old'])
+  })
+
+  it('returns an empty list for empty input', () => {
+    expect(groupByTrace([])).toEqual([])
+  })
+})

--- a/src/components/TraceOverlay/group-by-trace.ts
+++ b/src/components/TraceOverlay/group-by-trace.ts
@@ -1,0 +1,32 @@
+import type { Span } from '@/composables/useTracing'
+
+/** A trace plus the spans recorded under it. */
+export type TraceGroup = {
+  readonly traceId: string
+  readonly spans: ReadonlyArray<Span>
+  readonly startedAt: number
+}
+
+/**
+ * Group recorded spans by trace-id and sort each group oldest-
+ * first internally. The outer list is sorted newest-trace-first
+ * so the most recent activity surfaces at the top of the overlay.
+ * @param spans Recorded spans (any order).
+ * @returns Frozen array of trace groups.
+ */
+export const groupByTrace = (
+  spans: ReadonlyArray<Span>
+): ReadonlyArray<TraceGroup> => {
+  const map = new Map<string, Span[]>()
+  for (const span of spans) {
+    const list = map.get(span.traceId) ?? []
+    list.push(span)
+    map.set(span.traceId, list)
+  }
+  const groups = [...map.entries()].map(([traceId, spans]) => ({
+    traceId,
+    spans: spans.slice().sort((a, b) => a.startedAt - b.startedAt),
+    startedAt: spans[0]?.startedAt ?? 0,
+  }))
+  return groups.sort((a, b) => b.startedAt - a.startedAt)
+}

--- a/src/components/TraceOverlay/test-ids.ts
+++ b/src/components/TraceOverlay/test-ids.ts
@@ -1,0 +1,8 @@
+/** Test IDs used by the dev trace overlay. */
+export const TRACE_OVERLAY_TEST_IDS = {
+  root: 'trace-overlay',
+  traceRow: 'trace-overlay-trace',
+  spanRow: 'trace-overlay-span',
+  empty: 'trace-overlay-empty',
+  close: 'trace-overlay-close',
+} as const

--- a/src/composables/useTracing/index.ts
+++ b/src/composables/useTracing/index.ts
@@ -1,0 +1,8 @@
+/** W3C trace-context generation + propagation helpers. */
+export {
+  childOf,
+  newRootTraceparent,
+  parse as parseTraceparent,
+  serialise as serialiseTraceparent,
+} from './traceparent'
+export type { Traceparent } from './traceparent-types'

--- a/src/composables/useTracing/index.ts
+++ b/src/composables/useTracing/index.ts
@@ -1,4 +1,13 @@
-/** W3C trace-context generation + propagation helpers. */
+/** W3C trace-context + span recording helpers. */
+export type { Span, SpanStatus } from './span-types'
+export {
+  clearSpans,
+  currentSpan,
+  finishSpan,
+  listAllSpans,
+  MAX_SPANS,
+  startSpan,
+} from './spans-store'
 export {
   childOf,
   newRootTraceparent,

--- a/src/composables/useTracing/random-hex.ts
+++ b/src/composables/useTracing/random-hex.ts
@@ -1,0 +1,13 @@
+/**
+ * Generate a lower-case hex string of the requested byte length
+ * using `crypto.getRandomValues`. Throws when crypto is missing —
+ * intentionally fail loud rather than silently emit predictable
+ * trace ids that would mask outages later.
+ * @param bytes Number of random bytes to encode.
+ * @returns Hex string of length `bytes * 2`.
+ */
+export const randomHex = (bytes: number): string => {
+  const buf = new Uint8Array(bytes)
+  globalThis.crypto.getRandomValues(buf)
+  return Array.from(buf, b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/src/composables/useTracing/span-builder.ts
+++ b/src/composables/useTracing/span-builder.ts
@@ -1,0 +1,27 @@
+import { randomHex } from './random-hex'
+import type { Span } from './span-types'
+import { newRootTraceparent } from './traceparent'
+
+/**
+ * Build a fresh started span. Reused by the spans-store start
+ * action — extracted so the store stays under the max-lines
+ * budget and the helper can be unit-tested in isolation.
+ * @param name Operation name (e.g. `git.push`).
+ * @param parent Enclosing span, or undefined for a new trace root.
+ * @param attributes Attribute map shipped with the span.
+ * @returns Started span with `finishedAt` undefined.
+ */
+export const buildStartedSpan = (
+  name: string,
+  parent: Span | undefined,
+  attributes: Readonly<Record<string, string>>
+): Span => ({
+  id: randomHex(8),
+  traceId: parent?.traceId ?? newRootTraceparent().traceId,
+  parentId: parent?.id,
+  name,
+  startedAt: Date.now(),
+  finishedAt: undefined,
+  attributes,
+  status: 'unset',
+})

--- a/src/composables/useTracing/span-types.ts
+++ b/src/composables/useTracing/span-types.ts
@@ -1,0 +1,19 @@
+/** Outcome status carried on a finished span. */
+export type SpanStatus = 'ok' | 'error' | 'unset'
+
+/**
+ * Single recorded span. Trace-id is shared across all spans in a
+ * trace; parentId points at the enclosing span (undefined for the
+ * root span). Attributes are an arbitrary string→string map so
+ * the exporter (Epic 7) can ship them as OTLP attributes.
+ */
+export type Span = {
+  readonly id: string
+  readonly traceId: string
+  readonly parentId: string | undefined
+  readonly name: string
+  readonly startedAt: number
+  readonly finishedAt: number | undefined
+  readonly attributes: Readonly<Record<string, string>>
+  readonly status: SpanStatus
+}

--- a/src/composables/useTracing/spans-store.test.ts
+++ b/src/composables/useTracing/spans-store.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearSpans,
+  currentSpan,
+  finishSpan,
+  listAllSpans,
+  MAX_SPANS,
+  startSpan,
+} from './spans-store'
+
+describe('spans store', () => {
+  beforeEach(clearSpans)
+  afterEach(clearSpans)
+
+  it('start + finish round-trips with monotonic timestamps', () => {
+    const s = startSpan('op')
+    const finished = finishSpan(s.id)
+    expect(finished?.id).toBe(s.id)
+    expect(finished?.finishedAt).toBeGreaterThanOrEqual(s.startedAt)
+    expect(finished?.status).toBe('ok')
+  })
+
+  it('listAll returns oldest-first', () => {
+    const a = startSpan('a')
+    finishSpan(a.id)
+    const b = startSpan('b')
+    finishSpan(b.id)
+    expect(listAllSpans().map(s => s.name)).toEqual(['a', 'b'])
+  })
+
+  it('nested spans pick the correct parent via the active stack', () => {
+    const root = startSpan('root')
+    const child = startSpan('child', currentSpan())
+    expect(child.traceId).toBe(root.traceId)
+    expect(child.parentId).toBe(root.id)
+    finishSpan(child.id)
+    finishSpan(root.id)
+  })
+
+  it('eviction caps completed spans at MAX_SPANS', () => {
+    const total = MAX_SPANS + 100
+    for (let i = 0; i < total; i += 1) {
+      const s = startSpan(`op-${i}`)
+      finishSpan(s.id)
+    }
+    expect(listAllSpans()).toHaveLength(MAX_SPANS)
+    expect(listAllSpans()[0]?.name).toBe(`op-${total - MAX_SPANS}`)
+  })
+
+  it('finish status carries through', () => {
+    const s = startSpan('x')
+    finishSpan(s.id, 'error')
+    expect(listAllSpans()[0]?.status).toBe('error')
+  })
+
+  it('currentSpan returns undefined when nothing is active', () => {
+    expect(currentSpan()).toBeUndefined()
+    const s = startSpan('a')
+    expect(currentSpan()?.id).toBe(s.id)
+    finishSpan(s.id)
+    expect(currentSpan()).toBeUndefined()
+  })
+
+  it('finishSpan with an unknown id returns undefined', () => {
+    expect(finishSpan('does-not-exist')).toBeUndefined()
+    expect(listAllSpans()).toEqual([])
+  })
+
+  it('attributes propagate to the finished span', () => {
+    const s = startSpan('a', undefined, { foo: 'bar' })
+    finishSpan(s.id)
+    expect(listAllSpans()[0]?.attributes).toEqual({ foo: 'bar' })
+  })
+})

--- a/src/composables/useTracing/spans-store.ts
+++ b/src/composables/useTracing/spans-store.ts
@@ -1,0 +1,72 @@
+import { buildStartedSpan } from './span-builder'
+import type { Span, SpanStatus } from './span-types'
+
+/** Maximum spans retained in the in-memory ring. */
+export const MAX_SPANS = 500
+
+let active: Span[] = []
+let completed: Span[] = []
+
+const evictOldest = (): void => {
+  completed = completed.slice(Math.max(0, completed.length - MAX_SPANS))
+}
+
+/**
+ * Start a new span. Pushes onto the active stack so `currentSpan`
+ * returns it; root spans get a fresh trace-id, child spans inherit.
+ * @param name Operation name (e.g. `git.push`).
+ * @param parent Enclosing span, or undefined for a new trace root.
+ * @param attributes Attribute map shipped with the span.
+ * @returns The freshly started span.
+ */
+export const startSpan = (
+  name: string,
+  parent?: Span,
+  attributes: Readonly<Record<string, string>> = {}
+): Span => {
+  const span = buildStartedSpan(name, parent, attributes)
+  active = [...active, span]
+  return span
+}
+
+/**
+ * Finish a previously-started span. Removes it from the active
+ * stack and appends to the completed ring (FIFO eviction).
+ * @param id Span id returned by `startSpan`.
+ * @param status Final status, defaults to `ok`.
+ * @returns Finished span, or undefined when the id is unknown.
+ */
+export const finishSpan = (
+  id: string,
+  status: SpanStatus = 'ok'
+): Span | undefined => {
+  const found = active.find(s => s.id === id)
+  active = active.filter(s => s.id !== id)
+  const finished =
+    found === undefined
+      ? undefined
+      : { ...found, finishedAt: Date.now(), status }
+  completed = finished === undefined ? completed : [...completed, finished]
+  evictOldest()
+  return finished
+}
+
+/**
+ * Top of the active stack — most recent span that has not yet
+ * finished. Returns undefined when no span is active.
+ * @returns Active span at the top of the stack.
+ */
+export const currentSpan = (): Span | undefined => active[active.length - 1]
+
+/**
+ * Snapshot of completed spans, oldest-first. Used by the dev
+ * overlay (5.4) and the future exporter (Epic 7).
+ * @returns Frozen array of finished spans.
+ */
+export const listAllSpans = (): readonly Span[] => [...completed]
+
+/** Clear every recorded span. Used by tests and the dev overlay. */
+export const clearSpans = (): void => {
+  active = []
+  completed = []
+}

--- a/src/composables/useTracing/traceparent-types.ts
+++ b/src/composables/useTracing/traceparent-types.ts
@@ -1,0 +1,14 @@
+/**
+ * Decomposed W3C traceparent value. The `version` is fixed at
+ * `'00'` for the foreseeable future per the W3C spec.
+ */
+export type Traceparent = {
+  readonly version: '00'
+  readonly traceId: string
+  readonly parentId: string
+  readonly sampled: boolean
+}
+
+/** Validation regex for the serialised W3C traceparent string. */
+export const TRACEPARENT_RE =
+  /^[0-9a-f]{2}-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$/

--- a/src/composables/useTracing/traceparent.test.ts
+++ b/src/composables/useTracing/traceparent.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { childOf, newRootTraceparent, parse, serialise } from './traceparent'
+import { TRACEPARENT_RE } from './traceparent-types'
+
+describe('newRootTraceparent', () => {
+  it('produces a string matching the W3C wire format', () => {
+    const tp = newRootTraceparent()
+    expect(serialise(tp)).toMatch(TRACEPARENT_RE)
+  })
+
+  it('produces distinct trace-ids on consecutive calls', () => {
+    const a = newRootTraceparent()
+    const b = newRootTraceparent()
+    expect(a.traceId).not.toBe(b.traceId)
+    expect(a.parentId).not.toBe(b.parentId)
+  })
+
+  it('honours the sampled flag', () => {
+    expect(serialise(newRootTraceparent(true))).toMatch(/-01$/)
+    expect(serialise(newRootTraceparent(false))).toMatch(/-00$/)
+  })
+})
+
+describe('childOf', () => {
+  it('keeps the trace-id and replaces the parent-id', () => {
+    const root = newRootTraceparent()
+    const child = childOf(root)
+    expect(child.traceId).toBe(root.traceId)
+    expect(child.parentId).not.toBe(root.parentId)
+  })
+})
+
+describe('parse', () => {
+  it('round-trips a serialised traceparent', () => {
+    const root = newRootTraceparent()
+    const back = parse(serialise(root))
+    expect(back).toEqual(root)
+  })
+
+  it('returns undefined for malformed input', () => {
+    expect(parse('garbage')).toBeUndefined()
+    expect(parse('00-not-hex-thanks-01')).toBeUndefined()
+    expect(parse('')).toBeUndefined()
+  })
+
+  it('rejects unsupported version bytes', () => {
+    const tp = newRootTraceparent()
+    const wire = serialise(tp).replace(/^00/, 'ff')
+    expect(parse(wire)).toBeUndefined()
+  })
+})

--- a/src/composables/useTracing/traceparent.ts
+++ b/src/composables/useTracing/traceparent.ts
@@ -1,0 +1,60 @@
+import { randomHex } from './random-hex'
+import { TRACEPARENT_RE, type Traceparent } from './traceparent-types'
+
+const flagOf = (sampled: boolean): string => (sampled ? '01' : '00')
+
+/**
+ * Build a fresh root traceparent (new traceId + parentId). Sampled
+ * by default — the upstream collector applies head-based sampling
+ * later, so all locally generated traces are eligible to ship.
+ * @param sampled Whether the trace should carry the sampled flag.
+ * @returns Decomposed traceparent ready to serialise.
+ */
+export const newRootTraceparent = (sampled = true): Traceparent => ({
+  version: '00',
+  traceId: randomHex(16),
+  parentId: randomHex(8),
+  sampled,
+})
+
+/**
+ * Build a child traceparent that inherits the trace-id from the
+ * parent and gets a fresh span-id. Used when continuing a trace
+ * across boundaries (client → SW → fetch).
+ * @param parent Existing parent traceparent.
+ * @returns Child traceparent with a new parentId.
+ */
+export const childOf = (parent: Traceparent): Traceparent => ({
+  ...parent,
+  parentId: randomHex(8),
+})
+
+/**
+ * Serialise a decomposed traceparent into the W3C wire format
+ * `version-traceId-parentId-flags` so it can be set as a request
+ * header or BroadcastChannel envelope field.
+ * @param tp Decomposed traceparent.
+ * @returns Wire-format string.
+ */
+export const serialise = (tp: Traceparent): string =>
+  `${tp.version}-${tp.traceId}-${tp.parentId}-${flagOf(tp.sampled)}`
+
+/**
+ * Parse a W3C traceparent string back into the decomposed form.
+ * Returns undefined for malformed input so callers can fall back
+ * to a fresh root rather than crash.
+ * @param raw Wire-format string.
+ * @returns Decomposed traceparent, or undefined when invalid.
+ */
+export const parse = (raw: string): Traceparent | undefined => {
+  const match = TRACEPARENT_RE.test(raw)
+  const parts = match ? raw.split('-') : []
+  return parts.length === 4 && parts[0] === '00'
+    ? {
+        version: '00',
+        traceId: parts[1] ?? '',
+        parentId: parts[2] ?? '',
+        sampled: parts[3] === '01',
+      }
+    : undefined
+}


### PR DESCRIPTION
## Summary
Phase B / Epic 5 — client W3C trace context + in-memory span buffer + dev overlay. Foundation for the OTLP exporter + collector backend that follow in Epics 6-9.

## What's in this release
- **5.1 #117 / #121** — `Traceparent` type + `newRootTraceparent` / `childOf` / `serialise` / `parse`. Pure helpers, 7 unit specs.
- **5.3 #119 / #122** — `Span` ring buffer (cap 500 FIFO), `startSpan` / `finishSpan` / `currentSpan` / `listAllSpans`. 8 unit specs.
- **5.4 #120 / #123** — `<TraceOverlay>` toggled with `Ctrl+Shift+T`. Trace list (newest first) + active waterfall (oldest-first within a trace). Decomposed across 7 sub-components to satisfy depth-2.

## Deferred (within Epic 5)
- **5.2 #118** — SW outbound `traceparent` injection. Deferred to Epic 7 because the header value is meaningful only when there's a collector to receive it; landing it now would generate dead headers.

## Coverage
- Unit: 485/485 green (incl. tracing 19 new specs)
- E2E (chromium): notifications + tracing 3/3 — overlay toggles, close, empty state
- `bun run validate` clean

## Verification post-deploy
- [ ] dev-admin loads without console errors
- [ ] `Ctrl+Shift+T` opens the trace overlay (empty state initially)

## Phase B scoreboard
- Epic 5 — client tracing — partial (5.1, 5.3, 5.4 in master; 5.2 deferred)
- Epic 6 — Hono Worker collector — not started
- Epic 7 — batched OTLP exporter — not started (will pick up 5.2)
- Epic 8 — SSE subscriptions — not started
- Epic 9 — distributed trace viewer — not started

🤖 Generated with [Claude Code](https://claude.com/claude-code)