### PR TITLE
feat(e2e): introduce @prometheus/e2e-toolkit, migrate auth suite

### DIFF
--- a/e2e-toolkit/package.json
+++ b/e2e-toolkit/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@prometheus/e2e-toolkit",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Network-aware Playwright wrappers. Tests import from this package, never from @playwright/test directly. No blind timeouts — every wait polls a checker and watches the page's request graph; on a static site the wait returns on the first tick.",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "peerDependencies": {
+    "@playwright/test": "*"
+  }
+}

--- a/e2e-toolkit/src/actions.ts
+++ b/e2e-toolkit/src/actions.ts
@@ -1,0 +1,77 @@
+import type { Locator, Page, Response } from '@playwright/test'
+import { type WaitOptions, waitForCondition } from './wait-for'
+
+/**
+ * Navigate and return as soon as the request graph has settled.
+ * Mirrors `page.goto` but never falls back to `networkidle` — that
+ * heuristic is buggy on SSR sites and adds 500 ms minimum even when
+ * nothing fetches. The wait-for-condition primitive resolves on the
+ * first poll where DOM is ready and no new request has fired.
+ * @param page Page.
+ * @param url Absolute or relative URL.
+ * @param options Wait tunables.
+ * @returns Playwright response (forwarded from `page.goto`).
+ */
+export const visit = async (
+  page: Page,
+  url: string,
+  options?: WaitOptions
+): Promise<Response | null> => {
+  const response = await page.goto(url, { waitUntil: 'domcontentloaded' })
+  await waitForCondition(page, async () => true, options)
+  return response
+}
+
+/**
+ * Click a locator and wait for the request graph triggered by the
+ * click to settle. Drop-in replacement for `loc.click()` that frees
+ * tests from chasing `waitForLoadState('networkidle')` afterwards.
+ * @param page Page.
+ * @param locator Element to click.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const click = async (
+  page: Page,
+  locator: Locator,
+  options?: WaitOptions
+): Promise<void> => {
+  await locator.click()
+  await waitForCondition(page, async () => true, options)
+}
+
+/**
+ * Type into a form input and wait for any change-driven fetches to
+ * settle.
+ * @param page Page.
+ * @param locator Input element.
+ * @param value Value to fill.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const fill = async (
+  page: Page,
+  locator: Locator,
+  value: string,
+  options?: WaitOptions
+): Promise<void> => {
+  await locator.fill(value)
+  await waitForCondition(page, async () => true, options)
+}
+
+/**
+ * Press a key on the page (or focused element) and wait for the
+ * request graph to settle.
+ * @param page Page.
+ * @param key Key string per Playwright's `keyboard.press` syntax.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const pressKey = async (
+  page: Page,
+  key: string,
+  options?: WaitOptions
+): Promise<void> => {
+  await page.keyboard.press(key)
+  await waitForCondition(page, async () => true, options)
+}

--- a/e2e-toolkit/src/expect.ts
+++ b/e2e-toolkit/src/expect.ts
@@ -1,0 +1,229 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+import { type WaitOptions, waitForCondition } from './wait-for'
+
+/** Common checker shape — async predicate that never throws. */
+type Checker = () => Promise<boolean>
+
+const safe =
+  (checker: Checker): Checker =>
+  async () =>
+    checker().catch(() => false)
+
+/**
+ * Wait until `locator` is visible AND the request graph has settled,
+ * then assert it. Use this in place of `await expect(loc).toBeVisible()`.
+ * @param page Page (for the request graph).
+ * @param locator Element to look at.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectVisible = async (
+  page: Page,
+  locator: Locator,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => locator.isVisible()),
+    options
+  )
+  await expect(locator).toBeVisible()
+}
+
+/**
+ * Inverse of {@link expectVisible}.
+ * @param page Page.
+ * @param locator Element to look at.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectHidden = async (
+  page: Page,
+  locator: Locator,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => !(await locator.isVisible())),
+    options
+  )
+  await expect(locator).toBeHidden()
+}
+
+/**
+ * Wait until the locator's text contains / matches `text`.
+ * @param page Page.
+ * @param locator Element to read from.
+ * @param text Substring or regex.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectText = async (
+  page: Page,
+  locator: Locator,
+  text: string | RegExp,
+  options?: WaitOptions
+): Promise<void> => {
+  /*
+   * Use `.first()` for the wait probe so multi-match locators don't
+   * throw under strict mode and stall the wait until timeout. The
+   * final `toContainText` keeps the original semantics — it tolerates
+   * multi-match by checking each element.
+   */
+  await waitForCondition(
+    page,
+    safe(async () => {
+      const content = (await locator.first().textContent()) ?? ''
+      return typeof text === 'string'
+        ? content.includes(text)
+        : text.test(content)
+    }),
+    options
+  )
+  await expect(locator).toContainText(text)
+}
+
+/**
+ * Wait until `locator.count()` matches `count` exactly.
+ * @param page Page.
+ * @param locator Element collection.
+ * @param count Expected count.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectCount = async (
+  page: Page,
+  locator: Locator,
+  count: number,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => (await locator.count()) === count),
+    options
+  )
+  expect(await locator.count()).toBe(count)
+}
+
+/**
+ * Wait until `locator.count()` is at least `min`.
+ * @param page Page.
+ * @param locator Element collection.
+ * @param min Minimum count.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectMinCount = async (
+  page: Page,
+  locator: Locator,
+  min: number,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => (await locator.count()) >= min),
+    options
+  )
+  expect(await locator.count()).toBeGreaterThanOrEqual(min)
+}
+
+/**
+ * Wait until the locator carries the requested CSS class.
+ * @param page Page.
+ * @param locator Element to look at.
+ * @param className Substring or regex matched against the class attr.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectClass = async (
+  page: Page,
+  locator: Locator,
+  className: string | RegExp,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => {
+      const cls = (await locator.getAttribute('class')) ?? ''
+      return typeof className === 'string'
+        ? cls.includes(className)
+        : className.test(cls)
+    }),
+    options
+  )
+  await expect(locator).toHaveClass(className)
+}
+
+/**
+ * Wait until the locator does NOT have the given attribute value
+ * (either the attribute is absent or its value differs).
+ * @param page Page.
+ * @param locator Element to look at.
+ * @param name Attribute name.
+ * @param value Value the attribute must not equal.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectNotAttribute = async (
+  page: Page,
+  locator: Locator,
+  name: string,
+  value: string,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => (await locator.getAttribute(name)) !== value),
+    options
+  )
+  await expect(locator).not.toHaveAttribute(name, value)
+}
+
+/**
+ * Wait until the locator has the given attribute value.
+ * @param page Page.
+ * @param locator Element to look at.
+ * @param name Attribute name.
+ * @param value Expected value (string equality or regex).
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectAttribute = async (
+  page: Page,
+  locator: Locator,
+  name: string,
+  value: string | RegExp,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => {
+      const actual = (await locator.getAttribute(name)) ?? ''
+      return typeof value === 'string' ? actual === value : value.test(actual)
+    }),
+    options
+  )
+  await expect(locator).toHaveAttribute(name, value)
+}
+
+/**
+ * Wait until the locator has the requested input value.
+ * @param page Page.
+ * @param locator Form element.
+ * @param value Expected value.
+ * @param options Wait tunables.
+ * @returns void
+ */
+export const expectValue = async (
+  page: Page,
+  locator: Locator,
+  value: string,
+  options?: WaitOptions
+): Promise<void> => {
+  await waitForCondition(
+    page,
+    safe(async () => (await locator.inputValue()) === value),
+    options
+  )
+  await expect(locator).toHaveValue(value)
+}

--- a/e2e-toolkit/src/index.ts
+++ b/e2e-toolkit/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * Prometheus E2E toolkit — network-aware Playwright wrappers.
+ *
+ * Tests import only from this barrel; they never reach into
+ * `@playwright/test` directly. Every wait is built on the
+ * request-graph primitive in {@link waitForCondition}, so no test
+ * file ever calls `page.waitForTimeout(N)` or
+ * `page.waitForLoadState('networkidle')` again.
+ */
+
+export { expect, type Locator, type Page, test } from '@playwright/test'
+export { click, fill, pressKey, visit } from './actions'
+
+export {
+  expectAttribute,
+  expectClass,
+  expectCount,
+  expectHidden,
+  expectMinCount,
+  expectNotAttribute,
+  expectText,
+  expectValue,
+  expectVisible,
+} from './expect'
+export { type WaitOptions, waitForCondition } from './wait-for'

--- a/e2e-toolkit/src/wait-for.ts
+++ b/e2e-toolkit/src/wait-for.ts
@@ -1,0 +1,113 @@
+import type { Page } from '@playwright/test'
+
+/** Options for {@link waitForCondition}. */
+export interface WaitOptions {
+  /**
+   * How long the condition must hold AND the request graph must stay
+   * idle (no in-flight requests) before we consider the page settled.
+   * 50 ms is plenty on a static site; bump it to 200–500 ms when the
+   * page is genuinely dynamic.
+   */
+  readonly settleMs?: number
+  /**
+   * Hard ceiling for the entire wait, used purely as a safety net.
+   * Only an actual hang (the page kept firing requests forever) ever
+   * trips it; healthy pages return in milliseconds.
+   */
+  readonly maxMs?: number
+  /**
+   * Poll cadence. Lower means tighter latency at the cost of CPU.
+   * 25 ms is invisible to the user and well under any RTT.
+   */
+  readonly pollMs?: number
+}
+
+const DEFAULT: Required<WaitOptions> = {
+  settleMs: 50,
+  maxMs: 10_000,
+  pollMs: 25,
+}
+
+interface RequestTracker {
+  readonly active: Set<string>
+  lastChange: number
+}
+
+const trackers = new WeakMap<Page, RequestTracker>()
+
+/**
+ * Attach lazy listeners that count in-flight requests on a page.
+ * The listeners stay attached for the page's lifetime — Playwright
+ * tears them down when the page closes — so subsequent waits reuse
+ * the same tracker.
+ * @param page - Playwright page.
+ * @returns Tracker shared across waits on the same page.
+ */
+const ensureTracker = (page: Page): RequestTracker => {
+  const existing = trackers.get(page)
+  if (existing) return existing
+  const tracker: RequestTracker = { active: new Set<string>(), lastChange: 0 }
+  trackers.set(page, tracker)
+  page.on('request', req => {
+    tracker.active.add(req.url())
+    tracker.lastChange = Date.now()
+  })
+  page.on('response', resp => {
+    tracker.active.delete(resp.url())
+    tracker.lastChange = Date.now()
+  })
+  page.on('requestfailed', req => {
+    tracker.active.delete(req.url())
+    tracker.lastChange = Date.now()
+  })
+  return tracker
+}
+
+/**
+ * Generic wait built on a request-graph listener: poll a `checker`,
+ * track every in-flight request, and resolve as soon as both (1) the
+ * checker returns true, AND (2) the request graph has been quiet for
+ * `settleMs` (no in-flight requests, no recent request changes).
+ *
+ * On a static site the listener never fires, so the wait returns on
+ * the first poll where the checker passes — usually <1 frame. On a
+ * dynamic SPA it absorbs in-flight fetches without ever sleeping a
+ * blind N ms.
+ *
+ * @param page - Playwright page used as the request listener source.
+ * @param checker - Async predicate. MUST NOT throw — wrap risky reads in `.catch(() => false)`.
+ * @param options - Tunables (rarely needed).
+ * @throws Error when maxMs is hit; the message names the in-flight count + a sample stuck URL so you can find a runaway fetch.
+ */
+export const waitForCondition = async (
+  page: Page,
+  checker: () => Promise<boolean>,
+  options: WaitOptions = {}
+): Promise<void> => {
+  const { settleMs, maxMs, pollMs } = { ...DEFAULT, ...options }
+  const tracker = ensureTracker(page)
+  const startedAt = Date.now()
+  let metAt: number | undefined
+  while (true) {
+    const now = Date.now()
+    if (now - startedAt > maxMs) {
+      const stuck = [...tracker.active][0] ?? '(none)'
+      throw new Error(
+        `waitForCondition timed out after ${maxMs}ms; in-flight ${tracker.active.size}, sample ${stuck}`
+      )
+    }
+    const met = await checker()
+    if (met) {
+      metAt ??= now
+      const sinceMet = now - metAt
+      const sinceChange = now - tracker.lastChange
+      const idle = tracker.active.size === 0
+      if (idle && (sinceChange >= settleMs || sinceMet >= settleMs)) {
+        return
+      }
+    } else {
+      metAt = undefined
+    }
+    await new Promise(resolve => globalThis.setTimeout(resolve, pollMs))
+  }
+}

--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test'
-import { waitForNetworkIdle } from '../helpers/network'
+import { test, visit } from '@prometheus/e2e-toolkit'
 import { AuthPage } from '../pages/AuthPage'
 import { login } from './helpers'
 
@@ -11,8 +10,7 @@ test.describe('Login Flow', () => {
   }) => {
     const authPage = new AuthPage(page)
 
-    await page.goto('/')
-    await waitForNetworkIdle(page)
+    await visit(page, '/')
 
     await authPage.expectLoginButtonVisible()
   })
@@ -21,8 +19,7 @@ test.describe('Login Flow', () => {
     const authPage = new AuthPage(page)
 
     await login(page)
-    await page.goto('/')
-    await waitForNetworkIdle(page)
+    await visit(page, '/')
 
     await authPage.expectUserMenuVisible()
   })

--- a/e2e/auth/logout.spec.ts
+++ b/e2e/auth/logout.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test'
-import { waitForNetworkIdle } from '../helpers/network'
+import { test, visit } from '@prometheus/e2e-toolkit'
 import { AuthPage } from '../pages/AuthPage'
 import { login } from './helpers'
 
@@ -9,8 +8,7 @@ test('should logout and show login button again', async ({ page }) => {
   const authPage = new AuthPage(page)
 
   await login(page)
-  await page.goto('/')
-  await waitForNetworkIdle(page)
+  await visit(page, '/')
 
   await authPage.expectUserMenuVisible()
 

--- a/e2e/auth/menu.spec.ts
+++ b/e2e/auth/menu.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test'
-import { waitForNetworkIdle } from '../helpers/network'
+import { test, visit } from '@prometheus/e2e-toolkit'
 import { AuthPage } from '../pages/AuthPage'
 
 test('should show dropdown menu when clicking user button', async ({
@@ -7,8 +6,7 @@ test('should show dropdown menu when clicking user button', async ({
 }) => {
   const authPage = new AuthPage(page)
 
-  await page.goto('/')
-  await waitForNetworkIdle(page)
+  await visit(page, '/')
 
   await authPage.expectUserMenuVisible()
   await authPage.clickUserMenu()

--- a/e2e/auth/persistence.spec.ts
+++ b/e2e/auth/persistence.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test'
-import { waitForNetworkIdle } from '../helpers/network'
+import { test, visit, waitForCondition } from '@prometheus/e2e-toolkit'
 import { AuthPage } from '../pages/AuthPage'
 
 test('should persist authentication across page reloads', async ({
@@ -7,13 +6,12 @@ test('should persist authentication across page reloads', async ({
 }) => {
   const authPage = new AuthPage(page)
 
-  await page.goto('/')
-  await waitForNetworkIdle(page)
+  await visit(page, '/')
 
   await authPage.expectUserMenuVisible()
 
-  await page.reload()
-  await waitForNetworkIdle(page)
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await waitForCondition(page, async () => true)
 
   await authPage.expectUserMenuVisible()
 })

--- a/e2e/auth/popup-login.spec.ts
+++ b/e2e/auth/popup-login.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test } from '@playwright/test'
+import {
+  expect,
+  expectMinCount,
+  expectVisible,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 
 test.use({ storageState: { cookies: [], origins: [] } })
@@ -7,42 +13,33 @@ test.describe('Login Flow', () => {
   test('should load content after login without full reload', async ({
     page,
   }) => {
-    await page.goto('/')
-    await page.waitForLoadState('networkidle')
-
-    await expect(page.getByRole('button', { name: /login/i })).toBeVisible()
+    await visit(page, '/')
+    await expectVisible(page, page.getByRole('button', { name: /login/i }))
 
     await page.evaluate(() => localStorage.setItem('gh_token', 'mock-token'))
-    await page.reload()
-    await page.waitForLoadState('networkidle')
-
-    await expect(
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expectVisible(
+      page,
       page.getByRole('button', { name: /test user/i })
-    ).toBeVisible({ timeout: 10000 })
+    )
 
-    await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/blog')
     await waitForContentReady(page)
 
     const items = page.locator('[data-testid="content-item"]')
-    await items.first().waitFor({
-      state: 'visible',
-      timeout: 15000,
-    })
-    expect(await items.count()).toBeGreaterThanOrEqual(1)
+    await expectMinCount(page, items, 1)
   })
 
   test('should initialize SW with token after login', async ({ page }) => {
-    await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/')
 
     await page.evaluate(() => localStorage.setItem('gh_token', 'mock-token'))
-    await page.reload()
-    await page.waitForLoadState('networkidle')
+    await page.reload({ waitUntil: 'domcontentloaded' })
 
-    await expect(
+    await expectVisible(
+      page,
       page.getByRole('button', { name: /test user/i })
-    ).toBeVisible({ timeout: 10000 })
+    )
 
     const swReady = await page.evaluate(async () => {
       const reg = await navigator.serviceWorker.ready

--- a/e2e/auth/status.spec.ts
+++ b/e2e/auth/status.spec.ts
@@ -1,15 +1,12 @@
-import { expect, test } from '@playwright/test'
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit'
 
 test('should verify mock auth provides user', async ({ page }) => {
-  await page.goto('/')
-  await page.waitForLoadState('networkidle')
+  await visit(page, '/')
 
   const hasUser = await page.evaluate(
     () => !!localStorage.getItem('gh_token')
   )
   expect(hasUser).toBe(true)
 
-  await expect(page.getByRole('button', { name: /test user/i })).toBeVisible({
-    timeout: 10000,
-  })
+  await expectVisible(page, page.getByRole('button', { name: /test user/i }))
 })

--- a/e2e/pages/AuthPage.ts
+++ b/e2e/pages/AuthPage.ts
@@ -1,7 +1,9 @@
-import type { Page } from '@playwright/test'
-import { expect } from '@playwright/test'
+import {
+  expectVisible,
+  type Page,
+  waitForCondition,
+} from '@prometheus/e2e-toolkit'
 import { login } from '../auth/helpers'
-import { waitForNetworkIdle } from '../helpers/network'
 
 /**
  * Page object for auth-related test interactions.
@@ -14,16 +16,14 @@ export class AuthPage {
    */
   async clickUserMenu(): Promise<void> {
     await this.page.getByRole('button', { name: /test user/i }).click()
-    await waitForNetworkIdle(this.page, { idleTime: 200 })
+    await waitForCondition(this.page, async () => true)
   }
 
   /**
    * Click the logout button in the dropdown.
    */
   async clickLogout(): Promise<void> {
-    await this.page
-      .locator('.dropdown')
-      .waitFor({ state: 'visible', timeout: 5000 })
+    await expectVisible(this.page, this.page.locator('.dropdown'))
     await this.page.getByRole('button', { name: /logout/i }).click()
   }
 
@@ -31,25 +31,27 @@ export class AuthPage {
    * Assert login button is visible.
    */
   async expectLoginButtonVisible(): Promise<void> {
-    await expect(
+    await expectVisible(
+      this.page,
       this.page.getByRole('button', { name: /login/i })
-    ).toBeVisible()
+    )
   }
 
   /**
    * Assert user menu button is visible.
    */
   async expectUserMenuVisible(): Promise<void> {
-    await expect(
+    await expectVisible(
+      this.page,
       this.page.getByRole('button', { name: /test user/i })
-    ).toBeVisible({ timeout: 10000 })
+    )
   }
 
   /**
    * Assert dropdown menu is visible.
    */
   async expectDropdownVisible(): Promise<void> {
-    await expect(this.page.locator('.dropdown')).toBeVisible()
+    await expectVisible(this.page, this.page.locator('.dropdown'))
   }
 
   /**
@@ -64,7 +66,7 @@ export class AuthPage {
    */
   async clearAuth(): Promise<void> {
     await this.page.evaluate(() => localStorage.removeItem('gh_token'))
-    await this.page.reload()
-    await waitForNetworkIdle(this.page)
+    await this.page.reload({ waitUntil: 'domcontentloaded' })
+    await waitForCondition(this.page, async () => true)
   }
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,8 +1,11 @@
 {
   "extends": "@tsconfig/node24/tsconfig.json",
-  "include": ["./**/*"],
+  "include": ["./**/*", "../e2e-toolkit/**/*"],
   "compilerOptions": {
     "module": "ESNext",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@prometheus/e2e-toolkit": ["../e2e-toolkit/src/index.ts"]
+    }
   }
 }

--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -1,5 +1,4 @@
-import { test } from '@playwright/test'
-import { waitForNetworkIdle } from './helpers/network'
+import { test, visit } from '@prometheus/e2e-toolkit'
 import { AuthPage } from './pages/AuthPage'
 
 test.use({ storageState: { cookies: [], origins: [] } })
@@ -7,8 +6,7 @@ test.use({ storageState: { cookies: [], origins: [] } })
 test('visits the app root url', async ({ page }) => {
   const authPage = new AuthPage(page)
 
-  await page.goto('/')
-  await waitForNetworkIdle(page)
+  await visit(page, '/')
 
   await authPage.expectLoginButtonVisible()
 })


### PR DESCRIPTION
## Summary
- Adds `e2e-toolkit/` — a path-mapped local library that wraps Playwright with one network-aware wait primitive: poll a checker AND watch the request graph, return when both the checker holds AND no requests are in-flight for \`settleMs\`. Tests import only from the toolkit, never \`@playwright/test\` directly.
- Migrates the entire \`e2e/auth/\` directory (6 spec files) plus \`vue.spec.ts\` and \`pages/AuthPage.ts\` POM. Drops every \`waitForLoadState('networkidle')\` and \`waitForNetworkIdle\` from these files — both are absorbed into \`waitForCondition\`.
- The wait primitive tracks **in-flight** requests (request → +1, response/failed → -1), so SPAs with constant background polling settle correctly between actions.

## Result
- Auth suite: 9/9 chromium, **~12 s** (\`npx cross-env MOCK_OAUTH=true npx playwright test e2e/auth e2e/vue.spec.ts --project=chromium\`).
- Mobile-chromium has a pre-existing failure on \`auth/status\` (the test user button isn't visible on mobile viewports) — confirmed identical behaviour on master, not introduced here.

## Follow-up (per directory)
- \`e2e/content/\` — 46 specs, biggest swathe
- \`e2e/notifications/\` — 11 specs, push event waits need careful audit
- \`e2e/settings/\` / \`e2e/github-content/\` / \`e2e/tracing/\` — small
- \`e2e/mobile/\` / \`e2e/lighthouse/\` — separate projects
- \`e2e-prod/\` — 9 prod-mode specs
- POMs: \`pages/\` + \`helpers/\` still call \`waitForNetworkIdle\`; the old helper stays valid until last spec migrates.

## Test plan
- [x] \`MOCK_OAUTH=true playwright test e2e/auth e2e/vue.spec.ts --project=chromium\` 9/9 passes
- [x] \`bunx eslint --config eslint.config.js e2e/auth/**/*.ts e2e/pages/AuthPage.ts e2e/vue.spec.ts\` clean
- [x] \`bun run format:check\` clean