### PR TITLE
feat(collector): OTLP /v1/traces + /v1/logs endpoints (#127)

### DIFF
--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -9,10 +9,12 @@ import {
   registerExchangeRoute,
 } from './exchange-handler'
 import { registerHealthRoute } from './health'
+import { type OtlpBindings, registerOtlpRoutes } from './otlp-handlers'
 
 /** Combined worker bindings across all registered routes. */
 export type Bindings = AuthBindings &
-  ExchangeBindings & {
+  ExchangeBindings &
+  OtlpBindings & {
     readonly VERSION: string
   }
 
@@ -20,6 +22,7 @@ const app = new Hono<{ Bindings: Bindings; Variables: AuthVariables }>()
 app.use('*', authMiddleware())
 registerHealthRoute(app)
 registerExchangeRoute(app)
+registerOtlpRoutes(app)
 
 /** Cloudflare Worker entry — delegates everything to Hono. */
 export default {

--- a/services/log-collector/src/otlp-handlers.test.ts
+++ b/services/log-collector/src/otlp-handlers.test.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  type AuthBindings,
+  type AuthVariables,
+  authMiddleware,
+} from './auth-middleware'
+import { signJwt } from './jwt'
+import { type OtlpBindings, registerOtlpRoutes } from './otlp-handlers'
+
+const SECRET = 'test-secret-32-chars-long-or-better-1234'
+
+const buildApp = (bindings: Partial<OtlpBindings> = {}) => {
+  const app = new Hono<{
+    Bindings: AuthBindings & OtlpBindings
+    Variables: AuthVariables
+  }>()
+  app.use('*', authMiddleware())
+  registerOtlpRoutes(app)
+  return { app, env: { JWT_SECRET: SECRET, ...bindings } }
+}
+
+const span = {
+  traceId: 't1',
+  spanId: 's1',
+  name: 'op',
+  startedAt: 1000,
+  finishedAt: 1050,
+  status: 'ok',
+  attributes: { key: 'value' },
+}
+
+describe('POST /v1/traces', () => {
+  it('rejects without a token', async () => {
+    const { app, env } = buildApp()
+    const res = await app.fetch(
+      new Request('http://localhost/v1/traces', {
+        method: 'POST',
+        body: JSON.stringify({ spans: [span] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('persists spans and returns the accepted count', async () => {
+    const writeDataPoint = vi.fn()
+    const run = vi.fn().mockResolvedValue({ success: true })
+    const bind = vi.fn().mockReturnValue({ run })
+    const prepare = vi.fn().mockReturnValue({ bind })
+    const { app, env } = buildApp({
+      ANALYTICS_DATASET: { writeDataPoint },
+      D1: { prepare },
+    })
+    const token = await signJwt('alice', SECRET)
+    const res = await app.fetch(
+      new Request('http://localhost/v1/traces', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ spans: [span, span] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ accepted: 2 })
+    expect(writeDataPoint).toHaveBeenCalledTimes(2)
+    expect(prepare).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns 422 when no valid spans in batch', async () => {
+    const { app, env } = buildApp()
+    const token = await signJwt('alice', SECRET)
+    const res = await app.fetch(
+      new Request('http://localhost/v1/traces', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ spans: [{ traceId: 'only' }] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+  })
+})
+
+describe('POST /v1/logs', () => {
+  it('persists logs and returns the accepted count', async () => {
+    const run = vi.fn().mockResolvedValue({ success: true })
+    const bind = vi.fn().mockReturnValue({ run })
+    const prepare = vi.fn().mockReturnValue({ bind })
+    const { app, env } = buildApp({
+      D1: { prepare },
+    })
+    const token = await signJwt('alice', SECRET)
+    const res = await app.fetch(
+      new Request('http://localhost/v1/logs', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          logs: [
+            {
+              level: 'info',
+              message: 'hello',
+              at: 1000,
+              attributes: {},
+            },
+          ],
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ accepted: 1 })
+    expect(prepare).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/log-collector/src/otlp-handlers.ts
+++ b/services/log-collector/src/otlp-handlers.ts
@@ -1,0 +1,60 @@
+import type { Context, Hono } from 'hono'
+import type { AuthVariables } from './auth-middleware'
+import { parseLogBatch, parseTraceBatch } from './otlp-validate'
+import { persistLogs, persistSpans } from './storage'
+import type { StorageBindings } from './storage-types'
+
+/** Bindings the OTLP routes read off the worker env. */
+export type OtlpBindings = StorageBindings
+
+const handleTraces = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>
+): Promise<Response> => {
+  const body: unknown = await c.req.json().catch(() => undefined)
+  const spans = parseTraceBatch(body)
+  return spans.length === 0
+    ? c.json({ error: 'no valid spans in batch' }, 422)
+    : runPersistSpans(c, spans)
+}
+
+const runPersistSpans = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>,
+  spans: ReturnType<typeof parseTraceBatch>
+): Promise<Response> => {
+  const user = c.get('user').sub
+  await persistSpans(c.env, spans, user)
+  return c.json({ accepted: spans.length })
+}
+
+const handleLogs = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>
+): Promise<Response> => {
+  const body: unknown = await c.req.json().catch(() => undefined)
+  const logs = parseLogBatch(body)
+  return logs.length === 0
+    ? c.json({ error: 'no valid logs in batch' }, 422)
+    : runPersistLogs(c, logs)
+}
+
+const runPersistLogs = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>,
+  logs: ReturnType<typeof parseLogBatch>
+): Promise<Response> => {
+  await persistLogs(c.env, logs)
+  return c.json({ accepted: logs.length })
+}
+
+/**
+ * Wire `POST /v1/traces` and `POST /v1/logs`. Both routes are
+ * gated by the auth middleware in `src/index.ts`; the handlers
+ * therefore trust `c.get('user')`.
+ * @param app Hono app to extend.
+ * @returns Same app for chaining.
+ */
+export const registerOtlpRoutes = (
+  app: Hono<{ Bindings: OtlpBindings; Variables: AuthVariables }>
+): Hono<{ Bindings: OtlpBindings; Variables: AuthVariables }> => {
+  app.post('/v1/traces', handleTraces)
+  app.post('/v1/logs', handleLogs)
+  return app
+}

--- a/services/log-collector/src/otlp-log.ts
+++ b/services/log-collector/src/otlp-log.ts
@@ -1,0 +1,38 @@
+import { stringMap } from './otlp-string-map'
+import type { LogLevel, LogRecord } from './otlp-types'
+
+const LEVELS: ReadonlySet<LogLevel> = new Set([
+  'debug',
+  'info',
+  'warn',
+  'error',
+])
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Validate a single OTLP log entry. Returns `undefined` for
+ * malformed input.
+ * @param raw Raw entry from a `/v1/logs` batch.
+ * @returns Validated `LogRecord` or undefined.
+ */
+export const validLog = (raw: unknown): LogRecord | undefined => {
+  const v = isObject(raw) ? raw : undefined
+  const level = v?.['level']
+  const ok =
+    typeof v?.['message'] === 'string' &&
+    typeof v['at'] === 'number' &&
+    typeof level === 'string' &&
+    LEVELS.has(level as LogLevel)
+  return ok && v !== undefined
+    ? {
+        traceId: typeof v['traceId'] === 'string' ? v['traceId'] : undefined,
+        spanId: typeof v['spanId'] === 'string' ? v['spanId'] : undefined,
+        level: level as LogLevel,
+        message: v['message'] as string,
+        at: v['at'] as number,
+        attributes: stringMap(v['attributes']),
+      }
+    : undefined
+}

--- a/services/log-collector/src/otlp-span.ts
+++ b/services/log-collector/src/otlp-span.ts
@@ -1,0 +1,46 @@
+import { stringMap } from './otlp-string-map'
+import type { SpanRecord, SpanStatus } from './otlp-types'
+
+const STATUSES: ReadonlySet<SpanStatus> = new Set(['ok', 'error', 'unset'])
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const checkSpan = (raw: Record<string, unknown>): boolean => {
+  const status = raw['status']
+  return (
+    typeof raw['traceId'] === 'string' &&
+    typeof raw['spanId'] === 'string' &&
+    typeof raw['name'] === 'string' &&
+    typeof raw['startedAt'] === 'number' &&
+    typeof raw['finishedAt'] === 'number' &&
+    typeof status === 'string' &&
+    STATUSES.has(status as SpanStatus)
+  )
+}
+
+/**
+ * Validate a single OTLP span entry. Returns `undefined` for
+ * malformed input so the caller can `.filter` it out without a
+ * cast.
+ * @param raw Raw entry from a `/v1/traces` batch.
+ * @returns Validated `SpanRecord` or undefined.
+ */
+export const validSpan = (raw: unknown): SpanRecord | undefined => {
+  const v = isObject(raw) ? raw : undefined
+  return v !== undefined && checkSpan(v)
+    ? {
+        traceId: v['traceId'] as string,
+        spanId: v['spanId'] as string,
+        parentSpanId:
+          typeof v['parentSpanId'] === 'string'
+            ? v['parentSpanId']
+            : undefined,
+        name: v['name'] as string,
+        startedAt: v['startedAt'] as number,
+        finishedAt: v['finishedAt'] as number,
+        status: v['status'] as SpanStatus,
+        attributes: stringMap(v['attributes']),
+      }
+    : undefined
+}

--- a/services/log-collector/src/otlp-string-map.ts
+++ b/services/log-collector/src/otlp-string-map.ts
@@ -1,0 +1,19 @@
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Coerce an unknown value into a string→string map. Used to
+ * extract attributes from raw OTLP payloads while dropping any
+ * non-string values without throwing.
+ * @param value Source value (typically a parsed JSON object).
+ * @returns Frozen string-to-string map.
+ */
+export const stringMap = (
+  value: unknown
+): Readonly<Record<string, string>> => {
+  const obj = isObject(value) ? value : {}
+  const entries = Object.entries(obj).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string'
+  )
+  return Object.fromEntries(entries)
+}

--- a/services/log-collector/src/otlp-types.ts
+++ b/services/log-collector/src/otlp-types.ts
@@ -1,0 +1,27 @@
+/** Status carried on a finished span. */
+export type SpanStatus = 'ok' | 'error' | 'unset'
+
+/** Span as accepted by `/v1/traces`. */
+export type SpanRecord = {
+  readonly traceId: string
+  readonly spanId: string
+  readonly parentSpanId: string | undefined
+  readonly name: string
+  readonly startedAt: number
+  readonly finishedAt: number
+  readonly status: SpanStatus
+  readonly attributes: Readonly<Record<string, string>>
+}
+
+/** Log severity carried on a log record. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/** Log entry as accepted by `/v1/logs`. */
+export type LogRecord = {
+  readonly traceId: string | undefined
+  readonly spanId: string | undefined
+  readonly level: LogLevel
+  readonly message: string
+  readonly at: number
+  readonly attributes: Readonly<Record<string, string>>
+}

--- a/services/log-collector/src/otlp-validate.test.ts
+++ b/services/log-collector/src/otlp-validate.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { parseLogBatch, parseTraceBatch } from './otlp-validate'
+
+const span = {
+  traceId: 't1',
+  spanId: 's1',
+  parentSpanId: undefined,
+  name: 'op',
+  startedAt: 1000,
+  finishedAt: 1050,
+  status: 'ok',
+  attributes: { key: 'value' },
+}
+
+const log = {
+  traceId: 't1',
+  spanId: 's1',
+  level: 'info',
+  message: 'hello',
+  at: 1000,
+  attributes: { route: '/x' },
+}
+
+describe('parseTraceBatch', () => {
+  it('returns valid spans verbatim', () => {
+    const result = parseTraceBatch({ spans: [span] })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.spanId).toBe('s1')
+    expect(result[0]?.attributes).toEqual({ key: 'value' })
+  })
+
+  it('drops malformed spans', () => {
+    const result = parseTraceBatch({
+      spans: [span, { traceId: 't2' }, null, 42],
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('returns [] when shape is wrong', () => {
+    expect(parseTraceBatch(undefined)).toEqual([])
+    expect(parseTraceBatch({ no: 'spans' })).toEqual([])
+    expect(parseTraceBatch({ spans: 'oops' })).toEqual([])
+  })
+
+  it('rejects unknown statuses', () => {
+    expect(
+      parseTraceBatch({ spans: [{ ...span, status: 'weird' }] })
+    ).toEqual([])
+  })
+
+  it('drops non-string attribute values', () => {
+    const result = parseTraceBatch({
+      spans: [{ ...span, attributes: { a: 'ok', b: 42 } }],
+    })
+    expect(result[0]?.attributes).toEqual({ a: 'ok' })
+  })
+})
+
+describe('parseLogBatch', () => {
+  it('returns valid logs verbatim', () => {
+    const result = parseLogBatch({ logs: [log] })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.message).toBe('hello')
+  })
+
+  it('rejects unknown levels', () => {
+    expect(parseLogBatch({ logs: [{ ...log, level: 'panic' }] })).toEqual([])
+  })
+
+  it('treats traceId/spanId as optional', () => {
+    const minimal = { ...log, traceId: undefined, spanId: undefined }
+    const result = parseLogBatch({ logs: [minimal] })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.traceId).toBeUndefined()
+  })
+})

--- a/services/log-collector/src/otlp-validate.ts
+++ b/services/log-collector/src/otlp-validate.ts
@@ -1,0 +1,35 @@
+import { validLog } from './otlp-log'
+import { validSpan } from './otlp-span'
+import type { LogRecord, SpanRecord } from './otlp-types'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const collect = <T>(
+  raw: unknown,
+  key: string,
+  validate: (item: unknown) => T | undefined
+): readonly T[] => {
+  const arr = isObject(raw) ? raw[key] : undefined
+  return Array.isArray(arr)
+    ? arr.map(validate).filter((x): x is T => x !== undefined)
+    : []
+}
+
+/**
+ * Parse and validate a `/v1/traces` batch. Drops malformed spans
+ * rather than rejecting the whole batch — exporter is fire-and-
+ * forget so partial acceptance keeps healthy traces visible.
+ * @param body Raw `request.json()` result.
+ * @returns Frozen array of valid spans.
+ */
+export const parseTraceBatch = (body: unknown): readonly SpanRecord[] =>
+  collect(body, 'spans', validSpan)
+
+/**
+ * Parse and validate a `/v1/logs` batch. Drops malformed entries.
+ * @param body Raw `request.json()` result.
+ * @returns Frozen array of valid log records.
+ */
+export const parseLogBatch = (body: unknown): readonly LogRecord[] =>
+  collect(body, 'logs', validLog)

--- a/services/log-collector/src/storage-logs.ts
+++ b/services/log-collector/src/storage-logs.ts
@@ -1,0 +1,31 @@
+import type { LogRecord } from './otlp-types'
+import type { StorageBindings } from './storage-types'
+
+const INSERT_LOG_SQL =
+  'INSERT INTO logs (trace_id, level, at) VALUES (?, ?, ?)'
+
+const indexLogD1 = (
+  bindings: StorageBindings,
+  log: LogRecord
+): Promise<unknown> => {
+  const db = bindings.D1
+  return db === undefined
+    ? Promise.resolve()
+    : db
+        .prepare(INSERT_LOG_SQL)
+        .bind(log.traceId ?? '', log.level, log.at)
+        .run()
+}
+
+/**
+ * Persist a batch of validated logs to D1.
+ * @param bindings Storage bindings on the worker env.
+ * @param logs Validated logs to persist.
+ * @returns Resolves once all writes complete.
+ */
+export const persistLogs = async (
+  bindings: StorageBindings,
+  logs: readonly LogRecord[]
+): Promise<void> => {
+  await Promise.all(logs.map(log => indexLogD1(bindings, log)))
+}

--- a/services/log-collector/src/storage-spans.ts
+++ b/services/log-collector/src/storage-spans.ts
@@ -1,0 +1,57 @@
+import type { SpanRecord } from './otlp-types'
+import type { StorageBindings } from './storage-types'
+
+const INSERT_TRACE_SQL =
+  'INSERT INTO traces (trace_id, user, op, started_at) VALUES (?, ?, ?, ?)'
+
+const writeSpanAnalytics = (
+  bindings: StorageBindings,
+  span: SpanRecord,
+  user: string
+): void => {
+  const ds = bindings.ANALYTICS_DATASET
+  const noop = (): void => undefined
+  const fire =
+    ds === undefined
+      ? noop
+      : () =>
+          ds.writeDataPoint({
+            indexes: [span.traceId, user],
+            blobs: [span.name, span.spanId, span.status],
+            doubles: [span.startedAt, span.finishedAt],
+          })
+  fire()
+}
+
+const indexSpanD1 = (
+  bindings: StorageBindings,
+  span: SpanRecord,
+  user: string
+): Promise<unknown> => {
+  const db = bindings.D1
+  return db === undefined
+    ? Promise.resolve()
+    : db
+        .prepare(INSERT_TRACE_SQL)
+        .bind(span.traceId, user, span.name, span.startedAt)
+        .run()
+}
+
+/**
+ * Persist a batch of validated spans to Analytics Engine + D1.
+ * No-op when bindings are absent (local dev / tests).
+ * @param bindings Storage bindings on the worker env.
+ * @param spans Validated spans to persist.
+ * @param user GitHub login from the JWT subject claim.
+ * @returns Resolves once all writes complete.
+ */
+export const persistSpans = async (
+  bindings: StorageBindings,
+  spans: readonly SpanRecord[],
+  user: string
+): Promise<void> => {
+  spans.forEach(span => {
+    writeSpanAnalytics(bindings, span, user)
+  })
+  await Promise.all(spans.map(span => indexSpanD1(bindings, span, user)))
+}

--- a/services/log-collector/src/storage-types.ts
+++ b/services/log-collector/src/storage-types.ts
@@ -1,0 +1,25 @@
+/** Workers Analytics Engine binding shape (subset we use). */
+export type AnalyticsEngineDataset = {
+  readonly writeDataPoint: (point: {
+    readonly indexes: ReadonlyArray<string>
+    readonly blobs?: ReadonlyArray<string>
+    readonly doubles?: ReadonlyArray<number>
+  }) => void
+}
+
+/** D1 database binding shape (subset we use). */
+export type D1Database = {
+  readonly prepare: (sql: string) => D1PreparedStatement
+}
+
+/** D1 prepared statement (subset). */
+export type D1PreparedStatement = {
+  readonly bind: (...args: ReadonlyArray<unknown>) => D1PreparedStatement
+  readonly run: () => Promise<{ readonly success: boolean }>
+}
+
+/** Storage bindings exposed to the OTLP handlers. */
+export type StorageBindings = {
+  readonly ANALYTICS_DATASET: AnalyticsEngineDataset | undefined
+  readonly D1: D1Database | undefined
+}

--- a/services/log-collector/src/storage.ts
+++ b/services/log-collector/src/storage.ts
@@ -1,0 +1,3 @@
+/** Barrel re-exports so callers import storage from one place. */
+export { persistLogs } from './storage-logs'
+export { persistSpans } from './storage-spans'


### PR DESCRIPTION
Phase B / Epic 6 increment 6.3. POST /v1/traces and POST /v1/logs accept OTLP-shaped batches gated by JWT, write spans to Analytics Engine + index in D1. Defensive parser drops malformed entries; bindings optional so local dev no-ops. 12 new unit (26 total in collector). Closes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)