### PR TITLE
feat(collector): SSE trace subscription endpoint (#143)

### DIFF
--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -12,6 +12,7 @@ import {
 import { registerHealthRoute } from './health'
 import { type OtlpBindings, registerOtlpRoutes } from './otlp-handlers'
 import { rateLimit } from './rate-limit'
+import { registerSseRoute } from './sse-handler'
 
 /** Combined worker bindings across all registered routes. */
 export type Bindings = AuthBindings &
@@ -27,6 +28,7 @@ app.use('/v1/*', rateLimit())
 registerHealthRoute(app)
 registerExchangeRoute(app)
 registerOtlpRoutes(app)
+registerSseRoute(app)
 
 /** Cloudflare Worker entry — delegates everything to Hono. */
 export default {

--- a/services/log-collector/src/otlp-handlers.ts
+++ b/services/log-collector/src/otlp-handlers.ts
@@ -1,6 +1,7 @@
 import type { Context, Hono } from 'hono'
 import type { AuthVariables } from './auth-middleware'
 import { parseLogBatch, parseTraceBatch } from './otlp-validate'
+import { broadcast } from './sse-bus'
 import { persistLogs, persistSpans } from './storage'
 import type { StorageBindings } from './storage-types'
 
@@ -23,6 +24,7 @@ const runPersistSpans = async (
 ): Promise<Response> => {
   const user = c.get('user').sub
   await persistSpans(c.env, spans, user)
+  spans.forEach(broadcast)
   return c.json({ accepted: spans.length })
 }
 

--- a/services/log-collector/src/sse-bus.test.ts
+++ b/services/log-collector/src/sse-bus.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SpanRecord } from './otlp-types'
+import { broadcast, subscribe, subscriberCount } from './sse-bus'
+
+const span = (id: string, traceId: string): SpanRecord => ({
+  traceId,
+  spanId: id,
+  parentSpanId: undefined,
+  name: 'op',
+  startedAt: 1,
+  finishedAt: 2,
+  status: 'ok',
+  attributes: {},
+})
+
+describe('sse-bus', () => {
+  afterEach(() => {
+    while (subscriberCount() > 0) {
+      // safety net — shouldn't happen, but tests must leave a clean bus
+    }
+  })
+
+  it('delivers spans matching the filter', () => {
+    const sink = vi.fn()
+    const dispose = subscribe({ filter: () => true, send: sink })
+    broadcast(span('s1', 't1'))
+    expect(sink).toHaveBeenCalledTimes(1)
+    dispose()
+  })
+
+  it('skips spans the filter rejects', () => {
+    const sink = vi.fn()
+    const dispose = subscribe({
+      filter: s => s.traceId === 'wanted',
+      send: sink,
+    })
+    broadcast(span('s1', 'other'))
+    expect(sink).not.toHaveBeenCalled()
+    dispose()
+  })
+
+  it('disposer removes the subscriber from the registry', () => {
+    const before = subscriberCount()
+    const sink = vi.fn()
+    const dispose = subscribe({ filter: () => true, send: sink })
+    expect(subscriberCount()).toBe(before + 1)
+    dispose()
+    expect(subscriberCount()).toBe(before)
+  })
+
+  it('fans out to multiple subscribers', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const da = subscribe({ filter: () => true, send: a })
+    const db = subscribe({ filter: () => true, send: b })
+    broadcast(span('s1', 't1'))
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+    da()
+    db()
+  })
+})

--- a/services/log-collector/src/sse-bus.ts
+++ b/services/log-collector/src/sse-bus.ts
@@ -1,0 +1,50 @@
+import type { SpanRecord } from './otlp-types'
+
+/** Predicate that decides whether a subscriber receives a span. */
+export type SpanFilter = (span: SpanRecord) => boolean
+
+/** A live subscriber: filter + send callback. */
+export type Subscriber = {
+  readonly filter: SpanFilter
+  readonly send: (span: SpanRecord) => void
+}
+
+const subscribers = new Set<Subscriber>()
+
+/**
+ * Register a subscriber. Returns a disposer that removes the
+ * subscriber when the stream closes or the client aborts.
+ * @param sub Subscriber filter + sink.
+ * @returns Disposer.
+ */
+export const subscribe = (sub: Subscriber): (() => void) => {
+  subscribers.add(sub)
+  return () => {
+    subscribers.delete(sub)
+  }
+}
+
+const fanout = (sub: Subscriber, span: SpanRecord): void => {
+  const send = sub.filter(span) ? () => sub.send(span) : (): void => undefined
+  send()
+}
+
+/**
+ * Fan out a span to every matching subscriber. No-op when the
+ * registry is empty so ingest stays cheap when no one is
+ * watching.
+ * @param span Span to broadcast.
+ * @returns void
+ */
+export const broadcast = (span: SpanRecord): void => {
+  subscribers.forEach(sub => {
+    fanout(sub, span)
+  })
+}
+
+/**
+ * Snapshot of active subscriber count — used by tests and the
+ * future health endpoint.
+ * @returns Number of active subscribers.
+ */
+export const subscriberCount = (): number => subscribers.size

--- a/services/log-collector/src/sse-handler.test.ts
+++ b/services/log-collector/src/sse-handler.test.ts
@@ -1,0 +1,60 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import type { AuthVariables } from './auth-middleware'
+import type { SpanRecord } from './otlp-types'
+import { broadcast } from './sse-bus'
+import { registerSseRoute } from './sse-handler'
+
+const span = (id: string, traceId: string): SpanRecord => ({
+  traceId,
+  spanId: id,
+  parentSpanId: undefined,
+  name: 'op',
+  startedAt: 1,
+  finishedAt: 2,
+  status: 'ok',
+  attributes: {},
+})
+
+const buildApp = () => {
+  const app = new Hono<{ Variables: AuthVariables }>()
+  registerSseRoute(app)
+  return app
+}
+
+const readFirstChunk = async (res: Response): Promise<string> => {
+  const reader = res.body?.getReader()
+  const result = await reader?.read()
+  return new TextDecoder().decode(result?.value)
+}
+
+describe('GET /v1/subscribe', () => {
+  it('returns text/event-stream', async () => {
+    const app = buildApp()
+    const res = await app.request('/v1/subscribe')
+    expect(res.headers.get('content-type')).toMatch(/event-stream/)
+  })
+
+  it('streams a span event after broadcast', async () => {
+    const app = buildApp()
+    const res = await app.request('/v1/subscribe')
+    const reading = readFirstChunk(res)
+    await new Promise(r => setTimeout(r, 10))
+    broadcast(span('s1', 't1'))
+    const chunk = await reading
+    expect(chunk).toContain('"kind":"span"')
+    expect(chunk).toContain('"spanId":"s1"')
+  })
+
+  it('honours the traceId filter', async () => {
+    const app = buildApp()
+    const res = await app.request('/v1/subscribe?traceId=wanted')
+    const reading = readFirstChunk(res)
+    await new Promise(r => setTimeout(r, 10))
+    broadcast(span('a', 'other'))
+    broadcast(span('b', 'wanted'))
+    const chunk = await reading
+    expect(chunk).toContain('"spanId":"b"')
+    expect(chunk).not.toContain('"spanId":"a"')
+  })
+})

--- a/services/log-collector/src/sse-handler.ts
+++ b/services/log-collector/src/sse-handler.ts
@@ -1,0 +1,45 @@
+import type { Context, Hono } from 'hono'
+import { streamSSE } from 'hono/streaming'
+import type { AuthVariables } from './auth-middleware'
+import { type SpanFilter, subscribe } from './sse-bus'
+
+const filterFor = (traceId: string | undefined): SpanFilter =>
+  traceId === undefined ? () => true : span => span.traceId === traceId
+
+const runStream = (
+  c: Context<{ Variables: AuthVariables }>
+): Response | Promise<Response> => {
+  const traceId = c.req.query('traceId')
+  return streamSSE(c, async stream => {
+    const filter = filterFor(traceId)
+    const dispose = subscribe({
+      filter,
+      send: span => {
+        void stream.writeSSE({
+          data: JSON.stringify({ kind: 'span', span }),
+        })
+      },
+    })
+    await new Promise<void>(resolve => {
+      stream.onAbort(() => {
+        dispose()
+        resolve()
+      })
+    })
+  })
+}
+
+/**
+ * Wire `GET /v1/subscribe`. Auth and rate-limit middlewares run
+ * upstream in `index.ts`. The endpoint streams `text/event-stream`
+ * with one event per ingested span; the optional `traceId`
+ * query filters to a single trace.
+ * @param app Hono app to extend.
+ * @returns Same app for chaining.
+ */
+export const registerSseRoute = (
+  app: Hono<{ Variables: AuthVariables }>
+): Hono<{ Variables: AuthVariables }> => {
+  app.get('/v1/subscribe', runStream)
+  return app
+}


### PR DESCRIPTION
## Summary
- Adds `GET /v1/subscribe` returning `text/event-stream`. Each event payload is `{ kind: 'span', span: SpanRecord }`.
- Optional `?traceId=` filters to a single trace.
- `POST /v1/traces` fans out each persisted span through the new in-isolate `sse-bus` so subscribers see live ingest without external pub/sub.
- Subscriber teardown wired through `streamSSE`'s `onAbort` so per-isolate state stays bounded.

Closes #143. Heartbeat + reconnect (#144), client subscriber (#145), live panel (#146), and RBAC filter (#147) follow.

## Test plan
- [x] `services/log-collector/src/sse-bus.test.ts` (4 tests)
- [x] `services/log-collector/src/sse-handler.test.ts` (3 tests — content-type, span event delivery, traceId filter)
- [x] `bun run validate` clean
- [x] Full unit suite: 567 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)