### PR TITLE
feat(collector): SSE heartbeat + reconnect cursor (#144)

### DIFF
--- a/services/log-collector/src/sse-buffer.test.ts
+++ b/services/log-collector/src/sse-buffer.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { SpanRecord } from './otlp-types'
+import { append, MAX_BUFFER, replay, resetBuffer } from './sse-buffer'
+
+const span = (id: string): SpanRecord => ({
+  traceId: 't',
+  spanId: id,
+  parentSpanId: undefined,
+  name: 'op',
+  startedAt: 1,
+  finishedAt: 2,
+  status: 'ok',
+  attributes: {},
+})
+
+describe('sse-buffer', () => {
+  afterEach(() => {
+    resetBuffer()
+  })
+
+  it('assigns monotonic ids starting at 1', () => {
+    const a = append(span('a'))
+    const b = append(span('b'))
+    expect(a.id).toBe(1)
+    expect(b.id).toBe(2)
+  })
+
+  it('replays only events newer than the cursor', () => {
+    append(span('a'))
+    append(span('b'))
+    append(span('c'))
+    const { events, gap } = replay(1)
+    expect(events.map(e => e.span.spanId)).toEqual(['b', 'c'])
+    expect(gap).toBe(false)
+  })
+
+  it('flags a gap when the cursor predates the buffer head', () => {
+    Array.from({ length: MAX_BUFFER + 5 }).forEach((_, i) => {
+      append(span(`s${i}`))
+    })
+    const { gap, oldestId } = replay(1)
+    expect(gap).toBe(true)
+    expect(oldestId).toBeGreaterThan(1)
+  })
+
+  it('caps the buffer at MAX_BUFFER entries', () => {
+    Array.from({ length: MAX_BUFFER + 10 }).forEach((_, i) => {
+      append(span(`s${i}`))
+    })
+    const { events } = replay(0)
+    expect(events.length).toBe(MAX_BUFFER)
+  })
+})

--- a/services/log-collector/src/sse-buffer.ts
+++ b/services/log-collector/src/sse-buffer.ts
@@ -1,0 +1,53 @@
+import type { SpanRecord } from './otlp-types'
+
+/** A broadcast event with a stream-monotonic id and its span. */
+export type SpanEvent = {
+  readonly id: number
+  readonly span: SpanRecord
+}
+
+/** Replay buffer cap — older events drop with a `gap` notice. */
+export const MAX_BUFFER = 1000
+
+const buffer: SpanEvent[] = []
+let nextId = 1
+
+/**
+ * Append an event to the ring buffer with a fresh monotonic id
+ * and prune the oldest entry once the cap is reached.
+ * @param span Span being broadcast.
+ * @returns Event with assigned id.
+ */
+export const append = (span: SpanRecord): SpanEvent => {
+  const event: SpanEvent = { id: nextId, span }
+  nextId += 1
+  buffer.push(event)
+  buffer.splice(0, buffer.length > MAX_BUFFER ? 1 : 0)
+  return event
+}
+
+/**
+ * Replay events with id strictly greater than `cursor`. When the
+ * cursor predates the oldest buffered id, the caller gets a
+ * `gap` flag so it can warn the client about dropped events.
+ * @param cursor Last seen event id.
+ * @returns Backlog events and a gap flag.
+ */
+export const replay = (
+  cursor: number
+): {
+  readonly events: ReadonlyArray<SpanEvent>
+  readonly gap: boolean
+  readonly oldestId: number | undefined
+} => {
+  const oldestId = buffer[0]?.id
+  const gap = cursor > 0 && oldestId !== undefined && cursor < oldestId - 1
+  const events = buffer.filter(e => e.id > cursor)
+  return { events, gap, oldestId }
+}
+
+/** Reset the buffer — used by tests to isolate fixtures. */
+export const resetBuffer = (): void => {
+  buffer.length = 0
+  nextId = 1
+}

--- a/services/log-collector/src/sse-bus.ts
+++ b/services/log-collector/src/sse-bus.ts
@@ -1,12 +1,16 @@
 import type { SpanRecord } from './otlp-types'
+import { append, resetBuffer, type SpanEvent } from './sse-buffer'
 
-/** Predicate that decides whether a subscriber receives a span. */
+export type { SpanEvent } from './sse-buffer'
+export { MAX_BUFFER, replay } from './sse-buffer'
+
+/** Predicate that decides whether a subscriber receives an event. */
 export type SpanFilter = (span: SpanRecord) => boolean
 
 /** A live subscriber: filter + send callback. */
 export type Subscriber = {
   readonly filter: SpanFilter
-  readonly send: (span: SpanRecord) => void
+  readonly send: (event: SpanEvent) => void
 }
 
 const subscribers = new Set<Subscriber>()
@@ -24,22 +28,32 @@ export const subscribe = (sub: Subscriber): (() => void) => {
   }
 }
 
-const fanout = (sub: Subscriber, span: SpanRecord): void => {
-  const send = sub.filter(span) ? () => sub.send(span) : (): void => undefined
+const fanout = (sub: Subscriber, event: SpanEvent): void => {
+  const send = sub.filter(event.span)
+    ? () => sub.send(event)
+    : (): void => undefined
   send()
 }
 
 /**
- * Fan out a span to every matching subscriber. No-op when the
- * registry is empty so ingest stays cheap when no one is
- * watching.
+ * Append a span to the replay buffer and fan it out to every
+ * matching subscriber. Returns the freshly assigned event id so
+ * callers (e.g. ingest handlers) can echo it for diagnostics.
  * @param span Span to broadcast.
- * @returns void
+ * @returns Event id assigned by the buffer.
  */
-export const broadcast = (span: SpanRecord): void => {
+export const broadcast = (span: SpanRecord): number => {
+  const event = append(span)
   subscribers.forEach(sub => {
-    fanout(sub, span)
+    fanout(sub, event)
   })
+  return event.id
+}
+
+/** Reset the bus — used by tests to isolate fixtures. */
+export const resetSseBus = (): void => {
+  subscribers.clear()
+  resetBuffer()
 }
 
 /**

--- a/services/log-collector/src/sse-handler.test.ts
+++ b/services/log-collector/src/sse-handler.test.ts
@@ -1,8 +1,8 @@
 import { Hono } from 'hono'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import type { AuthVariables } from './auth-middleware'
 import type { SpanRecord } from './otlp-types'
-import { broadcast } from './sse-bus'
+import { broadcast, resetSseBus } from './sse-bus'
 import { registerSseRoute } from './sse-handler'
 
 const span = (id: string, traceId: string): SpanRecord => ({
@@ -22,20 +22,33 @@ const buildApp = () => {
   return app
 }
 
-const readFirstChunk = async (res: Response): Promise<string> => {
+const readChunks = async (res: Response, n: number): Promise<string> => {
   const reader = res.body?.getReader()
-  const result = await reader?.read()
-  return new TextDecoder().decode(result?.value)
+  const decoder = new TextDecoder()
+  const chunks: string[] = []
+  await Promise.all(
+    Array.from({ length: n }).map(async () => {
+      const result = await reader?.read()
+      chunks.push(decoder.decode(result?.value))
+    })
+  )
+  return chunks.join('')
 }
 
+const readFirstChunk = (res: Response): Promise<string> => readChunks(res, 1)
+
 describe('GET /v1/subscribe', () => {
+  afterEach(() => {
+    resetSseBus()
+  })
+
   it('returns text/event-stream', async () => {
     const app = buildApp()
     const res = await app.request('/v1/subscribe')
     expect(res.headers.get('content-type')).toMatch(/event-stream/)
   })
 
-  it('streams a span event after broadcast', async () => {
+  it('streams a span event with id after broadcast', async () => {
     const app = buildApp()
     const res = await app.request('/v1/subscribe')
     const reading = readFirstChunk(res)
@@ -43,7 +56,7 @@ describe('GET /v1/subscribe', () => {
     broadcast(span('s1', 't1'))
     const chunk = await reading
     expect(chunk).toContain('"kind":"span"')
-    expect(chunk).toContain('"spanId":"s1"')
+    expect(chunk).toContain('id: 1')
   })
 
   it('honours the traceId filter', async () => {
@@ -55,6 +68,20 @@ describe('GET /v1/subscribe', () => {
     broadcast(span('b', 'wanted'))
     const chunk = await reading
     expect(chunk).toContain('"spanId":"b"')
+    expect(chunk).not.toContain('"spanId":"a"')
+  })
+
+  it('replays buffered events when Last-Event-ID is set', async () => {
+    broadcast(span('a', 't1'))
+    broadcast(span('b', 't1'))
+    broadcast(span('c', 't1'))
+    const app = buildApp()
+    const res = await app.request('/v1/subscribe', {
+      headers: { 'Last-Event-ID': '1' },
+    })
+    const chunk = await readChunks(res, 2)
+    expect(chunk).toContain('"spanId":"b"')
+    expect(chunk).toContain('"spanId":"c"')
     expect(chunk).not.toContain('"spanId":"a"')
   })
 })

--- a/services/log-collector/src/sse-handler.ts
+++ b/services/log-collector/src/sse-handler.ts
@@ -1,39 +1,44 @@
 import type { Context, Hono } from 'hono'
-import { streamSSE } from 'hono/streaming'
+import { type SSEStreamingApi, streamSSE } from 'hono/streaming'
 import type { AuthVariables } from './auth-middleware'
 import { type SpanFilter, subscribe } from './sse-bus'
+import { cursorOf, replayBacklog } from './sse-replay'
+import { sendToStream } from './sse-write'
+
+/** Heartbeat cadence — keeps CF Worker streams open. */
+export const HEARTBEAT_MS = 20_000
 
 const filterFor = (traceId: string | undefined): SpanFilter =>
   traceId === undefined ? () => true : span => span.traceId === traceId
 
-const runStream = (
-  c: Context<{ Variables: AuthVariables }>
-): Response | Promise<Response> => {
-  const traceId = c.req.query('traceId')
-  return streamSSE(c, async stream => {
-    const filter = filterFor(traceId)
-    const dispose = subscribe({
-      filter,
-      send: span => {
-        void stream.writeSSE({
-          data: JSON.stringify({ kind: 'span', span }),
-        })
-      },
-    })
+const startHeartbeat = (
+  stream: SSEStreamingApi
+): ReturnType<typeof setInterval> =>
+  setInterval(() => {
+    void stream.write(': heartbeat\n\n')
+  }, HEARTBEAT_MS)
+
+const runStream = (c: Context<{ Variables: AuthVariables }>): Response =>
+  streamSSE(c, async stream => {
+    const filter = filterFor(c.req.query('traceId'))
+    await replayBacklog(stream, cursorOf(c), filter)
+    const dispose = subscribe({ filter, send: sendToStream(stream, filter) })
+    const heartbeat = startHeartbeat(stream)
     await new Promise<void>(resolve => {
       stream.onAbort(() => {
+        clearInterval(heartbeat)
         dispose()
         resolve()
       })
     })
   })
-}
 
 /**
  * Wire `GET /v1/subscribe`. Auth and rate-limit middlewares run
  * upstream in `index.ts`. The endpoint streams `text/event-stream`
- * with one event per ingested span; the optional `traceId`
- * query filters to a single trace.
+ * with one event per ingested span; supports `Last-Event-ID`
+ * (or `?since=`) replay and emits a heartbeat comment every
+ * 20 seconds so intermediaries do not drop the connection.
  * @param app Hono app to extend.
  * @returns Same app for chaining.
  */

--- a/services/log-collector/src/sse-replay.ts
+++ b/services/log-collector/src/sse-replay.ts
@@ -1,0 +1,40 @@
+import type { Context } from 'hono'
+import type { SSEStreamingApi } from 'hono/streaming'
+import { replay, type SpanFilter } from './sse-bus'
+import { writeGap, writeSpanEvent } from './sse-write'
+
+/**
+ * Resolve the replay cursor from `Last-Event-ID` (set by the
+ * browser EventSource on auto-reconnect) or from the `since`
+ * query for first-time clients. Defaults to 0 (no replay).
+ * @param c Hono context.
+ * @returns Numeric cursor; 0 when missing or malformed.
+ */
+export const cursorOf = (c: Context): number => {
+  const raw = c.req.header('Last-Event-ID') ?? c.req.query('since') ?? '0'
+  const n = Number.parseInt(raw, 10)
+  return Number.isNaN(n) ? 0 : n
+}
+
+/**
+ * Replay buffered events newer than `cursor` to the stream.
+ * Emits a `gap` event first when older events have rolled off
+ * the ring before the cursor.
+ * @param stream Hono SSE writer.
+ * @param cursor Last seen event id.
+ * @param filter Span predicate.
+ * @returns Promise that resolves after the backlog is flushed.
+ */
+export const replayBacklog = async (
+  stream: SSEStreamingApi,
+  cursor: number,
+  filter: SpanFilter
+): Promise<void> => {
+  const { events, gap, oldestId } = replay(cursor)
+  await (gap && oldestId !== undefined
+    ? writeGap(stream, oldestId)
+    : Promise.resolve())
+  await Promise.all(
+    events.filter(e => filter(e.span)).map(e => writeSpanEvent(stream, e))
+  )
+}

--- a/services/log-collector/src/sse-write.ts
+++ b/services/log-collector/src/sse-write.ts
@@ -1,0 +1,54 @@
+import type { SSEStreamingApi } from 'hono/streaming'
+import type { SpanEvent, SpanFilter } from './sse-bus'
+
+/**
+ * Write a span event to the SSE stream as a normal event with
+ * an `id:` so EventSource auto-reconnect can use Last-Event-ID.
+ * @param stream Hono SSE writer.
+ * @param event Buffered span event.
+ * @returns Promise that resolves once the chunk is flushed.
+ */
+export const writeSpanEvent = (
+  stream: SSEStreamingApi,
+  event: SpanEvent
+): Promise<void> =>
+  stream.writeSSE({
+    id: String(event.id),
+    data: JSON.stringify({ kind: 'span', span: event.span }),
+  })
+
+/**
+ * Emit a `gap` event so a reconnecting client knows that some
+ * events fell off the buffer before the cursor it sent.
+ * @param stream Hono SSE writer.
+ * @param oldestId Lowest id still in the buffer.
+ * @returns Promise that resolves once the chunk is flushed.
+ */
+export const writeGap = (
+  stream: SSEStreamingApi,
+  oldestId: number
+): Promise<void> =>
+  stream.writeSSE({
+    event: 'gap',
+    data: JSON.stringify({ droppedBefore: oldestId }),
+  })
+
+/**
+ * Wrap a filter into a subscriber that writes events to the
+ * SSE stream. Returns the subscriber object directly so the
+ * caller hooks it into `subscribe`.
+ * @param stream Hono SSE writer.
+ * @param filter Span predicate.
+ * @returns Send callback that writes filtered events.
+ */
+export const sendToStream =
+  (
+    stream: SSEStreamingApi,
+    filter: SpanFilter
+  ): ((event: SpanEvent) => void) =>
+  event => {
+    const fire = filter(event.span)
+      ? () => writeSpanEvent(stream, event)
+      : (): Promise<void> => Promise.resolve()
+    void fire()
+  }


### PR DESCRIPTION
## Summary
- **Replay buffer** (`sse-buffer.ts`): caps at 1k events with monotonic ids; events that roll off surface as a `gap` event so reconnecting clients know they missed traffic.
- **Cursor support**: the subscribe handler reads `Last-Event-ID` (set by EventSource on auto-reconnect) or the `?since=` query, replays matching backlog, then transitions to live updates.
- **Heartbeat**: a 20-second `: heartbeat\n\n` SSE comment keeps CF Worker streams open through intermediary idle timeouts.
- Refactored the handler into small focused helpers (`sse-write.ts`, `sse-replay.ts`) to stay under the 50-line cap.

Closes #144.

## Test plan
- [x] `sse-buffer.test.ts` — id ordering, replay, gap on overflow, MAX_BUFFER cap
- [x] `sse-handler.test.ts` — content-type, span event with id, traceId filter, Last-Event-ID replay
- [x] `bun run test:unit` — 572 tests pass
- [x] `bun run validate` — clean (only the pre-existing `auth-middleware.ts` optional-chain warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)