### PR TITLE
fix(sw): drain pending pushes on activate + auto-recover

### DIFF
--- a/src/sw/core/auto-recover.ts
+++ b/src/sw/core/auto-recover.ts
@@ -6,6 +6,19 @@ import { workerState } from '../state/state'
 
 let pending: Promise<boolean> | undefined
 
+/*
+ * Pending push entries live in IndexedDB and outlive SW evictions,
+ * but the `setTimeout`-based retry that scheduleRetry sets up does
+ * NOT — it lives in the in-memory SW that just got evicted. So the
+ * queue can accumulate stuck entries that have no trigger to drain
+ * until the user happens to commit again. Kicking a drain right
+ * after auto-recover is what unblocks them in practice.
+ */
+const drainAfterRecover = async (): Promise<void> => {
+  const { drainPushes } = await import('../push-queue/drain')
+  await drainPushes()
+}
+
 const recoverEffect: Effect.Effect<boolean, never> = Effect.tryPromise(() =>
   loadConfig()
 ).pipe(
@@ -18,6 +31,7 @@ const recoverEffect: Effect.Effect<boolean, never> = Effect.tryPromise(() =>
           workerState.config = config
           await checkRepoAndSync(config)
           log('info', 'lifecycle', 'Auto-recovered after SW restart')
+          if (workerState.state === 'ready') void drainAfterRecover()
           return workerState.state === 'ready'
         }),
     })

--- a/src/sw/core/lifecycle.ts
+++ b/src/sw/core/lifecycle.ts
@@ -3,10 +3,23 @@ import { ensureVersionMatch } from './version-gate'
 
 declare const self: ServiceWorkerGlobalScope
 
+/*
+ * scheduleRetry parks pending pushes behind a `setTimeout` that
+ * dies with the SW. Without an activate-time drain a queued entry
+ * whose retry timer fired into a dead SW sits in IndexedDB forever
+ * until the user happens to make another commit — the silent-fail
+ * mechanism behind "save said OK but nothing reached the remote".
+ */
+const drainOnActivate = async (): Promise<void> => {
+  const { drainPushes } = await import('../push-queue/drain')
+  await drainPushes()
+}
+
 /**
  * Register SW lifecycle event listeners.
  * Install: skipWaiting for immediate activation.
- * Activate: version-check IndexedDB + claim clients.
+ * Activate: version-check IndexedDB + claim clients + drain any
+ * pending pushes left behind by a previous SW eviction.
  */
 export const registerLifecycle = (): void => {
   self.addEventListener('install', () => {
@@ -16,6 +29,10 @@ export const registerLifecycle = (): void => {
 
   self.addEventListener('activate', event => {
     log('info', 'lifecycle', 'SW activated')
-    event.waitUntil(ensureVersionMatch().then(() => self.clients.claim()))
+    event.waitUntil(
+      ensureVersionMatch()
+        .then(() => self.clients.claim())
+        .then(() => drainOnActivate())
+    )
   })
 }

--- a/src/sw/git/remote/push-to-remote.ts
+++ b/src/sw/git/remote/push-to-remote.ts
@@ -12,6 +12,14 @@ export const pushToRemote = async (config: SWGitConfig): Promise<void> => {
   const git = await loadGit()
   const { default: http } = await import('isomorphic-git/http/web')
   const opts = buildAuthOpts(config, http)
+  /*
+   * Best-effort pre-pull keeps the push fast-forward. A failure
+   * here is NOT fatal — the explicit NFF recovery in
+   * handle-failure → tryMergeAfterNff handles real merges. But the
+   * actual error MUST surface; the old blanket `.catch(() => …)`
+   * swallowed everything, leaving "save said OK but nothing
+   * reached the remote" as the only observable symptom.
+   */
   await git
     .pull({
       ...opts,
@@ -22,7 +30,13 @@ export const pushToRemote = async (config: SWGitConfig): Promise<void> => {
         email: config.authorEmail ?? 'admin@prometheus.org',
       },
     })
-    .catch(() => log('warn', 'git', 'pull before push failed'))
+    .catch((err: unknown) =>
+      log(
+        'warn',
+        'git',
+        `pull before push failed: ${err instanceof Error ? err.message : String(err)}`
+      )
+    )
   const result = await git.push(opts)
   if (result.error) throw new Error(`Push rejected: ${result.error}`)
   log('info', 'git', 'pushed to remote')


### PR DESCRIPTION
## Summary
Root cause of the silent-fail save bug — "save said OK but nothing reached the remote" / "deleted 2 things, only 1 propagated".

Pending push entries live in IndexedDB so they survive SW eviction, but the retry trigger is a `setTimeout` inside scheduleRetry, which lives in the SW memory that just got evicted. Result: an entry whose retry timer fired into a dead SW sits in IDB with no event scheduling another drain. The user only notices when the next commit happens to flush it, or never.

## Fixes
1. `lifecycle.ts`: SW `activate` now calls `drainPushes()` after version check + clients.claim. New SW takes over → flushes whatever the old one left behind.
2. `auto-recover.ts`: after a successful auto-recover (post-eviction repo sync), kick a drain. Every fetch into `/api/github/*` triggers autoRecover, so this is the natural waking signal for the queue.
3. `push-to-remote.ts`: stop swallowing the pre-pull error message. The explicit NFF recovery in `handle-failure → tryMergeAfterNff` is still the proper merge path; the pre-pull stays best-effort but the log line now carries the underlying reason for future diagnosis.

## Test plan
- [x] `bun run build` clean
- [x] `bun run test:unit` 516/516 pass
- [ ] After deploy: delete two items in admin, verify both propagate to content remote (the original repro)
- [ ] After deploy: stale SW + queued entry → reload → push fires on activate