### PR TITLE
feat(collector): rate-limit + max-batch-size guards (#128)

### DIFF
--- a/services/log-collector/src/batch-size-guard.test.ts
+++ b/services/log-collector/src/batch-size-guard.test.ts
@@ -1,0 +1,42 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { batchSizeGuard, MAX_BATCH_SIZE_BYTES } from './batch-size-guard'
+
+const buildApp = () => {
+  const app = new Hono()
+  app.use('*', batchSizeGuard())
+  app.post('/v1/x', c => c.json({ ok: true }))
+  return app
+}
+
+describe('batchSizeGuard', () => {
+  it('passes payloads at or below the limit', async () => {
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/x', {
+        method: 'POST',
+        headers: {
+          'Content-Length': String(MAX_BATCH_SIZE_BYTES),
+          'Content-Type': 'application/json',
+        },
+        body: 'x'.repeat(10),
+      })
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 413 with a chunk-size hint above the limit', async () => {
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/x', {
+        method: 'POST',
+        headers: {
+          'Content-Length': String(MAX_BATCH_SIZE_BYTES + 1),
+          'Content-Type': 'application/json',
+        },
+        body: '',
+      })
+    )
+    expect(res.status).toBe(413)
+    const body = (await res.json()) as { chunkSize: number }
+    expect(body.chunkSize).toBe(MAX_BATCH_SIZE_BYTES / 2)
+  })
+})

--- a/services/log-collector/src/batch-size-guard.ts
+++ b/services/log-collector/src/batch-size-guard.ts
@@ -1,0 +1,30 @@
+import type { MiddlewareHandler } from 'hono'
+
+/** Default max batch size: 256 KB. */
+export const MAX_BATCH_SIZE_BYTES = 256 * 1024
+
+const sizeOf = (header: string | undefined): number =>
+  header === undefined ? 0 : Number.parseInt(header, 10) || 0
+
+/**
+ * Hono middleware that rejects ingest payloads whose
+ * `Content-Length` exceeds `MAX_BATCH_SIZE_BYTES`. Reply is 413
+ * with a `chunkSize` hint so the exporter (Epic 7) can split.
+ * Applied only to mutation routes — health and exchange are
+ * tiny and always under the cap.
+ * @param max Optional override for the limit (defaults to 256 KB).
+ * @returns Hono middleware handler.
+ */
+export const batchSizeGuard = (
+  max: number = MAX_BATCH_SIZE_BYTES
+): MiddlewareHandler => {
+  return async (c, next) => {
+    const size = sizeOf(c.req.header('content-length'))
+    return size > max
+      ? c.json(
+          { error: 'batch too large', limit: max, chunkSize: max / 2 },
+          413
+        )
+      : await next()
+  }
+}

--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -4,12 +4,14 @@ import {
   type AuthVariables,
   authMiddleware,
 } from './auth-middleware'
+import { batchSizeGuard } from './batch-size-guard'
 import {
   type ExchangeBindings,
   registerExchangeRoute,
 } from './exchange-handler'
 import { registerHealthRoute } from './health'
 import { type OtlpBindings, registerOtlpRoutes } from './otlp-handlers'
+import { rateLimit } from './rate-limit'
 
 /** Combined worker bindings across all registered routes. */
 export type Bindings = AuthBindings &
@@ -20,6 +22,8 @@ export type Bindings = AuthBindings &
 
 const app = new Hono<{ Bindings: Bindings; Variables: AuthVariables }>()
 app.use('*', authMiddleware())
+app.use('/v1/*', batchSizeGuard())
+app.use('/v1/*', rateLimit())
 registerHealthRoute(app)
 registerExchangeRoute(app)
 registerOtlpRoutes(app)

--- a/services/log-collector/src/rate-limit.test.ts
+++ b/services/log-collector/src/rate-limit.test.ts
@@ -1,0 +1,62 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { type AuthVariables, authMiddleware } from './auth-middleware'
+import { signJwt } from './jwt'
+import { clearRateBuckets, rateLimit } from './rate-limit'
+
+const SECRET = 'test-secret-32-chars-long-or-better-1234'
+
+const buildApp = (limit: number) => {
+  const app = new Hono<{
+    Bindings: { JWT_SECRET: string }
+    Variables: AuthVariables
+  }>()
+  app.use('*', authMiddleware())
+  app.use('/v1/*', rateLimit(limit))
+  app.post('/v1/x', c => c.json({ ok: true }))
+  return app
+}
+
+const fire = async (
+  app: ReturnType<typeof buildApp>,
+  token: string
+): Promise<Response> =>
+  app.fetch(
+    new Request('http://localhost/v1/x', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    { JWT_SECRET: SECRET }
+  )
+
+describe('rateLimit', () => {
+  beforeEach(clearRateBuckets)
+  afterEach(clearRateBuckets)
+
+  it('allows up to the configured limit per user', async () => {
+    const app = buildApp(3)
+    const token = await signJwt('alice', SECRET)
+    expect((await fire(app, token)).status).toBe(200)
+    expect((await fire(app, token)).status).toBe(200)
+    expect((await fire(app, token)).status).toBe(200)
+  })
+
+  it('returns 429 with Retry-After once the limit is hit', async () => {
+    const app = buildApp(2)
+    const token = await signJwt('alice', SECRET)
+    await fire(app, token)
+    await fire(app, token)
+    const res = await fire(app, token)
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toMatch(/^\d+$/)
+  })
+
+  it('isolates buckets per user', async () => {
+    const app = buildApp(1)
+    const alice = await signJwt('alice', SECRET)
+    const bob = await signJwt('bob', SECRET)
+    expect((await fire(app, alice)).status).toBe(200)
+    expect((await fire(app, alice)).status).toBe(429)
+    expect((await fire(app, bob)).status).toBe(200)
+  })
+})

--- a/services/log-collector/src/rate-limit.ts
+++ b/services/log-collector/src/rate-limit.ts
@@ -1,0 +1,53 @@
+import type { MiddlewareHandler } from 'hono'
+import type { AuthVariables } from './auth-middleware'
+
+/** Default per-user budget: 60 requests per 60-second window. */
+export const RATE_LIMIT_PER_MINUTE = 60
+const WINDOW_MS = 60_000
+
+type Bucket = { readonly start: number; readonly count: number }
+
+const buckets = new Map<string, Bucket>()
+
+const update = (
+  key: string,
+  now: number,
+  limit: number
+): { readonly allowed: boolean; readonly retryMs: number } => {
+  const bucket = buckets.get(key)
+  const fresh = bucket === undefined || now - bucket.start > WINDOW_MS
+  const next = fresh
+    ? { start: now, count: 1 }
+    : { start: bucket.start, count: bucket.count + 1 }
+  buckets.set(key, next)
+  return next.count <= limit
+    ? { allowed: true, retryMs: 0 }
+    : { allowed: false, retryMs: WINDOW_MS - (now - next.start) }
+}
+
+/** Reset every bucket. Used by tests. */
+export const clearRateBuckets = (): void => {
+  buckets.clear()
+}
+
+/**
+ * Hono middleware enforcing a per-user request budget. Sliding
+ * window keyed by the JWT subject claim. CF Rate Limiting will
+ * superset this in production; the in-memory variant catches
+ * loops in dev / tests and gives an obvious local signal.
+ * @param limit Max requests per minute, defaults to 60.
+ * @returns Hono middleware handler.
+ */
+export const rateLimit = (
+  limit: number = RATE_LIMIT_PER_MINUTE
+): MiddlewareHandler<{ Variables: AuthVariables }> => {
+  return async (c, next) => {
+    const user = c.get('user')?.sub ?? 'anon'
+    const result = update(user, Date.now(), limit)
+    return result.allowed
+      ? await next()
+      : c.json({ error: 'rate limited' }, 429, {
+          'Retry-After': String(Math.ceil(result.retryMs / 1000)),
+        })
+  }
+}


### PR DESCRIPTION
Phase B / Epic 6 increment 6.4. Closes Epic 6. 256 KB batch limit (413 + chunkSize hint) + 60 req/min/user sliding window (429 + Retry-After). 5/5 new unit tests; 31 total in the collector. Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)