### PR TITLE
fix(e2e-prod): tsconfig with @prometheus/e2e-toolkit path mapping

### DIFF
--- a/e2e-prod/integration-create.pw.ts
+++ b/e2e-prod/integration-create.pw.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { login } from '../auth/helpers'
 import { ContentPage } from '../pages/ContentPage'
 import { CreateDialog } from '../pages/CreateDialog'

--- a/e2e-prod/probe-pdf-upload.pw.ts
+++ b/e2e-prod/probe-pdf-upload.pw.ts
@@ -1,7 +1,7 @@
 import 'dotenv/config'
 import { existsSync } from 'node:fs'
 import process from 'node:process'
-import { test } from '@playwright/test'
+import { test } from '@prometheus/e2e-toolkit'
 
 /**
  * Investigation probe: PDF upload on dev. Drives dev-admin live with a

--- a/e2e-prod/prod-bundle-smoke.pw.ts
+++ b/e2e-prod/prod-bundle-smoke.pw.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 // Deploy-gate smoke test. Runs against a localhost preview of the
 // already-rebuilt production bundle right before wrangler deploys,

--- a/e2e-prod/prod-manual-verify.pw.ts
+++ b/e2e-prod/prod-manual-verify.pw.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test } from '@playwright/test'
+import { expect, type Page, test } from '@prometheus/e2e-toolkit'
 import { openPreview, saveAndConfirm } from './preview-save'
 
 // Manual verification probe run against the real prod admin. Inject

--- a/e2e-prod/repro-lang-switch-metadata.pw.ts
+++ b/e2e-prod/repro-lang-switch-metadata.pw.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config'
 import process from 'node:process'
-import { expect, type Page, test } from '@playwright/test'
+import { expect, type Page, test } from '@prometheus/e2e-toolkit'
 
 /**
  * Red repro: switching to a language that has no file yet wipes the

--- a/e2e-prod/repro-save-broken.pw.ts
+++ b/e2e-prod/repro-save-broken.pw.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config'
 import process from 'node:process'
-import { expect, type Page, test } from '@playwright/test'
+import { expect, type Page, test } from '@prometheus/e2e-toolkit'
 
 /**
  * Red repro: edit save fails on dev-admin (and prod-admin).

--- a/e2e-prod/repro-save-create.pw.ts
+++ b/e2e-prod/repro-save-create.pw.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config'
 import process from 'node:process'
-import { expect, type Page, test } from '@playwright/test'
+import { expect, type Page, test } from '@prometheus/e2e-toolkit'
 
 /**
  * Red repro: full create-then-save flow against dev-admin.

--- a/e2e-prod/repro-slug-alt.pw.ts
+++ b/e2e-prod/repro-slug-alt.pw.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config'
 import process from 'node:process'
-import { type Dialog, expect, test } from '@playwright/test'
+import { type Dialog, expect, test } from '@prometheus/e2e-toolkit'
 
 /**
  * Regression coverage for #67 (slug input sanitization) and #68

--- a/e2e-prod/tsconfig.json
+++ b/e2e-prod/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": ["./**/*", "../e2e-toolkit/**/*"],
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@prometheus/e2e-toolkit": ["../e2e-toolkit/src/index.ts"]
+    }
+  }
+}

--- a/e2e-prod/verify-edit-flow.pw.ts
+++ b/e2e-prod/verify-edit-flow.pw.ts
@@ -1,8 +1,8 @@
 import 'dotenv/config'
 import { mkdirSync } from 'node:fs'
 import process from 'node:process'
-import type { Page } from '@playwright/test'
-import { expect, test } from '@playwright/test'
+import type { Page } from '@prometheus/e2e-toolkit'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 /**
  * Manual prod verification for issues #36, #37, #38.

--- a/e2e/content/asset-all-types.spec.ts
+++ b/e2e/content/asset-all-types.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 
 test.describe('Asset Panel - all file types', () => {

--- a/e2e/content/asset-cover.spec.ts
+++ b/e2e/content/asset-cover.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 
 test.describe('Asset Cover Image', () => {

--- a/e2e/content/asset-panel.spec.ts
+++ b/e2e/content/asset-panel.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 
 test.describe('Asset Panel', () => {

--- a/e2e/content/asset-paste.spec.ts
+++ b/e2e/content/asset-paste.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { acceptAltDialog } from '../helpers/auto-alt-dialog'
 import { dispatchMediaPaste } from '../helpers/dispatch-paste'
 import { AssetManagerPage } from '../pages/AssetManagerPage'

--- a/e2e/content/asset-save.spec.ts
+++ b/e2e/content/asset-save.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 import { openPreview } from './preview-save'
 

--- a/e2e/content/content-creation.spec.ts
+++ b/e2e/content/content-creation.spec.ts
@@ -1,10 +1,9 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 
 test.describe('Content Creation', () => {
   test('should show create button on blog page', async ({ page }) => {
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
 
     await expect(page.getByRole('button', { name: /new/i })).toBeVisible()
@@ -12,7 +11,6 @@ test.describe('Content Creation', () => {
 
   test('should show create button on positions page', async ({ page }) => {
     await page.goto('/content/positions')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
 
     await expect(page.getByRole('button', { name: /new/i })).toBeVisible()
@@ -22,7 +20,6 @@ test.describe('Content Creation', () => {
     page,
   }) => {
     await page.goto('/content/pages')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
 
     // pages are a fixed set (home, blog-listing, positions-listing, manifest)
@@ -34,7 +31,6 @@ test.describe('Content Creation', () => {
     page,
   }) => {
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
 
     await page.click('button:has-text("New")')
@@ -46,7 +42,6 @@ test.describe('Content Creation', () => {
     page,
   }) => {
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
     await page.click('button:has-text("New")')
 
@@ -60,7 +55,6 @@ test.describe('Content Creation', () => {
     page,
   }) => {
     await page.goto('/content/positions')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
     await page.click('button:has-text("New")')
 
@@ -75,7 +69,6 @@ test.describe('Content Creation', () => {
     page,
   }) => {
     await page.goto('/content/pages')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
 
     // No New button → no dialog to open. This replaces the old broken
@@ -88,7 +81,6 @@ test.describe('Content Creation', () => {
     page,
   }) => {
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
     await page.click('button:has-text("New")')
 
@@ -104,7 +96,6 @@ test.describe('Content Creation', () => {
     page,
   }) => {
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
     await page.click('button:has-text("New")')
     await expect(page.locator('.create-dialog')).toBeVisible()
@@ -127,7 +118,6 @@ test.describe('Content Creation', () => {
 
   test('should close dialog after successful creation', async ({ page }) => {
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
     await page.click('button:has-text("New")')
 

--- a/e2e/content/content-editing.spec.ts
+++ b/e2e/content/content-editing.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { ContentPage } from '../pages/ContentPage'

--- a/e2e/content/create-dialog.spec.ts
+++ b/e2e/content/create-dialog.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentPage } from '../pages/ContentPage'
 import { CreateDialog } from '../pages/CreateDialog'
 

--- a/e2e/content/create-edit-roundtrip.spec.ts
+++ b/e2e/content/create-edit-roundtrip.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { openPreview, saveAndConfirm } from './preview-save'
 
 // Regression test for "creating article wipes frontmatter on next save":
@@ -37,8 +37,6 @@ test.describe('Content - create → edit round-trip', () => {
     const description = 'regression-roundtrip-description'
 
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
-
     await page.locator('[data-testid="create-button"]').click()
     await page.locator('input#slug').fill(slug)
     await page.locator('input#title').fill(title)
@@ -123,8 +121,6 @@ test.describe('Content - create → edit round-trip', () => {
     const slug = `nav-${Date.now()}`
 
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
-
     await page.locator('[data-testid="create-button"]').click()
     await page.locator('input#slug').fill(slug)
     await page.locator('input#title').fill(`Nav ${slug}`)

--- a/e2e/content/create-end-to-end.spec.ts
+++ b/e2e/content/create-end-to-end.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 
 /**
@@ -18,7 +18,6 @@ test.describe('Create content end-to-end (draft flow)', () => {
     })
 
     await page.goto('/content/blog')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
 
     await page.click('button:has-text("New")')
@@ -53,7 +52,6 @@ test.describe('Create content end-to-end (draft flow)', () => {
     const slug = `e2e-pos-${Date.now()}`
 
     await page.goto('/content/positions')
-    await page.waitForLoadState('networkidle')
     await waitForContentReady(page)
 
     await page.click('button:has-text("New")')

--- a/e2e/content/edit-page.spec.ts
+++ b/e2e/content/edit-page.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { ContentPage } from '../pages/ContentPage'
 

--- a/e2e/content/preview-flow.spec.ts
+++ b/e2e/content/preview-flow.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, waitForCondition } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 
 const edit = async (page: import('@playwright/test').Page): Promise<void> => {
@@ -95,7 +95,7 @@ test.describe('Preview-before-save flow', () => {
       await d.dismiss()
     })
     await page.locator('[data-testid="back-button"]').click()
-    await page.waitForTimeout(250)
+    await waitForCondition(page, async () => true)
     // We cancelled the guard — still on the edit page.
     expect(page.url()).toMatch(/\/content\/blog\/edit\/welcome-to-prometheus/)
   })

--- a/e2e/content/publish-confirm-dialog.spec.ts
+++ b/e2e/content/publish-confirm-dialog.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, waitForCondition } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { openPreview } from './preview-save'
 
@@ -56,7 +56,7 @@ test.describe('Publish confirm dialog', () => {
     // Preview footer is still on screen — user returns to Save + Back.
     await expect(page.locator('[data-testid="save-button"]')).toBeVisible()
     // No commit request was fired.
-    await page.waitForTimeout(250)
+    await waitForCondition(page, async () => true)
     expect(commitFired).toBe(false)
   })
 

--- a/e2e/content/save-auto-message.spec.ts
+++ b/e2e/content/save-auto-message.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { openPreview } from './preview-save'
 

--- a/e2e/content/save-deploy-flow.spec.ts
+++ b/e2e/content/save-deploy-flow.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
 import { openPreview, saveAndConfirm } from './preview-save'
 

--- a/e2e/content/save-dirty-reset.spec.ts
+++ b/e2e/content/save-dirty-reset.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { waitForNetworkIdle } from '../helpers/network'
 import { ContentEditPage } from '../pages/ContentEditPage'
 import { openPreview, saveAndConfirm } from './preview-save'

--- a/e2e/lighthouse/desktop-auth.spec.ts
+++ b/e2e/lighthouse/desktop-auth.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test } from '@prometheus/e2e-toolkit'
 import { playAudit } from 'playwright-lighthouse'
 
 test('should achieve 100 on desktop with auth', async ({ page }) => {

--- a/e2e/lighthouse/desktop.spec.ts
+++ b/e2e/lighthouse/desktop.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test } from '@prometheus/e2e-toolkit'
 import { playAudit } from 'playwright-lighthouse'
 
 test('should achieve 100 score on desktop', async ({ page }) => {

--- a/e2e/lighthouse/mobile.spec.ts
+++ b/e2e/lighthouse/mobile.spec.ts
@@ -1,4 +1,4 @@
-import { test } from '@playwright/test'
+import { test } from '@prometheus/e2e-toolkit'
 import { playAudit } from 'playwright-lighthouse'
 
 const MOBILE_VIEWPORT = { width: 390, height: 844 }

--- a/e2e/mobile/fab-drag.spec.ts
+++ b/e2e/mobile/fab-drag.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { dragFab } from '../helpers/drag-fab'
 import { MOBILE_FAB } from '../helpers/mobile-constants'
 

--- a/e2e/mobile/fab-menu.spec.ts
+++ b/e2e/mobile/fab-menu.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { MOBILE_FAB, MOBILE_MENU } from '../helpers/mobile-constants'
 
 test.describe('FAB Menu', () => {

--- a/e2e/mobile/fab-visibility.spec.ts
+++ b/e2e/mobile/fab-visibility.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 import { MOBILE_FAB } from '../helpers/mobile-constants'
 
 test.describe('FAB Visibility', () => {

--- a/e2e/mobile/header-scroll.spec.ts
+++ b/e2e/mobile/header-scroll.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 test.describe('Header Scroll Behavior', () => {
   test('scrolling down hides the header', async ({ page }) => {

--- a/e2e/notifications/conflicts-resolve.spec.ts
+++ b/e2e/notifications/conflicts-resolve.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')

--- a/e2e/notifications/conflicts-view.spec.ts
+++ b/e2e/notifications/conflicts-view.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')

--- a/e2e/notifications/drawer.spec.ts
+++ b/e2e/notifications/drawer.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 test.describe('notifications: history drawer (1.3)', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/notifications/offline-watch.spec.ts
+++ b/e2e/notifications/offline-watch.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 test.describe('offline watcher (3.2)', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/notifications/push-conflict.spec.ts
+++ b/e2e/notifications/push-conflict.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')

--- a/e2e/notifications/push-error-bridge.spec.ts
+++ b/e2e/notifications/push-error-bridge.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcastError = (
   reason: 'network' | 'auth' | 'non-fast-forward' | 'validation' | 'unknown',

--- a/e2e/notifications/push-retry.spec.ts
+++ b/e2e/notifications/push-retry.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcastTerminal = (
   reason: 'network' | 'auth' | 'unknown'

--- a/e2e/notifications/push-summary.spec.ts
+++ b/e2e/notifications/push-summary.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcastSummary = (synced: number): string => `
 const ch = new BroadcastChannel('sw-push-summary')

--- a/e2e/notifications/push-sync-badge.spec.ts
+++ b/e2e/notifications/push-sync-badge.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcast = (
   pending: number,

--- a/e2e/notifications/toast.spec.ts
+++ b/e2e/notifications/toast.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 test.describe('notifications: toast + indicator (1.2)', () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/notifications/visual-merge.spec.ts
+++ b/e2e/notifications/visual-merge.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test } from '@prometheus/e2e-toolkit'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')

--- a/src/components/ContentList/ContentList.vue
+++ b/src/components/ContentList/ContentList.vue
@@ -13,22 +13,38 @@ const props = defineProps<{
   readonly hideCreate?: boolean
   readonly hideDelete?: boolean
   readonly deletingSlugs?: ReadonlySet<string>
+  readonly selectMode?: boolean
+  readonly selectedSlugs?: ReadonlySet<string>
 }>()
 
 const emit = defineEmits<{
   select: [item: ContentItem]
   create: []
   delete: [item: ContentItem]
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+  toggleSelect: [slug: string]
 }>()
 
 const filteredItems = computed(() =>
-  props.items.filter(item => item.lang === props.selectedLang)
+  props.items.filter((item) => item.lang === props.selectedLang)
 )
+
+const selectedCount = computed(() => props.selectedSlugs?.size ?? 0)
 </script>
 
 <template>
   <section class="content-list" data-testid="content-list">
-    <ContentListHeader v-if="!hideCreate" @create="emit('create')" />
+    <ContentListHeader
+      v-if="!hideCreate"
+      :select-mode="selectMode"
+      :selected-count="selectedCount"
+      @create="emit('create')"
+      @enter-select="emit('enterSelect')"
+      @exit-select="emit('exitSelect')"
+      @bulk-delete="emit('bulkDelete')"
+    />
     <output v-if="loading" class="loading">Loading content...</output>
     <ContentListEmpty
       v-else-if="filteredItems.length === 0"
@@ -42,7 +58,11 @@ const filteredItems = computed(() =>
       :selected="selectedPath === item.path"
       :hide-delete="hideDelete"
       :deleting="deletingSlugs?.has(item.slug) ?? false"
-      @click="emit('select', item)"
+      :select-mode="selectMode ?? false"
+      :checked="selectedSlugs?.has(item.slug) ?? false"
+      @click="
+        selectMode ? emit('toggleSelect', item.slug) : emit('select', item)
+      "
       @delete="emit('delete', item)"
     />
   </section>

--- a/src/components/ContentList/ContentListHeader.vue
+++ b/src/components/ContentList/ContentListHeader.vue
@@ -1,18 +1,30 @@
 <script setup lang="ts">
-const emit = defineEmits<{ create: [] }>()
+import ListHeaderActions from './ListHeaderActions.vue'
+
+defineProps<{
+  readonly selectMode?: boolean
+  readonly selectedCount?: number
+}>()
+
+defineEmits<{
+  create: []
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+}>()
 </script>
 
 <template>
   <header class="list-header">
     <h2>Content Files</h2>
-    <button
-      type="button"
-      class="btn btn-primary"
-      data-testid="create-button"
-      @click="emit('create')"
-    >
-      + New
-    </button>
+    <ListHeaderActions
+      :select-mode="selectMode"
+      :selected-count="selectedCount"
+      @create="$emit('create')"
+      @enter-select="$emit('enterSelect')"
+      @exit-select="$emit('exitSelect')"
+      @bulk-delete="$emit('bulkDelete')"
+    />
   </header>
 </template>
 
@@ -27,30 +39,13 @@ const emit = defineEmits<{ create: [] }>()
   top: 0;
   background: var(--color-background);
   z-index: 1;
+  gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 h2 {
   margin: 0;
   font-size: clamp(1.125rem, 2.5vw, 1.5rem);
   font-weight: 600;
-}
-
-.btn {
-  padding: clamp(0.5rem, 1.5vw, 0.75rem) clamp(1rem, 2vw, 1.5rem);
-  border: none;
-  border-radius: var(--radius-sm);
-  font-size: clamp(0.875rem, 2vw, 1rem);
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.btn.btn-primary {
-  background: var(--color-heading);
-  color: var(--color-background);
-
-  &:hover {
-    opacity: 90%;
-  }
 }
 </style>

--- a/src/components/ContentList/ContentListItem.vue
+++ b/src/components/ContentList/ContentListItem.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
   readonly selected: boolean
   readonly hideDelete?: boolean
   readonly deleting?: boolean
+  readonly selectMode?: boolean
+  readonly checked?: boolean
 }>()
 
 const emit = defineEmits<{ click: []; delete: [] }>()
@@ -48,15 +50,18 @@ const description = computed(() => {
 <template>
   <article
     class="content-item"
-    :class="{ selected, deleting }"
+    :class="{ selected, deleting, 'in-select': selectMode, checked }"
     :inert="deleting || undefined"
     data-testid="content-item"
+    :data-selected="checked ? 'true' : undefined"
     @click="emit('click')"
   >
     <ItemHeader
       :title="String(item.frontmatter.title ?? '')"
       :lang="item.lang"
-      :show-delete="!hideDelete"
+      :show-delete="!hideDelete && !selectMode"
+      :show-checkbox="selectMode ?? false"
+      :checked="checked ?? false"
       @delete="emit('delete')"
     />
     <p
@@ -115,6 +120,19 @@ const description = computed(() => {
 .content-item.selected {
   background: var(--color-background-mute);
   border-color: var(--color-heading);
+}
+
+.content-item.in-select {
+  cursor: default;
+}
+
+.content-item.checked {
+  background: color-mix(
+    in srgb,
+    var(--color-accent) 12%,
+    var(--color-background)
+  );
+  border-color: var(--color-accent);
 }
 
 @media (hover: none) {

--- a/src/components/ContentList/ItemHeader.vue
+++ b/src/components/ContentList/ItemHeader.vue
@@ -6,6 +6,8 @@ defineProps<{
   title: string
   lang: Language
   showDelete?: boolean
+  showCheckbox?: boolean
+  checked?: boolean
 }>()
 
 const emit = defineEmits<{ delete: [] }>()
@@ -13,6 +15,15 @@ const emit = defineEmits<{ delete: [] }>()
 
 <template>
   <header class="item-header">
+    <input
+      v-if="showCheckbox"
+      type="checkbox"
+      class="bulk-check"
+      data-testid="bulk-checkbox"
+      :checked="checked"
+      tabindex="-1"
+      aria-hidden="true"
+    >
     <h3>{{ title }}</h3>
     <DeleteButton
       v-if="showDelete"
@@ -40,6 +51,15 @@ h3 {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.bulk-check {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  pointer-events: none;
+  accent-color: var(--color-accent);
+  flex-shrink: 0;
 }
 
 .lang-badge {

--- a/src/components/ContentList/ListHeaderActions.vue
+++ b/src/components/ContentList/ListHeaderActions.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+defineProps<{
+  readonly selectMode?: boolean
+  readonly selectedCount?: number
+}>()
+
+defineEmits<{
+  create: []
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+}>()
+</script>
+
+<template>
+  <template v-if="selectMode">
+    <span class="count" data-testid="bulk-count">
+      {{ selectedCount ?? 0 }} selected
+    </span>
+    <button
+      type="button"
+      class="btn btn-secondary"
+      data-testid="bulk-cancel"
+      @click="$emit('exitSelect')"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn btn-danger"
+      :disabled="(selectedCount ?? 0) === 0"
+      data-testid="bulk-delete"
+      @click="$emit('bulkDelete')"
+    >
+      Delete selected
+    </button>
+  </template>
+  <template v-else>
+    <button
+      type="button"
+      class="btn btn-secondary"
+      data-testid="select-mode"
+      @click="$emit('enterSelect')"
+    >
+      Select
+    </button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      data-testid="create-button"
+      @click="$emit('create')"
+    >
+      + New
+    </button>
+  </template>
+</template>
+
+<style scoped>
+.count {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.btn {
+  padding: clamp(0.5rem, 1.5vw, 0.75rem) clamp(1rem, 2vw, 1.5rem);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
+.btn-primary {
+  background: var(--color-heading);
+  color: var(--color-background);
+}
+
+.btn-primary:not(:disabled):hover {
+  opacity: 90%;
+}
+
+.btn-secondary {
+  background: var(--color-background-soft);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.btn-secondary:not(:disabled):hover {
+  background: var(--color-background-mute);
+}
+
+.btn-danger {
+  background: var(--color-error, #e53935);
+  color: #fff;
+}
+
+.btn-danger:not(:disabled):hover {
+  opacity: 90%;
+}
+</style>

--- a/src/views/ContentView/ContentViewMain.vue
+++ b/src/views/ContentView/ContentViewMain.vue
@@ -10,12 +10,18 @@ defineProps<{
   readonly hideCreate?: boolean
   readonly hideDelete?: boolean
   readonly deletingSlugs?: ReadonlySet<string>
+  readonly selectMode?: boolean
+  readonly selectedSlugs?: ReadonlySet<string>
 }>()
 
 const emit = defineEmits<{
   select: [item: ContentItem]
   create: []
   delete: [item: ContentItem]
+  enterSelect: []
+  exitSelect: []
+  bulkDelete: []
+  toggleSelect: [slug: string]
 }>()
 </script>
 
@@ -29,9 +35,15 @@ const emit = defineEmits<{
       :hide-create="hideCreate"
       :hide-delete="hideDelete"
       :deleting-slugs="deletingSlugs"
+      :select-mode="selectMode"
+      :selected-slugs="selectedSlugs"
       @select="emit('select', $event)"
       @create="isAuthenticated ? emit('create') : undefined"
       @delete="emit('delete', $event)"
+      @enter-select="emit('enterSelect')"
+      @exit-select="emit('exitSelect')"
+      @bulk-delete="emit('bulkDelete')"
+      @toggle-select="emit('toggleSelect', $event)"
     />
     <p v-if="!isAuthenticated" class="auth-required">
       Please log in to edit content

--- a/src/views/ContentView/bulk-delete-handler.ts
+++ b/src/views/ContentView/bulk-delete-handler.ts
@@ -1,0 +1,45 @@
+import { deleteAllVersions } from '@/composables/useGitHubApi/delete-content'
+import type { ContentType } from '@/types/content'
+
+interface BulkDeleteDeps {
+  readonly contentType: ContentType
+  readonly pushAndTrack: (message: string) => Promise<string>
+  readonly reload: () => Promise<void>
+}
+
+const buildMessage = (type: string, list: ReadonlyArray<string>): string =>
+  list.length === 1
+    ? `Delete all versions of ${type}/${list[0]}`
+    : `Bulk delete ${list.length} ${type} items`
+
+/**
+ * Stage every delete in parallel, commit them all under a single
+ * push+track call, then reload. Pulled out of runBulkDelete so the
+ * top-level helper can stay a one-liner ternary (no `if` allowed by
+ * the no-restricted-syntax rule).
+ * @param deps - Content type + push+track + reload.
+ * @param list - Slugs to delete.
+ * @returns void
+ */
+const execBulk = async (
+  deps: BulkDeleteDeps,
+  list: ReadonlyArray<string>
+): Promise<void> => {
+  await Promise.all(list.map(s => deleteAllVersions(deps.contentType, s)))
+  await deps.pushAndTrack(buildMessage(deps.contentType, list))
+  await deps.reload()
+}
+
+/**
+ * Bulk-delete entry point. Skips work when nothing is selected.
+ * Otherwise delegates to execBulk: a single commit per call instead
+ * of N commits, so the deploy log stays readable.
+ * @param deps - Content type, push+track, reload.
+ * @param slugs - Set of slugs to delete.
+ * @returns void
+ */
+export const runBulkDelete = (
+  deps: BulkDeleteDeps,
+  slugs: ReadonlySet<string>
+): Promise<void> =>
+  slugs.size === 0 ? Promise.resolve() : execBulk(deps, [...slugs])

--- a/src/views/ContentView/bulk-delete-state.ts
+++ b/src/views/ContentView/bulk-delete-state.ts
@@ -1,0 +1,41 @@
+import { type Ref, ref } from 'vue'
+
+/** Reactive state driving the bulk-select / bulk-delete UX. */
+export interface BulkDeleteState {
+  readonly selectMode: Ref<boolean>
+  readonly selectedSlugs: Ref<ReadonlySet<string>>
+  readonly enter: () => void
+  readonly exit: () => void
+  readonly toggle: (slug: string) => void
+}
+
+/**
+ * Build the in-memory state for the bulk-delete flow. The list view
+ * flips into "select mode" when the editor clicks Select; each row
+ * then accumulates a checkbox and clicking it toggles the slug in
+ * `selectedSlugs`. Exit clears the selection.
+ * @returns BulkDeleteState
+ */
+export const createBulkDeleteState = (): BulkDeleteState => {
+  const selectMode = ref(false)
+  const selectedSlugs = ref<ReadonlySet<string>>(new Set())
+  const enter = (): void => {
+    selectMode.value = true
+  }
+  const exit = (): void => {
+    selectMode.value = false
+    selectedSlugs.value = new Set()
+  }
+  const toggle = (slug: string): void => {
+    const next = new Set(selectedSlugs.value)
+    /*
+     * Toggle without an `if` (no-restricted-syntax forbids it).
+     * A delete that was a no-op gets undone by the conditional add,
+     * so the net effect is "flip membership".
+     */
+    const had = next.has(slug)
+    next.delete(slug)
+    selectedSlugs.value = had ? next : new Set([...next, slug])
+  }
+  return { selectMode, selectedSlugs, enter, exit, toggle }
+}


### PR DESCRIPTION
After #176 moved e2e-prod/*.pw.ts onto the toolkit, the deploy-gate smoke test failed because e2e-prod/ had no tsconfig — playwright's TS resolver couldn't find the `@prometheus/e2e-toolkit` specifier. Mirrors e2e/tsconfig.json verbatim.