### PR TITLE
feat(e2e): migrate 18 more content/ specs to toolkit (batch 2)

### DIFF
--- a/e2e/content/cmd-block-buttons.spec.ts
+++ b/e2e/content/cmd-block-buttons.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'welcome-to-prometheus'

--- a/e2e/content/cmd-block-special.spec.ts
+++ b/e2e/content/cmd-block-special.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'welcome-to-prometheus'

--- a/e2e/content/cmd-consistency.spec.ts
+++ b/e2e/content/cmd-consistency.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchDrop } from '../helpers/dispatch-drop'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'

--- a/e2e/content/cmd-drop-media.spec.ts
+++ b/e2e/content/cmd-drop-media.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchDrop } from '../helpers/dispatch-drop'
 import { ContentEditPage } from '../pages/ContentEditPage'

--- a/e2e/content/cmd-media-picker.spec.ts
+++ b/e2e/content/cmd-media-picker.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { ContentEditPage } from '../pages/ContentEditPage'
 

--- a/e2e/content/cmd-paste-media.spec.ts
+++ b/e2e/content/cmd-paste-media.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'

--- a/e2e/content/cmd-preview-insertion.spec.ts
+++ b/e2e/content/cmd-preview-insertion.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'welcome-to-prometheus'

--- a/e2e/content/cmd-undo.spec.ts
+++ b/e2e/content/cmd-undo.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { ContentEditPage } from '../pages/ContentEditPage'

--- a/e2e/content/cmd-upload-insert.spec.ts
+++ b/e2e/content/cmd-upload-insert.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { ContentEditPage } from '../pages/ContentEditPage'
 

--- a/e2e/content/cmd-wrap-buttons.spec.ts
+++ b/e2e/content/cmd-wrap-buttons.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'welcome-to-prometheus'

--- a/e2e/content/cmd-wrap-keyboard.spec.ts
+++ b/e2e/content/cmd-wrap-keyboard.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const SLUG = 'welcome-to-prometheus'

--- a/e2e/content/command-panel.spec.ts
+++ b/e2e/content/command-panel.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 test.describe('Command Panel', () => {

--- a/e2e/content/content-list.spec.ts
+++ b/e2e/content/content-list.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test } from '@prometheus/e2e-toolkit'
 import { ContentPage } from '../pages/ContentPage'
 
 test.describe('Content List', () => {

--- a/e2e/content/content-loading.spec.ts
+++ b/e2e/content/content-loading.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
@@ -11,30 +11,22 @@ test.describe('Content Loading', () => {
     }
 
     for (const section of ['blog', 'pages', 'positions']) {
-      await page.goto(`/content/${section}`)
-      await page.waitForLoadState('networkidle')
+      await visit(page, `/content/${section}`)
       await waitForContentReady(page)
 
       const items = page.locator('[data-testid="content-item"]')
-      await items.first().waitFor({
-        state: 'visible',
-        timeout: 15000,
-      })
+      await expectVisible(page, items.first())
       expect(await items.count()).toBe(expected[section])
     }
   })
 
   test('should display correct titles per language', async ({ page }) => {
-    await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/blog')
     await waitForContentReady(page)
 
     await page.getByRole('button', { name: 'English' }).click()
     const items = page.locator('[data-testid="content-item"]')
-    await items.first().waitFor({
-      state: 'visible',
-      timeout: 15000,
-    })
+    await expectVisible(page, items.first())
 
     const enTitles = (await items.allTextContents()).join(' ')
     expect(enTitles).toContain('Welcome to Prometheus')
@@ -45,28 +37,16 @@ test.describe('Content Loading', () => {
 
     for (const lang of ['Русский', 'Italiano', 'Español']) {
       await page.getByRole('button', { name: lang }).click()
-      await items.first().waitFor({
-        state: 'visible',
-        timeout: 15000,
-      })
+      await expectVisible(page, items.first())
       expect(await items.count()).toBe(5)
     }
   })
 
   test('should load article body on navigation', async ({ page }) => {
     const entries = [
-      {
-        title: 'Welcome to Prometheus',
-        slug: 'welcome-to-prometheus',
-      },
-      {
-        title: 'Why Choose Astro Framework',
-        slug: 'astro-framework',
-      },
-      {
-        title: 'Rich Media in Blog Posts',
-        slug: 'media-showcase',
-      },
+      { title: 'Welcome to Prometheus', slug: 'welcome-to-prometheus' },
+      { title: 'Why Choose Astro Framework', slug: 'astro-framework' },
+      { title: 'Rich Media in Blog Posts', slug: 'media-showcase' },
     ]
 
     for (const entry of entries) {

--- a/e2e/content/content-switch-verify.spec.ts
+++ b/e2e/content/content-switch-verify.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { ContentPage } from '../pages/ContentPage'
 

--- a/e2e/content/language-filtering.spec.ts
+++ b/e2e/content/language-filtering.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 
 test.describe('Language Filtering', () => {

--- a/e2e/content/language-selector.spec.ts
+++ b/e2e/content/language-selector.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test } from '@prometheus/e2e-toolkit'
 import { ContentPage } from '../pages/ContentPage'
 
 test.describe('Language Selector', () => {

--- a/e2e/content/section-switching.spec.ts
+++ b/e2e/content/section-switching.spec.ts
@@ -1,58 +1,65 @@
-import { expect, test } from '@playwright/test'
+import {
+  click,
+  expect,
+  expectVisible,
+  test,
+  visit,
+  waitForCondition,
+} from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 
 test.describe('Content Section Switching', () => {
-  // Content views do not render an h1 — the active nav link identifies the
-  // current section. These tests assert the URL and that the list renders.
+  /*
+   * Content views do not render an h1 — the active nav link
+   * identifies the current section. These tests assert the URL
+   * and that the list renders.
+   */
   test('should load blog content when navigating to /content/blog', async ({
     page,
   }) => {
-    await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/blog')
     await waitForContentReady(page)
 
     expect(page.url()).toContain('/content/blog')
-    await expect(page.locator('[data-testid="content-list"]')).toBeVisible()
+    await expectVisible(page, page.locator('[data-testid="content-list"]'))
   })
 
   test('should load positions content when navigating to /content/positions', async ({
     page,
   }) => {
-    await page.goto('/content/positions')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/positions')
     await waitForContentReady(page)
 
     expect(page.url()).toContain('/content/positions')
-    await expect(page.locator('[data-testid="content-list"]')).toBeVisible()
+    await expectVisible(page, page.locator('[data-testid="content-list"]'))
   })
 
   test('should load pages content when navigating to /content/pages', async ({
     page,
   }) => {
-    await page.goto('/content/pages')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/pages')
     await waitForContentReady(page)
 
     expect(page.url()).toContain('/content/pages')
-    await expect(page.locator('[data-testid="content-list"]')).toBeVisible()
+    await expectVisible(page, page.locator('[data-testid="content-list"]'))
   })
 
   test('should update content list when switching from blog to positions', async ({
     page,
   }) => {
-    await page.goto('/content/blog')
-    await page
-      .locator('[data-testid="content-item"]')
-      .first()
-      .waitFor({ state: 'visible', timeout: 15000 })
-
+    await visit(page, '/content/blog')
+    await expectVisible(
+      page,
+      page.locator('[data-testid="content-item"]').first()
+    )
     const blogItems = await page
       .locator('[data-testid="content-item"]')
       .count()
 
-    await page.click('a[href="/content/positions"]')
-    await page.waitForURL('/content/positions')
-    await page.waitForLoadState('networkidle')
+    await click(page, page.locator('a[href="/content/positions"]'))
+    await waitForCondition(page, async () =>
+      page.url().includes('/content/positions')
+    )
     await waitForContentReady(page)
 
     expect(blogItems).toBeGreaterThan(0)
@@ -61,32 +68,31 @@ test.describe('Content Section Switching', () => {
   test('should update content list when switching from positions to pages', async ({
     page,
   }) => {
-    await page.goto('/content/positions')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/positions')
     await waitForContentReady(page)
 
-    await page.click('a[href="/content/pages"]')
-    await page.waitForURL('/content/pages')
-    await page.waitForLoadState('networkidle')
+    await click(page, page.locator('a[href="/content/pages"]'))
+    await waitForCondition(page, async () =>
+      page.url().includes('/content/pages')
+    )
     await waitForContentReady(page)
 
-    await expect(page.locator('[data-testid="content-list"]')).toBeVisible()
+    await expectVisible(page, page.locator('[data-testid="content-list"]'))
   })
 
   test('clicking item navigates to edit page instead of inline editor', async ({
     page,
   }) => {
-    await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
+    await visit(page, '/content/blog')
     await waitForContentReady(page)
 
     const firstItem = page.locator('[data-testid="content-item"]').first()
-    await firstItem.waitFor({ state: 'visible', timeout: 30000 })
-    await firstItem.click()
+    await expectVisible(page, firstItem)
+    await click(page, firstItem)
 
-    await page.waitForURL(/\/content\/blog\/edit\//, { timeout: 10000 })
-    await expect(
-      page.locator('[data-testid="markdown-editor"]')
-    ).toBeVisible()
+    await waitForCondition(page, async () =>
+      /\/content\/blog\/edit\//.test(page.url())
+    )
+    await expectVisible(page, page.locator('[data-testid="markdown-editor"]'))
   })
 })


### PR DESCRIPTION
Continues #169. cmd-* family (11) + command-panel + content-list/loading/switch + section-switching + language-filtering/selector — 18 specs.

Most just needed the import swap. content-loading and section-switching also dropped their networkidle waits for the toolkit's visit + URL-driven waitForCondition.

64/64 chromium pass in 1.3 min.