### PR TITLE
chore(scripts): docx → content upload pipeline

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -121,7 +121,7 @@
       }
     },
     {
-      "includes": ["scripts/*.ts"],
+      "includes": ["scripts/**/*.ts"],
       "linter": {
         "rules": {
           "suspicious": {

--- a/scripts/upload/article-spec.ts
+++ b/scripts/upload/article-spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Authoritative mapping between docx files (RU + IT) and the
+ * target slot in the public-website-content repo. Singletons go
+ * to `pages/`; everything else goes to `blog/` with a category
+ * label.
+ */
+export type ArticleKind = 'page' | 'blog'
+
+export type ArticleSpec = {
+  readonly kind: ArticleKind
+  readonly slug: string
+  /** Category key from `settings/labels.json` (blog only). */
+  readonly category?: string
+  readonly ru: string
+  readonly it: string
+}
+
+const ROOT_RU = 'Rus'
+const ROOT_IT = 'Ita'
+
+/** RU + IT pairs the user provided. */
+export const SPECS: ReadonlyArray<ArticleSpec> = [
+  {
+    kind: 'page',
+    slug: 'about',
+    ru: 'О нас.docx',
+    it: 'Noi - it.docx',
+  },
+  {
+    kind: 'page',
+    slug: 'manifest',
+    ru: 'Манифест_группы_“Коммунистический_Прометей”.docx',
+    it: 'Manifesto del gruppo Prometeo comunista (it).docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'editorial-note',
+    category: 'editorial',
+    ru: 'Nota della redazione.docx',
+    it: 'Dalla redazione - it.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'international-review-april-2026',
+    category: 'international',
+    ru: 'МЕЖДУНАРОДНЫЙ ОБЗОР АПРЕЛЬ 2026.docx',
+    it: 'INTERNATIONAL REVIEW ita.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'about-the-manifesto',
+    category: 'programme',
+    ru: 'По поводу “Манифеста”.docx',
+    it: 'A proposito del Manifesto (ita).docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'programme-outline',
+    category: 'programme',
+    ru: 'Набросок_программы_Интернационалистской_коммунистической_партии.docx',
+    it: 'Il schema di Programma del Partito comunista internazionalista.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'programme-outline-intro',
+    category: 'programme',
+    ru: 'Введение_к_“Наброску_программы”_Интернационалистской_коммунистической.docx',
+    it: 'Schema di programma intro.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'iran-imperialism-crisis',
+    category: 'international',
+    ru: 'Иран_как_нервный_узел_кризиса_империализма.docx',
+    it: "Iran come punto nevralgico della crisi dell'imperialismo ita.docx",
+  },
+  {
+    kind: 'blog',
+    slug: 'from-manchester-to-global',
+    category: 'history',
+    ru: 'От_Манчестера_Энгельса_к_глобальному_Манчестеру.docx',
+    it: 'Da Manchester di Engels al Manchester globale ita.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'last-battle-of-the-bolsheviks',
+    category: 'history',
+    ru: 'Последнее сражение большевиков.docx',
+    it: 'L’ultima battaglia dei bolscevichi - it.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'in-search-of-the-way',
+    category: 'history',
+    ru: 'В поисках пути.docx',
+    it: 'In cerca della via - it.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'productivity-apologetics',
+    category: 'critique',
+    ru: 'АПОЛОГЕТИЧЕСКАЯ_КОНЦЕПЦИЯ_ПРОИЗВОДИТЕЛЬНОСТИ_ВСЕХ_ПРОФЕССИЙ.docx',
+    it: 'CONCETTO APOLOGETICO DI PRODUTTIVIT� DI TUTTE LE PROFESSIONI.docx',
+  },
+  {
+    kind: 'blog',
+    slug: 'appeal-to-russian-workers',
+    category: 'appeal',
+    ru: 'ОБРАЩЕНИЕ К РАБОЧИМ РОССИИ.docx',
+    it: 'APPELLO AI LAVORATORI DELLA RUSSIA - it.docx',
+  },
+]
+
+/** Source roots — passed as the first arg to the upload script. */
+export const SOURCE_DIRS = { ru: ROOT_RU, it: ROOT_IT } as const
+
+/**
+ * Categories used by the new article set. Translations cover the
+ * languages currently shipped on the public site.
+ */
+export const CATEGORIES = [
+  {
+    key: 'editorial',
+    translations: {
+      en: 'Editorial',
+      ru: 'Редакционная статья',
+      it: 'Editoriale',
+      es: 'Editorial',
+    },
+  },
+  {
+    key: 'international',
+    translations: {
+      en: 'International politics',
+      ru: 'Международная политика',
+      it: 'Politica internazionale',
+      es: 'Política internacional',
+    },
+  },
+  {
+    key: 'programme',
+    translations: {
+      en: 'Programme',
+      ru: 'Программа',
+      it: 'Programma',
+      es: 'Programa',
+    },
+  },
+  {
+    key: 'history',
+    translations: {
+      en: 'History',
+      ru: 'История',
+      it: 'Storia',
+      es: 'Historia',
+    },
+  },
+  {
+    key: 'critique',
+    translations: {
+      en: 'Critique',
+      ru: 'Критика',
+      it: 'Critica',
+      es: 'Crítica',
+    },
+  },
+  {
+    key: 'appeal',
+    translations: {
+      en: 'Appeal',
+      ru: 'Обращения',
+      it: 'Appello',
+      es: 'Llamamiento',
+    },
+  },
+] as const

--- a/scripts/upload/build-frontmatter.test.ts
+++ b/scripts/upload/build-frontmatter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { renderFrontmatter, stripFootnoteRefs } from './build-frontmatter'
+
+describe('stripFootnoteRefs', () => {
+  it('removes placeholder markers and collapses whitespace', () => {
+    const out = stripFootnoteRefs('Title @@FOOTNOTE_REF_1@@ continues')
+    expect(out).toBe('Title continues')
+  })
+  it('passes plain strings through', () => {
+    expect(stripFootnoteRefs('No refs here')).toBe('No refs here')
+  })
+})
+
+describe('renderFrontmatter', () => {
+  it('renders simple values without quoting', () => {
+    const out = renderFrontmatter({ title: 'Hello', lang: 'ru' })
+    expect(out).toContain('title: Hello')
+    expect(out).toContain('lang: ru')
+    expect(out.startsWith('---\n')).toBe(true)
+    expect(out.endsWith('---\n\n')).toBe(true)
+  })
+  it('quotes values with colons', () => {
+    const out = renderFrontmatter({
+      title: 'A: Subtitle and More',
+      lang: 'ru',
+    })
+    expect(out).toContain('title: "A: Subtitle and More"')
+  })
+  it('emits booleans without quotes', () => {
+    const out = renderFrontmatter({ published: true })
+    expect(out).toContain('published: true')
+  })
+  it('drops undefined keys', () => {
+    const out = renderFrontmatter({ title: 'x', category: undefined })
+    expect(out).not.toContain('category')
+  })
+})

--- a/scripts/upload/build-frontmatter.ts
+++ b/scripts/upload/build-frontmatter.ts
@@ -1,0 +1,39 @@
+/** Frontmatter shape per content kind. */
+export type Frontmatter = Readonly<
+  Record<string, string | boolean | undefined>
+>
+
+const FOOTNOTE_PLACEHOLDER_RE = /@@FOOTNOTE_REF_\d+@@/g
+
+const quote = (value: string): string =>
+  value.includes(':') || value.includes('"') || value.includes('\n')
+    ? `"${value.replace(/"/g, '\\"').replace(/\n/g, ' ')}"`
+    : value
+
+/**
+ * Strip footnote placeholders inserted by `extractFootnotes` from
+ * a string — titles and descriptions should not carry footnote
+ * references even if the source paragraph did.
+ * @param value Raw extracted text.
+ * @returns Cleaned text with placeholder markers removed.
+ */
+export const stripFootnoteRefs = (value: string): string =>
+  value.replace(FOOTNOTE_PLACEHOLDER_RE, '').replace(/\s+/g, ' ').trim()
+
+const formatValue = (value: string | boolean): string =>
+  typeof value === 'boolean' ? String(value) : quote(value)
+
+/**
+ * Render a frontmatter object as a YAML block bracketed by `---`.
+ * Skips undefined keys; quotes values that contain reserved chars.
+ * @param fm Frontmatter object.
+ * @returns YAML block including the trailing blank line.
+ */
+export const renderFrontmatter = (fm: Frontmatter): string => {
+  const lines = Object.entries(fm)
+    .filter(
+      (entry): entry is [string, string | boolean] => entry[1] !== undefined
+    )
+    .map(([k, v]) => `${k}: ${formatValue(v)}`)
+  return `---\n${lines.join('\n')}\n---\n\n`
+}

--- a/scripts/upload/extract-meta.test.ts
+++ b/scripts/upload/extract-meta.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import { extractMeta, looksLikeLead, looksLikeTitle } from './extract-meta'
+
+describe('looksLikeTitle', () => {
+  it('accepts a short whole-bold paragraph', () => {
+    expect(looksLikeTitle('<p><strong>Some Title</strong></p>')).toBe(true)
+  })
+  it('rejects sentence-terminated paragraphs', () => {
+    expect(
+      looksLikeTitle('<p><strong>This is a sentence.</strong></p>')
+    ).toBe(false)
+  })
+  it('rejects non-bold paragraphs', () => {
+    expect(looksLikeTitle('<p>Some Title</p>')).toBe(false)
+  })
+})
+
+describe('looksLikeLead', () => {
+  it('accepts long bold-italic paragraphs', () => {
+    const long = 'A'.repeat(120)
+    expect(looksLikeLead(`<p><strong><em>${long}</em></strong></p>`)).toBe(
+      true
+    )
+  })
+  it('rejects short bold-italic paragraphs (likely a section prefix)', () => {
+    expect(looksLikeLead('<p><strong><em>Section</em></strong></p>')).toBe(
+      false
+    )
+  })
+  it('rejects whole-bold-only paragraphs', () => {
+    expect(looksLikeLead('<p><strong>Just bold</strong></p>')).toBe(false)
+  })
+})
+
+describe('extractMeta', () => {
+  it('extracts title and lead description from a Prometheus-shaped doc', () => {
+    const html =
+      '<p><strong><em>Section prefix</em></strong></p>' +
+      '<p><strong>The Title</strong></p>' +
+      `<p><strong><em>${'A'.repeat(120)}</em></strong></p>` +
+      '<p>Body content here.</p>'
+    const meta = extractMeta(html)
+    expect(meta.title).toBe('The Title')
+    expect(meta.description.length).toBeGreaterThan(80)
+    expect(meta.bodyHtml).not.toContain('The Title')
+    expect(meta.bodyHtml).not.toContain('A'.repeat(120))
+    expect(meta.bodyHtml).toContain('Section prefix')
+    expect(meta.bodyHtml).toContain('Body content here.')
+  })
+
+  it('falls back to first body paragraph when no bold-italic lead exists', () => {
+    const html =
+      '<p><strong>Title</strong></p>' +
+      '<p>This is a long enough first paragraph to serve as a description.</p>' +
+      '<p><strong>Section</strong></p>' +
+      '<p>More content.</p>'
+    const meta = extractMeta(html)
+    expect(meta.title).toBe('Title')
+    expect(meta.description).toContain('This is a long enough first')
+    expect(meta.bodyHtml).toContain(
+      '<p>This is a long enough first paragraph to serve as a description.</p>'
+    )
+    expect(meta.bodyHtml).not.toContain('<p><strong>Title</strong></p>')
+  })
+
+  it('returns empty title when document has no bold paragraph', () => {
+    const meta = extractMeta('<p>Plain text only.</p>')
+    expect(meta.title).toBe('')
+    expect(meta.bodyHtml).toContain('Plain text')
+  })
+
+  it('picks up the lead even when it precedes the title', () => {
+    const lead = `<p><strong><em>${'L'.repeat(120)}</em></strong></p>`
+    const html = `${lead}<p><strong>Title</strong></p><p>Body content here.</p>`
+    const meta = extractMeta(html)
+    expect(meta.title).toBe('Title')
+    expect(meta.description.startsWith('LLLL')).toBe(true)
+    expect(meta.bodyHtml).not.toContain(lead)
+    expect(meta.bodyHtml).not.toContain('<p><strong>Title</strong></p>')
+  })
+
+  it('caps description length even when the bold-italic lead is huge', () => {
+    const lead = `<p><strong><em>${'X'.repeat(800)}</em></strong></p>`
+    const html = `${lead}<p><strong>Title</strong></p><p>Body.</p>`
+    const meta = extractMeta(html)
+    expect(meta.description.length).toBeLessThanOrEqual(300)
+    expect(meta.description.endsWith('…')).toBe(true)
+  })
+
+  it('skips short bold-italic prefixes before the title to find the real lead', () => {
+    const lead = `<p><strong><em>${'L'.repeat(150)}</em></strong></p>`
+    const sectionPrefix = '<p><strong><em>Short Section</em></strong></p>'
+    const html =
+      lead +
+      sectionPrefix +
+      '<p><strong>Real Title</strong></p>' +
+      '<p>Body.</p>' +
+      `<p><strong><em>${'Q'.repeat(120)}</em></strong></p>`
+    const meta = extractMeta(html)
+    expect(meta.title).toBe('Real Title')
+    expect(meta.description.startsWith('LLLL')).toBe(true)
+    // The unrelated bold-italic quote later in the doc must not be picked:
+    expect(meta.description).not.toContain('QQQ')
+  })
+
+  it('handles a bold-italic lead with mid-paragraph italics interrupted', () => {
+    const lead = `<p><strong><em>${'A'.repeat(60)}</em>«broken»<em>${'B'.repeat(60)}</em></strong></p>`
+    const html = `${lead}<p><strong>Real Title</strong></p><p>Body.</p>`
+    const meta = extractMeta(html)
+    expect(meta.title).toBe('Real Title')
+    expect(meta.description).toContain('AAAA')
+    expect(meta.description).toContain('«broken»')
+    expect(meta.description).toContain('BBBB')
+  })
+})

--- a/scripts/upload/extract-meta.ts
+++ b/scripts/upload/extract-meta.ts
@@ -1,0 +1,162 @@
+/**
+ * Heuristics for pulling title, description, and body out of the
+ * mammoth-generated HTML for the Prometheus content corpus. The
+ * upstream Word documents follow a consistent shape:
+ *
+ *   1. Optional short bold-italic "section" prefix
+ *   2. The title — a single short whole-bold paragraph
+ *   3. Optional long bold-italic lead paragraph (the description)
+ *   4. Body content (regular paragraphs, headings, lists, etc.)
+ *
+ * The functions here are pure and Node-friendly so they can be
+ * exercised by the upload script and from unit tests.
+ */
+
+const PARAGRAPH_RE = /<(?:p|h[1-3])\b[^>]*>[\s\S]*?<\/(?:p|h[1-3])>/g
+const HEADING_OPEN_RE = /^<h[1-3]\b/i
+const TITLE_MAX_LEN = 200
+const DESCRIPTION_MIN_LEN = 80
+const DESCRIPTION_MAX_LEN = 300
+const DESCRIPTION_FALLBACK_LEN = 220
+const TERMINATOR = /[.!…]\s*$/
+
+const stripTags = (html: string): string =>
+  html
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+const innerHtml = (block: string): string =>
+  block.replace(/^<(?:p|h[1-3])\b[^>]*>/, '').replace(/<\/(?:p|h[1-3])>$/, '')
+
+const isHeading = (block: string): boolean => HEADING_OPEN_RE.test(block)
+
+const isWholeBold = (block: string): boolean => {
+  const inner = innerHtml(block).trim()
+  return /^<strong>[\s\S]*<\/strong>$/.test(inner)
+}
+
+/**
+ * Word often inserts non-italic punctuation or quoted phrases
+ * inside a long italic-bold lead paragraph, breaking the strict
+ * `<strong><em>...</em></strong>` shape. Treat any paragraph
+ * that is whole-bold AND opens with `<em>` (or is wrapped in
+ * `<em><strong>...</strong></em>`) as visually italic too.
+ */
+const isWholeBoldItalic = (block: string): boolean => {
+  const inner = innerHtml(block).trim()
+  return (
+    /^<strong>\s*<em>[\s\S]*<\/strong>$/.test(inner) ||
+    /^<em>\s*<strong>[\s\S]*<\/em>$/.test(inner)
+  )
+}
+
+/** Split flattened mammoth HTML into top-level `<p>` blocks. */
+export const splitParagraphs = (html: string): ReadonlyArray<string> =>
+  html.match(PARAGRAPH_RE) ?? []
+
+/** True when the block looks like a document title — short and prominent. */
+export const looksLikeTitle = (block: string): boolean => {
+  const text = stripTags(block)
+  const fits =
+    text.length > 0 && text.length <= TITLE_MAX_LEN && !TERMINATOR.test(text)
+  return (
+    fits &&
+    (isHeading(block) || (isWholeBold(block) && !isWholeBoldItalic(block)))
+  )
+}
+
+/** True when the paragraph reads as a long bold-italic lead. */
+export const looksLikeLead = (block: string): boolean =>
+  isWholeBoldItalic(block) && stripTags(block).length >= DESCRIPTION_MIN_LEN
+
+const truncate = (text: string, max: number): string =>
+  text.length <= max ? text : `${text.slice(0, max - 1).trimEnd()}…`
+
+const findTitleIndex = (blocks: ReadonlyArray<string>): number =>
+  blocks.findIndex(looksLikeTitle)
+
+const isShortBoldItalicPrefix = (block: string): boolean =>
+  isWholeBoldItalic(block) && stripTags(block).length < DESCRIPTION_MIN_LEN
+
+const walkForLead = (
+  blocks: ReadonlyArray<string>,
+  start: number,
+  step: -1 | 1
+): number => {
+  let i = start + step
+  while (i >= 0 && i < blocks.length) {
+    const block = blocks[i] ?? ''
+    if (looksLikeLead(block)) return i
+    if (!isShortBoldItalicPrefix(block)) return -1
+    i += step
+  }
+  return -1
+}
+
+/**
+ * Locate a long bold-italic lead paragraph adjacent to the title,
+ * skipping short bold-italic prefixes (e.g. section labels).
+ * Tries forward first, then backward — many Prometheus documents
+ * put the lead BEFORE the title.
+ */
+const findLeadIndex = (
+  blocks: ReadonlyArray<string>,
+  titleIdx: number
+): number => {
+  const after = walkForLead(blocks, titleIdx, 1)
+  return after !== -1 ? after : walkForLead(blocks, titleIdx, -1)
+}
+
+const fallbackDescriptionFrom = (
+  blocks: ReadonlyArray<string>,
+  titleIdx: number
+): string => {
+  const lead = blocks
+    .slice(titleIdx + 1)
+    .find(b => !isWholeBold(b) && stripTags(b).length >= 30)
+  return lead === undefined
+    ? ''
+    : truncate(stripTags(lead), DESCRIPTION_FALLBACK_LEN)
+}
+
+/** Result of meta extraction — body is the HTML with title (and lead) removed. */
+export type ExtractedMeta = {
+  readonly title: string
+  readonly description: string
+  readonly bodyHtml: string
+}
+
+const removeBlocks = (html: string, blocks: ReadonlyArray<string>): string =>
+  blocks.reduce((acc, b) => acc.replace(b, ''), html)
+
+/**
+ * Extract title, description, and body from mammoth HTML.
+ * @param html Mammoth-generated HTML for one document.
+ * @returns Extracted title / description / cleaned body HTML.
+ */
+export const extractMeta = (html: string): ExtractedMeta => {
+  const blocks = splitParagraphs(html)
+  const titleIdx = findTitleIndex(blocks)
+  const titleBlock = titleIdx === -1 ? '' : (blocks[titleIdx] ?? '')
+  const title = stripTags(titleBlock)
+  const leadIdx = titleIdx === -1 ? -1 : findLeadIndex(blocks, titleIdx)
+  const leadBlock = leadIdx === -1 ? '' : (blocks[leadIdx] ?? '')
+  const description = truncate(
+    leadIdx === -1
+      ? fallbackDescriptionFrom(blocks, titleIdx)
+      : stripTags(leadBlock),
+    DESCRIPTION_MAX_LEN
+  )
+  const bodyHtml = removeBlocks(
+    html,
+    [titleBlock, leadBlock].filter(b => b !== '')
+  )
+  return { title, description, bodyHtml }
+}

--- a/scripts/upload/upload-content.ts
+++ b/scripts/upload/upload-content.ts
@@ -1,0 +1,201 @@
+/* eslint-disable */
+/**
+ * Upload the Russian + Italian docx corpus from
+ * `C:\Users\igor_\Downloads\Uploading` into the
+ * public-website-content repo. Reuses the same parsing modules
+ * the admin's "Import from docs" feature uses, so the result
+ * matches what the user would see clicking through the UI.
+ *
+ * Usage:
+ *   bun scripts/upload/upload-content.ts [--dry]
+ */
+
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import mammoth from 'mammoth'
+import { extractFootnotes } from '../../src/components/MarkdownEditor/ImportDocs/extract-footnotes'
+import { htmlToMarkdown } from '../../src/components/MarkdownEditor/ImportDocs/html-to-markdown'
+import { normaliseImportHtml } from '../../src/components/MarkdownEditor/ImportDocs/normalise-html'
+import {
+  type ArticleSpec,
+  CATEGORIES,
+  SOURCE_DIRS,
+  SPECS,
+} from './article-spec'
+import { renderFrontmatter, stripFootnoteRefs } from './build-frontmatter'
+import { extractMeta } from './extract-meta'
+
+const SOURCE_ROOT = String.raw`C:\Users\igor_\Downloads\Uploading`
+const TARGET_ROOT = String.raw`C:\Projects\Prometheus\public-website\src\content`
+const PUB_DATE = '2026-04-30'
+
+const STYLE_MAP = [
+  "p[style-name='Title'] => h1:fresh",
+  "p[style-name='Subtitle'] => h2:fresh",
+  "p[style-name='Heading 1'] => h1:fresh",
+  "p[style-name='Heading 2'] => h2:fresh",
+  "p[style-name='Heading 3'] => h3:fresh",
+  "p[style-name='Heading 4'] => h4:fresh",
+]
+
+type Lang = 'ru' | 'it'
+const LANGS: ReadonlyArray<Lang> = ['ru', 'it']
+
+const dryRun = process.argv.includes('--dry')
+
+const log = (...args: unknown[]): void => {
+  console.log('[upload]', ...args)
+}
+
+const docxToHtml = async (path: string): Promise<string> => {
+  const buffer = await readFile(path)
+  const result = await mammoth.convertToHtml(
+    { buffer },
+    { styleMap: STYLE_MAP }
+  )
+  return result.value
+}
+
+type Conversion = {
+  readonly title: string
+  readonly description: string
+  readonly markdown: string
+}
+
+const convertOne = async (path: string): Promise<Conversion> => {
+  const rawHtml = await docxToHtml(path)
+  const { html: deFootnoted } = extractFootnotes(rawHtml)
+  const meta = extractMeta(deFootnoted)
+  // Stitch the title back as a real <h1> so promoteVisualHeadings
+  // demotes any subsequent visual-bold paragraphs to <h2>+ instead
+  // of treating them as further document titles.
+  const stitchedBody = `<h1>${stripFootnoteRefs(meta.title)}</h1>${meta.bodyHtml}`
+  const cleanBody = normaliseImportHtml(stitchedBody)
+  const markdownBody = htmlToMarkdown(cleanBody)
+  return {
+    title: stripFootnoteRefs(meta.title),
+    description: stripFootnoteRefs(meta.description),
+    markdown: `${markdownBody.trim()}\n`,
+  }
+}
+
+const categoryLabel = (key: string, lang: Lang): string => {
+  const cat = CATEGORIES.find(c => c.key === key)
+  return cat?.translations[lang] ?? key
+}
+
+const targetPath = (spec: ArticleSpec, lang: Lang): string => {
+  const dir = spec.kind === 'page' ? 'pages' : 'blog'
+  return join(TARGET_ROOT, dir, spec.slug, `index.${lang}.md`)
+}
+
+const buildBlogFrontmatter = (
+  spec: ArticleSpec,
+  lang: Lang,
+  conv: Conversion
+): string =>
+  renderFrontmatter({
+    title: conv.title,
+    description: conv.description,
+    category: spec.category ? categoryLabel(spec.category, lang) : undefined,
+    pubDate: PUB_DATE,
+    published: true,
+    lang,
+  })
+
+const buildPageFrontmatter = (
+  _spec: ArticleSpec,
+  lang: Lang,
+  conv: Conversion
+): string =>
+  renderFrontmatter({
+    title: conv.title,
+    description: conv.description,
+    lang,
+  })
+
+const writeFileSafe = async (path: string, body: string): Promise<void> => {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, body, 'utf8')
+}
+
+const processArticle = async (spec: ArticleSpec): Promise<void> => {
+  log(`-- ${spec.kind} ${spec.slug}`)
+  for (const lang of LANGS) {
+    const filename = lang === 'ru' ? spec.ru : spec.it
+    const dir = SOURCE_DIRS[lang]
+    const src = join(SOURCE_ROOT, dir, filename)
+    const conv = await convertOne(src)
+    const fm =
+      spec.kind === 'page'
+        ? buildPageFrontmatter(spec, lang, conv)
+        : buildBlogFrontmatter(spec, lang, conv)
+    const out = targetPath(spec, lang)
+    log(`   ${lang}: ${conv.title.slice(0, 60)} -> ${out}`)
+    if (!dryRun) await writeFileSafe(out, fm + conv.markdown)
+  }
+}
+
+const upsertLabels = async (): Promise<void> => {
+  const path = join(TARGET_ROOT, 'settings', 'labels.json')
+  const existing = JSON.parse(await readFile(path, 'utf8'))
+  const map = new Map<string, unknown>(
+    existing.map((c: { key: string }) => [c.key, c])
+  )
+  for (const cat of CATEGORIES) {
+    map.set(cat.key, cat)
+  }
+  const merged = [...map.values()]
+  log(`labels.json: ${existing.length} → ${merged.length} entries`)
+  if (!dryRun)
+    await writeFile(path, `${JSON.stringify(merged, null, 2)}\n`, 'utf8')
+}
+
+const TEST_NAME_RE =
+  /^(test|testing|prod-?test|prodverify|oauth-?test|demo|artiche|456)/i
+
+const isObviouslyTest = (name: string): boolean =>
+  TEST_NAME_RE.test(name) || /^test-\d+$/.test(name)
+
+const cleanTestDirs = async (): Promise<void> => {
+  // Wipe newspaper entirely (all current entries are test fixtures).
+  // For positions, only delete obviously-named test entries — keep
+  // real production positions (digital-sovereignty, knowledge-access).
+  const wipeAll = [join(TARGET_ROOT, 'newspaper')]
+  for (const dir of wipeAll) {
+    const entries = await readdir(dir).catch(() => [])
+    for (const name of entries) {
+      const full = join(dir, name)
+      const info = await stat(full).catch(() => undefined)
+      if (info?.isDirectory() === true) {
+        log(`rm ${full}`)
+        if (!dryRun) await rm(full, { recursive: true, force: true })
+      }
+    }
+  }
+  const positionsDir = join(TARGET_ROOT, 'positions')
+  const positions = await readdir(positionsDir).catch(() => [])
+  for (const name of positions) {
+    if (!isObviouslyTest(name)) continue
+    const full = join(positionsDir, name)
+    log(`rm ${full}`)
+    if (!dryRun) await rm(full, { recursive: true, force: true })
+  }
+}
+
+const main = async (): Promise<void> => {
+  log(`mode=${dryRun ? 'DRY' : 'WRITE'}`)
+  await cleanTestDirs()
+  await upsertLabels()
+  for (const spec of SPECS) await processArticle(spec)
+  log('done')
+}
+
+await main()


### PR DESCRIPTION
## Summary
One-shot Node script (Bun) that mirrors the admin's "Import from docs" pipeline so the Russian + Italian docx corpus could be written straight into the public-website-content repo without manually clicking through the editor 26 times.

- Reuses the admin's existing modules (`extractFootnotes`, `normaliseImportHtml`, `htmlToMarkdown`) — no parser fork.
- Adds a small set of pure helpers, all tested:
  - `extract-meta.ts` — title / description / body extraction from mammoth HTML; handles bold-italic lead paragraphs both before and after the title, fallback to mammoth `<h2>` titles, mid-paragraph italic interrupts, and a 300-char description cap.
  - `build-frontmatter.ts` — YAML rendering + footnote-ref stripping.
  - `article-spec.ts` — explicit RU/IT pair list + category translations.
  - `upload-content.ts` — orchestrator: cleans test newspaper/positions entries, upserts `settings/labels.json`, writes `index.{ru,it}.md`.
- Extends the `scripts/*.ts` biome override to `scripts/**/*.ts` so the new subdir inherits the no-console exemption.

## Test plan
- [x] `bun run test:unit` — 602 tests pass (19 new under `scripts/upload/`)
- [x] `bun run validate` clean (only the pre-existing `auth-middleware.ts` optional-chain warning)
- [x] Real upload run produced 28 markdown files (2 pages + 11 blog × 2 langs + 4 mods); `astro check` on public-website returned 0 errors / 0 warnings / 0 hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)