### PR TITLE
feat(admin): bulk-delete via list select mode

### DIFF
--- a/src/components/ContentList/ContentList.vue
+++ b/src/components/ContentList/ContentList.vue
@@ -13,22 +13,38 @@ const props = defineProps<{
   readonly hideCreate?: boolean
   readonly hideDelete?: boolean
   readonly deletingSlugs?: ReadonlySet<string>
+  readonly selectMode?: boolean
+  readonly selectedSlugs?: ReadonlySet<string>
 }>()
 
 const emit = defineEmits<{
   select: [item: ContentItem]
   create: []
   delete: [item: ContentItem]
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+  toggleSelect: [slug: string]
 }>()
 
 const filteredItems = computed(() =>
-  props.items.filter(item => item.lang === props.selectedLang)
+  props.items.filter((item) => item.lang === props.selectedLang)
 )
+
+const selectedCount = computed(() => props.selectedSlugs?.size ?? 0)
 </script>
 
 <template>
   <section class="content-list" data-testid="content-list">
-    <ContentListHeader v-if="!hideCreate" @create="emit('create')" />
+    <ContentListHeader
+      v-if="!hideCreate"
+      :select-mode="selectMode"
+      :selected-count="selectedCount"
+      @create="emit('create')"
+      @enter-select="emit('enterSelect')"
+      @exit-select="emit('exitSelect')"
+      @bulk-delete="emit('bulkDelete')"
+    />
     <output v-if="loading" class="loading">Loading content...</output>
     <ContentListEmpty
       v-else-if="filteredItems.length === 0"
@@ -42,7 +58,11 @@ const filteredItems = computed(() =>
       :selected="selectedPath === item.path"
       :hide-delete="hideDelete"
       :deleting="deletingSlugs?.has(item.slug) ?? false"
-      @click="emit('select', item)"
+      :select-mode="selectMode ?? false"
+      :checked="selectedSlugs?.has(item.slug) ?? false"
+      @click="
+        selectMode ? emit('toggleSelect', item.slug) : emit('select', item)
+      "
       @delete="emit('delete', item)"
     />
   </section>

--- a/src/components/ContentList/ContentListHeader.vue
+++ b/src/components/ContentList/ContentListHeader.vue
@@ -1,18 +1,30 @@
 <script setup lang="ts">
-const emit = defineEmits<{ create: [] }>()
+import ListHeaderActions from './ListHeaderActions.vue'
+
+defineProps<{
+  readonly selectMode?: boolean
+  readonly selectedCount?: number
+}>()
+
+defineEmits<{
+  create: []
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+}>()
 </script>
 
 <template>
   <header class="list-header">
     <h2>Content Files</h2>
-    <button
-      type="button"
-      class="btn btn-primary"
-      data-testid="create-button"
-      @click="emit('create')"
-    >
-      + New
-    </button>
+    <ListHeaderActions
+      :select-mode="selectMode"
+      :selected-count="selectedCount"
+      @create="$emit('create')"
+      @enter-select="$emit('enterSelect')"
+      @exit-select="$emit('exitSelect')"
+      @bulk-delete="$emit('bulkDelete')"
+    />
   </header>
 </template>
 
@@ -27,30 +39,13 @@ const emit = defineEmits<{ create: [] }>()
   top: 0;
   background: var(--color-background);
   z-index: 1;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 h2 {
   margin: 0;
   font-size: clamp(1.125rem, 2.5vw, 1.5rem);
   font-weight: 600;
-}
-
-.btn {
-  padding: clamp(0.5rem, 1.5vw, 0.75rem) clamp(1rem, 2vw, 1.5rem);
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: clamp(0.875rem, 2vw, 1rem);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.btn.btn-primary {
-  background: var(--color-heading);
-  color: var(--color-background);
-
-  &:hover {
-    opacity: 90%;
-  }
 }
 </style>

--- a/src/components/ContentList/ContentListItem.vue
+++ b/src/components/ContentList/ContentListItem.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
   readonly selected: boolean
   readonly hideDelete?: boolean
   readonly deleting?: boolean
+  readonly selectMode?: boolean
+  readonly checked?: boolean
 }>()
 
 const emit = defineEmits<{ click: []; delete: [] }>()
@@ -48,15 +50,18 @@ const description = computed(() => {
 <template>
   <article
     class="content-item"
-    :class="{ selected, deleting }"
+    :class="{ selected, deleting, 'in-select': selectMode, checked }"
     :inert="deleting || undefined"
     data-testid="content-item"
+    :data-selected="checked ? 'true' : undefined"
     @click="emit('click')"
   >
     <ItemHeader
       :title="String(item.frontmatter.title ?? '')"
       :lang="item.lang"
-      :show-delete="!hideDelete"
+      :show-delete="!hideDelete && !selectMode"
+      :show-checkbox="selectMode ?? false"
+      :checked="checked ?? false"
       @delete="emit('delete')"
     />
     <p
@@ -115,6 +120,19 @@ const description = computed(() => {
 .content-item.selected {
   background: var(--color-background-mute);
   border-color: var(--color-heading);
+}
+
+.content-item.in-select {
+  cursor: default;
+}
+
+.content-item.checked {
+  background: color-mix(
+    in srgb,
+    var(--color-accent) 12%,
+    var(--color-background)
+  );
+  border-color: var(--color-accent);
 }
 
 @media (hover: none) {

--- a/src/components/ContentList/ItemHeader.vue
+++ b/src/components/ContentList/ItemHeader.vue
@@ -6,6 +6,8 @@ defineProps<{
   title: string
   lang: Language
   showDelete?: boolean
+  showCheckbox?: boolean
+  checked?: boolean
 }>()
 
 const emit = defineEmits<{ delete: [] }>()
@@ -13,6 +15,15 @@ const emit = defineEmits<{ delete: [] }>()
 
 <template>
   <header class="item-header">
+    <input
+      v-if="showCheckbox"
+      type="checkbox"
+      class="bulk-check"
+      data-testid="bulk-checkbox"
+      :checked="checked"
+      tabindex="-1"
+      aria-hidden="true"
+    >
     <h3>{{ title }}</h3>
     <DeleteButton
       v-if="showDelete"
@@ -40,6 +51,15 @@ h3 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.bulk-check {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  pointer-events: none;
+  accent-color: var(--color-accent);
+  flex-shrink: 0;
 }
 
 .lang-badge {

--- a/src/components/ContentList/ListHeaderActions.vue
+++ b/src/components/ContentList/ListHeaderActions.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+defineProps<{
+  readonly selectMode?: boolean
+  readonly selectedCount?: number
+}>()
+
+defineEmits<{
+  create: []
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+}>()
+</script>
+
+<template>
+  <template v-if="selectMode">
+    <span class="count" data-testid="bulk-count">
+      {{ selectedCount ?? 0 }} selected
+    </span>
+    <button
+      type="button"
+      class="btn btn-secondary"
+      data-testid="bulk-cancel"
+      @click="$emit('exitSelect')"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn-danger"
+      :disabled="(selectedCount ?? 0) === 0"
+      data-testid="bulk-delete"
+      @click="$emit('bulkDelete')"
+    >
+      Delete selected
+    </button>
+  </template>
+  <template v-else>
+    <button
+      type="button"
+      class="btn btn-secondary"
+      data-testid="select-mode"
+      @click="$emit('enterSelect')"
+    >
+      Select
+    </button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      data-testid="create-button"
+      @click="$emit('create')"
+    >
+      + New
+    </button>
+  </template>
+</template>
+
+<style scoped>
+.count {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.btn {
+  padding: clamp(0.5rem, 1.5vw, 0.75rem) clamp(1rem, 2vw, 1.5rem);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--color-heading);
+  color: var(--color-background);
+}
+
+.btn-primary:not(:disabled):hover {
+  opacity: 90%;
+}
+
+.btn-secondary {
+  background: var(--color-background-soft);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.btn-secondary:not(:disabled):hover {
+  background: var(--color-background-mute);
+}
+
+.btn-danger {
+  background: var(--color-error, #e53935);
+  color: #fff;
+}
+
+.btn-danger:not(:disabled):hover {
+  opacity: 90%;
+}
+</style>

--- a/src/views/ContentView/ContentViewMain.vue
+++ b/src/views/ContentView/ContentViewMain.vue
@@ -10,12 +10,18 @@ defineProps<{
   readonly hideCreate?: boolean
   readonly hideDelete?: boolean
   readonly deletingSlugs?: ReadonlySet<string>
+  readonly selectMode?: boolean
+  readonly selectedSlugs?: ReadonlySet<string>
 }>()
 
 const emit = defineEmits<{
   select: [item: ContentItem]
   create: []
   delete: [item: ContentItem]
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+  toggleSelect: [slug: string]
 }>()
 </script>
 
@@ -29,9 +35,15 @@ const emit = defineEmits<{
       :hide-create="hideCreate"
       :hide-delete="hideDelete"
       :deleting-slugs="deletingSlugs"
+      :select-mode="selectMode"
+      :selected-slugs="selectedSlugs"
       @select="emit('select', $event)"
       @create="isAuthenticated ? emit('create') : undefined"
       @delete="emit('delete', $event)"
+      @enter-select="emit('enterSelect')"
+      @exit-select="emit('exitSelect')"
+      @bulk-delete="emit('bulkDelete')"
+      @toggle-select="emit('toggleSelect', $event)"
     />
     <p v-if="!isAuthenticated" class="auth-required">
       Please log in to edit content

--- a/src/views/ContentView/bulk-delete-handler.ts
+++ b/src/views/ContentView/bulk-delete-handler.ts
@@ -1,0 +1,45 @@
+import { deleteAllVersions } from '@/composables/useGitHubApi/delete-content'
+import type { ContentType } from '@/types/content'
+
+interface BulkDeleteDeps {
+  readonly contentType: ContentType
+  readonly pushAndTrack: (message: string) => Promise<string>
+  readonly reload: () => Promise<void>
+}
+
+const buildMessage = (type: string, list: ReadonlyArray<string>): string =>
+  list.length === 1
+    ? `Delete all versions of ${type}/${list[0]}`
+    : `Bulk delete ${list.length} ${type} items`
+
+/**
+ * Stage every delete in parallel, commit them all under a single
+ * push+track call, then reload. Pulled out of runBulkDelete so the
+ * top-level helper can stay a one-liner ternary (no `if` allowed by
+ * the no-restricted-syntax rule).
+ * @param deps - Content type + push+track + reload.
+ * @param list - Slugs to delete.
+ * @returns void
+ */
+const execBulk = async (
+  deps: BulkDeleteDeps,
+  list: ReadonlyArray<string>
+): Promise<void> => {
+  await Promise.all(list.map(s => deleteAllVersions(deps.contentType, s)))
+  await deps.pushAndTrack(buildMessage(deps.contentType, list))
+  await deps.reload()
+}
+
+/**
+ * Bulk-delete entry point. Skips work when nothing is selected.
+ * Otherwise delegates to execBulk: a single commit per call instead
+ * of N commits, so the deploy log stays readable.
+ * @param deps - Content type, push+track, reload.
+ * @param slugs - Set of slugs to delete.
+ * @returns void
+ */
+export const runBulkDelete = (
+  deps: BulkDeleteDeps,
+  slugs: ReadonlySet<string>
+): Promise<void> =>
+  slugs.size === 0 ? Promise.resolve() : execBulk(deps, [...slugs])

--- a/src/views/ContentView/bulk-delete-state.ts
+++ b/src/views/ContentView/bulk-delete-state.ts
@@ -1,0 +1,41 @@
+import { type Ref, ref } from 'vue'
+
+/** Reactive state driving the bulk-select / bulk-delete UX. */
+export interface BulkDeleteState {
+  readonly selectMode: Ref<boolean>
+  readonly selectedSlugs: Ref<ReadonlySet<string>>
+  readonly enter: () => void
+  readonly exit: () => void
+  readonly toggle: (slug: string) => void
+}
+
+/**
+ * Build the in-memory state for the bulk-delete flow. The list view
+ * flips into "select mode" when the editor clicks Select; each row
+ * then accumulates a checkbox and clicking it toggles the slug in
+ * `selectedSlugs`. Exit clears the selection.
+ * @returns BulkDeleteState
+ */
+export const createBulkDeleteState = (): BulkDeleteState => {
+  const selectMode = ref(false)
+  const selectedSlugs = ref<ReadonlySet<string>>(new Set())
+  const enter = (): void => {
+    selectMode.value = true
+  }
+  const exit = (): void => {
+    selectMode.value = false
+    selectedSlugs.value = new Set()
+  }
+  const toggle = (slug: string): void => {
+    const next = new Set(selectedSlugs.value)
+    /*
+     * Toggle without an `if` (no-restricted-syntax forbids it).
+     * A delete that was a no-op gets undone by the conditional add,
+     * so the net effect is "flip membership".
+     */
+    const had = next.has(slug)
+    next.delete(slug)
+    selectedSlugs.value = had ? next : new Set([...next, slug])
+  }
+  return { selectMode, selectedSlugs, enter, exit, toggle }
+}


### PR DESCRIPTION
Closes ticket #5. List grows a Select toggle; in select mode each row gets a checkbox and the header offers `Cancel` + `Delete selected`. Bulk delete stages all picks in parallel and commits them under one push (`Bulk delete N items`).