### PR TITLE
feat(e2e): migrate 12 content/ specs to toolkit (batch 1 of 4)

### DIFF
--- a/e2e/content/auth-required.spec.ts
+++ b/e2e/content/auth-required.spec.ts
@@ -1,43 +1,32 @@
-import { expect, test } from '@playwright/test'
-import { waitForNetworkIdle } from '../helpers/network'
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit'
 
 test.use({ storageState: { cookies: [], origins: [] } })
 
 test.describe('Authentication Required', () => {
   test('should redirect blog to home without auth', async ({ page }) => {
-    await page.goto('/content/blog')
-    await waitForNetworkIdle(page)
-
+    await visit(page, '/content/blog')
     await expect(page).toHaveURL('/')
   })
 
   test('should redirect positions to home without auth', async ({ page }) => {
-    await page.goto('/content/positions')
-    await waitForNetworkIdle(page)
-
+    await visit(page, '/content/positions')
     await expect(page).toHaveURL('/')
   })
 
   test('should redirect pages to home without auth', async ({ page }) => {
-    await page.goto('/content/pages')
-    await waitForNetworkIdle(page)
-
+    await visit(page, '/content/pages')
     await expect(page).toHaveURL('/')
   })
 
   test('should show login button in header when not authenticated', async ({
     page,
   }) => {
-    await page.goto('/')
-    await waitForNetworkIdle(page)
-
-    await expect(page.getByRole('button', { name: /login/i })).toBeVisible()
+    await visit(page, '/')
+    await expectVisible(page, page.getByRole('button', { name: /login/i }))
   })
 
   test('should not show content nav links without auth', async ({ page }) => {
-    await page.goto('/')
-    await waitForNetworkIdle(page)
-
+    await visit(page, '/')
     await expect(page.getByRole('link', { name: /blog/i })).not.toBeVisible()
     await expect(
       page.getByRole('link', { name: /positions/i })

--- a/e2e/content/delete-article.spec.ts
+++ b/e2e/content/delete-article.spec.ts
@@ -1,86 +1,69 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expectCount,
+  expectHidden,
+  expectMinCount,
+  expectVisible,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
+
+/*
+ * Pages are fixed-structure (hide-delete=true). Use /content/blog
+ * so delete buttons are actually rendered.
+ */
+const setupBlog = async (
+  page: Parameters<Parameters<typeof test>[1]>[0]['page']
+) => {
+  await visit(page, '/content/blog')
+  const item = page.locator('[data-testid="content-item"]').first()
+  await expectVisible(page, item)
+  return item
+}
 
 test.describe('Delete Article', () => {
   test('should show delete button on hover', async ({ page }) => {
-    // Pages are fixed-structure (hide-delete=true). Use /content/blog so
-    // delete buttons are actually rendered.
-    await page.goto('/content/blog', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="content-item"]', {
-      timeout: 20000,
-    })
-
-    const item = page.locator('[data-testid="content-item"]').first()
+    const item = await setupBlog(page)
     await item.hover()
-
-    const deleteBtn = item.locator('[data-testid="delete-item-btn"]')
-    await expect(deleteBtn).toBeVisible({ timeout: 5000 })
+    await expectVisible(page, item.locator('[data-testid="delete-item-btn"]'))
   })
 
   test('should show delete confirmation dialog', async ({ page }) => {
-    // Pages are fixed-structure (hide-delete=true). Use /content/blog so
-    // delete buttons are actually rendered.
-    await page.goto('/content/blog', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="content-item"]', {
-      timeout: 20000,
-    })
-
-    const item = page.locator('[data-testid="content-item"]').first()
+    const item = await setupBlog(page)
     await item.hover()
-    await item.locator('[data-testid="delete-item-btn"]').click()
+    await click(page, item.locator('[data-testid="delete-item-btn"]'))
 
-    const dialog = page.locator('[data-testid="delete-dialog"]')
-    await expect(dialog).toBeVisible({ timeout: 5000 })
-
-    await expect(page.locator('[data-testid="delete-all-btn"]')).toBeVisible()
-    await expect(
-      page.locator('[data-testid="delete-lang-btn"]')
-    ).toBeVisible()
-    await expect(
+    await expectVisible(page, page.locator('[data-testid="delete-dialog"]'))
+    await expectVisible(page, page.locator('[data-testid="delete-all-btn"]'))
+    await expectVisible(page, page.locator('[data-testid="delete-lang-btn"]'))
+    await expectVisible(
+      page,
       page.locator('[data-testid="delete-cancel-btn"]')
-    ).toBeVisible()
+    )
   })
 
   test('should close dialog on cancel', async ({ page }) => {
-    // Pages are fixed-structure (hide-delete=true). Use /content/blog so
-    // delete buttons are actually rendered.
-    await page.goto('/content/blog', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="content-item"]', {
-      timeout: 20000,
-    })
-
-    const item = page.locator('[data-testid="content-item"]').first()
+    const item = await setupBlog(page)
     await item.hover()
-    await item.locator('[data-testid="delete-item-btn"]').click()
+    await click(page, item.locator('[data-testid="delete-item-btn"]'))
 
     const dialog = page.locator('[data-testid="delete-dialog"]')
-    await expect(dialog).toBeVisible({ timeout: 5000 })
-
-    await page.locator('[data-testid="delete-cancel-btn"]').click()
-    await expect(dialog).not.toBeVisible()
+    await expectVisible(page, dialog)
+    await click(page, page.locator('[data-testid="delete-cancel-btn"]'))
+    await expectHidden(page, dialog)
   })
 
   test('delete all should remove item from list', async ({ page }) => {
-    // Pages are fixed-structure (hide-delete=true). Use /content/blog so
-    // delete buttons are actually rendered.
-    await page.goto('/content/blog', { waitUntil: 'domcontentloaded' })
-    await page.waitForSelector('[data-testid="content-item"]', {
-      timeout: 20000,
-    })
+    await visit(page, '/content/blog')
+    const items = page.locator('[data-testid="content-item"]')
+    await expectMinCount(page, items, 1)
+    const initialCount = await items.count()
 
-    const initialCount = await page
-      .locator('[data-testid="content-item"]')
-      .count()
-
-    const item = page.locator('[data-testid="content-item"]').first()
+    const item = items.first()
     await item.hover()
-    await item.locator('[data-testid="delete-item-btn"]').click()
+    await click(page, item.locator('[data-testid="delete-item-btn"]'))
+    await click(page, page.locator('[data-testid="delete-all-btn"]'))
 
-    await page.locator('[data-testid="delete-all-btn"]').click()
-
-    // Wait for list to update
-    await expect(page.locator('[data-testid="content-item"]')).toHaveCount(
-      initialCount - 1,
-      { timeout: 15000 }
-    )
+    await expectCount(page, items, initialCount - 1)
   })
 })

--- a/e2e/content/edit-lang-selector.spec.ts
+++ b/e2e/content/edit-lang-selector.spec.ts
@@ -1,4 +1,11 @@
-import { expect, test } from '@playwright/test'
+import {
+  expect,
+  expectClass,
+  expectCount,
+  expectValue,
+  expectVisible,
+  test,
+} from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'media-showcase'
@@ -9,26 +16,20 @@ test.describe('Edit Page Language Selector', () => {
     await ep.navigate('blog', SLUG)
 
     const selector = page.locator('[data-testid="language-selector"]')
-    await expect(selector).toBeVisible({ timeout: 10000 })
-
-    const buttons = selector.locator('button')
-    await expect(buttons).toHaveCount(4)
+    await expectVisible(page, selector)
+    await expectCount(page, selector.locator('button'), 4)
   })
 
   test('current language should be active', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
-
-    const enBtn = ep.getLanguageButton('en')
-    await expect(enBtn).toHaveClass(/active/, { timeout: 10000 })
+    await expectClass(page, ep.getLanguageButton('en'), /active/)
   })
 
   test('available langs should have exists class', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
-
-    const enBtn = ep.getLanguageButton('en')
-    await expect(enBtn).toHaveClass(/exists/, { timeout: 10000 })
+    await expectClass(page, ep.getLanguageButton('en'), /exists/)
   })
 
   test('clicking another language should switch editor content', async ({
@@ -40,18 +41,17 @@ test.describe('Edit Page Language Selector', () => {
     const ta = ep.getEditorBody()
     const beforeContent = await ta.inputValue()
 
-    // Check if ru version exists (has exists class)
     const ruBtn = ep.getLanguageButton('ru')
     const hasRu = await ruBtn.evaluate(el => el.classList.contains('exists'))
 
     await ruBtn.click()
 
     if (hasRu) {
-      // Content should have changed
-      await expect(ta).not.toHaveValue(beforeContent, { timeout: 10000 })
+      /* ru variant exists — editor body should swap. */
+      await expect(ta).not.toHaveValue(beforeContent)
     } else {
-      // Editor should be empty for new translation
-      await expect(ta).toHaveValue('', { timeout: 10000 })
+      /* No ru variant yet — editor blanks for the new translation. */
+      await expectValue(page, ta, '')
     }
   })
 })

--- a/e2e/content/frontmatter-validation.spec.ts
+++ b/e2e/content/frontmatter-validation.spec.ts
@@ -1,13 +1,20 @@
-import { expect, test } from '@playwright/test'
+import {
+  expect,
+  expectHidden,
+  expectVisible,
+  type Page,
+  test,
+  waitForCondition,
+} from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { openPreview, saveAndConfirm } from './preview-save'
 
-const edit = async (page: import('@playwright/test').Page): Promise<void> => {
+const edit = async (page: Page): Promise<void> => {
   const ep = new ContentEditPage(page)
   await ep.navigate('blog', 'welcome-to-prometheus')
 }
 
-const errorBanner = (page: import('@playwright/test').Page) =>
+const errorBanner = (page: Page) =>
   page.locator('[data-testid="error-message"]')
 
 test.describe('Frontmatter validation before save', () => {
@@ -17,15 +24,16 @@ test.describe('Frontmatter validation before save', () => {
     await edit(page)
     await page.locator('#fm-title').fill('')
 
-    // Intercept the commit endpoint — it must not fire.
+    /* Intercept the commit endpoint — it must not fire. */
     let commitFired = false
     page.on('response', r => {
       if (r.url().includes('/api/github/commit')) commitFired = true
     })
 
     await saveAndConfirm(page, await openPreview(page))
-    await expect(errorBanner(page)).toBeVisible({ timeout: 5000 })
-    await page.waitForTimeout(250)
+    await expectVisible(page, errorBanner(page))
+    /* Toolkit waits for the request graph to idle, then assert. */
+    await waitForCondition(page, async () => true)
     expect(commitFired).toBe(false)
   })
 
@@ -39,23 +47,21 @@ test.describe('Frontmatter validation before save', () => {
     })
 
     await saveAndConfirm(page, await openPreview(page))
-    await expect(errorBanner(page)).toBeVisible({ timeout: 5000 })
-    await page.waitForTimeout(250)
+    await expectVisible(page, errorBanner(page))
+    await waitForCondition(page, async () => true)
     expect(commitFired).toBe(false)
   })
 
   test('valid frontmatter allows the save to complete', async ({ page }) => {
     await edit(page)
-    // Make a trivial dirty change so there's something to save.
+    /* Trivial dirty change so there's something to save. */
     const textarea = page.locator('[data-testid="editor-body"]')
     await textarea.fill(`${await textarea.inputValue()}\nvalid`)
 
     await saveAndConfirm(page, await openPreview(page))
-    await expect(errorBanner(page)).toBeHidden({ timeout: 2000 })
-    // Preview auto-exits on success.
-    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible({
-      timeout: 15000,
-    })
+    await expectHidden(page, errorBanner(page))
+    /* Preview auto-exits on success. */
+    await expectVisible(page, page.locator('[data-testid="preview-button"]'))
   })
 })
 
@@ -73,8 +79,8 @@ test.describe('Per-type validation', () => {
     })
 
     await saveAndConfirm(page, await openPreview(page))
-    await expect(errorBanner(page)).toBeVisible({ timeout: 5000 })
-    await page.waitForTimeout(250)
+    await expectVisible(page, errorBanner(page))
+    await waitForCondition(page, async () => true)
     expect(commitFired).toBe(false)
   })
 })

--- a/e2e/content/import-from-docs.spec.ts
+++ b/e2e/content/import-from-docs.spec.ts
@@ -1,22 +1,29 @@
-import { expect, test } from '@playwright/test'
+import {
+  expect,
+  expectHidden,
+  expectText,
+  expectVisible,
+  type Page,
+  test,
+  waitForCondition,
+} from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
-const edit = async (page: import('@playwright/test').Page): Promise<void> => {
+const edit = async (page: Page): Promise<void> => {
   const ep = new ContentEditPage(page)
   await ep.navigate('blog', 'welcome-to-prometheus')
 }
 
-const input = (page: import('@playwright/test').Page) =>
+const input = (page: Page) =>
   page.locator('[data-testid="import-docs-input"]')
 
-const button = (page: import('@playwright/test').Page) =>
+const button = (page: Page) =>
   page.locator('[data-testid="import-docs-button"]')
 
 test.describe('Import from Docs', () => {
   test('Import button is visible in the editor toolbar', async ({ page }) => {
     await edit(page)
-    await expect(button(page)).toBeVisible()
-    await expect(button(page)).toContainText(/import from docs/i)
+    await expectText(page, button(page), /import from docs/i)
   })
 
   test('upload a .md file inserts its body at the caret', async ({
@@ -24,7 +31,7 @@ test.describe('Import from Docs', () => {
   }) => {
     await edit(page)
     const textarea = page.locator('[data-testid="editor-body"]')
-    // Empty the textarea first so the insertion is easy to spot.
+    /* Empty the textarea first so the insertion is easy to spot. */
     await textarea.fill('')
 
     const payload = Buffer.from('# Imported heading\n\nImported body text\n')
@@ -34,7 +41,6 @@ test.describe('Import from Docs', () => {
       buffer: payload,
     })
 
-    // Wait for the content to land.
     await expect
       .poll(() => textarea.inputValue(), { timeout: 5000 })
       .toContain('Imported body text')
@@ -76,13 +82,10 @@ test.describe('Import from Docs', () => {
       buffer: Buffer.from('%PDF-1.4'),
     })
 
-    // Wait a moment, then assert unchanged.
-    await page.waitForTimeout(500)
+    /* Wait for the request graph to settle, then assert untouched. */
+    await waitForCondition(page, async () => true)
     expect(await textarea.inputValue()).toBe(before)
-    // The error path surfaces via the shared ErrorMessage banner.
-    await expect(page.locator('[data-testid="error-message"]')).toBeVisible({
-      timeout: 2000,
-    })
+    await expectVisible(page, page.locator('[data-testid="error-message"]'))
   })
 
   test('import is hidden while the user is on the preview page', async ({
@@ -90,7 +93,7 @@ test.describe('Import from Docs', () => {
   }) => {
     await edit(page)
     await page.locator('[data-testid="preview-button"]').click()
-    await expect(button(page)).toBeHidden()
+    await expectHidden(page, button(page))
   })
 
   test('html with single-item bold-only ordered lists becomes numbered ## headings', async ({
@@ -100,8 +103,10 @@ test.describe('Import from Docs', () => {
     const textarea = page.locator('[data-testid="editor-body"]')
     await textarea.fill('')
 
-    // Mirrors what mammoth emits for Word "List Paragraph" sections —
-    // each section is its own single-item bold-only ordered list.
+    /*
+     * Mirrors what mammoth emits for Word "List Paragraph" sections
+     * — each section is its own single-item bold-only ordered list.
+     */
     const html =
       '<ol><li><strong>Foreword</strong></li></ol>' +
       '<p>body</p>' +

--- a/e2e/content/markdown-editor.spec.ts
+++ b/e2e/content/markdown-editor.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expectVisible, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 test.describe('Markdown Editor', () => {
@@ -8,18 +8,14 @@ test.describe('Markdown Editor', () => {
     const editPage = new ContentEditPage(page)
     await editPage.navigate('blog', 'welcome-to-prometheus')
 
-    const textarea = editPage.getEditorBody()
-    await textarea.waitFor({ state: 'visible', timeout: 10000 })
-    await expect(textarea).toBeVisible()
+    await expectVisible(page, editPage.getEditorBody())
   })
 
   test('should display preview button', async ({ page }) => {
     const editPage = new ContentEditPage(page)
     await editPage.navigate('blog', 'welcome-to-prometheus')
 
-    const textarea = editPage.getEditorBody()
-    await textarea.waitFor({ state: 'visible', timeout: 10000 })
-
-    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible()
+    await expectVisible(page, editPage.getEditorBody())
+    await expectVisible(page, page.locator('[data-testid="preview-button"]'))
   })
 })

--- a/e2e/content/markdown-preview.spec.ts
+++ b/e2e/content/markdown-preview.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test } from '@playwright/test'
+import {
+  expectAttribute,
+  expectCount,
+  expectText,
+  expectVisible,
+  test,
+} from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 test.describe('Markdown Preview', () => {
@@ -7,8 +13,7 @@ test.describe('Markdown Preview', () => {
   }) => {
     const editPage = new ContentEditPage(page)
     await editPage.navigate('blog', 'welcome-to-prometheus')
-
-    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible()
+    await expectVisible(page, page.locator('[data-testid="preview-button"]'))
   })
 
   test('clicking preview shows rendered HTML', async ({ page }) => {
@@ -19,8 +24,8 @@ test.describe('Markdown Preview', () => {
     await editPage.expectPreviewVisible()
 
     const preview = page.locator('[data-testid="markdown-preview"]')
-    await expect(preview.locator('h1')).toBeVisible()
-    await expect(preview.locator('strong').first()).toBeVisible()
+    await expectVisible(page, preview.locator('h1'))
+    await expectVisible(page, preview.locator('strong').first())
   })
 
   test('clicking toggle again returns to textarea', async ({ page }) => {
@@ -47,12 +52,14 @@ test.describe('Markdown Preview', () => {
     await editPage.expectPreviewVisible()
 
     const preview = page.locator('[data-testid="markdown-preview"]')
-    await expect(preview.locator('h1')).toHaveText('Main Title')
-    await expect(preview.locator('h2')).toHaveText('Subtitle')
-    await expect(preview.locator('a')).toHaveAttribute(
+    await expectText(page, preview.locator('h1'), 'Main Title')
+    await expectText(page, preview.locator('h2'), 'Subtitle')
+    await expectAttribute(
+      page,
+      preview.locator('a'),
       'href',
       'https://example.com'
     )
-    await expect(preview.locator('li')).toHaveCount(2)
+    await expectCount(page, preview.locator('li'), 2)
   })
 })

--- a/e2e/content/navigation.spec.ts
+++ b/e2e/content/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentPage } from '../pages/ContentPage'
 
 test.describe('Content Navigation', () => {

--- a/e2e/content/regression-36-preview-toggle-save.spec.ts
+++ b/e2e/content/regression-36-preview-toggle-save.spec.ts
@@ -1,4 +1,9 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expectCount,
+  expectVisible,
+  test,
+} from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 /**
@@ -24,17 +29,13 @@ test.describe('Issue #36 — single "Preview" entry leads to Save', () => {
   test('the redundant in-editor preview-toggle is gone', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('pages', 'manifest')
-    await expect(page.locator('[data-testid="preview-toggle"]')).toHaveCount(
-      0
-    )
+    await expectCount(page, page.locator('[data-testid="preview-toggle"]'), 0)
   })
 
   test('the only Preview button reveals Save', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('pages', 'manifest')
-    await page.locator('[data-testid="preview-button"]').click()
-    await expect(page.locator('[data-testid="save-button"]')).toBeVisible({
-      timeout: 5000,
-    })
+    await click(page, page.locator('[data-testid="preview-button"]'))
+    await expectVisible(page, page.locator('[data-testid="save-button"]'))
   })
 })

--- a/e2e/content/regression-37-save-lang-respected.spec.ts
+++ b/e2e/content/regression-37-save-lang-respected.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expect,
+  expectClass,
+  expectVisible,
+  test,
+} from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 /**
@@ -22,15 +28,13 @@ test.describe('Issue #37 — save honours the currently selected language', () =
     await ep.navigate('pages', 'manifest')
 
     const ruBtn = ep.getLanguageButton('ru')
-    await expect(ruBtn).toHaveClass(/exists/, { timeout: 10000 })
-    await ruBtn.click()
+    await expectClass(page, ruBtn, /exists/)
+    await click(page, ruBtn)
 
     const editor = ep.getEditorBody()
-    // Wait for the editor to load the ru draft (non-empty ru content).
-    await expect(editor).not.toHaveValue('', { timeout: 10000 })
-    await expect(editor).toHaveValue(/Наш манифест|Наши/u, {
-      timeout: 10000,
-    })
+    /* Wait for the editor to load the ru draft (non-empty content). */
+    await expect(editor).not.toHaveValue('')
+    await expect(editor).toHaveValue(/Наш манифест|Наши/u)
     await editor.fill(
       `${await editor.inputValue()}\n\n<!-- regression-37 ru save -->`
     )
@@ -42,17 +46,19 @@ test.describe('Issue #37 — save honours the currently selected language', () =
       { timeout: 15000 }
     )
 
-    await page.locator('[data-testid="preview-button"]').click()
-    await page.locator('[data-testid="save-button"]').click()
-    // pages are autoPublic — confirm dialog appears.
-    await expect(
+    await click(page, page.locator('[data-testid="preview-button"]'))
+    await click(page, page.locator('[data-testid="save-button"]'))
+    /* pages are autoPublic — confirm dialog appears. */
+    await expectVisible(
+      page,
       page.locator('[data-testid="publish-confirm-btn"]')
-    ).toBeVisible({ timeout: 5000 })
-    await page.locator('[data-testid="publish-confirm-btn"]').click()
+    )
+    await click(page, page.locator('[data-testid="publish-confirm-btn"]'))
 
     const response = await stagePromise
-    const req = response.request()
-    const body = JSON.parse(req.postData() ?? '{}') as { path?: string }
+    const body = JSON.parse(response.request().postData() ?? '{}') as {
+      path?: string
+    }
     expect(body.path).toBeDefined()
     expect(body.path).toMatch(/index\.ru\.md$/)
     expect(body.path).not.toMatch(/index\.en\.md$/)

--- a/e2e/content/regression-38-pages-save-shows-deploy.spec.ts
+++ b/e2e/content/regression-38-pages-save-shows-deploy.spec.ts
@@ -1,4 +1,13 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expect,
+  expectClass,
+  expectCount,
+  expectText,
+  expectVisible,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 /**
@@ -25,49 +34,51 @@ test.describe('Issue #38 — saving a page surfaces the deploy in the UI', () =>
       `${await editor.inputValue()}\n\n<!-- regression-38 deploy bar -->`
     )
 
-    await page.locator('[data-testid="preview-button"]').click()
-    await page.locator('[data-testid="save-button"]').click()
-    // pages are autoPublic — confirm dialog opens.
-    await page
-      .locator('[data-testid="publish-confirm-btn"]')
-      .click({ timeout: 5000 })
+    await click(page, page.locator('[data-testid="preview-button"]'))
+    await click(page, page.locator('[data-testid="save-button"]'))
+    /* pages are autoPublic — confirm dialog opens. */
+    await click(page, page.locator('[data-testid="publish-confirm-btn"]'))
 
-    // Save success — preview auto-exits and Preview button reappears.
-    await expect(page.locator('[data-testid="preview-button"]')).toBeVisible({
-      timeout: 30000,
-    })
+    /* Save success — preview auto-exits and Preview button reappears. */
+    await expectVisible(page, page.locator('[data-testid="preview-button"]'))
 
-    // Deploy status bar is mounted globally and must reflect the
-    // running deploy after a save lands.
-    await expect(page.locator('.deploy-bar')).toBeVisible({
-      timeout: 15000,
-    })
-    await expect(page.locator('.deploy-bar')).toHaveClass(/\bbuilding\b/, {
-      timeout: 15000,
-    })
+    /*
+     * Deploy status bar is mounted globally and must reflect the
+     * running deploy after a save lands.
+     */
+    await expectVisible(page, page.locator('.deploy-bar'))
+    await expectClass(page, page.locator('.deploy-bar'), /\bbuilding\b/)
 
-    // Pending deploy is persisted in sessionStorage so the home page
-    // can render the optimistic entry.
+    /*
+     * Pending deploy is persisted in sessionStorage so the home page
+     * can render the optimistic entry.
+     */
     const pending = await page.evaluate(() =>
       globalThis.sessionStorage.getItem('pending_deploy')
     )
     expect(pending).not.toBeNull()
 
-    // Home dashboard must list the new pending entry, even while
-    // GitHub Actions polling is still in flight (the issue user saw
-    // on prod was "Loading deployments..." masking the entry).
-    await page.goto('/')
-    await expect(page.locator('section.deploy-list h2')).toContainText(
-      /recent deployments/i,
-      { timeout: 10000 }
+    /*
+     * Home dashboard must list the new pending entry, even while
+     * GitHub Actions polling is still in flight (the issue user saw
+     * on prod was "Loading deployments..." masking the entry).
+     */
+    await visit(page, '/')
+    await expectText(
+      page,
+      page.locator('section.deploy-list h2'),
+      /recent deployments/i
     )
-    await expect(
+    await expectVisible(
+      page,
       page.locator('section.deploy-list .deploy-item').first()
-    ).toBeVisible({ timeout: 10000 })
-    await expect(
+    )
+    await expectCount(
+      page,
       page.locator('section.deploy-list .status', {
         hasText: /loading deployments/i,
-      })
-    ).toHaveCount(0)
+      }),
+      0
+    )
   })
 })

--- a/e2e/content/rename-slug.spec.ts
+++ b/e2e/content/rename-slug.spec.ts
@@ -1,5 +1,13 @@
-import { expect, test } from '@playwright/test'
-import { waitForNetworkIdle } from '../helpers/network'
+import {
+  click,
+  expect,
+  expectCount,
+  expectHidden,
+  expectValue,
+  expectVisible,
+  test,
+  waitForCondition,
+} from '@prometheus/e2e-toolkit'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { openPreview, saveAndConfirm } from './preview-save'
@@ -11,80 +19,80 @@ test.describe('Rename Slug', () => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
-    await expect(input).toBeVisible({ timeout: 5000 })
+    await expectVisible(page, input)
 
-    // Sanitization strips non-[a-z0-9-]; "!!!" reduces to "" so the
-    // validator fires its empty-slug error.
+    /*
+     * Sanitization strips non-[a-z0-9-]; "!!!" reduces to "" so the
+     * validator fires its empty-slug error.
+     */
     await input.clear()
     await input.type('!!!', { delay: 30 })
     await input.press('Enter')
-    await expect(page.locator('[data-testid="slug-error"]')).toBeVisible({
-      timeout: 5000,
-    })
+    await expectVisible(page, page.locator('[data-testid="slug-error"]'))
   })
 
   test('lowercases uppercase keystrokes on the fly', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
     await input.clear()
     await input.type('FooBar', { delay: 30 })
-    await expect(input).toHaveValue('foobar')
+    await expectValue(page, input, 'foobar')
   })
 
   test('strips non-Latin keystrokes', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
     await input.clear()
     await input.type('пост-test', { delay: 30 })
-    await expect(input).toHaveValue('-test')
+    await expectValue(page, input, '-test')
   })
 
   test('should reject slug exceeding max length', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
     await input.clear()
     await input.type('a'.repeat(21), { delay: 10 })
     await input.press('Enter')
-    await expect(page.locator('[data-testid="slug-error"]')).toBeVisible({
-      timeout: 5000,
-    })
+    await expectVisible(page, page.locator('[data-testid="slug-error"]'))
   })
 
   test('should cancel edit on Escape', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
-    await expect(input).toBeVisible()
+    await expectVisible(page, input)
 
     await input.press('Escape')
-    await expect(input).not.toBeVisible()
-    await expect(page.locator('[data-testid="edit-title"]')).toBeVisible()
+    await expectHidden(page, input)
+    await expectVisible(page, page.locator('[data-testid="edit-title"]'))
   })
 
   test('valid rename should redirect to new URL', async ({ page }) => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
     await input.clear()
     await input.type('showcase-renamed', { delay: 30 })
     await input.press('Enter')
 
-    await page.waitForURL(/showcase-renamed/, { timeout: 15000 })
+    await waitForCondition(page, async () =>
+      /showcase-renamed/.test(page.url())
+    )
   })
 
   test('rename preserves assets and content', async ({ page }) => {
@@ -96,25 +104,23 @@ test.describe('Rename Slug', () => {
     const ep = new ContentEditPage(page)
     const bodyBefore = await ep.getEditorBody().inputValue()
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
     await input.clear()
     await input.type('renamed-showcase', { delay: 30 })
     await input.press('Enter')
-    await page.waitForURL(/renamed-showcase/, { timeout: 15000 })
+    await waitForCondition(page, async () =>
+      /renamed-showcase/.test(page.url())
+    )
 
-    // Wait for page to fully load after location.replace
-    await expect(ep.getEditorBody()).toBeVisible({ timeout: 20000 })
-    await expect(ep.getEditorBody()).not.toHaveValue('', {
-      timeout: 20000,
-    })
+    /* Wait for page to fully load after location.replace. */
+    await expectVisible(page, ep.getEditorBody())
+    await expect(ep.getEditorBody()).not.toHaveValue('')
 
     const bodyAfter = await ep.getEditorBody().inputValue()
     expect(bodyAfter).toBe(bodyBefore)
 
-    await expect(am.getAssetThumbnails()).toHaveCount(assetCount, {
-      timeout: 10000,
-    })
+    await expectCount(page, am.getAssetThumbnails(), assetCount)
   })
 
   test('rename + save does not create duplicate articles', async ({
@@ -123,29 +129,21 @@ test.describe('Rename Slug', () => {
     const ep = new ContentEditPage(page)
     await ep.navigate('blog', SLUG)
 
-    await page.locator('[data-testid="edit-title"]').click()
+    await click(page, page.locator('[data-testid="edit-title"]'))
     const input = page.locator('[data-testid="slug-input"]')
     await input.clear()
     await input.type('showcase-save', { delay: 30 })
     await input.press('Enter')
-    await page.waitForURL(/showcase-save/, { timeout: 15000 })
+    await waitForCondition(page, async () => /showcase-save/.test(page.url()))
 
-    await expect(ep.getEditorBody()).toBeVisible({ timeout: 20000 })
-    await expect(ep.getEditorBody()).not.toHaveValue('', {
-      timeout: 20000,
-    })
+    await expectVisible(page, ep.getEditorBody())
+    await expect(ep.getEditorBody()).not.toHaveValue('')
 
-    // Save
     await saveAndConfirm(page, await openPreview(page))
-    await waitForNetworkIdle(page, { idleTime: 1000 })
 
-    // Navigate back to list
-    await page.locator('[data-testid="back-button"]').click()
-    await expect(page.locator('[data-testid="content-list"]')).toBeVisible({
-      timeout: 10000,
-    })
+    await click(page, page.locator('[data-testid="back-button"]'))
+    await expectVisible(page, page.locator('[data-testid="content-list"]'))
 
-    // Count items with "Rich Media" title (should be exactly 1)
     const items = page.locator('[data-testid="content-item"]')
     const count = await items.count()
     let richMediaCount = 0


### PR DESCRIPTION
Continues #163 / #167. Twelve content/ specs (the smaller standalone ones) migrated to `@prometheus/e2e-toolkit`.

## Migrated
- auth-required, navigation, markdown-editor, markdown-preview, edit-lang-selector, delete-article, rename-slug, frontmatter-validation, import-from-docs, regression-36/37/38

## Notable
- frontmatter-validation: `waitForCondition(true)` replaces `waitForTimeout(250)` for the "commit must NOT fire" check — settle wait absorbs the actual request graph idle, which is the real signal.
- import-from-docs: keeps Playwright's `expect.poll` for textarea reads; that's already a poll-based assertion, no toolkit wrapper needed.

## Result
48/48 chromium pass in 1.3 min locally.

## Next batches
- batch 2: cmd-* specs (10) + command-panel + content-list/load/switch (~12 files)
- batch 3: asset-* (5)
- batch 4: create-/edit-/preview-/save-/publish-* (~10)