### PR TITLE
fix(e2e): unblock admin deploy — exempt e2e-toolkit from sonarjs limits

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -49,7 +49,8 @@
         "**/*.test.ts",
         "**/*.spec.ts",
         "e2e/**/*.ts",
-        "e2e-prod/**/*.ts"
+        "e2e-prod/**/*.ts",
+        "e2e-toolkit/**/*.ts"
       ],
       "rules": {
         "sonarjs/max-lines": "off",


### PR DESCRIPTION
Toolkit primitives need >50 lines of JSDoc + implementation each; e2e/ and e2e-prod/ already have an override for sonarjs/max-lines + max-lines-per-function. Add e2e-toolkit/**/*.ts to the same exception list.