### PR TITLE
fix(e2e): biome import-order in members.spec.ts

### DIFF
--- a/e2e/settings/members.spec.ts
+++ b/e2e/settings/members.spec.ts
@@ -2,11 +2,11 @@ import {
   click,
   expect,
   expectCount,
-  type Page,
   expectText,
   expectValue,
   expectVisible,
   fill,
+  type Page,
   test,
   visit,
 } from '@prometheus/e2e-toolkit'


### PR DESCRIPTION
Biome CI keeps imports alphabetised regardless of the `type` keyword. Move `type Page` to its alphabetical position.