### PR TITLE
release: log-collector backend Epic 6 (6.1+6.2+6.3+6.4)

### DIFF
--- a/services/log-collector/src/auth-middleware.test.ts
+++ b/services/log-collector/src/auth-middleware.test.ts
@@ -1,0 +1,73 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import {
+  type AuthBindings,
+  type AuthVariables,
+  authMiddleware,
+} from './auth-middleware'
+import { signJwt } from './jwt'
+
+const SECRET = 'test-secret-32-chars-long-or-better-1234'
+
+const buildApp = () => {
+  const app = new Hono<{
+    Bindings: AuthBindings
+    Variables: AuthVariables
+  }>()
+  app.use('*', authMiddleware())
+  app.get('/health', c => c.json({ ok: true }))
+  app.get('/v1/private', c => c.json({ user: c.get('user') }))
+  return app
+}
+
+describe('authMiddleware', () => {
+  it('lets /health through without a token', async () => {
+    const res = await buildApp().fetch(
+      new Request('http://localhost/health'),
+      { JWT_SECRET: SECRET }
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects protected routes without a token', async () => {
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/private'),
+      { JWT_SECRET: SECRET }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('rejects protected routes with a malformed token', async () => {
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/private', {
+        headers: { Authorization: 'Bearer garbage' },
+      }),
+      { JWT_SECRET: SECRET }
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('passes protected routes with a valid token', async () => {
+    const token = await signJwt('alice', SECRET)
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/private', {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      { JWT_SECRET: SECRET }
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { user: { sub: string } }
+    expect(body.user.sub).toBe('alice')
+  })
+
+  it('rejects expired tokens (sign with past secret then probe)', async () => {
+    const token = await signJwt('alice', SECRET)
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/private', {
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+      { JWT_SECRET: 'mismatched-secret' }
+    )
+    expect(res.status).toBe(401)
+  })
+})

--- a/services/log-collector/src/auth-middleware.ts
+++ b/services/log-collector/src/auth-middleware.ts
@@ -1,0 +1,53 @@
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import type { JwtPayload } from './jwt-types'
+import { verifyJwt } from './jwt-verify'
+
+/** Bindings the auth middleware reads. */
+export type AuthBindings = {
+  readonly JWT_SECRET: string
+}
+
+/** Variables the middleware writes onto the Hono context. */
+export type AuthVariables = {
+  readonly user: JwtPayload
+}
+
+const PUBLIC_PATHS = new Set<string>(['/health', '/auth/exchange'])
+
+const tokenFrom = (header: string | undefined): string | undefined => {
+  const prefix = 'Bearer '
+  return header !== undefined && header.startsWith(prefix)
+    ? header.slice(prefix.length)
+    : undefined
+}
+
+/**
+ * Hono middleware that enforces a valid HS256 JWT on every
+ * non-public route. Attaches the decoded payload to the Hono
+ * context under `user` so handlers can attribute incoming data.
+ * @returns Hono middleware handler.
+ */
+export const authMiddleware = (): MiddlewareHandler<{
+  Bindings: AuthBindings
+  Variables: AuthVariables
+}> => {
+  return async (
+    c: Context<{ Bindings: AuthBindings; Variables: AuthVariables }>,
+    next: Next
+  ): Promise<Response | undefined> => {
+    const url = new URL(c.req.url)
+    const isPublic = PUBLIC_PATHS.has(url.pathname)
+    const token = tokenFrom(c.req.header('authorization'))
+    const payload = isPublic
+      ? undefined
+      : token === undefined
+        ? undefined
+        : await verifyJwt(token, c.env.JWT_SECRET)
+    const reject = !isPublic && payload === undefined
+    const setUser = !isPublic && payload !== undefined
+    const noop = (): void => undefined
+    const apply = setUser ? () => c.set('user', payload) : noop
+    apply()
+    return reject ? c.json({ error: 'unauthorized' }, 401) : await next()
+  }
+}

--- a/services/log-collector/src/base64url.test.ts
+++ b/services/log-collector/src/base64url.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { base64urlDecode, base64urlEncode } from './base64url'
+
+describe('base64url', () => {
+  it('round-trips an ASCII string', () => {
+    const raw = 'hello world'
+    const enc = base64urlEncode(raw)
+    expect(new TextDecoder().decode(base64urlDecode(enc))).toBe(raw)
+  })
+
+  it('round-trips bytes', () => {
+    const bytes = new Uint8Array([1, 2, 3, 250, 251])
+    const enc = base64urlEncode(bytes.buffer)
+    expect(Array.from(base64urlDecode(enc))).toEqual([...bytes])
+  })
+
+  it('uses the URL-safe alphabet (no +, /, =)', () => {
+    const enc = base64urlEncode(new Uint8Array([0, 0, 0, 0, 0, 250, 250]))
+    expect(enc).not.toMatch(/[+/=]/)
+  })
+})

--- a/services/log-collector/src/base64url.ts
+++ b/services/log-collector/src/base64url.ts
@@ -1,0 +1,40 @@
+const ALPHABET =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_'
+
+const fromBase64Std = (b64: string): string =>
+  b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+const toBase64Std = (b64url: string): string => {
+  const padded = b64url + '='.repeat((4 - (b64url.length % 4)) % 4)
+  return padded.replace(/-/g, '+').replace(/_/g, '/')
+}
+
+/**
+ * Encode bytes (or a string) to base64url. Uses `btoa` for the
+ * std encoding then translates the alphabet, dropping padding.
+ * @param input Bytes or UTF-8 string to encode.
+ * @returns Base64url string.
+ */
+export const base64urlEncode = (input: ArrayBuffer | string): string => {
+  const bytes =
+    typeof input === 'string'
+      ? new TextEncoder().encode(input)
+      : new Uint8Array(input)
+  const bin = Array.from(bytes, b => String.fromCharCode(b)).join('')
+  return fromBase64Std(globalThis.btoa(bin))
+}
+
+/**
+ * Decode a base64url string to a `Uint8Array`. Throws on
+ * non-base64 input.
+ * @param raw Base64url-encoded string.
+ * @returns Decoded bytes.
+ */
+export const base64urlDecode = (raw: string): Uint8Array => {
+  const std = toBase64Std(raw)
+  const bin = globalThis.atob(std)
+  return Uint8Array.from(bin, c => c.charCodeAt(0))
+}
+
+/** ASCII alphabet for the base64url variant. */
+export const BASE64URL_ALPHABET = ALPHABET

--- a/services/log-collector/src/batch-size-guard.test.ts
+++ b/services/log-collector/src/batch-size-guard.test.ts
@@ -1,0 +1,42 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { batchSizeGuard, MAX_BATCH_SIZE_BYTES } from './batch-size-guard'
+
+const buildApp = () => {
+  const app = new Hono()
+  app.use('*', batchSizeGuard())
+  app.post('/v1/x', c => c.json({ ok: true }))
+  return app
+}
+
+describe('batchSizeGuard', () => {
+  it('passes payloads at or below the limit', async () => {
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/x', {
+        method: 'POST',
+        headers: {
+          'Content-Length': String(MAX_BATCH_SIZE_BYTES),
+          'Content-Type': 'application/json',
+        },
+        body: 'x'.repeat(10),
+      })
+    )
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 413 with a chunk-size hint above the limit', async () => {
+    const res = await buildApp().fetch(
+      new Request('http://localhost/v1/x', {
+        method: 'POST',
+        headers: {
+          'Content-Length': String(MAX_BATCH_SIZE_BYTES + 1),
+          'Content-Type': 'application/json',
+        },
+        body: '',
+      })
+    )
+    expect(res.status).toBe(413)
+    const body = (await res.json()) as { chunkSize: number }
+    expect(body.chunkSize).toBe(MAX_BATCH_SIZE_BYTES / 2)
+  })
+})

--- a/services/log-collector/src/batch-size-guard.ts
+++ b/services/log-collector/src/batch-size-guard.ts
@@ -1,0 +1,30 @@
+import type { MiddlewareHandler } from 'hono'
+
+/** Default max batch size: 256 KB. */
+export const MAX_BATCH_SIZE_BYTES = 256 * 1024
+
+const sizeOf = (header: string | undefined): number =>
+  header === undefined ? 0 : Number.parseInt(header, 10) || 0
+
+/**
+ * Hono middleware that rejects ingest payloads whose
+ * `Content-Length` exceeds `MAX_BATCH_SIZE_BYTES`. Reply is 413
+ * with a `chunkSize` hint so the exporter (Epic 7) can split.
+ * Applied only to mutation routes — health and exchange are
+ * tiny and always under the cap.
+ * @param max Optional override for the limit (defaults to 256 KB).
+ * @returns Hono middleware handler.
+ */
+export const batchSizeGuard = (
+  max: number = MAX_BATCH_SIZE_BYTES
+): MiddlewareHandler => {
+  return async (c, next) => {
+    const size = sizeOf(c.req.header('content-length'))
+    return size > max
+      ? c.json(
+          { error: 'batch too large', limit: max, chunkSize: max / 2 },
+          413
+        )
+      : await next()
+  }
+}

--- a/services/log-collector/src/exchange-handler.ts
+++ b/services/log-collector/src/exchange-handler.ts
@@ -1,0 +1,56 @@
+import type { Context, Hono } from 'hono'
+import { exchangeCodeForToken, fetchUserLogin } from './gh-user'
+import { signJwt } from './jwt'
+
+/** Bindings the exchange handler reads from the worker env. */
+export type ExchangeBindings = {
+  readonly JWT_SECRET: string
+  readonly GH_CLIENT_ID: string
+  readonly GH_CLIENT_SECRET: string
+}
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const codeFrom = (body: unknown): string | undefined => {
+  const code = isObject(body) ? body['code'] : undefined
+  return typeof code === 'string' ? code : undefined
+}
+
+const handle = async (
+  c: Context<{ Bindings: ExchangeBindings }>
+): Promise<Response> => {
+  const body: unknown = await c.req.json().catch(() => undefined)
+  const code = codeFrom(body)
+  return code === undefined
+    ? c.json({ error: 'code required' }, 400)
+    : runExchange(c, code)
+}
+
+const runExchange = async (
+  c: Context<{ Bindings: ExchangeBindings }>,
+  code: string
+): Promise<Response> => {
+  const token = await exchangeCodeForToken(
+    code,
+    c.env.GH_CLIENT_ID,
+    c.env.GH_CLIENT_SECRET
+  )
+  const login = await fetchUserLogin(token)
+  const jwt = await signJwt(login, c.env.JWT_SECRET)
+  return c.json({ token: jwt, login })
+}
+
+/**
+ * Wire the `POST /auth/exchange` route. Accepts `{ code }`,
+ * exchanges with GitHub, fetches the login, and returns a signed
+ * collector JWT.
+ * @param app Hono app to extend.
+ * @returns Same app for chaining.
+ */
+export const registerExchangeRoute = (
+  app: Hono<{ Bindings: ExchangeBindings }>
+): Hono<{ Bindings: ExchangeBindings }> => {
+  app.post('/auth/exchange', handle)
+  return app
+}

--- a/services/log-collector/src/gh-user.ts
+++ b/services/log-collector/src/gh-user.ts
@@ -1,0 +1,60 @@
+const GH_USER_URL = 'https://api.github.com/user'
+const GH_TOKEN_URL = 'https://github.com/login/oauth/access_token'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Exchange a GitHub OAuth `code` for an access token. The
+ * client_id is taken from the worker env so each environment can
+ * point at its own GitHub App. Throws when GH refuses the swap
+ * so the handler returns 4xx.
+ * @param code OAuth code from the redirect.
+ * @param clientId GitHub App client id.
+ * @param clientSecret GitHub App client secret.
+ * @returns Access token GH issues for the code.
+ */
+export const exchangeCodeForToken = async (
+  code: string,
+  clientId: string,
+  clientSecret: string
+): Promise<string> => {
+  const res = await fetch(GH_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+    }),
+  })
+  const body: unknown = await res.json()
+  const token = isObject(body) ? body['access_token'] : undefined
+  return typeof token === 'string'
+    ? token
+    : Promise.reject(new Error('GitHub OAuth exchange failed'))
+}
+
+/**
+ * Resolve the GitHub `login` of the user behind an access token.
+ * Used by `/auth/exchange` to populate the JWT subject claim.
+ * @param token Access token from `exchangeCodeForToken`.
+ * @returns GitHub login string.
+ */
+export const fetchUserLogin = async (token: string): Promise<string> => {
+  const res = await fetch(GH_USER_URL, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'log-collector',
+    },
+  })
+  const body: unknown = await res.json()
+  const login = isObject(body) ? body['login'] : undefined
+  return typeof login === 'string'
+    ? login
+    : Promise.reject(new Error('Could not read GitHub user login'))
+}

--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -4,12 +4,14 @@ import {
   type AuthVariables,
   authMiddleware,
 } from './auth-middleware'
+import { batchSizeGuard } from './batch-size-guard'
 import {
   type ExchangeBindings,
   registerExchangeRoute,
 } from './exchange-handler'
 import { registerHealthRoute } from './health'
 import { type OtlpBindings, registerOtlpRoutes } from './otlp-handlers'
+import { rateLimit } from './rate-limit'
 
 /** Combined worker bindings across all registered routes. */
 export type Bindings = AuthBindings &
@@ -20,6 +22,8 @@ export type Bindings = AuthBindings &
 
 const app = new Hono<{ Bindings: Bindings; Variables: AuthVariables }>()
 app.use('*', authMiddleware())
+app.use('/v1/*', batchSizeGuard())
+app.use('/v1/*', rateLimit())
 registerHealthRoute(app)
 registerExchangeRoute(app)
 registerOtlpRoutes(app)

--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -1,12 +1,29 @@
 import { Hono } from 'hono'
+import {
+  type AuthBindings,
+  type AuthVariables,
+  authMiddleware,
+} from './auth-middleware'
+import {
+  type ExchangeBindings,
+  registerExchangeRoute,
+} from './exchange-handler'
 import { registerHealthRoute } from './health'
 
-/** Hono app composed of all registered routes. */
-export const app = registerHealthRoute(
-  new Hono<{ Bindings: { VERSION: string } }>()
-)
+/** Combined worker bindings across all registered routes. */
+export type Bindings = AuthBindings &
+  ExchangeBindings & {
+    readonly VERSION: string
+  }
+
+const app = new Hono<{ Bindings: Bindings; Variables: AuthVariables }>()
+app.use('*', authMiddleware())
+registerHealthRoute(app)
+registerExchangeRoute(app)
 
 /** Cloudflare Worker entry — delegates everything to Hono. */
 export default {
   fetch: app.fetch,
 }
+
+export { app }

--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -9,10 +9,12 @@ import {
   registerExchangeRoute,
 } from './exchange-handler'
 import { registerHealthRoute } from './health'
+import { type OtlpBindings, registerOtlpRoutes } from './otlp-handlers'
 
 /** Combined worker bindings across all registered routes. */
 export type Bindings = AuthBindings &
-  ExchangeBindings & {
+  ExchangeBindings &
+  OtlpBindings & {
     readonly VERSION: string
   }
 
@@ -20,6 +22,7 @@ const app = new Hono<{ Bindings: Bindings; Variables: AuthVariables }>()
 app.use('*', authMiddleware())
 registerHealthRoute(app)
 registerExchangeRoute(app)
+registerOtlpRoutes(app)
 
 /** Cloudflare Worker entry — delegates everything to Hono. */
 export default {

--- a/services/log-collector/src/jwt-key.ts
+++ b/services/log-collector/src/jwt-key.ts
@@ -1,0 +1,14 @@
+/**
+ * Import an HMAC key for HS256 JWT sign/verify. Reused by both
+ * sign and verify to keep the algorithm choice in one place.
+ * @param secret HS256 signing secret.
+ * @returns CryptoKey ready for sign/verify.
+ */
+export const importHs256Key = (secret: string): Promise<CryptoKey> =>
+  globalThis.crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  )

--- a/services/log-collector/src/jwt-shape.ts
+++ b/services/log-collector/src/jwt-shape.ts
@@ -1,0 +1,20 @@
+import type { JwtPayload } from './jwt-types'
+
+/**
+ * Type guard for the decoded JWT payload shape. Used in
+ * `verifyJwt` after `JSON.parse` to fail fast on malformed input
+ * without sprinkling `as` assertions.
+ * @param value Result of `JSON.parse`.
+ * @returns True when value matches `JwtPayload`.
+ */
+export const isJwtPayload = (value: unknown): value is JwtPayload => {
+  const v = value as Record<string, unknown>
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof v['sub'] === 'string' &&
+    typeof v['aud'] === 'string' &&
+    typeof v['iat'] === 'number' &&
+    typeof v['exp'] === 'number'
+  )
+}

--- a/services/log-collector/src/jwt-types.ts
+++ b/services/log-collector/src/jwt-types.ts
@@ -1,0 +1,19 @@
+/** Audience the collector accepts. */
+export const JWT_AUDIENCE = 'log-collector'
+
+/** Default token lifetime in seconds (1 hour). */
+export const JWT_TTL_SECONDS = 3600
+
+/** Decoded JWT payload — claim names follow RFC 7519. */
+export type JwtPayload = {
+  readonly sub: string
+  readonly aud: string
+  readonly iat: number
+  readonly exp: number
+}
+
+/** JWT header — fixed alg+typ, validated on verify. */
+export type JwtHeader = {
+  readonly alg: 'HS256'
+  readonly typ: 'JWT'
+}

--- a/services/log-collector/src/jwt-verify.ts
+++ b/services/log-collector/src/jwt-verify.ts
@@ -1,0 +1,48 @@
+import { base64urlDecode } from './base64url'
+import { importHs256Key } from './jwt-key'
+import { isJwtPayload } from './jwt-shape'
+import { JWT_AUDIENCE, type JwtPayload } from './jwt-types'
+
+const checkSignature = async (
+  data: string,
+  signature: string,
+  secret: string
+): Promise<boolean> => {
+  const key = await importHs256Key(secret)
+  return globalThis.crypto.subtle.verify(
+    'HMAC',
+    key,
+    base64urlDecode(signature),
+    new TextEncoder().encode(data)
+  )
+}
+
+/**
+ * Verify an HS256 JWT and return the decoded payload when valid.
+ * Returns undefined for any failure (bad shape, bad signature,
+ * wrong audience, expired).
+ * @param token Compact-serialised JWT.
+ * @param secret HS256 verification secret.
+ * @returns Decoded payload or undefined.
+ */
+export const verifyJwt = async (
+  token: string,
+  secret: string
+): Promise<JwtPayload | undefined> => {
+  const parts = token.split('.')
+  const [head, body, sig] = parts
+  const data = `${head}.${body}`
+  const validSig =
+    parts.length === 3 && (await checkSignature(data, sig ?? '', secret))
+  const decoded = validSig
+    ? (JSON.parse(
+        new TextDecoder().decode(base64urlDecode(body ?? ''))
+      ) as unknown)
+    : undefined
+  const now = Math.floor(Date.now() / 1000)
+  return isJwtPayload(decoded) &&
+    decoded.aud === JWT_AUDIENCE &&
+    decoded.exp > now
+    ? decoded
+    : undefined
+}

--- a/services/log-collector/src/jwt.test.ts
+++ b/services/log-collector/src/jwt.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { signJwt } from './jwt'
+import { verifyJwt } from './jwt-verify'
+
+const SECRET = 'test-secret-32-chars-long-or-better-1234'
+
+describe('jwt sign + verify', () => {
+  it('round-trips a valid token', async () => {
+    const token = await signJwt('alice', SECRET)
+    const payload = await verifyJwt(token, SECRET)
+    expect(payload?.sub).toBe('alice')
+    expect(payload?.aud).toBe('log-collector')
+    expect(payload?.exp).toBeGreaterThan(Math.floor(Date.now() / 1000))
+  })
+
+  it('rejects a token signed with a different secret', async () => {
+    const token = await signJwt('alice', SECRET)
+    expect(await verifyJwt(token, 'other-secret')).toBeUndefined()
+  })
+
+  it('rejects a malformed token', async () => {
+    expect(await verifyJwt('garbage', SECRET)).toBeUndefined()
+    expect(await verifyJwt('', SECRET)).toBeUndefined()
+    expect(await verifyJwt('a.b', SECRET)).toBeUndefined()
+  })
+
+  it('rejects a tampered payload', async () => {
+    const token = await signJwt('alice', SECRET)
+    const parts = token.split('.')
+    const tampered = `${parts[0]}.${parts[1]}x.${parts[2]}`
+    expect(await verifyJwt(tampered, SECRET)).toBeUndefined()
+  })
+})

--- a/services/log-collector/src/jwt.ts
+++ b/services/log-collector/src/jwt.ts
@@ -1,0 +1,41 @@
+import { base64urlEncode } from './base64url'
+import { importHs256Key } from './jwt-key'
+import {
+  JWT_AUDIENCE,
+  JWT_TTL_SECONDS,
+  type JwtHeader,
+  type JwtPayload,
+} from './jwt-types'
+
+const HEADER: JwtHeader = { alg: 'HS256', typ: 'JWT' }
+
+/**
+ * Sign a payload as an HS256 JWT. The `iat` and `exp` claims are
+ * filled automatically; callers supply only `sub` (the user
+ * identifier — typically the GitHub login).
+ * @param sub Subject identifier (e.g. GitHub login).
+ * @param secret HS256 signing secret read from `JWT_SECRET`.
+ * @returns Signed JWT in compact serialisation form.
+ */
+export const signJwt = async (
+  sub: string,
+  secret: string
+): Promise<string> => {
+  const now = Math.floor(Date.now() / 1000)
+  const payload: JwtPayload = {
+    sub,
+    aud: JWT_AUDIENCE,
+    iat: now,
+    exp: now + JWT_TTL_SECONDS,
+  }
+  const head = base64urlEncode(JSON.stringify(HEADER))
+  const body = base64urlEncode(JSON.stringify(payload))
+  const data = `${head}.${body}`
+  const key = await importHs256Key(secret)
+  const sig = await globalThis.crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(data)
+  )
+  return `${data}.${base64urlEncode(sig)}`
+}

--- a/services/log-collector/src/otlp-handlers.test.ts
+++ b/services/log-collector/src/otlp-handlers.test.ts
@@ -1,0 +1,115 @@
+import { Hono } from 'hono'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  type AuthBindings,
+  type AuthVariables,
+  authMiddleware,
+} from './auth-middleware'
+import { signJwt } from './jwt'
+import { type OtlpBindings, registerOtlpRoutes } from './otlp-handlers'
+
+const SECRET = 'test-secret-32-chars-long-or-better-1234'
+
+const buildApp = (bindings: Partial<OtlpBindings> = {}) => {
+  const app = new Hono<{
+    Bindings: AuthBindings & OtlpBindings
+    Variables: AuthVariables
+  }>()
+  app.use('*', authMiddleware())
+  registerOtlpRoutes(app)
+  return { app, env: { JWT_SECRET: SECRET, ...bindings } }
+}
+
+const span = {
+  traceId: 't1',
+  spanId: 's1',
+  name: 'op',
+  startedAt: 1000,
+  finishedAt: 1050,
+  status: 'ok',
+  attributes: { key: 'value' },
+}
+
+describe('POST /v1/traces', () => {
+  it('rejects without a token', async () => {
+    const { app, env } = buildApp()
+    const res = await app.fetch(
+      new Request('http://localhost/v1/traces', {
+        method: 'POST',
+        body: JSON.stringify({ spans: [span] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('persists spans and returns the accepted count', async () => {
+    const writeDataPoint = vi.fn()
+    const run = vi.fn().mockResolvedValue({ success: true })
+    const bind = vi.fn().mockReturnValue({ run })
+    const prepare = vi.fn().mockReturnValue({ bind })
+    const { app, env } = buildApp({
+      ANALYTICS_DATASET: { writeDataPoint },
+      D1: { prepare },
+    })
+    const token = await signJwt('alice', SECRET)
+    const res = await app.fetch(
+      new Request('http://localhost/v1/traces', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ spans: [span, span] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ accepted: 2 })
+    expect(writeDataPoint).toHaveBeenCalledTimes(2)
+    expect(prepare).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns 422 when no valid spans in batch', async () => {
+    const { app, env } = buildApp()
+    const token = await signJwt('alice', SECRET)
+    const res = await app.fetch(
+      new Request('http://localhost/v1/traces', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ spans: [{ traceId: 'only' }] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+  })
+})
+
+describe('POST /v1/logs', () => {
+  it('persists logs and returns the accepted count', async () => {
+    const run = vi.fn().mockResolvedValue({ success: true })
+    const bind = vi.fn().mockReturnValue({ run })
+    const prepare = vi.fn().mockReturnValue({ bind })
+    const { app, env } = buildApp({
+      D1: { prepare },
+    })
+    const token = await signJwt('alice', SECRET)
+    const res = await app.fetch(
+      new Request('http://localhost/v1/logs', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: JSON.stringify({
+          logs: [
+            {
+              level: 'info',
+              message: 'hello',
+              at: 1000,
+              attributes: {},
+            },
+          ],
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ accepted: 1 })
+    expect(prepare).toHaveBeenCalledTimes(1)
+  })
+})

--- a/services/log-collector/src/otlp-handlers.ts
+++ b/services/log-collector/src/otlp-handlers.ts
@@ -1,0 +1,60 @@
+import type { Context, Hono } from 'hono'
+import type { AuthVariables } from './auth-middleware'
+import { parseLogBatch, parseTraceBatch } from './otlp-validate'
+import { persistLogs, persistSpans } from './storage'
+import type { StorageBindings } from './storage-types'
+
+/** Bindings the OTLP routes read off the worker env. */
+export type OtlpBindings = StorageBindings
+
+const handleTraces = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>
+): Promise<Response> => {
+  const body: unknown = await c.req.json().catch(() => undefined)
+  const spans = parseTraceBatch(body)
+  return spans.length === 0
+    ? c.json({ error: 'no valid spans in batch' }, 422)
+    : runPersistSpans(c, spans)
+}
+
+const runPersistSpans = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>,
+  spans: ReturnType<typeof parseTraceBatch>
+): Promise<Response> => {
+  const user = c.get('user').sub
+  await persistSpans(c.env, spans, user)
+  return c.json({ accepted: spans.length })
+}
+
+const handleLogs = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>
+): Promise<Response> => {
+  const body: unknown = await c.req.json().catch(() => undefined)
+  const logs = parseLogBatch(body)
+  return logs.length === 0
+    ? c.json({ error: 'no valid logs in batch' }, 422)
+    : runPersistLogs(c, logs)
+}
+
+const runPersistLogs = async (
+  c: Context<{ Bindings: OtlpBindings; Variables: AuthVariables }>,
+  logs: ReturnType<typeof parseLogBatch>
+): Promise<Response> => {
+  await persistLogs(c.env, logs)
+  return c.json({ accepted: logs.length })
+}
+
+/**
+ * Wire `POST /v1/traces` and `POST /v1/logs`. Both routes are
+ * gated by the auth middleware in `src/index.ts`; the handlers
+ * therefore trust `c.get('user')`.
+ * @param app Hono app to extend.
+ * @returns Same app for chaining.
+ */
+export const registerOtlpRoutes = (
+  app: Hono<{ Bindings: OtlpBindings; Variables: AuthVariables }>
+): Hono<{ Bindings: OtlpBindings; Variables: AuthVariables }> => {
+  app.post('/v1/traces', handleTraces)
+  app.post('/v1/logs', handleLogs)
+  return app
+}

--- a/services/log-collector/src/otlp-log.ts
+++ b/services/log-collector/src/otlp-log.ts
@@ -1,0 +1,38 @@
+import { stringMap } from './otlp-string-map'
+import type { LogLevel, LogRecord } from './otlp-types'
+
+const LEVELS: ReadonlySet<LogLevel> = new Set([
+  'debug',
+  'info',
+  'warn',
+  'error',
+])
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Validate a single OTLP log entry. Returns `undefined` for
+ * malformed input.
+ * @param raw Raw entry from a `/v1/logs` batch.
+ * @returns Validated `LogRecord` or undefined.
+ */
+export const validLog = (raw: unknown): LogRecord | undefined => {
+  const v = isObject(raw) ? raw : undefined
+  const level = v?.['level']
+  const ok =
+    typeof v?.['message'] === 'string' &&
+    typeof v['at'] === 'number' &&
+    typeof level === 'string' &&
+    LEVELS.has(level as LogLevel)
+  return ok && v !== undefined
+    ? {
+        traceId: typeof v['traceId'] === 'string' ? v['traceId'] : undefined,
+        spanId: typeof v['spanId'] === 'string' ? v['spanId'] : undefined,
+        level: level as LogLevel,
+        message: v['message'] as string,
+        at: v['at'] as number,
+        attributes: stringMap(v['attributes']),
+      }
+    : undefined
+}

--- a/services/log-collector/src/otlp-span.ts
+++ b/services/log-collector/src/otlp-span.ts
@@ -1,0 +1,46 @@
+import { stringMap } from './otlp-string-map'
+import type { SpanRecord, SpanStatus } from './otlp-types'
+
+const STATUSES: ReadonlySet<SpanStatus> = new Set(['ok', 'error', 'unset'])
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const checkSpan = (raw: Record<string, unknown>): boolean => {
+  const status = raw['status']
+  return (
+    typeof raw['traceId'] === 'string' &&
+    typeof raw['spanId'] === 'string' &&
+    typeof raw['name'] === 'string' &&
+    typeof raw['startedAt'] === 'number' &&
+    typeof raw['finishedAt'] === 'number' &&
+    typeof status === 'string' &&
+    STATUSES.has(status as SpanStatus)
+  )
+}
+
+/**
+ * Validate a single OTLP span entry. Returns `undefined` for
+ * malformed input so the caller can `.filter` it out without a
+ * cast.
+ * @param raw Raw entry from a `/v1/traces` batch.
+ * @returns Validated `SpanRecord` or undefined.
+ */
+export const validSpan = (raw: unknown): SpanRecord | undefined => {
+  const v = isObject(raw) ? raw : undefined
+  return v !== undefined && checkSpan(v)
+    ? {
+        traceId: v['traceId'] as string,
+        spanId: v['spanId'] as string,
+        parentSpanId:
+          typeof v['parentSpanId'] === 'string'
+            ? v['parentSpanId']
+            : undefined,
+        name: v['name'] as string,
+        startedAt: v['startedAt'] as number,
+        finishedAt: v['finishedAt'] as number,
+        status: v['status'] as SpanStatus,
+        attributes: stringMap(v['attributes']),
+      }
+    : undefined
+}

--- a/services/log-collector/src/otlp-string-map.ts
+++ b/services/log-collector/src/otlp-string-map.ts
@@ -1,0 +1,19 @@
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Coerce an unknown value into a string→string map. Used to
+ * extract attributes from raw OTLP payloads while dropping any
+ * non-string values without throwing.
+ * @param value Source value (typically a parsed JSON object).
+ * @returns Frozen string-to-string map.
+ */
+export const stringMap = (
+  value: unknown
+): Readonly<Record<string, string>> => {
+  const obj = isObject(value) ? value : {}
+  const entries = Object.entries(obj).filter(
+    (entry): entry is [string, string] => typeof entry[1] === 'string'
+  )
+  return Object.fromEntries(entries)
+}

--- a/services/log-collector/src/otlp-types.ts
+++ b/services/log-collector/src/otlp-types.ts
@@ -1,0 +1,27 @@
+/** Status carried on a finished span. */
+export type SpanStatus = 'ok' | 'error' | 'unset'
+
+/** Span as accepted by `/v1/traces`. */
+export type SpanRecord = {
+  readonly traceId: string
+  readonly spanId: string
+  readonly parentSpanId: string | undefined
+  readonly name: string
+  readonly startedAt: number
+  readonly finishedAt: number
+  readonly status: SpanStatus
+  readonly attributes: Readonly<Record<string, string>>
+}
+
+/** Log severity carried on a log record. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/** Log entry as accepted by `/v1/logs`. */
+export type LogRecord = {
+  readonly traceId: string | undefined
+  readonly spanId: string | undefined
+  readonly level: LogLevel
+  readonly message: string
+  readonly at: number
+  readonly attributes: Readonly<Record<string, string>>
+}

--- a/services/log-collector/src/otlp-validate.test.ts
+++ b/services/log-collector/src/otlp-validate.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { parseLogBatch, parseTraceBatch } from './otlp-validate'
+
+const span = {
+  traceId: 't1',
+  spanId: 's1',
+  parentSpanId: undefined,
+  name: 'op',
+  startedAt: 1000,
+  finishedAt: 1050,
+  status: 'ok',
+  attributes: { key: 'value' },
+}
+
+const log = {
+  traceId: 't1',
+  spanId: 's1',
+  level: 'info',
+  message: 'hello',
+  at: 1000,
+  attributes: { route: '/x' },
+}
+
+describe('parseTraceBatch', () => {
+  it('returns valid spans verbatim', () => {
+    const result = parseTraceBatch({ spans: [span] })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.spanId).toBe('s1')
+    expect(result[0]?.attributes).toEqual({ key: 'value' })
+  })
+
+  it('drops malformed spans', () => {
+    const result = parseTraceBatch({
+      spans: [span, { traceId: 't2' }, null, 42],
+    })
+    expect(result).toHaveLength(1)
+  })
+
+  it('returns [] when shape is wrong', () => {
+    expect(parseTraceBatch(undefined)).toEqual([])
+    expect(parseTraceBatch({ no: 'spans' })).toEqual([])
+    expect(parseTraceBatch({ spans: 'oops' })).toEqual([])
+  })
+
+  it('rejects unknown statuses', () => {
+    expect(
+      parseTraceBatch({ spans: [{ ...span, status: 'weird' }] })
+    ).toEqual([])
+  })
+
+  it('drops non-string attribute values', () => {
+    const result = parseTraceBatch({
+      spans: [{ ...span, attributes: { a: 'ok', b: 42 } }],
+    })
+    expect(result[0]?.attributes).toEqual({ a: 'ok' })
+  })
+})
+
+describe('parseLogBatch', () => {
+  it('returns valid logs verbatim', () => {
+    const result = parseLogBatch({ logs: [log] })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.message).toBe('hello')
+  })
+
+  it('rejects unknown levels', () => {
+    expect(parseLogBatch({ logs: [{ ...log, level: 'panic' }] })).toEqual([])
+  })
+
+  it('treats traceId/spanId as optional', () => {
+    const minimal = { ...log, traceId: undefined, spanId: undefined }
+    const result = parseLogBatch({ logs: [minimal] })
+    expect(result).toHaveLength(1)
+    expect(result[0]?.traceId).toBeUndefined()
+  })
+})

--- a/services/log-collector/src/otlp-validate.ts
+++ b/services/log-collector/src/otlp-validate.ts
@@ -1,0 +1,35 @@
+import { validLog } from './otlp-log'
+import { validSpan } from './otlp-span'
+import type { LogRecord, SpanRecord } from './otlp-types'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const collect = <T>(
+  raw: unknown,
+  key: string,
+  validate: (item: unknown) => T | undefined
+): readonly T[] => {
+  const arr = isObject(raw) ? raw[key] : undefined
+  return Array.isArray(arr)
+    ? arr.map(validate).filter((x): x is T => x !== undefined)
+    : []
+}
+
+/**
+ * Parse and validate a `/v1/traces` batch. Drops malformed spans
+ * rather than rejecting the whole batch — exporter is fire-and-
+ * forget so partial acceptance keeps healthy traces visible.
+ * @param body Raw `request.json()` result.
+ * @returns Frozen array of valid spans.
+ */
+export const parseTraceBatch = (body: unknown): readonly SpanRecord[] =>
+  collect(body, 'spans', validSpan)
+
+/**
+ * Parse and validate a `/v1/logs` batch. Drops malformed entries.
+ * @param body Raw `request.json()` result.
+ * @returns Frozen array of valid log records.
+ */
+export const parseLogBatch = (body: unknown): readonly LogRecord[] =>
+  collect(body, 'logs', validLog)

--- a/services/log-collector/src/rate-limit.test.ts
+++ b/services/log-collector/src/rate-limit.test.ts
@@ -1,0 +1,62 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { type AuthVariables, authMiddleware } from './auth-middleware'
+import { signJwt } from './jwt'
+import { clearRateBuckets, rateLimit } from './rate-limit'
+
+const SECRET = 'test-secret-32-chars-long-or-better-1234'
+
+const buildApp = (limit: number) => {
+  const app = new Hono<{
+    Bindings: { JWT_SECRET: string }
+    Variables: AuthVariables
+  }>()
+  app.use('*', authMiddleware())
+  app.use('/v1/*', rateLimit(limit))
+  app.post('/v1/x', c => c.json({ ok: true }))
+  return app
+}
+
+const fire = async (
+  app: ReturnType<typeof buildApp>,
+  token: string
+): Promise<Response> =>
+  app.fetch(
+    new Request('http://localhost/v1/x', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+    { JWT_SECRET: SECRET }
+  )
+
+describe('rateLimit', () => {
+  beforeEach(clearRateBuckets)
+  afterEach(clearRateBuckets)
+
+  it('allows up to the configured limit per user', async () => {
+    const app = buildApp(3)
+    const token = await signJwt('alice', SECRET)
+    expect((await fire(app, token)).status).toBe(200)
+    expect((await fire(app, token)).status).toBe(200)
+    expect((await fire(app, token)).status).toBe(200)
+  })
+
+  it('returns 429 with Retry-After once the limit is hit', async () => {
+    const app = buildApp(2)
+    const token = await signJwt('alice', SECRET)
+    await fire(app, token)
+    await fire(app, token)
+    const res = await fire(app, token)
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toMatch(/^\d+$/)
+  })
+
+  it('isolates buckets per user', async () => {
+    const app = buildApp(1)
+    const alice = await signJwt('alice', SECRET)
+    const bob = await signJwt('bob', SECRET)
+    expect((await fire(app, alice)).status).toBe(200)
+    expect((await fire(app, alice)).status).toBe(429)
+    expect((await fire(app, bob)).status).toBe(200)
+  })
+})

--- a/services/log-collector/src/rate-limit.ts
+++ b/services/log-collector/src/rate-limit.ts
@@ -1,0 +1,53 @@
+import type { MiddlewareHandler } from 'hono'
+import type { AuthVariables } from './auth-middleware'
+
+/** Default per-user budget: 60 requests per 60-second window. */
+export const RATE_LIMIT_PER_MINUTE = 60
+const WINDOW_MS = 60_000
+
+type Bucket = { readonly start: number; readonly count: number }
+
+const buckets = new Map<string, Bucket>()
+
+const update = (
+  key: string,
+  now: number,
+  limit: number
+): { readonly allowed: boolean; readonly retryMs: number } => {
+  const bucket = buckets.get(key)
+  const fresh = bucket === undefined || now - bucket.start > WINDOW_MS
+  const next = fresh
+    ? { start: now, count: 1 }
+    : { start: bucket.start, count: bucket.count + 1 }
+  buckets.set(key, next)
+  return next.count <= limit
+    ? { allowed: true, retryMs: 0 }
+    : { allowed: false, retryMs: WINDOW_MS - (now - next.start) }
+}
+
+/** Reset every bucket. Used by tests. */
+export const clearRateBuckets = (): void => {
+  buckets.clear()
+}
+
+/**
+ * Hono middleware enforcing a per-user request budget. Sliding
+ * window keyed by the JWT subject claim. CF Rate Limiting will
+ * superset this in production; the in-memory variant catches
+ * loops in dev / tests and gives an obvious local signal.
+ * @param limit Max requests per minute, defaults to 60.
+ * @returns Hono middleware handler.
+ */
+export const rateLimit = (
+  limit: number = RATE_LIMIT_PER_MINUTE
+): MiddlewareHandler<{ Variables: AuthVariables }> => {
+  return async (c, next) => {
+    const user = c.get('user')?.sub ?? 'anon'
+    const result = update(user, Date.now(), limit)
+    return result.allowed
+      ? await next()
+      : c.json({ error: 'rate limited' }, 429, {
+          'Retry-After': String(Math.ceil(result.retryMs / 1000)),
+        })
+  }
+}

--- a/services/log-collector/src/storage-logs.ts
+++ b/services/log-collector/src/storage-logs.ts
@@ -1,0 +1,31 @@
+import type { LogRecord } from './otlp-types'
+import type { StorageBindings } from './storage-types'
+
+const INSERT_LOG_SQL =
+  'INSERT INTO logs (trace_id, level, at) VALUES (?, ?, ?)'
+
+const indexLogD1 = (
+  bindings: StorageBindings,
+  log: LogRecord
+): Promise<unknown> => {
+  const db = bindings.D1
+  return db === undefined
+    ? Promise.resolve()
+    : db
+        .prepare(INSERT_LOG_SQL)
+        .bind(log.traceId ?? '', log.level, log.at)
+        .run()
+}
+
+/**
+ * Persist a batch of validated logs to D1.
+ * @param bindings Storage bindings on the worker env.
+ * @param logs Validated logs to persist.
+ * @returns Resolves once all writes complete.
+ */
+export const persistLogs = async (
+  bindings: StorageBindings,
+  logs: readonly LogRecord[]
+): Promise<void> => {
+  await Promise.all(logs.map(log => indexLogD1(bindings, log)))
+}

--- a/services/log-collector/src/storage-spans.ts
+++ b/services/log-collector/src/storage-spans.ts
@@ -1,0 +1,57 @@
+import type { SpanRecord } from './otlp-types'
+import type { StorageBindings } from './storage-types'
+
+const INSERT_TRACE_SQL =
+  'INSERT INTO traces (trace_id, user, op, started_at) VALUES (?, ?, ?, ?)'
+
+const writeSpanAnalytics = (
+  bindings: StorageBindings,
+  span: SpanRecord,
+  user: string
+): void => {
+  const ds = bindings.ANALYTICS_DATASET
+  const noop = (): void => undefined
+  const fire =
+    ds === undefined
+      ? noop
+      : () =>
+          ds.writeDataPoint({
+            indexes: [span.traceId, user],
+            blobs: [span.name, span.spanId, span.status],
+            doubles: [span.startedAt, span.finishedAt],
+          })
+  fire()
+}
+
+const indexSpanD1 = (
+  bindings: StorageBindings,
+  span: SpanRecord,
+  user: string
+): Promise<unknown> => {
+  const db = bindings.D1
+  return db === undefined
+    ? Promise.resolve()
+    : db
+        .prepare(INSERT_TRACE_SQL)
+        .bind(span.traceId, user, span.name, span.startedAt)
+        .run()
+}
+
+/**
+ * Persist a batch of validated spans to Analytics Engine + D1.
+ * No-op when bindings are absent (local dev / tests).
+ * @param bindings Storage bindings on the worker env.
+ * @param spans Validated spans to persist.
+ * @param user GitHub login from the JWT subject claim.
+ * @returns Resolves once all writes complete.
+ */
+export const persistSpans = async (
+  bindings: StorageBindings,
+  spans: readonly SpanRecord[],
+  user: string
+): Promise<void> => {
+  spans.forEach(span => {
+    writeSpanAnalytics(bindings, span, user)
+  })
+  await Promise.all(spans.map(span => indexSpanD1(bindings, span, user)))
+}

--- a/services/log-collector/src/storage-types.ts
+++ b/services/log-collector/src/storage-types.ts
@@ -1,0 +1,25 @@
+/** Workers Analytics Engine binding shape (subset we use). */
+export type AnalyticsEngineDataset = {
+  readonly writeDataPoint: (point: {
+    readonly indexes: ReadonlyArray<string>
+    readonly blobs?: ReadonlyArray<string>
+    readonly doubles?: ReadonlyArray<number>
+  }) => void
+}
+
+/** D1 database binding shape (subset we use). */
+export type D1Database = {
+  readonly prepare: (sql: string) => D1PreparedStatement
+}
+
+/** D1 prepared statement (subset). */
+export type D1PreparedStatement = {
+  readonly bind: (...args: ReadonlyArray<unknown>) => D1PreparedStatement
+  readonly run: () => Promise<{ readonly success: boolean }>
+}
+
+/** Storage bindings exposed to the OTLP handlers. */
+export type StorageBindings = {
+  readonly ANALYTICS_DATASET: AnalyticsEngineDataset | undefined
+  readonly D1: D1Database | undefined
+}

--- a/services/log-collector/src/storage.ts
+++ b/services/log-collector/src/storage.ts
@@ -1,0 +1,3 @@
+/** Barrel re-exports so callers import storage from one place. */
+export { persistLogs } from './storage-logs'
+export { persistSpans } from './storage-spans'


### PR DESCRIPTION
## Summary
Phase B / Epic 6 — Hono Worker collector backend complete. Receives OpenTelemetry-shaped trace + log batches from the admin client, gates them with HS256 JWT auth, and persists them to Workers Analytics Engine + D1.

## What's in this release
- **6.1 #125 / #129 / #130** — `services/log-collector/` package with `GET /health` and CI deploy workflow.
- **6.2 #126 / #131** — JWT HS256 sign + verify via Web Crypto, `POST /auth/exchange` swaps GH OAuth code for a 1-hour collector JWT, middleware gates every non-public route.
- **6.3 #127 / #132** — `POST /v1/traces` + `POST /v1/logs` accept OTLP-shaped batches, validate defensively (drop malformed entries), persist to Analytics Engine + D1; bindings optional so local dev no-ops.
- **6.4 #128 / #133** — 256 KB batch cap (413 + chunkSize hint) + 60 req/min/user sliding window (429 + Retry-After).

## Coverage
- 31 unit specs in `services/log-collector/` (base64url, JWT, auth middleware, OTLP validate, OTLP handlers, batch-size guard, rate-limit)
- 511/511 unit total across the workspace
- Validate clean

## Verification post-deploy
- [ ] CF dashboard shows the `log-collector` worker
- [ ] `https://log-collector.<account>.workers.dev/health` returns 200
- [ ] `JWT_SECRET`, `GH_CLIENT_ID`, `GH_CLIENT_SECRET`, `ANALYTICS_DATASET`, `D1` secrets/bindings configured before /auth/exchange and /v1/* are called
- [ ] D1 schema migration applied: `traces (trace_id, user, op, started_at)` + `logs (trace_id, level, at)`

## Phase B scoreboard (now in master)
- Epic 5 — partial (5.1, 5.3, 5.4); 5.2 deferred to Epic 7
- Epic 6 — 4/4 ✅
- Epic 7 — not started (will pick up 5.2 + chunked exporter)
- Epic 8 — not started (SSE subs)
- Epic 9 — not started (trace viewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)