### PR TITLE
feat(tracing): batched OTLP exporter (size + time triggers) (#135)

### DIFF
--- a/src/composables/useTracing/exporter-config.ts
+++ b/src/composables/useTracing/exporter-config.ts
@@ -1,0 +1,24 @@
+/** Default flush trigger: 100 spans. */
+export const FLUSH_AT_SPANS = 100
+
+/** Default flush trigger: 30 seconds since the first add. */
+export const FLUSH_AT_MS = 30_000
+
+/**
+ * Resolve the collector base URL. Reads `VITE_COLLECTOR_URL`
+ * when present, falling back to the published worker host so a
+ * default build still posts to a real endpoint.
+ * @returns Origin string with no trailing slash.
+ */
+export const collectorBaseUrl = (): string =>
+  (import.meta.env['VITE_COLLECTOR_URL'] as string | undefined) ??
+  'https://log-collector.workers.dev'
+
+/**
+ * Read the active collector JWT. Source order: localStorage
+ * (set by the auth flow). Returns `''` when missing — the
+ * collector's auth middleware will reject anonymous calls.
+ * @returns JWT string or empty.
+ */
+export const collectorToken = (): string =>
+  globalThis.localStorage?.getItem('collector_jwt') ?? ''

--- a/src/composables/useTracing/exporter-send.ts
+++ b/src/composables/useTracing/exporter-send.ts
@@ -1,0 +1,28 @@
+import { collectorBaseUrl, collectorToken } from './exporter-config'
+import type { Span } from './span-types'
+
+/**
+ * POST a batch of spans to the collector. Returns true on 2xx,
+ * false on any other outcome. Errors are swallowed so the
+ * exporter loop never throws — failed batches are retained by
+ * the caller for the next flush attempt.
+ * @param spans Frozen list of spans to ship.
+ * @returns True when the collector accepted the batch.
+ */
+export const sendBatch = async (
+  spans: ReadonlyArray<Span>
+): Promise<boolean> => {
+  try {
+    const res = await fetch(`${collectorBaseUrl()}/v1/traces`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${collectorToken()}`,
+      },
+      body: JSON.stringify({ spans }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}

--- a/src/composables/useTracing/exporter-types.ts
+++ b/src/composables/useTracing/exporter-types.ts
@@ -1,0 +1,12 @@
+import type { Span } from './span-types'
+
+/** Wire format for the `/v1/traces` batch payload. */
+export type SpanBatch = {
+  readonly spans: ReadonlyArray<Span>
+}
+
+/** Result of a single flush attempt. */
+export type FlushOutcome =
+  | { readonly kind: 'sent'; readonly count: number }
+  | { readonly kind: 'fail'; readonly count: number }
+  | { readonly kind: 'idle' }

--- a/src/composables/useTracing/exporter.test.ts
+++ b/src/composables/useTracing/exporter.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  bufferedSpanCount,
+  flushNow,
+  recordSpan,
+  resetExporter,
+} from './exporter'
+import { FLUSH_AT_MS, FLUSH_AT_SPANS } from './exporter-config'
+import type { Span } from './span-types'
+
+const span = (id: string): Span => ({
+  id,
+  traceId: 't1',
+  parentId: undefined,
+  name: id,
+  startedAt: 1,
+  finishedAt: 2,
+  attributes: {},
+  status: 'ok',
+})
+
+describe('exporter', () => {
+  beforeEach(() => {
+    resetExporter()
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    )
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    resetExporter()
+  })
+
+  it('flushes immediately at FLUSH_AT_SPANS', async () => {
+    for (let i = 0; i < FLUSH_AT_SPANS; i += 1) {
+      recordSpan(span(`s${i}`))
+    }
+    await vi.runAllTimersAsync()
+    expect(bufferedSpanCount()).toBe(0)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('flushes after FLUSH_AT_MS when below the size trigger', async () => {
+    recordSpan(span('a'))
+    expect(bufferedSpanCount()).toBe(1)
+    await vi.advanceTimersByTimeAsync(FLUSH_AT_MS - 1)
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(2)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('retains spans on failed flush', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 500 }))
+    )
+    recordSpan(span('a'))
+    recordSpan(span('b'))
+    const result = await flushNow()
+    expect(result.kind).toBe('fail')
+    expect(bufferedSpanCount()).toBe(2)
+  })
+
+  it('returns idle when nothing buffered', async () => {
+    expect((await flushNow()).kind).toBe('idle')
+  })
+})

--- a/src/composables/useTracing/exporter.ts
+++ b/src/composables/useTracing/exporter.ts
@@ -1,0 +1,70 @@
+import { FLUSH_AT_MS, FLUSH_AT_SPANS } from './exporter-config'
+import { sendBatch } from './exporter-send'
+import type { FlushOutcome } from './exporter-types'
+import type { Span } from './span-types'
+
+let buffer: Span[] = []
+let firstAddedAt: number | undefined
+let timer: ReturnType<typeof setTimeout> | undefined
+
+const scheduleFlush = (run: () => void): void => {
+  globalThis.clearTimeout(timer)
+  timer = globalThis.setTimeout(run, FLUSH_AT_MS)
+}
+
+/**
+ * Push a finished span into the exporter buffer. Triggers a
+ * flush when the buffer reaches `FLUSH_AT_SPANS` spans;
+ * otherwise schedules a `FLUSH_AT_MS` time-based flush.
+ * @param span Finished span to enqueue.
+ * @returns void
+ */
+export const recordSpan = (span: Span): void => {
+  buffer = [...buffer, span]
+  firstAddedAt ??= Date.now()
+  const trigger =
+    buffer.length >= FLUSH_AT_SPANS
+      ? () => {
+          void flushNow()
+        }
+      : () =>
+          scheduleFlush(() => {
+            void flushNow()
+          })
+  trigger()
+}
+
+/**
+ * Flush the buffer immediately. Failed sends keep the spans
+ * around so the next call retries them.
+ * @returns Outcome describing what was sent.
+ */
+export const flushNow = async (): Promise<FlushOutcome> => {
+  globalThis.clearTimeout(timer)
+  timer = undefined
+  const pending = buffer.slice()
+  const empty = pending.length === 0
+  const ok = empty ? false : await sendBatch(pending)
+  const sent = !empty && ok
+  buffer = sent ? [] : pending
+  firstAddedAt = sent ? undefined : firstAddedAt
+  return empty
+    ? { kind: 'idle' }
+    : sent
+      ? { kind: 'sent', count: pending.length }
+      : { kind: 'fail', count: pending.length }
+}
+
+/** Reset the buffer and any pending timer. Used by tests. */
+export const resetExporter = (): void => {
+  globalThis.clearTimeout(timer)
+  timer = undefined
+  buffer = []
+  firstAddedAt = undefined
+}
+
+/**
+ * Current buffer length — for tests and dev overlays.
+ * @returns Number of spans waiting to be flushed.
+ */
+export const bufferedSpanCount = (): number => buffer.length

--- a/src/composables/useTracing/index.ts
+++ b/src/composables/useTracing/index.ts
@@ -1,4 +1,10 @@
-/** W3C trace-context + span recording helpers. */
+/** W3C trace-context + span recording + OTLP exporter helpers. */
+export {
+  bufferedSpanCount,
+  flushNow,
+  recordSpan,
+  resetExporter,
+} from './exporter'
 export type { Span, SpanStatus } from './span-types'
 export {
   clearSpans,
@@ -6,6 +12,7 @@ export {
   finishSpan,
   listAllSpans,
   MAX_SPANS,
+  onFinishSpan,
   startSpan,
 } from './spans-store'
 export {

--- a/src/composables/useTracing/spans-store.ts
+++ b/src/composables/useTracing/spans-store.ts
@@ -6,6 +6,18 @@ export const MAX_SPANS = 500
 
 let active: Span[] = []
 let completed: Span[] = []
+let onFinishHook: ((span: Span) => void) | undefined
+
+/**
+ * Register a single hook to receive every span as it finishes.
+ * Used by the exporter (7.1) to ship spans to the collector.
+ * Idempotent — repeat calls overwrite the previous hook.
+ * @param hook Callback that runs synchronously on `finishSpan`.
+ * @returns void
+ */
+export const onFinishSpan = (hook: (span: Span) => void): void => {
+  onFinishHook = hook
+}
 
 const evictOldest = (): void => {
   completed = completed.slice(Math.max(0, completed.length - MAX_SPANS))
@@ -48,6 +60,12 @@ export const finishSpan = (
       : { ...found, finishedAt: Date.now(), status }
   completed = finished === undefined ? completed : [...completed, finished]
   evictOldest()
+  const noop = (): void => undefined
+  const fire =
+    finished === undefined || onFinishHook === undefined
+      ? noop
+      : () => onFinishHook?.(finished)
+  fire()
   return finished
 }
 
@@ -69,4 +87,5 @@ export const listAllSpans = (): readonly Span[] => [...completed]
 export const clearSpans = (): void => {
   active = []
   completed = []
+  onFinishHook = undefined
 }


### PR DESCRIPTION
Phase B / Epic 7 increment 7.1. recordSpan + flushNow with size/time triggers; spans-store.onFinishSpan hook so callers can wire auto-export without a circular import. 4/4 unit. Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)