### PR TITLE
feat(collector): scaffold Hono Worker + healthcheck (#125)

### DIFF
--- a/.github/workflows/deploy-log-collector.yml
+++ b/.github/workflows/deploy-log-collector.yml
@@ -1,0 +1,37 @@
+name: Deploy log-collector to Cloudflare Workers
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'services/log-collector/**'
+      - '.github/workflows/deploy-log-collector.yml'
+
+concurrency:
+  group: deploy-log-collector-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning git repository
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install root dependencies (provides hono, wrangler)
+        run: bun install --frozen-lockfile
+
+      - name: Run log-collector unit tests
+        run: bun run test:unit -- run services/log-collector/
+
+      - name: Deploy to Cloudflare Workers
+        run: |
+          cd services/log-collector
+          npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.VITE_CF_API_TOKEN }}

--- a/biome.json
+++ b/biome.json
@@ -100,7 +100,8 @@
         "e2e/auth/setup.ts",
         "eslint.config.js",
         "src/router/index.ts",
-        "worker.ts"
+        "worker.ts",
+        "services/log-collector/src/index.ts"
       ],
       "linter": {
         "rules": {

--- a/services/log-collector/README.md
+++ b/services/log-collector/README.md
@@ -1,0 +1,22 @@
+# log-collector
+
+Hono-on-Cloudflare-Workers service that accepts batched OpenTelemetry-shaped traces and logs from the admin client and persists them.
+
+Phase B / Epic 6 host package. Increment 6.1 (scaffold + healthcheck) lands in #125; auth / OTLP / rate-limit follow in 6.2 / 6.3 / 6.4.
+
+## Endpoints
+
+- `GET /health` — liveness probe; returns `{ status: 'ok', version, at }`.
+
+Auth + ingest endpoints land with 6.2+.
+
+## Deploy
+
+Deploys via `.github/workflows/deploy-log-collector.yml` on push to `master`. Locally:
+
+```
+cd services/log-collector
+npx wrangler deploy
+```
+
+Bindings declared in `wrangler.jsonc` are optional until later increments wire them.

--- a/services/log-collector/src/health.test.ts
+++ b/services/log-collector/src/health.test.ts
@@ -1,0 +1,28 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { type HealthBody, registerHealthRoute } from './health'
+
+const buildApp = () =>
+  registerHealthRoute(new Hono<{ Bindings: { VERSION: string } }>())
+
+describe('GET /health', () => {
+  it('returns status ok and the configured version', async () => {
+    const app = buildApp()
+    const res = await app.fetch(new Request('http://localhost/health'), {
+      VERSION: '1.2.3',
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as HealthBody
+    expect(body.status).toBe('ok')
+    expect(body.version).toBe('1.2.3')
+    expect(body.at).toBeGreaterThan(0)
+  })
+
+  it('returns 404 for unknown routes', async () => {
+    const app = buildApp()
+    const res = await app.fetch(new Request('http://localhost/missing'), {
+      VERSION: '1',
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/services/log-collector/src/health.ts
+++ b/services/log-collector/src/health.ts
@@ -1,0 +1,29 @@
+import type { Context, Hono } from 'hono'
+
+/** Healthcheck reply payload returned by the `/health` route. */
+export type HealthBody = {
+  readonly status: 'ok'
+  readonly version: string
+  readonly at: number
+}
+
+/**
+ * Wire the `/health` route on the supplied Hono instance. Reads
+ * the build-time `VERSION` var so deploys can ship a known
+ * identifier without rebuilding the route.
+ * @param app Hono app to extend.
+ * @returns Same Hono app for chaining.
+ */
+export const registerHealthRoute = (
+  app: Hono<{ Bindings: { VERSION: string } }>
+): Hono<{ Bindings: { VERSION: string } }> => {
+  app.get('/health', (c: Context<{ Bindings: { VERSION: string } }>) => {
+    const body: HealthBody = {
+      status: 'ok',
+      version: c.env.VERSION,
+      at: Date.now(),
+    }
+    return c.json(body)
+  })
+  return app
+}

--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -1,0 +1,12 @@
+import { Hono } from 'hono'
+import { registerHealthRoute } from './health'
+
+/** Hono app composed of all registered routes. */
+export const app = registerHealthRoute(
+  new Hono<{ Bindings: { VERSION: string } }>()
+)
+
+/** Cloudflare Worker entry — delegates everything to Hono. */
+export default {
+  fetch: app.fetch,
+}

--- a/services/log-collector/wrangler.jsonc
+++ b/services/log-collector/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "name": "log-collector",
+  "compatibility_date": "2026-03-23",
+  "main": "src/index.ts",
+  // Bindings declared but optional at deploy time so 6.1 can ship
+  // before the secrets land (added in 6.2 / 6.3).
+  // - JWT_SECRET — HS256 signing secret (set via `wrangler secret put`)
+  // - ANALYTICS_DATASET — Workers Analytics Engine dataset for spans
+  // - D1 — D1 database for trace metadata index
+  "vars": {
+    "VERSION": "0.1.0"
+  }
+}


### PR DESCRIPTION
Phase B / Epic 6 increment 6.1. New services/log-collector/ Hono package + healthcheck + CI deploy. 2/2 unit. Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)