### PR TITLE
feat: admin docx upload for newspaper issues (#8 follow-up)

### DIFF
--- a/src/components/MarkdownEditor/DocxUpload.vue
+++ b/src/components/MarkdownEditor/DocxUpload.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { AssetDisplay } from '@/composables/useAssets/types'
+import { createDragHandlers } from './pdf-upload-handlers'
+
+const props = defineProps<{
+  readonly assets?: readonly AssetDisplay[]
+}>()
+
+const emit = defineEmits<{
+  'upload-docx': [file: File]
+}>()
+
+const inputRef = ref<HTMLInputElement>()
+const dragging = ref(false)
+
+const DOCX_MIME =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+const docxAsset = computed(() =>
+  props.assets?.find(
+    a => a.mimeType === DOCX_MIME && a.status !== 'pending-delete'
+  )
+)
+
+const triggerUpload = () => {
+  inputRef.value?.click()
+}
+
+/*
+ * Newspaper issues can ship a .docx alongside the PDF; the public
+ * site's build integration converts it to FB2 for offline e-readers
+ * (public-website#72). The MIME check is the OOXML wordprocessingml
+ * variant — old binary .doc is rejected so we don't break the FB2
+ * pipeline that expects mammoth-readable input.
+ */
+const handleFile = (file: File): void => {
+  if (file.type !== DOCX_MIME) return
+  emit('upload-docx', file)
+}
+
+const handleChange = (event: Event): void => {
+  if (!(event.target instanceof HTMLInputElement)) return
+  const file = event.target.files?.[0]
+  if (file) handleFile(file)
+  event.target.value = ''
+}
+
+const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
+  dragging,
+  handleFile
+)
+</script>
+
+<template>
+  <article
+    v-if="docxAsset"
+    class="docx-current"
+    data-testid="docx-current"
+  >
+    <span class="docx-icon" aria-hidden="true">DOCX</span>
+    <span class="docx-name">{{ docxAsset.name }}</span>
+    <button
+      type="button"
+      class="docx-replace"
+      @click="triggerUpload"
+    >
+      Replace DOCX
+    </button>
+  </article>
+  <button
+    v-else
+    type="button"
+    class="docx-dropzone"
+    :class="{ dragging }"
+    data-testid="docx-dropzone"
+    @click="triggerUpload"
+    @drop.prevent="onDrop"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+  >
+    <span class="dropzone-icon" aria-hidden="true">DOCX</span>
+    <span class="dropzone-label">
+      Drop a .docx file here or click to upload (auto-converts to FB2 on the
+      public site)
+    </span>
+  </button>
+  <input
+    ref="inputRef"
+    type="file"
+    :accept="DOCX_MIME"
+    hidden
+    @change="handleChange"
+  />
+</template>
+
+<style scoped>
+.docx-current {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+}
+
+.docx-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-sm);
+  background: var(--color-info, #1976d2);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.docx-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: clamp(0.875rem, 2vw, 1rem);
+}
+
+.docx-replace {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.875rem;
+  flex-shrink: 0;
+}
+
+.docx-replace:hover {
+  background: var(--color-background-mute);
+}
+
+.docx-dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.docx-dropzone:hover,
+.docx-dropzone.dragging {
+  border-color: var(--color-accent);
+  background: var(--color-background-mute);
+}
+
+.dropzone-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-md);
+  background: var(--color-info, #1976d2);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.dropzone-label {
+  color: var(--color-text-secondary);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  text-align: center;
+}
+</style>

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
 import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
 import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
@@ -49,6 +50,11 @@ const currentCover = (fm: Record<string, unknown>): string | undefined => {
     @upload-pdf="$emit('upload-asset', $event)"
     @upload-cover="$emit('upload-asset', $event)"
     @set-cover="$emit('set-cover', $event)"
+  />
+  <DocxUpload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    @upload-docx="$emit('upload-asset', $event)"
   />
   <MarkdownEditorBody
     v-else-if="hasBodyEditor(contentType, slug)"


### PR DESCRIPTION
## Summary

Pairs with [public-website#72](https://github.com/communist-prometheus/public-website/pull/72). Newspaper editors can now drop a \`.docx\` alongside the PDF. The asset hits the existing upload pipeline unchanged; on the next public-site build, the \`newspaper-docx-fb2\` integration finds the docx and emits both a passthrough \`gazette.docx\` and a converted \`gazette.fb2\` into dist. The card surfaces DOCX + FB2 download links automatically.

## Implementation

- **\`DocxUpload.vue\`** — thin sibling to \`PdfUpload.vue\`. Same dropzone UX, OOXML \`wordprocessingml\` MIME check (rejects legacy \`.doc\`), no cover extraction. Reuses \`createDragHandlers\` from \`pdf-upload-handlers\`.
- **\`ContentEditMainBody\`** — renders \`<DocxUpload>\` alongside \`<PdfUpload>\` only for the \`newspaper\` content type. The \`upload-docx\` event flows into the same \`upload-asset\` handler the PDF + cover use.

Closes the editor-side half of [tickets#8](https://github.com/communist-prometheus/tickets/issues/8) (already closed; this delivers the upload UI promised in the close comment).

## Test plan

- [x] \`bun run build\` clean
- [ ] Manual: open a newspaper edit page, drop a .docx, save, verify it commits to git and the public-site card surfaces the download links after deploy