### PR TITLE
feat(tracing): chunked OTLP send with 413 rebudget (#137)

### DIFF
--- a/src/composables/useTracing/chunk-batch.test.ts
+++ b/src/composables/useTracing/chunk-batch.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { chunkSpans, DEFAULT_CHUNK_BYTES } from './chunk-batch'
+import type { Span } from './span-types'
+
+const span = (traceId: string, id: string, fillBytes: number = 0): Span => ({
+  id,
+  traceId,
+  parentId: undefined,
+  name: 'op',
+  startedAt: 1,
+  finishedAt: 2,
+  attributes: { fill: 'x'.repeat(fillBytes) },
+  status: 'ok',
+})
+
+describe('chunkSpans', () => {
+  it('returns one chunk when total fits the budget', () => {
+    const result = chunkSpans([span('t1', 'a'), span('t1', 'b')])
+    expect(result).toHaveLength(1)
+    expect(result[0]).toHaveLength(2)
+  })
+
+  it('returns [] for empty input', () => {
+    expect(chunkSpans([])).toEqual([])
+  })
+
+  it('keeps a single trace in one chunk when possible', () => {
+    const a = Array.from({ length: 5 }, (_, i) => span('t1', `a${i}`))
+    const b = Array.from({ length: 5 }, (_, i) => span('t2', `b${i}`))
+    const result = chunkSpans([...a, ...b])
+    expect(result).toHaveLength(1)
+  })
+
+  it('splits across traces when total exceeds the budget', () => {
+    const big = (id: string, t: string) => span(t, id, 70_000)
+    const total = [
+      big('a', 't1'),
+      big('b', 't2'),
+      big('c', 't3'),
+      big('d', 't4'),
+    ]
+    const result = chunkSpans(total)
+    expect(result.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('honours a smaller budget passed in', () => {
+    const total = [span('t1', 'a'), span('t2', 'b')]
+    const tiny = chunkSpans(total, 200)
+    expect(tiny.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('default budget stays well under the 256 KB collector cap', () => {
+    expect(DEFAULT_CHUNK_BYTES).toBeLessThan(256 * 1024)
+  })
+})

--- a/src/composables/useTracing/chunk-batch.ts
+++ b/src/composables/useTracing/chunk-batch.ts
@@ -1,0 +1,41 @@
+import { emptyFold, finalize, stepFold } from './chunk-fold'
+import { groupByTrace } from './chunk-group'
+import type { Span } from './span-types'
+
+/** Default chunk budget — must stay below the collector's 256 KB cap. */
+export const DEFAULT_CHUNK_BYTES = 200 * 1024
+
+const splitGroup = (
+  group: ReadonlyArray<Span>,
+  budget: number
+): ReadonlyArray<ReadonlyArray<Span>> =>
+  finalize(
+    group.reduce((acc, span) => stepFold(acc, [span], budget), emptyFold)
+  )
+
+const mergeGroupChunks = (
+  groupChunks: ReadonlyArray<ReadonlyArray<ReadonlyArray<Span>>>,
+  budget: number
+): ReadonlyArray<ReadonlyArray<Span>> =>
+  finalize(
+    groupChunks
+      .flat()
+      .reduce((acc, piece) => stepFold(acc, piece, budget), emptyFold)
+  )
+
+/**
+ * Split a span batch into chunks that each stay under `budget`
+ * bytes when serialised. Groups by trace-id first; if one trace
+ * exceeds the budget alone, it is split internally rather than
+ * emitted oversized.
+ * @param spans Spans to chunk.
+ * @param budget Per-chunk byte budget (default 200 KB).
+ * @returns Frozen array of chunks; never empty when input is non-empty.
+ */
+export const chunkSpans = (
+  spans: ReadonlyArray<Span>,
+  budget: number = DEFAULT_CHUNK_BYTES
+): ReadonlyArray<ReadonlyArray<Span>> => {
+  const groupChunks = groupByTrace(spans).map(g => splitGroup(g, budget))
+  return spans.length === 0 ? [] : mergeGroupChunks(groupChunks, budget)
+}

--- a/src/composables/useTracing/chunk-fold.ts
+++ b/src/composables/useTracing/chunk-fold.ts
@@ -1,0 +1,48 @@
+import type { Span } from './span-types'
+
+/** Accumulator state for the chunking fold. */
+export type FoldState = {
+  readonly chunks: ReadonlyArray<ReadonlyArray<Span>>
+  readonly current: ReadonlyArray<Span>
+}
+
+const sizeOf = (spans: ReadonlyArray<Span>): number =>
+  JSON.stringify({ spans }).length
+
+/**
+ * Fold step: append `next` to the current bucket if it still
+ * fits inside `budget`; otherwise close the bucket and start a
+ * fresh one with `next`.
+ * @param state Current fold accumulator.
+ * @param next Spans to append (single span or chunk piece).
+ * @param budget Per-chunk byte budget.
+ * @returns Next fold state.
+ */
+export const stepFold = (
+  state: FoldState,
+  next: ReadonlyArray<Span>,
+  budget: number
+): FoldState => {
+  const combined = [...state.current, ...next]
+  const fits = state.current.length === 0 || sizeOf(combined) <= budget
+  return fits
+    ? { chunks: state.chunks, current: combined }
+    : {
+        chunks: [...state.chunks, state.current],
+        current: [...next],
+      }
+}
+
+/**
+ * Convert a fold state into the final chunk list, including
+ * any non-empty trailing bucket.
+ * @param state Final fold state.
+ * @returns Flat list of chunks.
+ */
+export const finalize = (
+  state: FoldState
+): ReadonlyArray<ReadonlyArray<Span>> =>
+  state.current.length === 0 ? state.chunks : [...state.chunks, state.current]
+
+/** Empty initial fold state. */
+export const emptyFold: FoldState = { chunks: [], current: [] }

--- a/src/composables/useTracing/chunk-group.ts
+++ b/src/composables/useTracing/chunk-group.ts
@@ -1,0 +1,20 @@
+import type { Span } from './span-types'
+
+/**
+ * Group spans by trace-id to keep all spans of a trace in the
+ * same chunk. Returned order is insertion order — the first
+ * trace seen comes first.
+ * @param spans Spans to group.
+ * @returns Array of per-trace span arrays.
+ */
+export const groupByTrace = (
+  spans: ReadonlyArray<Span>
+): ReadonlyArray<ReadonlyArray<Span>> => {
+  const groups = new Map<string, Span[]>()
+  for (const span of spans) {
+    const list = groups.get(span.traceId) ?? []
+    list.push(span)
+    groups.set(span.traceId, list)
+  }
+  return [...groups.values()]
+}

--- a/src/composables/useTracing/exporter-send.ts
+++ b/src/composables/useTracing/exporter-send.ts
@@ -1,28 +1,40 @@
-import { collectorBaseUrl, collectorToken } from './exporter-config'
+import { chunkSpans, DEFAULT_CHUNK_BYTES } from './chunk-batch'
+import { type ChunkOutcome, postChunk } from './send-chunk'
 import type { Span } from './span-types'
 
+const sendOne = async (chunk: ReadonlyArray<Span>): Promise<boolean> => {
+  const outcome: ChunkOutcome = await postChunk(chunk)
+  return outcome.kind === 'ok'
+    ? true
+    : outcome.kind === 'retry'
+      ? sendChunked(chunk, outcome.chunkSize)
+      : false
+}
+
 /**
- * POST a batch of spans to the collector. Returns true on 2xx,
- * false on any other outcome. Errors are swallowed so the
- * exporter loop never throws — failed batches are retained by
- * the caller for the next flush attempt.
- * @param spans Frozen list of spans to ship.
- * @returns True when the collector accepted the batch.
+ * Ship spans in collector-friendly chunks. Splits any input above
+ * `budget` bytes; honours collector 413 by re-splitting with the
+ * hint. Returns true only when every chunk lands.
+ * @param spans Spans to ship.
+ * @param budget Per-chunk byte budget; defaults to DEFAULT_CHUNK_BYTES.
+ * @returns True when every chunk was accepted.
+ */
+export const sendChunked = async (
+  spans: ReadonlyArray<Span>,
+  budget: number = DEFAULT_CHUNK_BYTES
+): Promise<boolean> => {
+  const chunks = chunkSpans(spans, budget)
+  const results = await Promise.all(chunks.map(chunk => sendOne(chunk)))
+  return results.every(ok => ok)
+}
+
+/**
+ * Ship a batch of spans through the chunked sender. Kept named
+ * `sendBatch` so existing callers (`flushNow`, `drainQueuedBatches`)
+ * stay unchanged.
+ * @param spans Spans to ship.
+ * @returns True on success across all chunks.
  */
 export const sendBatch = async (
   spans: ReadonlyArray<Span>
-): Promise<boolean> => {
-  try {
-    const res = await fetch(`${collectorBaseUrl()}/v1/traces`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${collectorToken()}`,
-      },
-      body: JSON.stringify({ spans }),
-    })
-    return res.ok
-  } catch {
-    return false
-  }
-}
+): Promise<boolean> => sendChunked(spans)

--- a/src/composables/useTracing/exporter.ts
+++ b/src/composables/useTracing/exporter.ts
@@ -5,7 +5,6 @@ import { enqueueBatch } from './queue-idb-write'
 import type { Span } from './span-types'
 
 let buffer: Span[] = []
-let firstAddedAt: number | undefined
 let timer: ReturnType<typeof setTimeout> | undefined
 
 const scheduleFlush = (run: () => void): void => {
@@ -22,7 +21,6 @@ const scheduleFlush = (run: () => void): void => {
  */
 export const recordSpan = (span: Span): void => {
   buffer = [...buffer, span]
-  firstAddedAt ??= Date.now()
   const trigger =
     buffer.length >= FLUSH_AT_SPANS
       ? () => {
@@ -49,7 +47,6 @@ export const flushNow = async (): Promise<FlushOutcome> => {
   const ok = empty ? false : await sendBatch(pending)
   const sent = !empty && ok
   buffer = sent ? [] : []
-  firstAddedAt = undefined
   await (!empty && !ok ? enqueueBatch(pending) : Promise.resolve())
   return empty
     ? { kind: 'idle' }
@@ -63,7 +60,6 @@ export const resetExporter = (): void => {
   globalThis.clearTimeout(timer)
   timer = undefined
   buffer = []
-  firstAddedAt = undefined
 }
 
 /**

--- a/src/composables/useTracing/send-chunk.test.ts
+++ b/src/composables/useTracing/send-chunk.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { sendChunked } from './exporter-send'
+import type { Span } from './span-types'
+
+const span = (id: string, fillBytes = 0): Span => ({
+  id,
+  traceId: 't1',
+  parentId: undefined,
+  name: 'op',
+  startedAt: 1,
+  finishedAt: 2,
+  attributes: { fill: 'x'.repeat(fillBytes) },
+  status: 'ok',
+})
+
+describe('sendChunked', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    )
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns true when all chunks land', async () => {
+    expect(await sendChunked([span('a'), span('b')])).toBe(true)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('issues multiple POSTs for oversized batches', async () => {
+    const big = Array.from({ length: 6 }, (_, i) => span(`s${i}`, 70_000))
+    await sendChunked(big)
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls
+      .length
+    expect(calls).toBeGreaterThanOrEqual(2)
+  })
+
+  it('returns false when a chunk fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 500 }))
+    )
+    expect(await sendChunked([span('a')])).toBe(false)
+  })
+
+  it('honours a 413 with chunkSize hint on retry', async () => {
+    let calls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() => {
+        calls += 1
+        return calls === 1
+          ? new Response(JSON.stringify({ chunkSize: 50 }), {
+              status: 413,
+              headers: { 'content-type': 'application/json' },
+            })
+          : new Response(null, { status: 200 })
+      })
+    )
+    const big = [span('a', 1000), span('b', 1000)]
+    expect(await sendChunked(big, 5_000)).toBe(true)
+    expect(calls).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/src/composables/useTracing/send-chunk.ts
+++ b/src/composables/useTracing/send-chunk.ts
@@ -1,0 +1,49 @@
+import { collectorBaseUrl, collectorToken } from './exporter-config'
+import type { Span } from './span-types'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/** Outcome of a single chunk POST. */
+export type ChunkOutcome =
+  | { readonly kind: 'ok' }
+  | { readonly kind: 'fail' }
+  | { readonly kind: 'retry'; readonly chunkSize: number }
+
+const parseRetry = async (res: Response): Promise<ChunkOutcome> => {
+  const body: unknown = await res.json().catch(() => undefined)
+  const hint = isObject(body) ? body['chunkSize'] : undefined
+  return typeof hint === 'number'
+    ? { kind: 'retry', chunkSize: hint }
+    : { kind: 'fail' }
+}
+
+/**
+ * POST a single chunk to `/v1/traces`. 413 responses surface as a
+ * `retry` outcome carrying the collector's chunkSize hint so the
+ * caller can re-split. Network and 5xx come back as `fail`; the
+ * caller persists the chunk and retries on reconnect.
+ * @param spans Spans to ship in this chunk.
+ * @returns Discriminated chunk outcome.
+ */
+export const postChunk = async (
+  spans: ReadonlyArray<Span>
+): Promise<ChunkOutcome> => {
+  try {
+    const res = await fetch(`${collectorBaseUrl()}/v1/traces`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${collectorToken()}`,
+      },
+      body: JSON.stringify({ spans }),
+    })
+    return res.status === 413
+      ? await parseRetry(res)
+      : res.ok
+        ? { kind: 'ok' }
+        : { kind: 'fail' }
+  } catch {
+    return { kind: 'fail' }
+  }
+}


### PR DESCRIPTION
## Summary
- Splits the exporter batch into ≤200 KB chunks before POST, grouping by trace-id and only splitting within a single trace when that trace alone exceeds the budget.
- Honours the collector's 413 response with a `chunkSize` hint by recursively re-chunking and resending under the smaller budget.
- Keeps `sendBatch` as a thin alias over `sendChunked`, so `flushNow` and `drainQueuedBatches` are unchanged.

Closes #137.

## Test plan
- [x] `bun run test:unit src/composables/useTracing` (32 tests)
- [x] Full unit suite (`bun run test:unit`, 533 tests)
- [x] `bun run validate` clean (only the pre-existing `services/log-collector/src/auth-middleware.ts` optional-chain warning remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)