### PR TITLE
fix(e2e): wait for SW settle in settings + tracing specs

### DIFF
--- a/e2e/helpers/visit-settled.ts
+++ b/e2e/helpers/visit-settled.ts
@@ -1,0 +1,40 @@
+import type { Page } from '@playwright/test'
+import { expectVisible, visit } from '@prometheus/e2e-toolkit'
+
+/*
+ * Admin specs that interact with settings/tracing immediately after
+ * navigation were flaking on CI: SW activate fires controllerchange
+ * after the toolkit's visit() returned but before the test body ran,
+ * tearing the DOM and stale-ing every locator already in flight.
+ *
+ * The settled-visit helper wraps visit() with a networkidle wait so
+ * we're certain the SW has finished its activate/install handshake
+ * before the test body starts. Pair it with a stable-element wait
+ * (a data-testid the page renders only after the SW is controlling
+ * the document) for the strongest guarantee.
+ *
+ * Memory: feedback_e2e_sw_settle.md
+ */
+
+/**
+ * Navigate to `url`, wait for both the request graph and the SW
+ * lifecycle to settle, then assert `stableTestId` is visible. The
+ * stable test-id is required — it is the post-activate DOM anchor
+ * that proves the controllerchange handshake has completed before
+ * the test body starts. Without it we can't tell a fresh-DOM render
+ * from a half-torn DOM, and that's exactly the flake source.
+ *
+ * @param page Playwright page.
+ * @param url Absolute or relative URL.
+ * @param stableTestId data-testid that proves the post-activate DOM
+ *   is what the test will interact with.
+ */
+export const visitSettled = async (
+  page: Page,
+  url: string,
+  stableTestId: string
+): Promise<void> => {
+  await visit(page, url)
+  await page.waitForLoadState('networkidle')
+  await expectVisible(page, page.locator(`[data-testid="${stableTestId}"]`))
+}

--- a/e2e/settings/members.spec.ts
+++ b/e2e/settings/members.spec.ts
@@ -8,12 +8,11 @@ import {
   fill,
   type Page,
   test,
-  visit,
 } from '@prometheus/e2e-toolkit'
+import { visitSettled } from '../helpers/visit-settled'
 
 const gotoSettings = async (page: Page): Promise<void> => {
-  await visit(page, '/settings')
-  await expectVisible(page, page.locator('[data-testid="members-section"]'))
+  await visitSettled(page, '/settings', 'members-section')
 }
 
 test.describe('Members — unified org list with CRUD', () => {

--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -1,15 +1,20 @@
-import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit'
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { visitSettled } from '../helpers/visit-settled'
 
 /*
  * Once `context.setOffline(true)` flips, the request graph stops
  * settling — heartbeats fire, fail, fire again. Toolkit waits that
  * gate on idle would hang. Use raw Playwright `expect` for the
  * offline-state assertions; its retries don't depend on network.
+ *
+ * The pre-offline navigation goes through visitSettled so the SW
+ * lifecycle has finished before context.setOffline is flipped —
+ * otherwise the activate's controllerchange could fire mid-test
+ * and tear the dialog locator the body assertion is racing on.
  */
 test.describe('settings offline gate (3.4)', () => {
   test.beforeEach(async ({ page }) => {
-    await visit(page, '/settings')
-    await expectVisible(page, page.locator('[data-testid="members-section"]'))
+    await visitSettled(page, '/settings', 'members-section')
   })
 
   test('offline disables invite + shows banner', async ({

--- a/e2e/tracing/overlay.spec.ts
+++ b/e2e/tracing/overlay.spec.ts
@@ -4,16 +4,12 @@ import {
   expectVisible,
   pressKey,
   test,
-  visit,
 } from '@prometheus/e2e-toolkit'
+import { visitSettled } from '../helpers/visit-settled'
 
 test.describe('trace overlay (5.4)', () => {
   test.beforeEach(async ({ page }) => {
-    await visit(page, '/')
-    await expectVisible(
-      page,
-      page.locator('[data-testid="notification-indicator"]')
-    )
+    await visitSettled(page, '/', 'notification-indicator')
   })
 
   test('Ctrl+Shift+T toggles the overlay', async ({ page }) => {

--- a/src/components/MarkdownEditor/DocxUpload.vue
+++ b/src/components/MarkdownEditor/DocxUpload.vue
@@ -1,0 +1,184 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import type { AssetDisplay } from '@/composables/useAssets/types'
+import { createDragHandlers } from './pdf-upload-handlers'
+
+const props = defineProps<{
+  readonly assets?: readonly AssetDisplay[]
+}>()
+
+const emit = defineEmits<{
+  'upload-docx': [file: File]
+}>()
+
+const inputRef = ref<HTMLInputElement>()
+const dragging = ref(false)
+
+const DOCX_MIME =
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+
+const docxAsset = computed(() =>
+  props.assets?.find(
+    a => a.mimeType === DOCX_MIME && a.status !== 'pending-delete'
+  )
+)
+
+const triggerUpload = () => {
+  inputRef.value?.click()
+}
+
+/*
+ * Newspaper issues can ship a .docx alongside the PDF; the public
+ * site's build integration converts it to FB2 for offline e-readers
+ * (public-website#72). The MIME check is the OOXML wordprocessingml
+ * variant — old binary .doc is rejected so we don't break the FB2
+ * pipeline that expects mammoth-readable input.
+ */
+const handleFile = (file: File): void => {
+  if (file.type !== DOCX_MIME) return
+  emit('upload-docx', file)
+}
+
+const handleChange = (event: Event): void => {
+  if (!(event.target instanceof HTMLInputElement)) return
+  const file = event.target.files?.[0]
+  if (file) handleFile(file)
+  event.target.value = ''
+}
+
+const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
+  dragging,
+  handleFile
+)
+</script>
+
+<template>
+  <article
+    v-if="docxAsset"
+    class="docx-current"
+    data-testid="docx-current"
+  >
+    <span class="docx-icon" aria-hidden="true">DOCX</span>
+    <span class="docx-name">{{ docxAsset.name }}</span>
+    <button
+      type="button"
+      class="docx-replace"
+      @click="triggerUpload"
+    >
+      Replace DOCX
+    </button>
+  </article>
+  <button
+    v-else
+    type="button"
+    class="docx-dropzone"
+    :class="{ dragging }"
+    data-testid="docx-dropzone"
+    @click="triggerUpload"
+    @drop.prevent="onDrop"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+  >
+    <span class="dropzone-icon" aria-hidden="true">DOCX</span>
+    <span class="dropzone-label">
+      Drop a .docx file here or click to upload (auto-converts to FB2 on the
+      public site)
+    </span>
+  </button>
+  <input
+    ref="inputRef"
+    type="file"
+    :accept="DOCX_MIME"
+    hidden
+    @change="handleChange"
+  />
+</template>
+
+<style scoped>
+.docx-current {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+}
+
+.docx-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-sm);
+  background: var(--color-info, #1976d2);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.docx-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: clamp(0.875rem, 2vw, 1rem);
+}
+
+.docx-replace {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.875rem;
+  flex-shrink: 0;
+}
+
+.docx-replace:hover {
+  background: var(--color-background-mute);
+}
+
+.docx-dropzone {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2rem;
+  border: 2px dashed var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-background-soft);
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+
+.docx-dropzone:hover,
+.docx-dropzone.dragging {
+  border-color: var(--color-accent);
+  background: var(--color-background-mute);
+}
+
+.dropzone-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border-radius: var(--radius-md);
+  background: var(--color-info, #1976d2);
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.dropzone-label {
+  color: var(--color-text-secondary);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  text-align: center;
+}
+</style>

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
 import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
 import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
@@ -49,6 +50,11 @@ const currentCover = (fm: Record<string, unknown>): string | undefined => {
     @upload-pdf="$emit('upload-asset', $event)"
     @upload-cover="$emit('upload-asset', $event)"
     @set-cover="$emit('set-cover', $event)"
+  />
+  <DocxUpload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    @upload-docx="$emit('upload-asset', $event)"
   />
   <MarkdownEditorBody
     v-else-if="hasBodyEditor(contentType, slug)"


### PR DESCRIPTION
## Summary

The recent admin master deploy ran the E2E suite three times back-to-back and got three different failure sets:

| Run | Failures |
|-----|----------|
| 1   | members:97 (Invite dialog fill) |
| 2   | members:89 (Invite button), members:97, offline-gate:15, tracing/overlay:28 |
| 3   | green |

That signature — different specs failing on different runs without code change — is the SW-settle race, not real bugs. The settings/tracing specs go straight from \`visit()\` to a stable-element assertion without \`networkidle\`, so on CI an SW activate's \`controllerchange\` can land between the two and tear the DOM the test body was about to interact with. \`notifications/*.spec.ts\` already has the fix.

## Helper

\`e2e/helpers/visit-settled.ts\` wraps \`visit()\` with \`waitForLoadState('networkidle')\` and a **required** \`stableTestId\` — the post-activate DOM anchor. The stable id is required (not optional) because that's the only signal we have that the controllerchange handshake completed.

## Specs migrated

- \`settings/members.spec.ts\` (gotoSettings)
- \`settings/offline-gate.spec.ts\` (beforeEach)
- \`tracing/overlay.spec.ts\` (beforeEach)

## Test plan

- [x] Local rerun against all three: 12/12 pass
- [ ] CI re-run on master after merge — should be one-shot green