### PR TITLE
feat(tracing): live traces panel UI (#146)

### DIFF
--- a/src/composables/useTracing/remote-to-span.test.ts
+++ b/src/composables/useTracing/remote-to-span.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import type { RemoteSpan } from './remote-span'
+import { remoteToSpan } from './remote-to-span'
+
+const remote: RemoteSpan = {
+  traceId: 't1',
+  spanId: 's1',
+  parentSpanId: 'p1',
+  name: 'op',
+  startedAt: 100,
+  finishedAt: 250,
+  status: 'ok',
+  attributes: { service: 'sw' },
+}
+
+describe('remoteToSpan', () => {
+  it('renames spanId / parentSpanId to id / parentId', () => {
+    const local = remoteToSpan(remote)
+    expect(local.id).toBe('s1')
+    expect(local.parentId).toBe('p1')
+    expect(local.traceId).toBe('t1')
+    expect(local.name).toBe('op')
+    expect(local.startedAt).toBe(100)
+    expect(local.finishedAt).toBe(250)
+    expect(local.status).toBe('ok')
+    expect(local.attributes).toEqual({ service: 'sw' })
+  })
+
+  it('passes a missing parent through as undefined', () => {
+    const local = remoteToSpan({ ...remote, parentSpanId: undefined })
+    expect(local.parentId).toBeUndefined()
+  })
+})

--- a/src/composables/useTracing/remote-to-span.ts
+++ b/src/composables/useTracing/remote-to-span.ts
@@ -1,0 +1,20 @@
+import type { RemoteSpan } from './remote-span'
+import type { Span } from './span-types'
+
+/**
+ * Adapt a collector-shaped `RemoteSpan` into the local `Span`
+ * shape used by `TraceList` / `TraceWaterfall`. Maps `spanId`
+ * to `id` and `parentSpanId` to `parentId`.
+ * @param remote Remote span from the SSE stream.
+ * @returns Local span suitable for the existing overlay UI.
+ */
+export const remoteToSpan = (remote: RemoteSpan): Span => ({
+  id: remote.spanId,
+  traceId: remote.traceId,
+  parentId: remote.parentSpanId,
+  name: remote.name,
+  startedAt: remote.startedAt,
+  finishedAt: remote.finishedAt,
+  attributes: remote.attributes,
+  status: remote.status,
+})

--- a/src/router/non-content-routes.ts
+++ b/src/router/non-content-routes.ts
@@ -26,4 +26,10 @@ export const nonContentRoutes: RouteRecordRaw[] = [
     meta: { requiresAuth: true },
     component: () => import('../views/VisualMergeView/VisualMergeView.vue'),
   },
+  {
+    path: '/live-traces',
+    name: 'live-traces',
+    meta: { requiresAuth: true },
+    component: () => import('../views/LiveTracesView/LiveTracesView.vue'),
+  },
 ]

--- a/src/views/LiveTracesView/LiveTracesView.vue
+++ b/src/views/LiveTracesView/LiveTracesView.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { groupByTrace } from '@/components/TraceOverlay/group-by-trace'
+import { useTraceStream } from '@/composables/useTracing/use-trace-stream'
+import PanelBody from './PanelBody.vue'
+import PanelToolbar from './PanelToolbar.vue'
+import { useLiveSpans } from './use-live-spans'
+
+const stream = useTraceStream()
+const { spans, paused, pause, resume, clear } = useLiveSpans(stream.spans)
+const activeId = ref<string | undefined>(undefined)
+
+const groups = computed(() => groupByTrace(spans.value))
+const activeSpans = computed(
+  () => groups.value.find(g => g.traceId === activeId.value)?.spans ?? []
+)
+
+const select = (id: string): void => {
+  activeId.value = id
+}
+</script>
+
+<template>
+  <main class="live-traces">
+    <PanelToolbar
+      :status="stream.status.value"
+      :paused="paused"
+      :count="spans.length"
+      @pause="pause"
+      @resume="resume"
+      @clear="clear"
+    />
+    <PanelBody
+      :groups="groups"
+      :active-id="activeId"
+      :active-spans="activeSpans"
+      @select="select"
+    />
+  </main>
+</template>
+
+<style scoped>
+.live-traces {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 400px;
+}
+</style>

--- a/src/views/LiveTracesView/PanelBody.vue
+++ b/src/views/LiveTracesView/PanelBody.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { TraceGroup } from '@/components/TraceOverlay/group-by-trace'
+import TraceList from '@/components/TraceOverlay/TraceList.vue'
+import TraceWaterfall from '@/components/TraceOverlay/TraceWaterfall.vue'
+import type { Span } from '@/composables/useTracing/span-types'
+
+defineProps<{
+  readonly groups: ReadonlyArray<TraceGroup>
+  readonly activeId: string | undefined
+  readonly activeSpans: ReadonlyArray<Span>
+}>()
+
+defineEmits<{
+  readonly select: [traceId: string]
+}>()
+</script>
+
+<template>
+  <section class="body">
+    <TraceList
+      :groups="groups"
+      :active-id="activeId"
+      @select="$emit('select', $event)"
+    />
+    <TraceWaterfall :spans="activeSpans" />
+  </section>
+</template>
+
+<style scoped>
+.body {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 2fr;
+  gap: 1rem;
+  padding: 1rem;
+  flex: 1;
+  overflow: auto;
+}
+</style>

--- a/src/views/LiveTracesView/PanelToolbar.vue
+++ b/src/views/LiveTracesView/PanelToolbar.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import type { TraceStreamStatus } from '@/composables/useTracing/remote-span'
+import { statusLabel } from './status-label'
+
+defineProps<{
+  readonly status: TraceStreamStatus
+  readonly paused: boolean
+  readonly count: number
+}>()
+
+defineEmits<{
+  readonly pause: []
+  readonly resume: []
+  readonly clear: []
+}>()
+</script>
+
+<template>
+  <header class="toolbar">
+    <span class="status" :data-status="status">
+      {{ statusLabel(status) }}
+    </span>
+    <span class="count">{{ count }} spans</span>
+    <span class="spacer" />
+    <button
+      v-if="paused"
+      type="button"
+      data-testid="resume-button"
+      @click="$emit('resume')"
+    >
+      Resume
+    </button>
+    <button
+      v-else
+      type="button"
+      data-testid="pause-button"
+      @click="$emit('pause')"
+    >
+      Pause
+    </button>
+    <button type="button" data-testid="clear-button" @click="$emit('clear')">
+      Clear
+    </button>
+  </header>
+</template>
+
+<style scoped>
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.875rem;
+}
+
+.status {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--color-background-soft);
+}
+
+.status[data-status='open'] {
+  background: hsl(140deg 50% 30% / 25%);
+}
+
+.status[data-status='reconnecting'] {
+  background: hsl(40deg 70% 30% / 25%);
+}
+
+.status[data-status='closed'] {
+  background: hsl(0deg 50% 30% / 25%);
+}
+
+.count {
+  color: var(--color-text-secondary);
+}
+
+.spacer {
+  flex: 1;
+}
+
+button {
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  cursor: pointer;
+}
+
+button:hover {
+  background: var(--color-background-soft);
+}
+</style>

--- a/src/views/LiveTracesView/live-spans-handlers.ts
+++ b/src/views/LiveTracesView/live-spans-handlers.ts
@@ -1,0 +1,37 @@
+import type { Ref } from 'vue'
+import type { RemoteSpan } from '@/composables/useTracing/remote-span'
+import { remoteToSpan } from '@/composables/useTracing/remote-to-span'
+import type { Span } from '@/composables/useTracing/span-types'
+
+/** Pause / resume / clear callbacks the panel toolbar binds to. */
+export type LiveSpanHandlers = {
+  readonly pause: () => void
+  readonly resume: () => void
+  readonly clear: () => void
+}
+
+/**
+ * Build the handler trio that drives the live-spans buffer.
+ * Sharing the upstream `remote` ref means resume re-syncs to
+ * the latest snapshot without bouncing the SSE connection.
+ * @param remote Reactive remote spans from `useTraceStream`.
+ * @param buffered Buffer of mapped local spans (mutated in place).
+ * @param paused Flag controlling whether the watch propagates.
+ * @returns Handler trio.
+ */
+export const buildHandlers = (
+  remote: Ref<ReadonlyArray<RemoteSpan>>,
+  buffered: Ref<ReadonlyArray<Span>>,
+  paused: Ref<boolean>
+): LiveSpanHandlers => ({
+  pause: () => {
+    paused.value = true
+  },
+  resume: () => {
+    paused.value = false
+    buffered.value = remote.value.map(remoteToSpan)
+  },
+  clear: () => {
+    buffered.value = []
+  },
+})

--- a/src/views/LiveTracesView/status-label.ts
+++ b/src/views/LiveTracesView/status-label.ts
@@ -1,0 +1,16 @@
+import type { TraceStreamStatus } from '@/composables/useTracing/remote-span'
+
+/**
+ * Human-readable label for the SSE connection state. Used by
+ * the status pill on the live trace panel.
+ * @param status Current `useTraceStream` status.
+ * @returns Localised label string (English for now).
+ */
+export const statusLabel = (status: TraceStreamStatus): string =>
+  status === 'connecting'
+    ? 'Connecting…'
+    : status === 'open'
+      ? 'Connected'
+      : status === 'reconnecting'
+        ? 'Reconnecting…'
+        : 'Closed'

--- a/src/views/LiveTracesView/use-live-spans.test.ts
+++ b/src/views/LiveTracesView/use-live-spans.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { ref } from 'vue'
+import type { RemoteSpan } from '@/composables/useTracing/remote-span'
+import { useLiveSpans } from './use-live-spans'
+
+const span = (id: string, traceId = 't1'): RemoteSpan => ({
+  traceId,
+  spanId: id,
+  parentSpanId: undefined,
+  name: 'op',
+  startedAt: 1,
+  finishedAt: 2,
+  status: 'ok',
+  attributes: {},
+})
+
+describe('useLiveSpans', () => {
+  it('mirrors incoming remote spans into local Span shape', () => {
+    const remote = ref<ReadonlyArray<RemoteSpan>>([span('a'), span('b')])
+    const live = useLiveSpans(remote)
+    expect(live.spans.value.map(s => s.id)).toEqual(['a', 'b'])
+  })
+
+  it('pause holds the buffer; new spans do not propagate', () => {
+    const remote = ref<ReadonlyArray<RemoteSpan>>([span('a')])
+    const live = useLiveSpans(remote)
+    live.pause()
+    remote.value = [span('a'), span('b')]
+    expect(live.spans.value.map(s => s.id)).toEqual(['a'])
+  })
+
+  it('resume re-syncs to the latest remote snapshot', () => {
+    const remote = ref<ReadonlyArray<RemoteSpan>>([span('a')])
+    const live = useLiveSpans(remote)
+    live.pause()
+    remote.value = [span('a'), span('b'), span('c')]
+    live.resume()
+    expect(live.spans.value.map(s => s.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('clear empties the buffer without affecting the upstream', () => {
+    const remote = ref<ReadonlyArray<RemoteSpan>>([span('a')])
+    const live = useLiveSpans(remote)
+    live.clear()
+    expect(live.spans.value).toEqual([])
+    expect(remote.value).toHaveLength(1)
+  })
+})

--- a/src/views/LiveTracesView/use-live-spans.ts
+++ b/src/views/LiveTracesView/use-live-spans.ts
@@ -1,0 +1,52 @@
+import { computed, type Ref, ref, watch } from 'vue'
+import type { RemoteSpan } from '@/composables/useTracing/remote-span'
+import { remoteToSpan } from '@/composables/useTracing/remote-to-span'
+import type { Span } from '@/composables/useTracing/span-types'
+import { buildHandlers, type LiveSpanHandlers } from './live-spans-handlers'
+
+/** Reactive surface returned by `useLiveSpans`. */
+export type LiveSpansHandle = LiveSpanHandlers & {
+  readonly spans: Ref<ReadonlyArray<Span>>
+  readonly paused: Ref<boolean>
+}
+
+const wireMirror = (
+  remote: Ref<ReadonlyArray<RemoteSpan>>,
+  buffered: Ref<ReadonlyArray<Span>>,
+  paused: Ref<boolean>
+): void => {
+  watch(
+    remote,
+    next => {
+      const adopt = paused.value
+        ? () => undefined
+        : () => {
+            buffered.value = next.map(remoteToSpan)
+          }
+      adopt()
+    },
+    { immediate: true }
+  )
+}
+
+/**
+ * Mirror an upstream `RemoteSpan` ref into local `Span` shape and
+ * expose pause / resume / clear without tearing down the SSE
+ * connection. Pause holds the buffer; resume re-syncs to the
+ * latest snapshot; clear empties the buffer (upstream ref
+ * untouched).
+ * @param remote Reactive ref of remote spans.
+ * @returns Buffered spans + paused flag + handlers.
+ */
+export const useLiveSpans = (
+  remote: Ref<ReadonlyArray<RemoteSpan>>
+): LiveSpansHandle => {
+  const buffered = ref<ReadonlyArray<Span>>([])
+  const paused = ref(false)
+  wireMirror(remote, buffered, paused)
+  return {
+    spans: computed(() => buffered.value),
+    paused,
+    ...buildHandlers(remote, buffered, paused),
+  }
+}


### PR DESCRIPTION
## Summary
- New `/live-traces` route hosts `LiveTracesView`, which composes the existing `useTraceStream` (SSE, #145) with a small `useLiveSpans` buffer that supports pause / resume / clear without tearing down the SSE connection.
- `remoteToSpan` adapts the collector's `RemoteSpan` shape into the local `Span` shape used by the existing `TraceList` / `TraceWaterfall` overlay components, so the new panel reuses the Epic 5 visualisation as-is.
- `PanelToolbar` exposes a connection-status pill (colour-coded for `connecting / open / reconnecting / closed`), span count, and pause/resume + clear buttons.
- `PanelBody` wraps the list + waterfall pair so `LiveTracesView` stays under the project's `max template depth = 2` rule.

Closes #146.

## Test plan
- [x] `useLiveSpans` — 4 tests (mirror, pause, resume, clear)
- [x] `remoteToSpan` — 2 tests (rename + missing parent)
- [x] `bun run test:unit` — 638/638
- [x] `bun run validate` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)