### PR TITLE
feat(tracing): SW logs → exporter + trace-context continuation (#138)

### DIFF
--- a/src/composables/useSWBridge/post-with-timeout.ts
+++ b/src/composables/useSWBridge/post-with-timeout.ts
@@ -1,5 +1,6 @@
 import { Duration, Effect } from 'effect'
 import type { SWRequest } from '@/sw/protocol'
+import { stampTraceparent } from './stamp-traceparent'
 
 const TIMEOUT = Duration.seconds(15)
 
@@ -24,7 +25,8 @@ const listen = <T>(
 
 /**
  * Send a message to a ServiceWorker via MessageChannel.
- * Used for init (when no controller) and data fallback.
+ * Stamps the active client span's traceparent on the envelope
+ * so the SW can correlate logs and outbound calls.
  * @param worker - Target ServiceWorker
  * @param message - Request payload
  * @returns Response from the SW
@@ -32,12 +34,14 @@ const listen = <T>(
 export const postWithTimeout = <T>(
   worker: ServiceWorker,
   message: SWRequest
-): Promise<T> =>
-  Effect.runPromise(
-    listen<T>(worker, message).pipe(
+): Promise<T> => {
+  const stamped = stampTraceparent(message)
+  return Effect.runPromise(
+    listen<T>(worker, stamped).pipe(
       Effect.timeoutFail({
         duration: TIMEOUT,
-        onTimeout: () => new Error(`SW message timeout: ${message.type}`),
+        onTimeout: () => new Error(`SW message timeout: ${stamped.type}`),
       })
     )
   )
+}

--- a/src/composables/useSWBridge/stamp-traceparent.test.ts
+++ b/src/composables/useSWBridge/stamp-traceparent.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { clearSpans, startSpan } from '@/composables/useTracing/spans-store'
+import { stampTraceparent } from './stamp-traceparent'
+
+describe('stampTraceparent', () => {
+  afterEach(() => {
+    clearSpans()
+  })
+
+  it('returns the message untouched when no span is active', () => {
+    const out = stampTraceparent({ type: 'SW_STATUS' })
+    expect(out).toEqual({ type: 'SW_STATUS' })
+  })
+
+  it('stamps a W3C traceparent from the active span', () => {
+    const span = startSpan('client.op')
+    const out = stampTraceparent({ type: 'SW_STATUS' })
+    expect(out.traceparent).toMatch(
+      new RegExp(`^00-${span.traceId}-${span.id}-01$`)
+    )
+  })
+})

--- a/src/composables/useSWBridge/stamp-traceparent.ts
+++ b/src/composables/useSWBridge/stamp-traceparent.ts
@@ -1,0 +1,27 @@
+import { currentSpan } from '@/composables/useTracing/spans-store'
+import { serialise } from '@/composables/useTracing/traceparent'
+import type { SWRequest } from '@/sw/protocol'
+
+/**
+ * Stamp the outgoing SW message with the active client span's
+ * traceparent so the SW dispatcher can install a matching trace
+ * context. No-op when no client span is active.
+ * @param message Request to stamp.
+ * @returns Message with `traceparent` populated, or the input.
+ */
+export const stampTraceparent = <T extends SWRequest>(
+  message: T
+): T & { readonly traceparent?: string } => {
+  const span = currentSpan()
+  return span === undefined
+    ? message
+    : {
+        ...message,
+        traceparent: serialise({
+          version: '00',
+          traceId: span.traceId,
+          parentId: span.id,
+          sampled: true,
+        }),
+      }
+}

--- a/src/composables/useTracing/exporter-config.ts
+++ b/src/composables/useTracing/exporter-config.ts
@@ -1,6 +1,9 @@
 /** Default flush trigger: 100 spans. */
 export const FLUSH_AT_SPANS = 100
 
+/** Default flush trigger: 200 log entries. */
+export const FLUSH_AT_LOGS = 200
+
 /** Default flush trigger: 30 seconds since the first add. */
 export const FLUSH_AT_MS = 30_000
 

--- a/src/composables/useTracing/exporter-logs.test.ts
+++ b/src/composables/useTracing/exporter-logs.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  bufferedLogCount,
+  flushLogs,
+  recordLog,
+  resetLogExporter,
+} from './exporter-logs'
+import type { LogRecord } from './log-record'
+
+const log = (msg: string): LogRecord => ({
+  traceId: undefined,
+  spanId: undefined,
+  level: 'info',
+  message: msg,
+  at: 1,
+  attributes: {},
+})
+
+describe('exporter-logs', () => {
+  beforeEach(() => {
+    resetLogExporter()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    )
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    resetLogExporter()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('buffers entries and flushes on demand', async () => {
+    recordLog(log('a'))
+    recordLog(log('b'))
+    expect(bufferedLogCount()).toBe(2)
+    expect(await flushLogs()).toBe(true)
+    expect(bufferedLogCount()).toBe(0)
+  })
+
+  it('returns false when flushing an empty buffer', async () => {
+    expect(await flushLogs()).toBe(false)
+  })
+
+  it('drops the buffer on send failure (best-effort)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 500 }))
+    )
+    recordLog(log('x'))
+    expect(await flushLogs()).toBe(false)
+    expect(bufferedLogCount()).toBe(0)
+  })
+})

--- a/src/composables/useTracing/exporter-logs.ts
+++ b/src/composables/useTracing/exporter-logs.ts
@@ -1,0 +1,58 @@
+import { FLUSH_AT_LOGS, FLUSH_AT_MS } from './exporter-config'
+import type { LogRecord } from './log-record'
+import { sendLogs } from './send-logs'
+
+let buffer: LogRecord[] = []
+let timer: ReturnType<typeof setTimeout> | undefined
+
+const scheduleFlush = (run: () => void): void => {
+  globalThis.clearTimeout(timer)
+  timer = globalThis.setTimeout(run, FLUSH_AT_MS)
+}
+
+/**
+ * Push a log record into the exporter buffer. Triggers an
+ * immediate flush at `FLUSH_AT_LOGS` entries; otherwise
+ * schedules a `FLUSH_AT_MS` time-based flush.
+ * @param entry Log record to enqueue.
+ * @returns void
+ */
+export const recordLog = (entry: LogRecord): void => {
+  buffer = [...buffer, entry]
+  const trigger =
+    buffer.length >= FLUSH_AT_LOGS
+      ? () => {
+          void flushLogs()
+        }
+      : () =>
+          scheduleFlush(() => {
+            void flushLogs()
+          })
+  trigger()
+}
+
+/**
+ * Flush the log buffer immediately. Drops on send failure —
+ * logs are best-effort; spans remain the source of truth.
+ * @returns True when a non-empty batch landed.
+ */
+export const flushLogs = async (): Promise<boolean> => {
+  globalThis.clearTimeout(timer)
+  timer = undefined
+  const pending = buffer.slice()
+  buffer = []
+  return pending.length === 0 ? false : sendLogs(pending)
+}
+
+/** Reset the log buffer and any pending timer. Used by tests. */
+export const resetLogExporter = (): void => {
+  globalThis.clearTimeout(timer)
+  timer = undefined
+  buffer = []
+}
+
+/**
+ * Current log buffer length — for tests and dev overlays.
+ * @returns Number of logs waiting to be flushed.
+ */
+export const bufferedLogCount = (): number => buffer.length

--- a/src/composables/useTracing/log-from-sw.test.ts
+++ b/src/composables/useTracing/log-from-sw.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { LogEntry } from '@/sw/protocol'
+import { logFromSWEntry } from './log-from-sw'
+
+const baseEntry: LogEntry = {
+  ts: 1700000000,
+  level: 'info',
+  cat: 'git',
+  msg: 'fetched',
+  spanId: 'abcd',
+}
+
+describe('logFromSWEntry', () => {
+  it('maps SW fields into a collector LogRecord', () => {
+    const out = logFromSWEntry(baseEntry)
+    expect(out.message).toBe('fetched')
+    expect(out.level).toBe('info')
+    expect(out.spanId).toBe('abcd')
+    expect(out.at).toBe(1700000000)
+    expect(out.attributes['cat']).toBe('git')
+    expect(out.traceId).toBeUndefined()
+  })
+
+  it('flattens data fields into stringified attributes', () => {
+    const out = logFromSWEntry({
+      ...baseEntry,
+      data: { url: 'https://x', count: 42, ok: true },
+    })
+    expect(out.attributes['url']).toBe('https://x')
+    expect(out.attributes['count']).toBe('42')
+    expect(out.attributes['ok']).toBe('true')
+  })
+
+  it('omits data attributes when entry has none', () => {
+    const out = logFromSWEntry(baseEntry)
+    expect(Object.keys(out.attributes)).toEqual(['cat'])
+  })
+})

--- a/src/composables/useTracing/log-from-sw.test.ts
+++ b/src/composables/useTracing/log-from-sw.test.ts
@@ -21,6 +21,11 @@ describe('logFromSWEntry', () => {
     expect(out.traceId).toBeUndefined()
   })
 
+  it('passes the SW-stamped traceId through', () => {
+    const out = logFromSWEntry({ ...baseEntry, traceId: 'tttt' })
+    expect(out.traceId).toBe('tttt')
+  })
+
   it('flattens data fields into stringified attributes', () => {
     const out = logFromSWEntry({
       ...baseEntry,

--- a/src/composables/useTracing/log-from-sw.ts
+++ b/src/composables/useTracing/log-from-sw.ts
@@ -1,0 +1,30 @@
+import type { LogEntry } from '@/sw/protocol'
+import type { LogRecord } from './log-record'
+
+const stringify = (value: unknown): string =>
+  typeof value === 'string' ? value : JSON.stringify(value)
+
+const dataAttributes = (
+  data: Record<string, unknown> | undefined
+): Record<string, string> =>
+  data === undefined
+    ? {}
+    : Object.fromEntries(
+        Object.entries(data).map(([k, v]) => [k, stringify(v)])
+      )
+
+/**
+ * Convert a Service Worker log entry into a collector log record.
+ * Preserves the SW span id and category; the trace id is filled
+ * by the SW context once 7.4b lands.
+ * @param entry Log entry broadcast by the SW.
+ * @returns Collector-shaped log record.
+ */
+export const logFromSWEntry = (entry: LogEntry): LogRecord => ({
+  traceId: undefined,
+  spanId: entry.spanId,
+  level: entry.level,
+  message: entry.msg,
+  at: entry.ts,
+  attributes: { cat: entry.cat, ...dataAttributes(entry.data) },
+})

--- a/src/composables/useTracing/log-from-sw.ts
+++ b/src/composables/useTracing/log-from-sw.ts
@@ -15,13 +15,13 @@ const dataAttributes = (
 
 /**
  * Convert a Service Worker log entry into a collector log record.
- * Preserves the SW span id and category; the trace id is filled
- * by the SW context once 7.4b lands.
+ * Preserves SW trace+span ids stamped by the dispatcher so the
+ * viewer can stitch logs into the originating client trace.
  * @param entry Log entry broadcast by the SW.
  * @returns Collector-shaped log record.
  */
 export const logFromSWEntry = (entry: LogEntry): LogRecord => ({
-  traceId: undefined,
+  traceId: entry.traceId,
   spanId: entry.spanId,
   level: entry.level,
   message: entry.msg,

--- a/src/composables/useTracing/log-record.ts
+++ b/src/composables/useTracing/log-record.ts
@@ -1,0 +1,12 @@
+/** Log severity carried on a log record. Mirrors the collector. */
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+/** Log entry as accepted by the collector's `/v1/logs`. */
+export type LogRecord = {
+  readonly traceId: string | undefined
+  readonly spanId: string | undefined
+  readonly level: LogLevel
+  readonly message: string
+  readonly at: number
+  readonly attributes: Readonly<Record<string, string>>
+}

--- a/src/composables/useTracing/send-logs.test.ts
+++ b/src/composables/useTracing/send-logs.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LogRecord } from './log-record'
+import { sendLogs } from './send-logs'
+
+const log = (msg: string): LogRecord => ({
+  traceId: undefined,
+  spanId: undefined,
+  level: 'info',
+  message: msg,
+  at: 1,
+  attributes: { cat: 'git' },
+})
+
+describe('sendLogs', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    )
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns true on 2xx', async () => {
+    expect(await sendLogs([log('hello')])).toBe(true)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('posts to /v1/logs with bearer auth', async () => {
+    await sendLogs([log('a')])
+    const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>
+    const call = fetchMock.mock.calls[0] ?? []
+    expect(String(call[0])).toContain('/v1/logs')
+    expect(call[1].method).toBe('POST')
+    expect(call[1].headers.Authorization).toMatch(/^Bearer /)
+  })
+
+  it('returns false on 5xx', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 500 }))
+    )
+    expect(await sendLogs([log('a')])).toBe(false)
+  })
+
+  it('returns false on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    expect(await sendLogs([log('a')])).toBe(false)
+  })
+})

--- a/src/composables/useTracing/send-logs.ts
+++ b/src/composables/useTracing/send-logs.ts
@@ -1,0 +1,29 @@
+import { collectorBaseUrl, collectorToken } from './exporter-config'
+import type { LogRecord } from './log-record'
+
+/**
+ * POST a log batch to `/v1/logs`. Network errors and non-2xx
+ * responses come back as `false`; the caller decides whether to
+ * drop or retain. The collector enforces its own size cap and
+ * will return 413 if exceeded — we surface that as `false` here
+ * since logs are smaller than spans and chunking is a follow-up.
+ * @param logs Logs to ship in this batch.
+ * @returns True when the collector accepted the batch.
+ */
+export const sendLogs = async (
+  logs: ReadonlyArray<LogRecord>
+): Promise<boolean> => {
+  try {
+    const res = await fetch(`${collectorBaseUrl()}/v1/logs`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${collectorToken()}`,
+      },
+      body: JSON.stringify({ logs }),
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}

--- a/src/composables/useTracing/use-exporter-bootstrap.ts
+++ b/src/composables/useTracing/use-exporter-bootstrap.ts
@@ -3,16 +3,19 @@ import { isOnline } from '@/composables/useConnectivity'
 import { drainQueuedBatches } from './drain-queued'
 import { recordSpan } from './exporter'
 import { onFinishSpan } from './spans-store'
+import { useLogBridge } from './use-log-bridge'
 
 /**
  * Wire the tracing pipeline at app boot:
  *   - every finished span flows into the exporter buffer
+ *   - SW log entries flow into the log exporter buffer
  *   - every transition `offline → online` drains queued batches
  * Mount once near the app root.
  * @returns void
  */
 export const useExporterBootstrap = (): void => {
   onFinishSpan(recordSpan)
+  useLogBridge()
   watch(
     isOnline,
     (next, prev) => {

--- a/src/composables/useTracing/use-log-bridge.test.ts
+++ b/src/composables/useTracing/use-log-bridge.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LogEntry } from '@/sw/protocol'
+import { SW_LOG_CHANNEL } from '@/sw/protocol'
+import {
+  bufferedLogCount,
+  flushLogs,
+  resetLogExporter,
+} from './exporter-logs'
+import { bridgeSWLogs } from './use-log-bridge'
+
+const entry: LogEntry = {
+  ts: 1,
+  level: 'info',
+  cat: 'git',
+  msg: 'pulled',
+  spanId: 'aabb',
+}
+
+describe('bridgeSWLogs', () => {
+  beforeEach(() => {
+    resetLogExporter()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(new Response(null, { status: 200 }))
+    )
+  })
+  afterEach(() => {
+    resetLogExporter()
+    vi.unstubAllGlobals()
+  })
+
+  it('forwards SW logs into the exporter buffer', async () => {
+    const close = bridgeSWLogs()
+    const sender = new BroadcastChannel(SW_LOG_CHANNEL)
+    sender.postMessage(entry)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(bufferedLogCount()).toBe(1)
+    sender.close()
+    close()
+  })
+
+  it('reaches the collector after flush', async () => {
+    const close = bridgeSWLogs()
+    const sender = new BroadcastChannel(SW_LOG_CHANNEL)
+    sender.postMessage(entry)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(await flushLogs()).toBe(true)
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    sender.close()
+    close()
+  })
+
+  it('disposer closes the channel', async () => {
+    const close = bridgeSWLogs()
+    close()
+    const sender = new BroadcastChannel(SW_LOG_CHANNEL)
+    sender.postMessage(entry)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(bufferedLogCount()).toBe(0)
+    sender.close()
+  })
+})

--- a/src/composables/useTracing/use-log-bridge.ts
+++ b/src/composables/useTracing/use-log-bridge.ts
@@ -1,0 +1,42 @@
+import { onUnmounted } from 'vue'
+import type { LogEntry } from '@/sw/protocol'
+import { SW_LOG_CHANNEL } from '@/sw/protocol'
+import { recordLog } from './exporter-logs'
+import { logFromSWEntry } from './log-from-sw'
+
+const noop = (): void => undefined
+
+/**
+ * Wire a BroadcastChannel listener that forwards SW log entries
+ * into the log exporter buffer. Returns a disposer.
+ *
+ * Pure (non-Vue) for testability — `useLogBridge` adds the
+ * `onUnmounted` hook on top.
+ * @returns Function that closes the channel listener.
+ */
+export const bridgeSWLogs = (): (() => void) => {
+  const supported = typeof BroadcastChannel !== 'undefined'
+  const channel = supported ? new BroadcastChannel(SW_LOG_CHANNEL) : undefined
+  const handle = (event: MessageEvent<LogEntry>): void => {
+    recordLog(logFromSWEntry(event.data))
+  }
+  const close = channel === undefined ? noop : () => channel.close()
+  const wire =
+    channel === undefined
+      ? noop
+      : () => {
+          channel.onmessage = handle
+        }
+  wire()
+  return close
+}
+
+/**
+ * Vue composable wrapping `bridgeSWLogs` with lifecycle teardown.
+ * Mount once near the app root alongside `useExporterBootstrap`.
+ * @returns void
+ */
+export const useLogBridge = (): void => {
+  const close = bridgeSWLogs()
+  onUnmounted(close)
+}

--- a/src/sw/conflicts/finalize.ts
+++ b/src/sw/conflicts/finalize.ts
@@ -2,6 +2,7 @@ import { fs, REPO_DIR } from '../git/fs'
 import { loadGit } from '../git/load-git'
 import { buildAuthOpts } from '../git/remote/build-auth-opts'
 import { workerState } from '../state/state'
+import { loadTracedHttp } from '../tracing/load-traced-http'
 import { clearForcePending, hasForcePending } from './resolve-file'
 
 const commitResolution = async (
@@ -24,7 +25,7 @@ const pushResolution = async (
   force: boolean
 ): Promise<void> => {
   const git = await loadGit()
-  const { default: http } = await import('isomorphic-git/http/web')
+  const http = await loadTracedHttp()
   const opts = buildAuthOpts(config, http)
   await git.push({ ...opts, force })
 }

--- a/src/sw/core/messaging/message-handler.test.ts
+++ b/src/sw/core/messaging/message-handler.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearLogEntries, log } from '../../logging/logger'
+import { activeContext, setActiveContext } from '../../tracing/active-context'
+import { handleMessage } from './message-handler'
+
+vi.mock('./handle-init', () => ({
+  handleInit: vi.fn(),
+}))
+vi.mock('./handle-fetch-message', () => ({
+  handleFetchMessage: vi.fn(),
+}))
+vi.mock('./handle-invalidate', () => ({
+  handleInvalidate: vi.fn(),
+}))
+vi.mock('../../state/build-status', () => ({
+  buildStatus: () => ({ state: 'idle' }),
+}))
+vi.mock('../../logging/metrics', () => ({
+  getMetrics: () => ({}),
+}))
+
+describe('handleMessage trace context', () => {
+  beforeEach(() => {
+    clearLogEntries()
+    setActiveContext(undefined)
+  })
+  afterEach(() => {
+    setActiveContext(undefined)
+  })
+
+  it('clears the trace context after dispatch', () => {
+    const tp = '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01'
+    handleMessage({ type: 'SW_STATUS', traceparent: tp }, () => undefined)
+    expect(activeContext()).toBeUndefined()
+  })
+
+  it('stamps logs emitted during dispatch with the traceId', () => {
+    const tp = '00-cccccccccccccccccccccccccccccccc-dddddddddddddddd-01'
+    let captured: string | undefined
+    const reply = (): void => {
+      log('info', 'lifecycle', 'inside')
+      captured = activeContext()?.traceId
+    }
+    handleMessage({ type: 'SW_STATUS', traceparent: tp }, reply)
+    expect(captured).toBe('cccccccccccccccccccccccccccccccc')
+  })
+
+  it('runs without a traceparent', () => {
+    expect(() =>
+      handleMessage({ type: 'SW_STATUS' }, () => undefined)
+    ).not.toThrow()
+    expect(activeContext()).toBeUndefined()
+  })
+})

--- a/src/sw/core/messaging/message-handler.ts
+++ b/src/sw/core/messaging/message-handler.ts
@@ -3,19 +3,15 @@ import { getLogEntries, log } from '../../logging/logger'
 import { getMetrics } from '../../logging/metrics'
 import type { SWRequest } from '../../protocol'
 import { buildStatus } from '../../state/build-status'
+import { setActiveContext } from '../../tracing/active-context'
+import { parseTraceparent } from '../../tracing/parse-traceparent'
 import { handleFetchMessage } from './handle-fetch-message'
 import { handleInit } from './handle-init'
 import { handleInvalidate } from './handle-invalidate'
 
 type Reply = (data: unknown) => void
 
-/**
- * Handle an incoming postMessage from the client.
- * @param msg - The message payload
- * @param reply - Callback to send response via MessagePort
- * @returns void
- */
-export const handleMessage = (msg: SWRequest, reply: Reply): void =>
+const dispatch = (msg: SWRequest, reply: Reply): void =>
   Match.value(msg).pipe(
     Match.when({ type: 'SW_INIT' }, m => handleInit(m.config, reply)),
     Match.when({ type: 'SW_FETCH' }, m => handleFetchMessage(m, reply)),
@@ -27,3 +23,18 @@ export const handleMessage = (msg: SWRequest, reply: Reply): void =>
     Match.when({ type: 'SW_INVALIDATE' }, () => handleInvalidate(reply)),
     Match.orElse(() => log('warn', 'lifecycle', 'Unknown message type'))
   )
+
+/**
+ * Handle an incoming postMessage from the client. Installs the
+ * trace context from the envelope's `traceparent` so logs and
+ * outbound fetches can stitch back to the originating client
+ * span. Cleared after dispatch returns synchronously.
+ * @param msg - The message payload
+ * @param reply - Callback to send response via MessagePort
+ * @returns void
+ */
+export const handleMessage = (msg: SWRequest, reply: Reply): void => {
+  setActiveContext(parseTraceparent(msg.traceparent))
+  dispatch(msg, reply)
+  setActiveContext(undefined)
+}

--- a/src/sw/git/remote/push-to-remote.ts
+++ b/src/sw/git/remote/push-to-remote.ts
@@ -1,5 +1,6 @@
 import { log } from '../../logging/logger'
 import type { SWGitConfig } from '../../protocol'
+import { loadTracedHttp } from '../../tracing/load-traced-http'
 import { loadGit } from '../load-git'
 import { buildAuthOpts } from './build-auth-opts'
 
@@ -10,7 +11,7 @@ import { buildAuthOpts } from './build-auth-opts'
  */
 export const pushToRemote = async (config: SWGitConfig): Promise<void> => {
   const git = await loadGit()
-  const { default: http } = await import('isomorphic-git/http/web')
+  const http = await loadTracedHttp()
   const opts = buildAuthOpts(config, http)
   await git
     .pull({

--- a/src/sw/git/sync/clone/clone-repo.ts
+++ b/src/sw/git/sync/clone/clone-repo.ts
@@ -1,6 +1,7 @@
 import { log } from '../../../logging/logger'
 import { recordOp } from '../../../logging/metrics'
 import type { SWGitConfig } from '../../../protocol'
+import { loadTracedHttp } from '../../../tracing/load-traced-http'
 import { loadGit } from '../../load-git'
 import { buildCloneOptions } from './clone-options'
 
@@ -16,7 +17,7 @@ export const cloneRepo = async (config: SWGitConfig): Promise<void> => {
     repo: config.repo,
   })
   const git = await loadGit()
-  const { default: http } = await import('isomorphic-git/http/web')
+  const http = await loadTracedHttp()
   await git.clone(buildCloneOptions(config, http))
   recordOp('clone', Date.now() - start)
   log('info', 'git', 'Clone complete')

--- a/src/sw/git/sync/pull/pull-repo.ts
+++ b/src/sw/git/sync/pull/pull-repo.ts
@@ -1,6 +1,7 @@
 import { log } from '../../../logging/logger'
 import { recordOp } from '../../../logging/metrics'
 import type { SWGitConfig } from '../../../protocol'
+import { loadTracedHttp } from '../../../tracing/load-traced-http'
 import { fs, REPO_DIR } from '../../fs'
 import { loadGit } from '../../load-git'
 
@@ -13,7 +14,7 @@ export const pullRepo = async (config: SWGitConfig): Promise<void> => {
   const start = Date.now()
   log('info', 'git', 'Pulling remote updates')
   const git = await loadGit()
-  const { default: http } = await import('isomorphic-git/http/web')
+  const http = await loadTracedHttp()
 
   await git.pull({
     fs,

--- a/src/sw/logging/logger.ts
+++ b/src/sw/logging/logger.ts
@@ -1,5 +1,6 @@
 import type { LogCategory, LogEntry, LogLevel } from '../protocol'
 import { SW_LOG_CHANNEL } from '../protocol'
+import { activeContext } from '../tracing/active-context'
 import type { RingBuffer } from './ring-buffer/ring-buffer'
 import { createRingBuffer } from './ring-buffer/ring-buffer'
 
@@ -39,7 +40,16 @@ export const log = (
   msg: string,
   data?: Record<string, unknown>
 ): void => {
-  const entry: LogEntry = { ts: Date.now(), level, cat, msg, data }
+  const ctx = activeContext()
+  const entry: LogEntry = {
+    ts: Date.now(),
+    level,
+    cat,
+    msg,
+    data,
+    spanId: ctx?.spanId,
+    traceId: ctx?.traceId,
+  }
   state.buffer.push(entry)
   state.channel?.postMessage(entry)
 }

--- a/src/sw/protocol/log-types.ts
+++ b/src/sw/protocol/log-types.ts
@@ -18,4 +18,5 @@ export interface LogEntry {
   readonly msg: string
   readonly data?: Record<string, unknown>
   readonly spanId?: string
+  readonly traceId?: string
 }

--- a/src/sw/protocol/request-types.ts
+++ b/src/sw/protocol/request-types.ts
@@ -19,6 +19,7 @@ export interface SWFetchRequest {
   readonly method?: string
   readonly headers?: Record<string, string>
   readonly body?: string
+  readonly traceparent?: string
 }
 
 /** Response from SW_FETCH proxy */
@@ -28,13 +29,16 @@ export interface SWFetchResponse {
   readonly headers: Record<string, string>
 }
 
+/** Fields shared by every SW request envelope. */
+type Traced = { readonly traceparent?: string }
+
 /** Messages from client to Service Worker */
 export type SWRequest =
-  | { readonly type: 'SW_INIT'; readonly config: SWGitConfig }
-  | { readonly type: 'SW_STATUS' }
-  | { readonly type: 'SW_INVALIDATE' }
-  | { readonly type: 'SW_METRICS' }
-  | { readonly type: 'SW_LOG_SUBSCRIBE' }
+  | (Traced & { readonly type: 'SW_INIT'; readonly config: SWGitConfig })
+  | (Traced & { readonly type: 'SW_STATUS' })
+  | (Traced & { readonly type: 'SW_INVALIDATE' })
+  | (Traced & { readonly type: 'SW_METRICS' })
+  | (Traced & { readonly type: 'SW_LOG_SUBSCRIBE' })
   | SWFetchRequest
 
 /** Service Worker readiness state */

--- a/src/sw/push-queue/attempt-merge.ts
+++ b/src/sw/push-queue/attempt-merge.ts
@@ -2,6 +2,7 @@ import { fs, REPO_DIR } from '../git/fs'
 import { loadGit } from '../git/load-git'
 import { buildAuthOpts } from '../git/remote/build-auth-opts'
 import type { SWGitConfig } from '../protocol'
+import { loadTracedHttp } from '../tracing/load-traced-http'
 import { filesFromError, filesFromStatus } from './merge-conflict-files'
 
 /** Outcome of a single auto-merge attempt. */
@@ -34,7 +35,7 @@ export const attemptMerge = async (
   config: SWGitConfig
 ): Promise<MergeOutcome> => {
   const git = await loadGit()
-  const { default: http } = await import('isomorphic-git/http/web')
+  const http = await loadTracedHttp()
   const opts = buildAuthOpts(config, http)
   try {
     await git.pull({

--- a/src/sw/rbac/github-api.test.ts
+++ b/src/sw/rbac/github-api.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { setActiveContext } from '../tracing/active-context'
+import { ghHeaders } from './github-api'
+
+describe('ghHeaders', () => {
+  afterEach(() => {
+    setActiveContext(undefined)
+  })
+
+  it('omits traceparent when no SW context is active', () => {
+    const h = ghHeaders('tok')
+    expect(h['traceparent']).toBeUndefined()
+  })
+
+  it('emits W3C traceparent from the active SW context', () => {
+    setActiveContext({ traceId: 'a'.repeat(32), spanId: 'b'.repeat(16) })
+    const h = ghHeaders('tok')
+    expect(h['traceparent']).toBe(`00-${'a'.repeat(32)}-${'b'.repeat(16)}-01`)
+  })
+
+  it('keeps the bearer + accept headers intact', () => {
+    setActiveContext({ traceId: 'c'.repeat(32), spanId: 'd'.repeat(16) })
+    const h = ghHeaders('tok')
+    expect(h['authorization']).toBe('Bearer tok')
+    expect(h['accept']).toBe('application/vnd.github+json')
+  })
+})

--- a/src/sw/rbac/github-api.ts
+++ b/src/sw/rbac/github-api.ts
@@ -1,16 +1,28 @@
+import { activeContext } from '../tracing/active-context'
+
 /** GitHub REST API base URL. */
 export const API = 'https://api.github.com'
 
+const traceparentHeader = (): Record<string, string> => {
+  const ctx = activeContext()
+  return ctx === undefined
+    ? {}
+    : { traceparent: `00-${ctx.traceId}-${ctx.spanId}-01` }
+}
+
 /**
  * Standard headers for a GitHub API call with the admin's bearer.
+ * Adds a W3C `traceparent` when the SW dispatcher has an active
+ * context so server logs can stitch back to the client trace.
  *
  * @param token OAuth bearer token
  * @returns request headers
  */
-export const ghHeaders = (token: string): HeadersInit => ({
+export const ghHeaders = (token: string): Record<string, string> => ({
   authorization: `Bearer ${token}`,
   accept: 'application/vnd.github+json',
   'x-github-api-version': '2022-11-28',
+  ...traceparentHeader(),
 })
 
 /**

--- a/src/sw/tracing/active-context.ts
+++ b/src/sw/tracing/active-context.ts
@@ -1,0 +1,28 @@
+/** Per-handler trace context — populated by the dispatcher. */
+export type TraceContext = {
+  readonly traceId: string
+  readonly spanId: string
+}
+
+let active: TraceContext | undefined
+
+/**
+ * Set the active trace context for the synchronous portion of
+ * the current handler. Cleared with `setActiveContext(undefined)`.
+ *
+ * Caveat: the SW does not have AsyncLocalStorage, so contexts
+ * across `await` boundaries can be lost when other messages
+ * dispatch between yields. Logs emitted at synchronous handler
+ * entry are reliable; later logs are best-effort.
+ * @param ctx Context to install, or undefined to clear.
+ * @returns void
+ */
+export const setActiveContext = (ctx: TraceContext | undefined): void => {
+  active = ctx
+}
+
+/**
+ * Read the active trace context.
+ * @returns Active context, or undefined when none is set.
+ */
+export const activeContext = (): TraceContext | undefined => active

--- a/src/sw/tracing/http-traceparent.test.ts
+++ b/src/sw/tracing/http-traceparent.test.ts
@@ -1,0 +1,49 @@
+import type { HttpClient } from 'isomorphic-git'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { setActiveContext } from './active-context'
+import { withTraceparent } from './http-traceparent'
+
+const okResponse = {
+  url: 'https://x/info/refs',
+  method: 'GET',
+  headers: {},
+  body: [],
+  statusCode: 200,
+  statusMessage: 'OK',
+}
+
+describe('withTraceparent', () => {
+  afterEach(() => {
+    setActiveContext(undefined)
+  })
+
+  it('passes opts through unchanged when no context is set', async () => {
+    const reqMock = vi.fn().mockResolvedValue(okResponse)
+    const inner: HttpClient = { request: reqMock }
+    const wrapped = withTraceparent(inner)
+    await wrapped.request({
+      url: 'https://x/info/refs',
+      method: 'GET',
+      headers: { Accept: 'application/json' },
+    })
+    const call = reqMock.mock.calls[0] ?? []
+    expect(call[0]?.headers?.traceparent).toBeUndefined()
+    expect(call[0]?.headers?.Accept).toBe('application/json')
+  })
+
+  it('injects traceparent when a context is active', async () => {
+    setActiveContext({ traceId: 'e'.repeat(32), spanId: 'f'.repeat(16) })
+    const reqMock = vi.fn().mockResolvedValue(okResponse)
+    const inner: HttpClient = { request: reqMock }
+    const wrapped = withTraceparent(inner)
+    await wrapped.request({
+      url: 'https://x/info/refs',
+      method: 'GET',
+      headers: {},
+    })
+    const call = reqMock.mock.calls[0] ?? []
+    expect(call[0]?.headers?.traceparent).toBe(
+      `00-${'e'.repeat(32)}-${'f'.repeat(16)}-01`
+    )
+  })
+})

--- a/src/sw/tracing/http-traceparent.ts
+++ b/src/sw/tracing/http-traceparent.ts
@@ -1,0 +1,24 @@
+import type { HttpClient } from 'isomorphic-git'
+import { activeContext } from './active-context'
+
+const traceparentHeader = (): Record<string, string> => {
+  const ctx = activeContext()
+  return ctx === undefined
+    ? {}
+    : { traceparent: `00-${ctx.traceId}-${ctx.spanId}-01` }
+}
+
+/**
+ * Wrap an isomorphic-git HTTP client so every outbound request
+ * carries the active SW trace context as a W3C `traceparent`
+ * header. No-op when no context is active.
+ * @param inner Underlying HTTP client (web or node flavour).
+ * @returns Wrapped client with header injection.
+ */
+export const withTraceparent = (inner: HttpClient): HttpClient => ({
+  request: async opts =>
+    inner.request({
+      ...opts,
+      headers: { ...opts.headers, ...traceparentHeader() },
+    }),
+})

--- a/src/sw/tracing/load-traced-http.ts
+++ b/src/sw/tracing/load-traced-http.ts
@@ -1,0 +1,13 @@
+import type { HttpClient } from 'isomorphic-git'
+import { withTraceparent } from './http-traceparent'
+
+/**
+ * Lazily import isomorphic-git's web HTTP client and wrap it so
+ * every outbound request carries the active SW trace context.
+ * Replaces `await import('isomorphic-git/http/web')` callsites.
+ * @returns Wrapped HTTP client.
+ */
+export const loadTracedHttp = async (): Promise<HttpClient> => {
+  const { default: http } = await import('isomorphic-git/http/web')
+  return withTraceparent(http)
+}

--- a/src/sw/tracing/parse-traceparent.test.ts
+++ b/src/sw/tracing/parse-traceparent.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { parseTraceparent } from './parse-traceparent'
+
+describe('parseTraceparent', () => {
+  it('parses a well-formed traceparent', () => {
+    const out = parseTraceparent(
+      '00-0123456789abcdef0123456789abcdef-fedcba9876543210-01'
+    )
+    expect(out?.traceId).toBe('0123456789abcdef0123456789abcdef')
+    expect(out?.spanId).toBe('fedcba9876543210')
+  })
+
+  it('returns undefined for malformed input', () => {
+    expect(parseTraceparent('garbage')).toBeUndefined()
+    expect(parseTraceparent('00-short-x-01')).toBeUndefined()
+    expect(parseTraceparent(undefined)).toBeUndefined()
+  })
+
+  it('rejects unknown version', () => {
+    expect(
+      parseTraceparent(
+        '01-0123456789abcdef0123456789abcdef-fedcba9876543210-01'
+      )
+    ).toBeUndefined()
+  })
+})

--- a/src/sw/tracing/parse-traceparent.ts
+++ b/src/sw/tracing/parse-traceparent.ts
@@ -1,0 +1,22 @@
+import type { TraceContext } from './active-context'
+
+const TRACEPARENT_RE = /^00-[0-9a-f]{32}-[0-9a-f]{16}-(00|01)$/
+
+/**
+ * Parse a W3C `traceparent` header into a SW trace context.
+ * Returns undefined for malformed input so callers fall back
+ * to a missing-context state rather than crashing.
+ * @param raw Wire-format traceparent string.
+ * @returns Trace context, or undefined when invalid.
+ */
+export const parseTraceparent = (
+  raw: string | undefined
+): TraceContext | undefined => {
+  const ok = typeof raw === 'string' && TRACEPARENT_RE.test(raw)
+  const parts = ok ? raw.split('-') : []
+  return parts.length === 4 &&
+    parts[1] !== undefined &&
+    parts[2] !== undefined
+    ? { traceId: parts[1], spanId: parts[2] }
+    : undefined
+}


### PR DESCRIPTION
## Summary
- **Log bridge** — SW log entries flow through a `BroadcastChannel` listener (`bridgeSWLogs`) into a new log buffer (`recordLog`) that batch-POSTs to the collector's `/v1/logs` endpoint.
- **Per-handler trace context** — every SW request envelope now carries a `traceparent`; the dispatcher parses it and installs the active context for the synchronous portion of the handler. `postWithTimeout` stamps the field from the current client span via `stampTraceparent`.
- **Log continuation** — the SW logger reads the active context and stamps each `LogEntry` with `traceId` + `spanId`; `logFromSWEntry` carries them into the `LogRecord` so the viewer (Epic 9) can stitch trace + logs.
- **Outbound traceparent** — `ghHeaders` adds a `traceparent` header from the active context, and a wrapped isomorphic-git HTTP client (`withTraceparent` / `loadTracedHttp`) injects it on every clone, fetch, pull, push, and merge attempt.

Closes #138.

## Test plan
- [x] `bun run test:unit` — 560 tests, all green
- [x] New unit coverage:
  - `exporter-logs`, `send-logs`, `log-from-sw`, `use-log-bridge`
  - `parse-traceparent`, `http-traceparent`, `stamp-traceparent`, `message-handler` (context lifecycle)
  - `ghHeaders` (traceparent injection)
- [x] `bun run validate` — 0 errors; the lone biome warning (`auth-middleware.ts` optional-chain) pre-dates this branch

## Notes
- AsyncLocalStorage is unavailable in Service Workers, so the context is single module-scoped and cleared after dispatch returns. Synchronous-prefix logs are reliable; logs after `await` boundaries are best-effort. Documented in `active-context.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)