### PR TITLE
feat(tracing): IDB queue + drain on reconnect (#136)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-wa
 import { usePushConflictBridge } from '@/composables/useNotifications/use-push-conflict-bridge'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { usePushSummaryBridge } from '@/composables/useNotifications/use-push-summary-bridge'
+import { useExporterBootstrap } from '@/composables/useTracing/use-exporter-bootstrap'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
@@ -24,6 +25,7 @@ usePushErrorBridge()
 useOfflineWatcher()
 usePushSummaryBridge()
 usePushConflictBridge()
+useExporterBootstrap()
 
 const poll = useDeployPolling()
 const mergedEntries = useMergedEntries(poll.entries)

--- a/src/composables/useTracing/drain-queued.ts
+++ b/src/composables/useTracing/drain-queued.ts
@@ -1,0 +1,36 @@
+import { sendBatch } from './exporter-send'
+import { listQueued, type QueuedBatch } from './queue-idb'
+import { dropBatch } from './queue-idb-write'
+
+const tryNext = async (
+  pending: readonly QueuedBatch[],
+  index: number,
+  shipped: number
+): Promise<number> => {
+  const batch = pending[index]
+  return batch === undefined
+    ? shipped
+    : tryShip(pending, index, batch, shipped)
+}
+
+const tryShip = async (
+  pending: readonly QueuedBatch[],
+  index: number,
+  batch: QueuedBatch,
+  shipped: number
+): Promise<number> => {
+  const ok = await sendBatch(batch.spans)
+  await (ok ? dropBatch(batch.id) : Promise.resolve())
+  return ok ? tryNext(pending, index + 1, shipped + 1) : shipped
+}
+
+/**
+ * Walk the persisted queue oldest-first and ship every batch.
+ * Drops shipped batches; halts on the first failure so the
+ * queue order stays preserved for the next drain.
+ * @returns Number of batches successfully shipped.
+ */
+export const drainQueuedBatches = async (): Promise<number> => {
+  const pending = await listQueued()
+  return tryNext(pending, 0, 0)
+}

--- a/src/composables/useTracing/exporter.test.ts
+++ b/src/composables/useTracing/exporter.test.ts
@@ -1,3 +1,4 @@
+import 'fake-indexeddb/auto'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   bufferedSpanCount,
@@ -6,6 +7,8 @@ import {
   resetExporter,
 } from './exporter'
 import { FLUSH_AT_MS, FLUSH_AT_SPANS } from './exporter-config'
+import { listQueued } from './queue-idb'
+import { clearQueuedBatches } from './queue-idb-write'
 import type { Span } from './span-types'
 
 const span = (id: string): Span => ({
@@ -20,18 +23,20 @@ const span = (id: string): Span => ({
 })
 
 describe('exporter', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     resetExporter()
+    await clearQueuedBatches()
     vi.useFakeTimers()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
     )
   })
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers()
     vi.unstubAllGlobals()
     resetExporter()
+    await clearQueuedBatches()
   })
 
   it('flushes immediately at FLUSH_AT_SPANS', async () => {
@@ -52,7 +57,8 @@ describe('exporter', () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(1)
   })
 
-  it('retains spans on failed flush', async () => {
+  it('persists failed batches to the IDB queue', async () => {
+    vi.useRealTimers()
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue(new Response(null, { status: 500 }))
@@ -61,7 +67,10 @@ describe('exporter', () => {
     recordSpan(span('b'))
     const result = await flushNow()
     expect(result.kind).toBe('fail')
-    expect(bufferedSpanCount()).toBe(2)
+    expect(bufferedSpanCount()).toBe(0)
+    const queued = await listQueued()
+    expect(queued).toHaveLength(1)
+    expect(queued[0]?.spans).toHaveLength(2)
   })
 
   it('returns idle when nothing buffered', async () => {

--- a/src/composables/useTracing/exporter.ts
+++ b/src/composables/useTracing/exporter.ts
@@ -1,6 +1,7 @@
 import { FLUSH_AT_MS, FLUSH_AT_SPANS } from './exporter-config'
 import { sendBatch } from './exporter-send'
 import type { FlushOutcome } from './exporter-types'
+import { enqueueBatch } from './queue-idb-write'
 import type { Span } from './span-types'
 
 let buffer: Span[] = []
@@ -35,8 +36,9 @@ export const recordSpan = (span: Span): void => {
 }
 
 /**
- * Flush the buffer immediately. Failed sends keep the spans
- * around so the next call retries them.
+ * Flush the buffer immediately. Successful sends drain the
+ * buffer; failed sends persist the batch to IDB so the
+ * connectivity-online drain (#7.2) picks it up later.
  * @returns Outcome describing what was sent.
  */
 export const flushNow = async (): Promise<FlushOutcome> => {
@@ -46,8 +48,9 @@ export const flushNow = async (): Promise<FlushOutcome> => {
   const empty = pending.length === 0
   const ok = empty ? false : await sendBatch(pending)
   const sent = !empty && ok
-  buffer = sent ? [] : pending
-  firstAddedAt = sent ? undefined : firstAddedAt
+  buffer = sent ? [] : []
+  firstAddedAt = undefined
+  await (!empty && !ok ? enqueueBatch(pending) : Promise.resolve())
   return empty
     ? { kind: 'idle' }
     : sent

--- a/src/composables/useTracing/queue-idb-write.ts
+++ b/src/composables/useTracing/queue-idb-write.ts
@@ -1,0 +1,63 @@
+import {
+  listQueued,
+  MAX_QUEUED_BATCHES,
+  promisify,
+  type QueuedBatch,
+  txStore,
+} from './queue-idb'
+import { randomHex } from './random-hex'
+import type { Span } from './span-types'
+
+let seq = 0
+
+const evictOverflow = async (): Promise<void> => {
+  const all = await listQueued()
+  const overflow = all.length - MAX_QUEUED_BATCHES
+  const toRemove = overflow > 0 ? all.slice(0, overflow) : []
+  await Promise.all(
+    toRemove.map(async batch => {
+      const store = await txStore('readwrite')
+      await promisify(store.delete(batch.id))
+    })
+  )
+}
+
+/**
+ * Persist a failed batch so it can be retried after reconnect.
+ * Returns the queued entry so the caller can log / cancel it.
+ * @param spans Spans to retain.
+ * @returns The persisted batch record.
+ */
+export const enqueueBatch = async (
+  spans: ReadonlyArray<Span>
+): Promise<QueuedBatch> => {
+  seq += 1
+  const entry: QueuedBatch = {
+    id: randomHex(8),
+    spans,
+    enqueuedAt: Date.now() * 1000 + (seq % 1000),
+  }
+  const store = await txStore('readwrite')
+  await promisify(store.put(entry))
+  await evictOverflow()
+  return entry
+}
+
+/**
+ * Drop a persisted batch by id. Used after a successful resend.
+ * @param id Batch id from `enqueueBatch`.
+ * @returns Resolves once the delete completes.
+ */
+export const dropBatch = async (id: string): Promise<void> => {
+  const store = await txStore('readwrite')
+  await promisify(store.delete(id))
+}
+
+/**
+ * Wipe every queued batch. Used by tests.
+ * @returns Resolves once the store is empty.
+ */
+export const clearQueuedBatches = async (): Promise<void> => {
+  const store = await txStore('readwrite')
+  await promisify(store.clear())
+}

--- a/src/composables/useTracing/queue-idb.test.ts
+++ b/src/composables/useTracing/queue-idb.test.ts
@@ -1,0 +1,58 @@
+import 'fake-indexeddb/auto'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { listQueued, MAX_QUEUED_BATCHES } from './queue-idb'
+import {
+  clearQueuedBatches,
+  dropBatch,
+  enqueueBatch,
+} from './queue-idb-write'
+import type { Span } from './span-types'
+
+const span = (id: string): Span => ({
+  id,
+  traceId: 't',
+  parentId: undefined,
+  name: id,
+  startedAt: 1,
+  finishedAt: 2,
+  attributes: {},
+  status: 'ok',
+})
+
+describe('export queue idb', () => {
+  beforeEach(async () => {
+    await clearQueuedBatches()
+  })
+  afterEach(async () => {
+    await clearQueuedBatches()
+  })
+
+  it('enqueueBatch + listQueued round-trip', async () => {
+    await enqueueBatch([span('a'), span('b')])
+    const all = await listQueued()
+    expect(all).toHaveLength(1)
+    expect(all[0]?.spans).toHaveLength(2)
+  })
+
+  it(
+    'evicts oldest past MAX_QUEUED_BATCHES',
+    { timeout: 30_000 },
+    async () => {
+      const total = MAX_QUEUED_BATCHES + 5
+      for (let i = 0; i < total; i += 1) {
+        await enqueueBatch([span(`s${i}`)])
+      }
+      const all = await listQueued()
+      expect(all).toHaveLength(MAX_QUEUED_BATCHES)
+      expect(all[0]?.spans[0]?.id).toBe('s5')
+    }
+  )
+
+  it('dropBatch removes a single entry', async () => {
+    const a = await enqueueBatch([span('a')])
+    await enqueueBatch([span('b')])
+    await dropBatch(a.id)
+    const all = await listQueued()
+    expect(all).toHaveLength(1)
+  })
+})

--- a/src/composables/useTracing/queue-idb.ts
+++ b/src/composables/useTracing/queue-idb.ts
@@ -1,0 +1,56 @@
+import type { Span } from './span-types'
+
+const DB_NAME = 'admin-tracing-export-queue'
+const STORE_NAME = 'batches'
+const VERSION = 1
+
+/** FIFO eviction cap — older batches are dropped past this. */
+export const MAX_QUEUED_BATCHES = 1000
+
+/** Persisted batch waiting to be re-shipped after a failure. */
+export type QueuedBatch = {
+  readonly id: string
+  readonly spans: ReadonlyArray<Span>
+  readonly enqueuedAt: number
+}
+
+/**
+ * Promisify an IDB request so callers can `await` it.
+ * @param req IDB request to wrap.
+ * @returns Promise resolving with `request.result`.
+ */
+const promisify = <T>(req: IDBRequest<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    req.onsuccess = (): void => resolve(req.result)
+    req.onerror = (): void => reject(req.error)
+  })
+
+const openDb = (): Promise<IDBDatabase> => {
+  const req = globalThis.indexedDB.open(DB_NAME, VERSION)
+  req.onupgradeneeded = (): void => {
+    req.result.createObjectStore(STORE_NAME, { keyPath: 'id' })
+  }
+  return promisify(req)
+}
+
+/**
+ * Open the export queue object store inside a fresh transaction.
+ * @param mode Transaction mode.
+ * @returns Object store inside a freshly opened transaction.
+ */
+const txStore = async (mode: IDBTransactionMode): Promise<IDBObjectStore> => {
+  const db = await openDb()
+  return db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)
+}
+
+/**
+ * List queued batches sorted oldest-first.
+ * @returns Frozen array of pending batches.
+ */
+export const listQueued = async (): Promise<readonly QueuedBatch[]> => {
+  const store = await txStore('readonly')
+  const all: readonly QueuedBatch[] = await promisify(store.getAll())
+  return [...all].sort((a, b) => a.enqueuedAt - b.enqueuedAt)
+}
+
+export { promisify, txStore }

--- a/src/composables/useTracing/use-exporter-bootstrap.ts
+++ b/src/composables/useTracing/use-exporter-bootstrap.ts
@@ -1,0 +1,29 @@
+import { watch } from 'vue'
+import { isOnline } from '@/composables/useConnectivity'
+import { drainQueuedBatches } from './drain-queued'
+import { recordSpan } from './exporter'
+import { onFinishSpan } from './spans-store'
+
+/**
+ * Wire the tracing pipeline at app boot:
+ *   - every finished span flows into the exporter buffer
+ *   - every transition `offline → online` drains queued batches
+ * Mount once near the app root.
+ * @returns void
+ */
+export const useExporterBootstrap = (): void => {
+  onFinishSpan(recordSpan)
+  watch(
+    isOnline,
+    (next, prev) => {
+      const becameOnline = prev !== true && next === true
+      const drain = becameOnline
+        ? () => {
+            void drainQueuedBatches()
+          }
+        : (): void => undefined
+      drain()
+    },
+    { immediate: false }
+  )
+}


### PR DESCRIPTION
Phase B / Epic 7 increment 7.2. Failed export batches persist to IDB (cap 1000 FIFO), useExporterBootstrap drains them on offline → online transition. 3/3 IDB unit + 4/4 exporter unit. Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)