### PR TITLE
fix(ci): admin deploy red since 04-30 — pin Node 22 for wrangler

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,15 @@ jobs:
             echo "WRANGLER_COMMAND=deploy" >> "$GITHUB_ENV"
           fi
 
+      # Wrangler 4 (used by `bunx wrangler dev` below) requires Node 22+.
+      # setup-bun ships bundled Node, but `bunx wrangler` resolves against
+      # whatever node is on $PATH. Pin Node 22 so the wrangler CLI doesn't
+      # refuse to start with "requires at least Node.js v22".
+      - name: Installing Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Installing tools and dependencies
         uses: oven-sh/setup-bun@v2
       - run: bun install --frozen-lockfile


### PR DESCRIPTION
Wrangler 4 needs Node 22+. `bunx wrangler dev` resolves against $PATH, where setup-bun's bundled Node isn't exposed — so wrangler falls back to the runner's stock Node 20 and fails with `Wrangler requires at least Node.js v22.0.0`. Add an explicit setup-node@v4 step pinning v22 before bun install. Pre-existing failure across the last 5 admin deploys, not introduced by recent PRs.