### PR TITLE
feat(collector): trace detail endpoint + RBAC (#149)

### DIFF
--- a/services/log-collector/src/detail-handler.test.ts
+++ b/services/log-collector/src/detail-handler.test.ts
@@ -1,0 +1,88 @@
+import { Hono } from 'hono'
+import { describe, expect, it, vi } from 'vitest'
+import type { AuthVariables } from './auth-middleware'
+import { type DetailBindings, registerDetailRoute } from './detail-handler'
+
+const spanRow = (org: string | undefined) => ({
+  trace_id: 't1',
+  span_id: 's1',
+  parent_span_id: null,
+  name: 'op',
+  started_at: 100,
+  finished_at: 200,
+  status: 'ok',
+  attrs: org === undefined ? '{}' : JSON.stringify({ org }),
+})
+
+const logRow = () => ({
+  trace_id: 't1',
+  span_id: 's1',
+  level: 'info',
+  message: 'hi',
+  at: 150,
+  attrs: '{}',
+})
+
+const buildApp = (
+  spanRows: ReadonlyArray<unknown>,
+  logRows: ReadonlyArray<unknown>,
+  admins?: string
+) => {
+  const prepare = vi.fn().mockImplementation((sql: string) => {
+    const isSpans = sql.includes('FROM spans')
+    const all = vi.fn().mockResolvedValue({
+      results: isSpans ? spanRows : logRows,
+      success: true,
+    })
+    const stmt = { bind: vi.fn(), all, run: vi.fn() }
+    stmt.bind.mockReturnValue(stmt)
+    return stmt
+  })
+  const env: DetailBindings = {
+    ANALYTICS_DATASET: undefined,
+    D1: { prepare },
+    RBAC_ADMINS: admins,
+  }
+  const app = new Hono<{
+    Bindings: DetailBindings
+    Variables: AuthVariables
+  }>()
+  app.use('*', async (c, next) => {
+    c.set('user', { sub: 'alice', exp: 0, iat: 0, aud: 'a' })
+    await next()
+  })
+  registerDetailRoute(app)
+  return { app, env }
+}
+
+describe('GET /v1/traces/:traceId', () => {
+  it('returns the full span tree + logs for an authorised trace', async () => {
+    const { app, env } = buildApp([spanRow('alice')], [logRow()], 'admin1')
+    const res = await app.request('/v1/traces/t1', {}, env)
+    expect(res.status).toBe(200)
+    const body: unknown = await res.json()
+    expect(body).toMatchObject({
+      traceId: 't1',
+      spans: [{ traceId: 't1', spanId: 's1', name: 'op' }],
+      logs: [{ traceId: 't1', spanId: 's1', message: 'hi' }],
+    })
+  })
+
+  it('returns 404 when no spans match the trace id', async () => {
+    const { app, env } = buildApp([], [], 'alice')
+    const res = await app.request('/v1/traces/nope', {}, env)
+    expect(res.status).toBe(404)
+  })
+
+  it('returns 403 when the user is not in any of the trace orgs', async () => {
+    const { app, env } = buildApp([spanRow('other-org')], [], '')
+    const res = await app.request('/v1/traces/t1', {}, env)
+    expect(res.status).toBe(403)
+  })
+
+  it('lets admins through even when org metadata excludes them', async () => {
+    const { app, env } = buildApp([spanRow('other-org')], [], 'alice')
+    const res = await app.request('/v1/traces/t1', {}, env)
+    expect(res.status).toBe(200)
+  })
+})

--- a/services/log-collector/src/detail-handler.ts
+++ b/services/log-collector/src/detail-handler.ts
@@ -1,0 +1,51 @@
+import type { Context, Hono } from 'hono'
+import type { AuthVariables } from './auth-middleware'
+import {
+  buildRbac,
+  canSeeTrace,
+  orgsFromSpans,
+  type RbacBindings,
+} from './rbac-policy'
+import type { StorageBindings } from './storage-types'
+import { fetchTraceDetail } from './trace-detail-fetch'
+
+/** Bindings the detail handler reads from the env. */
+export type DetailBindings = StorageBindings & RbacBindings
+
+const runDetail = async (
+  c: Context<{ Bindings: DetailBindings; Variables: AuthVariables }>
+): Promise<Response> => {
+  const traceId = c.req.param('traceId')
+  const detail = await fetchTraceDetail(c.env, traceId)
+  const empty = detail.spans.length === 0
+  return empty
+    ? c.json({ error: 'not found' }, 404)
+    : runRbac(c, traceId, detail)
+}
+
+const runRbac = (
+  c: Context<{ Bindings: DetailBindings; Variables: AuthVariables }>,
+  traceId: string,
+  detail: Awaited<ReturnType<typeof fetchTraceDetail>>
+): Response => {
+  const ctx = buildRbac(c.env, c.get('user').sub)
+  const allowed = canSeeTrace(ctx, orgsFromSpans(detail.spans))
+  return allowed
+    ? c.json({ traceId, ...detail })
+    : c.json({ error: 'forbidden' }, 403)
+}
+
+/**
+ * Wire `GET /v1/traces/:traceId`. Auth + rate-limit middlewares
+ * run upstream. Returns the full span tree + correlated logs
+ * when the user is allowed, 403 when denied, 404 when the trace
+ * has no spans.
+ * @param app Hono app to extend.
+ * @returns Same app for chaining.
+ */
+export const registerDetailRoute = (
+  app: Hono<{ Bindings: DetailBindings; Variables: AuthVariables }>
+): Hono<{ Bindings: DetailBindings; Variables: AuthVariables }> => {
+  app.get('/v1/traces/:traceId', runDetail)
+  return app
+}

--- a/services/log-collector/src/index.ts
+++ b/services/log-collector/src/index.ts
@@ -5,6 +5,7 @@ import {
   authMiddleware,
 } from './auth-middleware'
 import { batchSizeGuard } from './batch-size-guard'
+import { type DetailBindings, registerDetailRoute } from './detail-handler'
 import {
   type ExchangeBindings,
   registerExchangeRoute,
@@ -18,7 +19,8 @@ import { registerSseRoute } from './sse-handler'
 /** Combined worker bindings across all registered routes. */
 export type Bindings = AuthBindings &
   ExchangeBindings &
-  OtlpBindings & {
+  OtlpBindings &
+  DetailBindings & {
     readonly VERSION: string
   }
 
@@ -30,6 +32,7 @@ registerHealthRoute(app)
 registerExchangeRoute(app)
 registerOtlpRoutes(app)
 registerSearchRoute(app)
+registerDetailRoute(app)
 registerSseRoute(app)
 
 /** Cloudflare Worker entry — delegates everything to Hono. */

--- a/services/log-collector/src/parse-attrs.ts
+++ b/services/log-collector/src/parse-attrs.ts
@@ -1,0 +1,32 @@
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === 'object'
+
+const isString = (v: unknown): v is string => typeof v === 'string'
+
+const safeJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Normalise a D1 `attrs` cell into a string→string map.
+ * Accepts a JSON string or an already-parsed object; drops
+ * non-string values so callers can rely on the shape.
+ * @param raw Raw cell value.
+ * @returns Frozen attribute map.
+ */
+export const parseAttrs = (
+  raw: unknown
+): Readonly<Record<string, string>> => {
+  const parsed: unknown = isString(raw) ? safeJson(raw) : (raw ?? {})
+  return isObject(parsed)
+    ? Object.fromEntries(
+        Object.entries(parsed).filter((entry): entry is [string, string] =>
+          isString(entry[1])
+        )
+      )
+    : {}
+}

--- a/services/log-collector/src/rbac-policy.test.ts
+++ b/services/log-collector/src/rbac-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import type { SpanRecord } from './otlp-types'
+import { buildRbac, canSeeTrace, orgsFromSpans } from './rbac-policy'
+
+const span = (org: string | undefined): SpanRecord => ({
+  traceId: 't',
+  spanId: 's',
+  parentSpanId: undefined,
+  name: 'op',
+  startedAt: 1,
+  finishedAt: 2,
+  status: 'ok',
+  attributes: org === undefined ? {} : { org },
+})
+
+describe('buildRbac', () => {
+  it('parses comma-separated admins', () => {
+    const ctx = buildRbac({ RBAC_ADMINS: 'alice, bob ,carol' }, 'alice')
+    expect(ctx.user).toBe('alice')
+    expect(ctx.admins.has('alice')).toBe(true)
+    expect(ctx.admins.has('bob')).toBe(true)
+    expect(ctx.admins.has('carol')).toBe(true)
+  })
+
+  it('handles missing RBAC_ADMINS', () => {
+    const ctx = buildRbac({}, 'alice')
+    expect(ctx.admins.size).toBe(0)
+  })
+})
+
+describe('orgsFromSpans', () => {
+  it('collects unique non-empty org attrs', () => {
+    const orgs = orgsFromSpans([
+      span('a'),
+      span('a'),
+      span('b'),
+      span(undefined),
+    ])
+    expect([...orgs].sort()).toEqual(['a', 'b'])
+  })
+})
+
+describe('canSeeTrace', () => {
+  it('lets admins see anything', () => {
+    const ctx = buildRbac({ RBAC_ADMINS: 'alice' }, 'alice')
+    expect(canSeeTrace(ctx, new Set())).toBe(true)
+    expect(canSeeTrace(ctx, new Set(['unrelated']))).toBe(true)
+  })
+
+  it('lets a non-admin see traces from their own org', () => {
+    const ctx = buildRbac({}, 'alice')
+    expect(canSeeTrace(ctx, new Set(['alice']))).toBe(true)
+    expect(canSeeTrace(ctx, new Set(['bob']))).toBe(false)
+  })
+
+  it('denies non-admins on traces with no org metadata', () => {
+    const ctx = buildRbac({}, 'alice')
+    expect(canSeeTrace(ctx, new Set())).toBe(false)
+  })
+})

--- a/services/log-collector/src/rbac-policy.ts
+++ b/services/log-collector/src/rbac-policy.ts
@@ -1,0 +1,62 @@
+import type { SpanRecord } from './otlp-types'
+
+/** Bindings the RBAC layer reads off the worker env. */
+export type RbacBindings = {
+  readonly RBAC_ADMINS?: string
+}
+
+const splitList = (raw: string | undefined): ReadonlySet<string> =>
+  new Set(
+    (raw ?? '')
+      .split(',')
+      .map(s => s.trim())
+      .filter(s => s.length > 0)
+  )
+
+/** Active RBAC context for a single request. */
+export type RbacContext = {
+  readonly user: string
+  readonly admins: ReadonlySet<string>
+}
+
+/**
+ * Build an RBAC context from the worker env + the JWT subject.
+ * Admins come from the comma-separated `RBAC_ADMINS` binding;
+ * everyone else is a regular user.
+ * @param bindings Worker bindings.
+ * @param user GitHub login from the JWT `sub` claim.
+ * @returns RBAC context.
+ */
+export const buildRbac = (
+  bindings: RbacBindings,
+  user: string
+): RbacContext => ({ user, admins: splitList(bindings.RBAC_ADMINS) })
+
+/**
+ * Collect the unique `org` attribute values from a span list.
+ * @param spans Spans associated with a single trace.
+ * @returns Frozen set of orgs the spans claim.
+ */
+export const orgsFromSpans = (
+  spans: ReadonlyArray<SpanRecord>
+): ReadonlySet<string> =>
+  new Set(
+    spans
+      .map(s => s.attributes['org'])
+      .filter((o): o is string => typeof o === 'string' && o.length > 0)
+  )
+
+/**
+ * Decide whether `ctx.user` may read a trace whose spans claim
+ * the given orgs. Admins always pass. Non-admins must own at
+ * least one of the trace's orgs (i.e. `ctx.user` ∈ orgs). When
+ * the trace carries no org attribute, only admins may see it.
+ * @param ctx RBAC context.
+ * @param orgs Orgs claimed by the trace.
+ * @returns True when the user is allowed.
+ */
+export const canSeeTrace = (
+  ctx: RbacContext,
+  orgs: ReadonlySet<string>
+): boolean =>
+  ctx.admins.has(ctx.user) || (orgs.size > 0 && orgs.has(ctx.user))

--- a/services/log-collector/src/row-to-log.ts
+++ b/services/log-collector/src/row-to-log.ts
@@ -1,0 +1,38 @@
+import type { LogRecord } from './otlp-types'
+import { parseAttrs } from './parse-attrs'
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === 'object'
+
+const isString = (v: unknown): v is string => typeof v === 'string'
+const isNumber = (v: unknown): v is number => typeof v === 'number'
+
+const isLogLevel = (v: unknown): v is LogRecord['level'] =>
+  v === 'debug' || v === 'info' || v === 'warn' || v === 'error'
+
+const buildLog = (
+  row: Record<string, unknown>,
+  level: LogRecord['level']
+): LogRecord => ({
+  traceId: isString(row['trace_id']) ? row['trace_id'] : undefined,
+  spanId: isString(row['span_id']) ? row['span_id'] : undefined,
+  level,
+  message: isString(row['message']) ? row['message'] : '',
+  at: isNumber(row['at']) ? row['at'] : 0,
+  attributes: parseAttrs(row['attrs']),
+})
+
+/**
+ * Convert a raw D1 `logs` row into a LogRecord. Returns
+ * undefined for rows missing required columns.
+ * @param row Raw D1 row.
+ * @returns LogRecord or undefined.
+ */
+export const rowToLog = (row: unknown): LogRecord | undefined => {
+  const ok =
+    isObject(row) &&
+    isLogLevel(row['level']) &&
+    isString(row['message']) &&
+    isNumber(row['at'])
+  return ok ? buildLog(row, row['level']) : undefined
+}

--- a/services/log-collector/src/row-to-span.ts
+++ b/services/log-collector/src/row-to-span.ts
@@ -1,0 +1,45 @@
+import type { SpanRecord } from './otlp-types'
+import { parseAttrs } from './parse-attrs'
+
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  v !== null && typeof v === 'object'
+
+const isString = (v: unknown): v is string => typeof v === 'string'
+const isNumber = (v: unknown): v is number => typeof v === 'number'
+
+const isSpanStatus = (v: unknown): v is SpanRecord['status'] =>
+  v === 'ok' || v === 'error' || v === 'unset'
+
+const buildSpan = (
+  row: Record<string, unknown>,
+  status: SpanRecord['status']
+): SpanRecord => ({
+  traceId: isString(row['trace_id']) ? row['trace_id'] : '',
+  spanId: isString(row['span_id']) ? row['span_id'] : '',
+  parentSpanId: isString(row['parent_span_id'])
+    ? row['parent_span_id']
+    : undefined,
+  name: isString(row['name']) ? row['name'] : '',
+  startedAt: isNumber(row['started_at']) ? row['started_at'] : 0,
+  finishedAt: isNumber(row['finished_at']) ? row['finished_at'] : 0,
+  status,
+  attributes: parseAttrs(row['attrs']),
+})
+
+/**
+ * Convert a raw D1 `spans` row into a SpanRecord. Returns
+ * undefined for rows missing required columns.
+ * @param row Raw D1 row.
+ * @returns SpanRecord or undefined.
+ */
+export const rowToSpan = (row: unknown): SpanRecord | undefined => {
+  const ok =
+    isObject(row) &&
+    isString(row['trace_id']) &&
+    isString(row['span_id']) &&
+    isString(row['name']) &&
+    isNumber(row['started_at']) &&
+    isNumber(row['finished_at']) &&
+    isSpanStatus(row['status'])
+  return ok ? buildSpan(row, row['status']) : undefined
+}

--- a/services/log-collector/src/storage-logs.ts
+++ b/services/log-collector/src/storage-logs.ts
@@ -2,7 +2,8 @@ import type { LogRecord } from './otlp-types'
 import type { StorageBindings } from './storage-types'
 
 const INSERT_LOG_SQL =
-  'INSERT INTO logs (trace_id, level, at) VALUES (?, ?, ?)'
+  'INSERT INTO logs (trace_id, span_id, level, message, at, attrs) ' +
+  'VALUES (?, ?, ?, ?, ?, ?)'
 
 const indexLogD1 = (
   bindings: StorageBindings,
@@ -13,7 +14,14 @@ const indexLogD1 = (
     ? Promise.resolve()
     : db
         .prepare(INSERT_LOG_SQL)
-        .bind(log.traceId ?? '', log.level, log.at)
+        .bind(
+          log.traceId ?? null,
+          log.spanId ?? null,
+          log.level,
+          log.message,
+          log.at,
+          JSON.stringify(log.attributes ?? {})
+        )
         .run()
 }
 

--- a/services/log-collector/src/trace-detail-fetch.ts
+++ b/services/log-collector/src/trace-detail-fetch.ts
@@ -1,0 +1,56 @@
+import type { LogRecord, SpanRecord } from './otlp-types'
+import { rowToLog } from './row-to-log'
+import { rowToSpan } from './row-to-span'
+import type { StorageBindings } from './storage-types'
+
+const SPANS_SQL =
+  'SELECT trace_id, span_id, parent_span_id, name, started_at, ' +
+  'finished_at, status, attrs FROM spans WHERE trace_id = ? ' +
+  'ORDER BY started_at ASC'
+
+const LOGS_SQL =
+  'SELECT trace_id, span_id, level, message, at, attrs FROM logs ' +
+  'WHERE trace_id = ? ORDER BY at ASC'
+
+const fetchAll = async (
+  db: NonNullable<StorageBindings['D1']>,
+  sql: string,
+  traceId: string
+): Promise<ReadonlyArray<unknown>> => {
+  const result = await db.prepare(sql).bind(traceId).all()
+  return result.results
+}
+
+const isDefined = <T>(value: T | undefined): value is T => value !== undefined
+
+/** Spans + logs for one trace, both ordered chronologically. */
+export type TraceFetchResult = {
+  readonly spans: ReadonlyArray<SpanRecord>
+  readonly logs: ReadonlyArray<LogRecord>
+}
+
+const empty: TraceFetchResult = { spans: [], logs: [] }
+
+/**
+ * Pull every span + log carrying `traceId` from D1 in one round.
+ * Returns the empty shape when D1 is absent so callers can
+ * short-circuit in tests.
+ * @param bindings Worker storage bindings.
+ * @param traceId Trace identifier from the URL.
+ * @returns Spans + logs, both chronologically ordered.
+ */
+export const fetchTraceDetail = async (
+  bindings: StorageBindings,
+  traceId: string
+): Promise<TraceFetchResult> => {
+  const db = bindings.D1
+  if (db === undefined) return empty
+  const [spanRows, logRows] = await Promise.all([
+    fetchAll(db, SPANS_SQL, traceId),
+    fetchAll(db, LOGS_SQL, traceId),
+  ])
+  return {
+    spans: spanRows.map(rowToSpan).filter(isDefined),
+    logs: logRows.map(rowToLog).filter(isDefined),
+  }
+}

--- a/services/log-collector/src/trace-detail-types.ts
+++ b/services/log-collector/src/trace-detail-types.ts
@@ -1,0 +1,8 @@
+import type { LogRecord, SpanRecord } from './otlp-types'
+
+/** Response body for `GET /v1/traces/:traceId`. */
+export type TraceDetail = {
+  readonly traceId: string
+  readonly spans: ReadonlyArray<SpanRecord>
+  readonly logs: ReadonlyArray<LogRecord>
+}


### PR DESCRIPTION
## Summary
- **New endpoint** `GET /v1/traces/:traceId` returns `{ traceId, spans, logs }` — the full span tree plus all correlated logs, both ordered chronologically.
- **D1 fetcher** (`fetchTraceDetail`) runs two indexed queries in parallel and projects rows into typed `SpanRecord` / `LogRecord` via `rowToSpan` / `rowToLog`. `parseAttrs` normalises the JSON `attrs` cell.
- **Logs persistence** now writes the new columns (`span_id`, `message`, `attrs`) introduced by `0001_initial.sql`.
- **RBAC policy** (`rbac-policy.ts`): admins (from `RBAC_ADMINS` env binding) bypass; non-admins must own at least one of the trace's `org` attributes. Traces with no org metadata are admin-only.
- **Hono handler**:
  - 200 + body when allowed
  - 403 when the user fails the RBAC check
  - 404 when the trace has no spans

Closes #149.

## Test plan
- [x] `rbac-policy.test.ts` — admin bypass, own-org pass, foreign-org deny, no-org admin-only (4 tests)
- [x] `detail-handler.test.ts` — 200 happy path, 404 missing, 403 foreign org, admin bypass (4 tests)
- [x] `bun run test:unit` — 626/626
- [x] `bun run validate` clean (only the pre-existing `auth-middleware.ts` optional-chain warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)