### PR TITLE
feat(e2e): migrate settings + github-content + tracing to toolkit

### DIFF
--- a/e2e/github-content/create-content.spec.ts
+++ b/e2e/github-content/create-content.spec.ts
@@ -1,59 +1,62 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expectHidden,
+  expectVisible,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 
 test.describe('GitHub Content - Create', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/blog')
     await waitForContentReady(page)
   })
 
   test('should open create dialog', async ({ page }) => {
-    await page.click('button:has-text("New")')
-    await expect(page.locator('.create-dialog')).toBeVisible()
+    await click(page, page.getByRole('button', { name: /new/i }).first())
+    await expectVisible(page, page.locator('.create-dialog'))
   })
 
   test('should show required fields in create dialog', async ({ page }) => {
-    await page.click('button:has-text("New")')
-    const dialog = page.locator('.create-dialog')
-    await expect(dialog).toBeVisible()
-    await expect(page.getByLabel(/slug/i)).toBeVisible()
-    await expect(page.getByLabel(/title/i)).toBeVisible()
+    await click(page, page.getByRole('button', { name: /new/i }).first())
+    await expectVisible(page, page.locator('.create-dialog'))
+    await expectVisible(page, page.getByLabel(/slug/i))
+    await expectVisible(page, page.getByLabel(/title/i))
   })
 
   test('should show blog-specific fields for blog content', async ({
     page,
   }) => {
-    await page.click('button:has-text("New")')
-    await expect(page.getByLabel(/description/i)).toBeVisible()
-    await expect(page.getByLabel(/category/i)).toBeVisible()
+    await click(page, page.getByRole('button', { name: /new/i }).first())
+    await expectVisible(page, page.getByLabel(/description/i))
+    await expectVisible(page, page.getByLabel(/category/i))
   })
 
   test('should show position-specific fields for positions', async ({
     page,
   }) => {
-    await page.goto('/content/positions')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/positions')
     await waitForContentReady(page)
-    await page.click('button:has-text("New")')
-    await expect(page.getByLabel(/description/i)).toBeVisible()
-    // Positions no longer expose an Order field (migrated to pubDate).
-    await expect(page.locator('#order')).toBeHidden()
+    await click(page, page.getByRole('button', { name: /new/i }).first())
+    await expectVisible(page, page.getByLabel(/description/i))
+    /* Positions no longer expose an Order field (migrated to pubDate). */
+    await expectHidden(page, page.locator('#order'))
   })
 
   test('should keep dialog open when submitting empty form', async ({
     page,
   }) => {
-    await page.click('button:has-text("New")')
-    await expect(page.locator('.create-dialog')).toBeVisible()
-    await page.click('button:has-text("Create")')
-    await expect(page.locator('.create-dialog')).toBeVisible()
+    await click(page, page.getByRole('button', { name: /new/i }).first())
+    await expectVisible(page, page.locator('.create-dialog'))
+    await click(page, page.getByRole('button', { name: /^create$/i }))
+    await expectVisible(page, page.locator('.create-dialog'))
   })
 
   test('should close dialog after cancel', async ({ page }) => {
-    await page.click('button:has-text("New")')
-    await expect(page.locator('.create-dialog')).toBeVisible()
-    await page.click('button:has-text("Cancel")')
-    await expect(page.locator('.create-dialog')).not.toBeVisible()
+    await click(page, page.getByRole('button', { name: /new/i }).first())
+    await expectVisible(page, page.locator('.create-dialog'))
+    await click(page, page.getByRole('button', { name: /cancel/i }))
+    await expectHidden(page, page.locator('.create-dialog'))
   })
 })

--- a/e2e/github-content/edit-content.spec.ts
+++ b/e2e/github-content/edit-content.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, expectVisible, test } from '@prometheus/e2e-toolkit'
 import { openPreview, saveAndConfirm } from '../content/preview-save'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -27,8 +27,7 @@ test.describe('GitHub Content - Edit', () => {
     const editPage = new ContentEditPage(page)
     await editPage.navigate('blog', 'welcome-to-prometheus')
 
-    const previewBtn = page.locator('[data-testid="preview-button"]')
-    await expect(previewBtn).toBeVisible()
+    await expectVisible(page, page.locator('[data-testid="preview-button"]'))
   })
 
   test('should save content with commit message via API', async ({
@@ -42,10 +41,8 @@ test.describe('GitHub Content - Edit', () => {
 
     await saveAndConfirm(page, await openPreview(page))
 
-    // Wait for preview to auto-close, then re-navigate and verify.
-    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible({
-      timeout: 15000,
-    })
+    /* Preview auto-closes after save; re-navigate and verify. */
+    await expectVisible(page, page.locator('[data-testid="preview-button"]'))
     await editPage.navigate('blog', 'welcome-to-prometheus')
     const savedContent = await textarea.inputValue()
     expect(savedContent).toContain('Updated via E2E test')

--- a/e2e/github-content/list-content.spec.ts
+++ b/e2e/github-content/list-content.spec.ts
@@ -1,4 +1,11 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expect,
+  expectText,
+  expectVisible,
+  test,
+  waitForCondition,
+} from '@prometheus/e2e-toolkit'
 import { ContentPage } from '../pages/ContentPage'
 
 test.describe('GitHub Content - List', () => {
@@ -18,35 +25,34 @@ test.describe('GitHub Content - List', () => {
     const items = page.locator('[data-testid="content-item"]')
     const count = await items.count()
     if (count > 0) {
-      const langBadge = items.first().locator('.lang-badge')
-      await expect(langBadge).toContainText('ru')
+      await expectText(page, items.first().locator('.lang-badge'), 'ru')
     }
   })
 
   test('should select content item', async ({ page }) => {
     const firstItem = page.locator('[data-testid="content-item"]').first()
-    await firstItem.waitFor({ state: 'visible', timeout: 30000 })
-    await firstItem.click()
-
-    const editor = page.locator('[data-testid="markdown-editor"]')
-    await expect(editor).toBeVisible()
+    await expectVisible(page, firstItem)
+    await click(page, firstItem)
+    await expectVisible(page, page.locator('[data-testid="markdown-editor"]'))
   })
 
   test('should display content types navigation', async ({ page }) => {
-    await expect(page.getByRole('link', { name: /blog/i })).toBeVisible()
-    await expect(page.getByRole('link', { name: /pages/i })).toBeVisible()
-    await expect(page.getByRole('link', { name: /positions/i })).toBeVisible()
+    await expectVisible(page, page.getByRole('link', { name: /blog/i }))
+    await expectVisible(page, page.getByRole('link', { name: /pages/i }))
+    await expectVisible(page, page.getByRole('link', { name: /positions/i }))
   })
 
   test('should navigate between content types', async ({ page }) => {
-    await page.click('a[href="/content/pages"]')
-    await page.waitForURL('/content/pages')
-    // There's no page heading in ContentView — assert by URL + content list.
+    await click(page, page.locator('a[href="/content/pages"]'))
+    await waitForCondition(page, async () =>
+      page.url().includes('/content/pages')
+    )
+    /* No page heading on ContentView — assert by URL + content list. */
     expect(page.url()).toContain('/content/pages')
-    await expect(page.locator('[data-testid="content-list"]')).toBeVisible()
+    await expectVisible(page, page.locator('[data-testid="content-list"]'))
   })
 
   test('should show create button', async ({ page }) => {
-    await expect(page.getByRole('button', { name: /new/i })).toBeVisible()
+    await expectVisible(page, page.getByRole('button', { name: /new/i }))
   })
 })

--- a/e2e/settings/languages.spec.ts
+++ b/e2e/settings/languages.spec.ts
@@ -1,180 +1,156 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expectCount,
+  expectMinCount,
+  expectText,
+  expectValue,
+  expectVisible,
+  fill,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
 
 test.describe('Settings - Languages', () => {
   test('should show Settings link in header navigation', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('.app-nav', { timeout: 20000 })
+    await visit(page, '/')
     const settingsLink = page.locator('.app-nav a[href="/settings"]')
-    await expect(settingsLink).toBeVisible()
-    await expect(settingsLink).toHaveText('Settings')
+    await expectText(page, settingsLink, 'Settings')
   })
 
   test('should navigate to settings page', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    await expect(page.locator('h1')).toHaveText('Settings')
-    // Settings has two sections (Languages + Labels). Assert the first h2
-    // rather than pinning all h2 text.
-    await expect(page.locator('h2').first()).toHaveText('Languages')
+    await visit(page, '/settings')
+    await expectText(page, page.locator('h1'), 'Settings')
+    /*
+     * Settings has two sections (Languages + Labels). Assert the
+     * first h2 rather than pinning all h2 text.
+     */
+    await expectText(page, page.locator('h2').first(), 'Languages')
   })
 
   test('should show languages editor with table', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    const editor = page.locator('[data-testid="languages-editor"]')
-    await expect(editor).toBeVisible({ timeout: 20000 })
-
-    const table = page.locator('[data-testid="languages-table"]')
-    await expect(table).toBeVisible()
+    await visit(page, '/settings')
+    await expectVisible(
+      page,
+      page.locator('[data-testid="languages-editor"]')
+    )
+    await expectVisible(page, page.locator('[data-testid="languages-table"]'))
   })
 
   test('should display language rows from settings', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="language-row"]', {
-      timeout: 20000,
-    })
-
+    await visit(page, '/settings')
     const rows = page.locator('[data-testid="language-row"]')
-    const count = await rows.count()
-    expect(count).toBeGreaterThanOrEqual(1)
+    await expectMinCount(page, rows, 1)
 
     const firstCode = rows.first().locator('[data-testid="language-code"]')
-    await expect(firstCode).toHaveValue('en')
+    await expectValue(page, firstCode, 'en')
   })
 
   test('should add a new language row', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="language-row"]', {
-      timeout: 20000,
-    })
+    await visit(page, '/settings')
+    const rows = page.locator('[data-testid="language-row"]')
+    await expectMinCount(page, rows, 1)
 
-    const initialCount = await page
-      .locator('[data-testid="language-row"]')
-      .count()
-
-    await page.locator('[data-testid="add-language"]').click()
-
-    await expect(page.locator('[data-testid="language-row"]')).toHaveCount(
-      initialCount + 1
-    )
+    const initialCount = await rows.count()
+    await click(page, page.locator('[data-testid="add-language"]'))
+    await expectCount(page, rows, initialCount + 1)
   })
 
   test('should remove a language row', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="language-row"]', {
-      timeout: 20000,
-    })
+    await visit(page, '/settings')
+    const rows = page.locator('[data-testid="language-row"]')
+    await expectMinCount(page, rows, 1)
 
-    const initialCount = await page
-      .locator('[data-testid="language-row"]')
-      .count()
-
-    await page.locator('[data-testid="remove-language"]').last().click()
-
-    await expect(page.locator('[data-testid="language-row"]')).toHaveCount(
-      initialCount - 1
-    )
+    const initialCount = await rows.count()
+    await click(page, page.locator('[data-testid="remove-language"]').last())
+    await expectCount(page, rows, initialCount - 1)
   })
 
   test('should show save button', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="languages-editor"]', {
-      timeout: 20000,
-    })
+    await visit(page, '/settings')
+    await expectVisible(
+      page,
+      page.locator('[data-testid="languages-editor"]')
+    )
 
     const saveBtn = page.locator('[data-testid="save-languages"]')
-    await expect(saveBtn).toBeVisible()
-    await expect(saveBtn).toHaveText('Save')
+    await expectText(page, saveBtn, 'Save')
   })
 
   test('should save languages and persist after reload', async ({ page }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="language-row"]', {
-      timeout: 20000,
-    })
+    await visit(page, '/settings')
+    const rows = page.locator('[data-testid="language-row"]')
+    await expectMinCount(page, rows, 1)
 
-    const initialCount = await page
-      .locator('[data-testid="language-row"]')
-      .count()
+    const initialCount = await rows.count()
 
-    // Add a new language
-    await page.locator('[data-testid="add-language"]').click()
-    const newRow = page.locator('[data-testid="language-row"]').last()
-    await newRow.locator('[data-testid="language-code"]').fill('de')
-    await newRow.locator('[data-testid="language-label"]').fill('Deutsch')
-
-    // Save
-    await page.locator('[data-testid="save-languages"]').click()
-
-    // Wait for save to complete (button text reverts from "Saving..." to "Save")
-    await expect(page.locator('[data-testid="save-languages"]')).toHaveText(
-      'Save',
-      { timeout: 10000 }
+    await click(page, page.locator('[data-testid="add-language"]'))
+    const newRow = rows.last()
+    await fill(page, newRow.locator('[data-testid="language-code"]'), 'de')
+    await fill(
+      page,
+      newRow.locator('[data-testid="language-label"]'),
+      'Deutsch'
     )
 
-    // Reload page completely
+    await click(page, page.locator('[data-testid="save-languages"]'))
+    /*
+     * Save button text reverts from "Saving..." to "Save" once the
+     * commit lands; that's what we wait on to know the persistence
+     * round-trip is done.
+     */
+    await expectText(
+      page,
+      page.locator('[data-testid="save-languages"]'),
+      'Save'
+    )
+
     await page.reload({ waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="language-row"]', {
-      timeout: 20000,
-    })
+    await expectCount(page, rows, initialCount + 1)
+    const lastCode = rows.last().locator('[data-testid="language-code"]')
+    await expectValue(page, lastCode, 'de')
 
-    // Verify new language persisted
-    await expect(page.locator('[data-testid="language-row"]')).toHaveCount(
-      initialCount + 1
-    )
-    const lastCode = page
-      .locator('[data-testid="language-row"]')
-      .last()
-      .locator('[data-testid="language-code"]')
-    await expect(lastCode).toHaveValue('de')
-
-    // Clean up: remove the added language and save again
-    await page.locator('[data-testid="remove-language"]').last().click()
-    await page.locator('[data-testid="save-languages"]').click()
-    await expect(page.locator('[data-testid="save-languages"]')).toHaveText(
-      'Save',
-      { timeout: 10000 }
+    await click(page, page.locator('[data-testid="remove-language"]').last())
+    await click(page, page.locator('[data-testid="save-languages"]'))
+    await expectText(
+      page,
+      page.locator('[data-testid="save-languages"]'),
+      'Save'
     )
   })
 
   test('should remove a language, save, and verify removal persists', async ({
     page,
   }) => {
-    await page.goto('/settings', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="language-row"]', {
-      timeout: 20000,
-    })
+    await visit(page, '/settings')
+    const rows = page.locator('[data-testid="language-row"]')
+    await expectMinCount(page, rows, 1)
 
-    const initialCount = await page
-      .locator('[data-testid="language-row"]')
-      .count()
+    const initialCount = await rows.count()
 
-    // Remove last language
-    await page.locator('[data-testid="remove-language"]').last().click()
-    await page.locator('[data-testid="save-languages"]').click()
-    await expect(page.locator('[data-testid="save-languages"]')).toHaveText(
-      'Save',
-      { timeout: 10000 }
+    await click(page, page.locator('[data-testid="remove-language"]').last())
+    await click(page, page.locator('[data-testid="save-languages"]'))
+    await expectText(
+      page,
+      page.locator('[data-testid="save-languages"]'),
+      'Save'
     )
 
-    // Reload
     await page.reload({ waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="language-row"]', {
-      timeout: 20000,
-    })
+    await expectCount(page, rows, initialCount - 1)
 
-    // Verify removal persisted
-    await expect(page.locator('[data-testid="language-row"]')).toHaveCount(
-      initialCount - 1
+    await click(page, page.locator('[data-testid="add-language"]'))
+    const newRow = rows.last()
+    await fill(page, newRow.locator('[data-testid="language-code"]'), 'es')
+    await fill(
+      page,
+      newRow.locator('[data-testid="language-label"]'),
+      'Español'
     )
-
-    // Restore: add back the language and save
-    await page.locator('[data-testid="add-language"]').click()
-    const newRow = page.locator('[data-testid="language-row"]').last()
-    await newRow.locator('[data-testid="language-code"]').fill('es')
-    await newRow.locator('[data-testid="language-label"]').fill('Español')
-    await page.locator('[data-testid="save-languages"]').click()
-    await expect(page.locator('[data-testid="save-languages"]')).toHaveText(
-      'Save',
-      { timeout: 10000 }
+    await click(page, page.locator('[data-testid="save-languages"]'))
+    await expectText(
+      page,
+      page.locator('[data-testid="save-languages"]'),
+      'Save'
     )
   })
 })

--- a/e2e/settings/members.spec.ts
+++ b/e2e/settings/members.spec.ts
@@ -1,12 +1,19 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expect,
+  expectCount,
+  type Page,
+  expectText,
+  expectValue,
+  expectVisible,
+  fill,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
 
-const gotoSettings = async (
-  page: import('@playwright/test').Page
-): Promise<void> => {
-  await page.goto('/settings')
-  await expect(page.locator('[data-testid="members-section"]')).toBeVisible({
-    timeout: 15000,
-  })
+const gotoSettings = async (page: Page): Promise<void> => {
+  await visit(page, '/settings')
+  await expectVisible(page, page.locator('[data-testid="members-section"]'))
 }
 
 test.describe('Members — unified org list with CRUD', () => {
@@ -14,31 +21,36 @@ test.describe('Members — unified org list with CRUD', () => {
     page,
   }) => {
     await gotoSettings(page)
-    await expect(
-      page.locator('[data-testid="org-admins-group"]')
-    ).toHaveCount(0)
-    await expect(
-      page.locator('[data-testid="members-section"]')
-    ).toBeVisible()
+    await expectCount(
+      page,
+      page.locator('[data-testid="org-admins-group"]'),
+      0
+    )
+    await expectVisible(page, page.locator('[data-testid="members-section"]'))
   })
 
   test('lists every org member with an app-role select', async ({ page }) => {
     await gotoSettings(page)
-    await expect(
+    await expectVisible(
+      page,
       page.locator('[data-testid="member-row-alice-admin"]')
-    ).toBeVisible({ timeout: 10000 })
-    await expect(
+    )
+    await expectVisible(
+      page,
       page.locator('[data-testid="member-row-bob-chief"]')
-    ).toBeVisible()
-    await expect(
+    )
+    await expectVisible(
+      page,
       page.locator('[data-testid="member-row-carol-edit"]')
-    ).toBeVisible()
-    await expect(
+    )
+    await expectVisible(
+      page,
       page.locator('[data-testid="member-row-dave-none"]')
-    ).toBeVisible()
-    await expect(
+    )
+    await expectVisible(
+      page,
       page.locator('[data-testid="role-select-alice-admin"]')
-    ).toBeVisible()
+    )
   })
 
   test('changing a role on a row sends it through the SW', async ({
@@ -46,57 +58,61 @@ test.describe('Members — unified org list with CRUD', () => {
   }) => {
     await gotoSettings(page)
     const select = page.locator('[data-testid="role-select-dave-none"]')
-    await expect(select).toBeVisible({ timeout: 10000 })
+    await expectVisible(page, select)
     await select.selectOption('editor')
-    // In mock mode the SW returns success and the UI reloads;
-    // mock data still reflects dave-none as unassigned, so this
-    // assertion just proves the option was accepted by the select.
+    /*
+     * In mock mode the SW returns success and the UI reloads; mock
+     * data still reflects dave-none as unassigned, so this just
+     * proves the option was accepted by the select.
+     */
     await expect(select).not.toBeDisabled()
   })
 
   test('admin org-member is badged as "Org admin"', async ({ page }) => {
     await gotoSettings(page)
     const row = page.locator('[data-testid="member-row-alice-admin"]')
-    await expect(row).toBeVisible({ timeout: 10000 })
-    await expect(row.locator('.org-badge.is-admin')).toBeVisible()
-    await expect(row.locator('.org-badge.is-admin')).toContainText(
-      /org admin/i
-    )
+    await expectVisible(page, row)
+    await expectText(page, row.locator('.org-badge.is-admin'), /org admin/i)
   })
 
   test('a pending invitation is rendered with the Revoke button', async ({
     page,
   }) => {
     await gotoSettings(page)
-    await expect(page.locator('[data-testid="invite-row-99"]')).toBeVisible({
-      timeout: 10000,
-    })
-    await expect(
+    await expectVisible(page, page.locator('[data-testid="invite-row-99"]'))
+    await expectVisible(
+      page,
       page.locator('[data-testid="invite-revoke-99"]')
-    ).toBeVisible()
+    )
   })
 
   test('Invite button opens the dialog', async ({ page }) => {
     await gotoSettings(page)
-    await page.locator('[data-testid="invite-open"]').click()
-    await expect(page.locator('[data-testid="invite-dialog"]')).toBeVisible()
-    await expect(page.locator('[data-testid="invite-cancel"]')).toBeVisible()
-    await expect(page.locator('[data-testid="invite-submit"]')).toBeVisible()
+    await click(page, page.locator('[data-testid="invite-open"]'))
+    await expectVisible(page, page.locator('[data-testid="invite-dialog"]'))
+    await expectVisible(page, page.locator('[data-testid="invite-cancel"]'))
+    await expectVisible(page, page.locator('[data-testid="invite-submit"]'))
   })
 
   test('Invite dialog can be filled in with an email and role', async ({
     page,
   }) => {
     await gotoSettings(page)
-    await page.locator('[data-testid="invite-open"]').click()
-    await page
-      .locator('[data-testid="invite-identifier"]')
-      .fill('newperson@example.com')
+    await click(page, page.locator('[data-testid="invite-open"]'))
+    await fill(
+      page,
+      page.locator('[data-testid="invite-identifier"]'),
+      'newperson@example.com'
+    )
     await page.locator('[data-testid="invite-role"]').selectOption('editor')
-    await expect(
-      page.locator('[data-testid="invite-identifier"]')
-    ).toHaveValue('newperson@example.com')
-    await expect(page.locator('[data-testid="invite-role"]')).toHaveValue(
+    await expectValue(
+      page,
+      page.locator('[data-testid="invite-identifier"]'),
+      'newperson@example.com'
+    )
+    await expectValue(
+      page,
+      page.locator('[data-testid="invite-role"]'),
       'editor'
     )
   })

--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -1,12 +1,15 @@
-import { expect, test } from '@playwright/test'
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit'
 
+/*
+ * Once `context.setOffline(true)` flips, the request graph stops
+ * settling — heartbeats fire, fail, fire again. Toolkit waits that
+ * gate on idle would hang. Use raw Playwright `expect` for the
+ * offline-state assertions; its retries don't depend on network.
+ */
 test.describe('settings offline gate (3.4)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/settings')
-    await page.waitForLoadState('networkidle')
-    await page
-      .locator('[data-testid="members-section"]')
-      .waitFor({ state: 'visible' })
+    await visit(page, '/settings')
+    await expectVisible(page, page.locator('[data-testid="members-section"]'))
   })
 
   test('offline disables invite + shows banner', async ({

--- a/e2e/tracing/overlay.spec.ts
+++ b/e2e/tracing/overlay.spec.ts
@@ -1,34 +1,43 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expectHidden,
+  expectVisible,
+  pressKey,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
 
 test.describe('trace overlay (5.4)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
-    await page
-      .locator('[data-testid="notification-indicator"]')
-      .waitFor({ state: 'visible', timeout: 15_000 })
+    await visit(page, '/')
+    await expectVisible(
+      page,
+      page.locator('[data-testid="notification-indicator"]')
+    )
   })
 
   test('Ctrl+Shift+T toggles the overlay', async ({ page }) => {
     const overlay = page.locator('[data-testid="trace-overlay"]')
-    await expect(overlay).toBeHidden()
-    await page.keyboard.press('Control+Shift+T')
-    await expect(overlay).toBeVisible()
-    await page.keyboard.press('Control+Shift+T')
-    await expect(overlay).toBeHidden()
+    await expectHidden(page, overlay)
+    await pressKey(page, 'Control+Shift+T')
+    await expectVisible(page, overlay)
+    await pressKey(page, 'Control+Shift+T')
+    await expectHidden(page, overlay)
   })
 
   test('close button hides the overlay', async ({ page }) => {
-    await page.keyboard.press('Control+Shift+T')
+    await pressKey(page, 'Control+Shift+T')
     const overlay = page.locator('[data-testid="trace-overlay"]')
-    await expect(overlay).toBeVisible()
-    await page.locator('[data-testid="trace-overlay-close"]').click()
-    await expect(overlay).toBeHidden()
+    await expectVisible(page, overlay)
+    await click(page, page.locator('[data-testid="trace-overlay-close"]'))
+    await expectHidden(page, overlay)
   })
 
   test('shows empty state when no spans recorded', async ({ page }) => {
-    await page.keyboard.press('Control+Shift+T')
-    await expect(
+    await pressKey(page, 'Control+Shift+T')
+    await expectVisible(
+      page,
       page.locator('[data-testid="trace-overlay-empty"]')
-    ).toBeVisible()
+    )
   })
 })


### PR DESCRIPTION
Continuation of #163. Seven specs across three small dirs migrated to `@prometheus/e2e-toolkit`'s network-aware waits, replacing `waitForLoadState('networkidle')` + raw `waitForSelector` + hardcoded 5–15 s timeouts.

## Migrated
- `e2e/settings/{languages,members,offline-gate}.spec.ts` (3)
- `e2e/github-content/{create,edit,list}-content.spec.ts` (3)
- `e2e/tracing/overlay.spec.ts` (1)

## Note on offline-gate
`context.setOffline(true)` makes the request graph never settle — heartbeats keep firing/failing — so the toolkit's idle wait would hang. That spec keeps raw `expect` for the offline-state asserts; a comment in the file explains why.

## Test plan
- [x] `MOCK_OAUTH=true playwright test e2e/{settings,github-content,tracing} --project=chromium` 37/37 in 58.6 s
- [x] `bun run lint:check`, `lint:sonar`, `lint:jsdoc` clean