### PR TITLE
refactor(newspaper): docx as import source, add FB2 direct upload

### DIFF
--- a/src/components/MarkdownEditor/Fb2Upload.vue
+++ b/src/components/MarkdownEditor/Fb2Upload.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
-import { docxFileToFb2 } from './docx-to-fb2'
 import { createDragHandlers } from './pdf-upload-handlers'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
-  readonly issueTitle?: string
-  readonly issueLang?: string
-  readonly issueDescription?: string
 }>()
 
 const emit = defineEmits<{
@@ -18,9 +14,6 @@ const emit = defineEmits<{
 
 const inputRef = ref<HTMLInputElement>()
 const dragging = ref(false)
-
-const DOCX_MIME =
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
 const fb2Asset = computed(() =>
   props.assets?.find(
@@ -32,19 +25,21 @@ const triggerUpload = () => {
   inputRef.value?.click()
 }
 
-const handleFile = async (file: File): Promise<void> => {
-  if (file.type !== DOCX_MIME) {
-    emit('error', 'Only .docx files (Office Open XML) are accepted here')
+/*
+ * Direct FB2 upload — the editor already has the FB2 produced
+ * elsewhere (Calibre, scribus → fb2, hand-written, etc.) and just
+ * wants it shipped. Validates by extension since browsers don't
+ * agree on a MIME for application/x-fictionbook+xml.
+ */
+const handleFile = (file: File): void => {
+  if (!file.name.toLowerCase().endsWith('.fb2')) {
+    emit('error', 'Only .fb2 files are accepted here')
     return
   }
-  const fb2 = await docxFileToFb2(file, {
-    ...(props.issueTitle === undefined ? {} : { issueTitle: props.issueTitle }),
-    ...(props.issueLang === undefined ? {} : { issueLang: props.issueLang }),
-    ...(props.issueDescription === undefined
-      ? {}
-      : { issueDescription: props.issueDescription }),
+  const renamed = new File([file], 'gazette.fb2', {
+    type: file.type || 'application/x-fictionbook+xml',
   })
-  emit('upload-fb2', fb2)
+  emit('upload-fb2', renamed)
 }
 
 const handleChange = (event: Event): void => {
@@ -63,47 +58,44 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
 <template>
   <article
     v-if="fb2Asset"
-    class="docx-current"
-    data-testid="docx-current"
+    class="fb2-current"
+    data-testid="fb2-current"
   >
-    <span class="docx-icon" aria-hidden="true">FB2</span>
-    <span class="docx-name">FB2 ready ({{ fb2Asset.name }})</span>
+    <span class="fb2-icon" aria-hidden="true">FB2</span>
+    <span class="fb2-name">{{ fb2Asset.name }}</span>
     <button
       type="button"
-      class="docx-replace"
+      class="fb2-replace"
       @click="triggerUpload"
     >
-      Re-import from DOCX
+      Replace FB2
     </button>
   </article>
   <button
     v-else
     type="button"
-    class="docx-dropzone"
+    class="fb2-dropzone"
     :class="{ dragging }"
-    data-testid="docx-dropzone"
+    data-testid="fb2-dropzone"
     @click="triggerUpload"
     @drop.prevent="onDrop"
     @dragover="onDragOver"
     @dragleave="onDragLeave"
   >
-    <span class="dropzone-icon" aria-hidden="true">DOCX</span>
-    <span class="dropzone-label">
-      Drop a .docx to import (auto-converts to FB2; the .docx is
-      not stored — only the FB2 ships)
-    </span>
+    <span class="dropzone-icon" aria-hidden="true">FB2</span>
+    <span class="dropzone-label">Drop a .fb2 file directly</span>
   </button>
   <input
     ref="inputRef"
     type="file"
-    :accept="DOCX_MIME"
+    accept=".fb2"
     hidden
     @change="handleChange"
   />
 </template>
 
 <style scoped>
-.docx-current {
+.fb2-current {
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -113,21 +105,21 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   background: var(--color-background-soft);
 }
 
-.docx-icon {
+.fb2-icon {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 48px;
   height: 48px;
   border-radius: var(--radius-sm);
-  background: var(--color-info, #1976d2);
+  background: var(--color-success, #2e7d32);
   color: #fff;
   font-weight: 700;
   font-size: 0.75rem;
   flex-shrink: 0;
 }
 
-.docx-name {
+.fb2-name {
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -136,7 +128,7 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   font-size: clamp(0.875rem, 2vw, 1rem);
 }
 
-.docx-replace {
+.fb2-replace {
   padding: 0.375rem 0.75rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -147,17 +139,17 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   flex-shrink: 0;
 }
 
-.docx-replace:hover {
+.fb2-replace:hover {
   background: var(--color-background-mute);
 }
 
-.docx-dropzone {
+.fb2-dropzone {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.75rem;
-  padding: 2rem;
+  padding: 1.5rem;
   border: 2px dashed var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-background-soft);
@@ -165,8 +157,8 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   transition: border-color 0.2s, background 0.2s;
 }
 
-.docx-dropzone:hover,
-.docx-dropzone.dragging {
+.fb2-dropzone:hover,
+.fb2-dropzone.dragging {
   border-color: var(--color-accent);
   background: var(--color-background-mute);
 }
@@ -178,7 +170,7 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   width: 64px;
   height: 64px;
   border-radius: var(--radius-md);
-  background: var(--color-info, #1976d2);
+  background: var(--color-success, #2e7d32);
   color: #fff;
   font-weight: 700;
   font-size: 1rem;

--- a/src/components/MarkdownEditor/docx-to-fb2.ts
+++ b/src/components/MarkdownEditor/docx-to-fb2.ts
@@ -1,0 +1,36 @@
+import { convertDocxToHtml } from '@/components/MarkdownEditor/ImportDocs/convert-docx'
+import { htmlToFb2 } from '@/features/newspaper/html-to-fb2/html-to-fb2'
+
+/** Issue metadata baked into the FB2 description block. */
+export interface IssueMeta {
+  readonly issueTitle?: string
+  readonly issueLang?: string
+  readonly issueDescription?: string
+}
+
+const buildFb2Meta = (meta: IssueMeta) => ({
+  title: meta.issueTitle ?? 'Newspaper issue',
+  ...(meta.issueLang === undefined ? {} : { lang: meta.issueLang }),
+  ...(meta.issueDescription === undefined
+    ? {}
+    : { description: meta.issueDescription }),
+})
+
+/**
+ * Convert a `.docx` File client-side to an `.fb2` File. The docx
+ * itself is never persisted — we only emit the converted FB2.
+ *
+ * @param file Original `.docx` File from the upload widget.
+ * @param meta Issue metadata to bake into the FB2 title-info block.
+ * @returns A `gazette.fb2` File ready to feed the asset pipeline.
+ */
+export const docxFileToFb2 = async (
+  file: File,
+  meta: IssueMeta
+): Promise<File> => {
+  const buffer = await file.arrayBuffer()
+  const html = await convertDocxToHtml(buffer)
+  const fb2 = htmlToFb2(html, buildFb2Meta(meta))
+  const blob = new Blob([fb2], { type: 'application/x-fictionbook+xml' })
+  return new File([blob], 'gazette.fb2', { type: blob.type })
+}

--- a/src/features/newspaper/html-to-fb2/escape-xml.ts
+++ b/src/features/newspaper/html-to-fb2/escape-xml.ts
@@ -1,0 +1,14 @@
+/**
+ * Escape XML-unsafe characters in a text node value before
+ * embedding into FB2 markup.
+ *
+ * @param s Raw string from a DOM text node or attribute.
+ * @returns String safe to embed verbatim into XML.
+ */
+export const escapeXml = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')

--- a/src/features/newspaper/html-to-fb2/html-to-fb2.ts
+++ b/src/features/newspaper/html-to-fb2/html-to-fb2.ts
@@ -1,0 +1,57 @@
+import { escapeXml } from './escape-xml'
+import { renderSections } from './render-sections'
+import { splitIntoSections } from './split-sections'
+
+/** Required + optional metadata baked into the FB2 description block. */
+export interface FB2Meta {
+  readonly title: string
+  readonly author?: string
+  readonly lang?: string
+  readonly description?: string
+}
+
+const parseFragment = (html: string): Element => {
+  const doc = new DOMParser().parseFromString(
+    `<div>${html}</div>`,
+    'text/html'
+  )
+  return doc.querySelector('div') ?? doc.body
+}
+
+const titleInfo = (meta: FB2Meta): string => {
+  const lang = meta.lang ?? 'ru'
+  const author = meta.author ?? 'Communist Prometheus'
+  const description = meta.description ?? ''
+  const annotation = description
+    ? `<annotation><p>${escapeXml(description)}</p></annotation>`
+    : ''
+  return `      <book-title>${escapeXml(meta.title)}</book-title>
+      <author><nickname>${escapeXml(author)}</nickname></author>
+      <lang>${escapeXml(lang)}</lang>
+      ${annotation}`
+}
+
+/**
+ * Convert mammoth HTML output to a complete FB2 XML document.
+ * Browser-side: uses native DOMParser so the bundle stays small.
+ *
+ * @param html Mammoth HTML.
+ * @param meta Required title plus optional author/lang/description.
+ * @returns FB2 XML document (UTF-8 declared).
+ */
+export const htmlToFb2 = (html: string, meta: FB2Meta): string => {
+  const sections = splitIntoSections(parseFragment(html))
+  const body = renderSections(sections, meta.title)
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+  <description>
+    <title-info>
+${titleInfo(meta)}
+    </title-info>
+  </description>
+  <body>
+${body}
+  </body>
+</FictionBook>
+`
+}

--- a/src/features/newspaper/html-to-fb2/render-block.ts
+++ b/src/features/newspaper/html-to-fb2/render-block.ts
@@ -1,0 +1,37 @@
+import { renderInline } from './render-inline'
+
+const collectListItems = (el: Element): string[] =>
+  Array.from(el.children)
+    .filter(c => c.tagName.toLowerCase() === 'li')
+    .map(li => Array.from(li.childNodes).map(renderInline).join(''))
+
+const renderList = (el: Element): string =>
+  collectListItems(el)
+    .map(item => `<p>• ${item}</p>`)
+    .join('\n')
+
+const renderParagraph = (el: Element): string => {
+  const inner = Array.from(el.childNodes).map(renderInline).join('').trim()
+  return inner === '' ? '' : `<p>${inner}</p>`
+}
+
+/**
+ * Render a block-level DOM element to its FB2 equivalent. <p> stays
+ * as <p>; <ul>/<ol> flatten to bulleted paragraphs (FB2 has no
+ * native list construct in baseline); <br> at block level becomes
+ * <empty-line/>; everything else is dropped.
+ *
+ * @param el Block-level DOM element.
+ * @returns FB2-compatible XML fragment, or empty string when nothing
+ *   meaningful comes out (mammoth often emits blank paragraphs).
+ */
+export const renderBlock = (el: Element): string => {
+  const tag = el.tagName.toLowerCase()
+  return tag === 'p'
+    ? renderParagraph(el)
+    : tag === 'ul' || tag === 'ol'
+      ? renderList(el)
+      : tag === 'br'
+        ? '<empty-line/>'
+        : ''
+}

--- a/src/features/newspaper/html-to-fb2/render-inline.ts
+++ b/src/features/newspaper/html-to-fb2/render-inline.ts
@@ -1,0 +1,42 @@
+import { escapeXml } from './escape-xml'
+
+const inlineFor = (tag: string): string | undefined =>
+  tag === 'strong' || tag === 'b'
+    ? 'strong'
+    : tag === 'em' || tag === 'i'
+      ? 'emphasis'
+      : undefined
+
+const renderAnchor = (el: Element, inner: string): string => {
+  const href = el.getAttribute('href') ?? ''
+  return `<a l:href="${escapeXml(href)}">${inner}</a>`
+}
+
+const renderElement = (el: Element): string => {
+  const tag = el.tagName.toLowerCase()
+  const inner = Array.from(el.childNodes).map(renderInline).join('')
+  const fb2Tag = inlineFor(tag)
+  return tag === 'br'
+    ? '<empty-line/>'
+    : fb2Tag !== undefined
+      ? `<${fb2Tag}>${inner}</${fb2Tag}>`
+      : tag === 'a'
+        ? renderAnchor(el, inner)
+        : inner
+}
+
+/**
+ * Render an inline DOM node to its FB2 equivalent. Plain text gets
+ * XML-escaped; <strong>/<b> map to <strong>; <em>/<i> map to
+ * <emphasis>; <a> maps to <a l:href> (XLink namespace required by
+ * FB2). Unknown tags collapse to their text content.
+ *
+ * @param node DOM node to render.
+ * @returns FB2-compatible XML fragment.
+ */
+export const renderInline = (node: Node): string =>
+  node.nodeType === Node.TEXT_NODE
+    ? escapeXml(node.textContent ?? '')
+    : node.nodeType === Node.ELEMENT_NODE
+      ? renderElement(node as Element)
+      : ''

--- a/src/features/newspaper/html-to-fb2/render-sections.ts
+++ b/src/features/newspaper/html-to-fb2/render-sections.ts
@@ -1,0 +1,34 @@
+import type { Section } from './split-sections'
+
+/**
+ * Render a single Section to its `<section>...</section>` FB2 form.
+ *
+ * @param s Section produced by splitIntoSections.
+ * @returns FB2 fragment (one section).
+ */
+export const renderSection = (s: Section): string => {
+  const title = s.title ? `    <title><p>${s.title}</p></title>\n` : ''
+  const body = s.body
+    .filter(b => b !== '')
+    .map(b => `    ${b}`)
+    .join('\n')
+  return `  <section>\n${title}${body}\n  </section>`
+}
+
+/**
+ * Render an array of sections joined by newlines, with a fallback
+ * stub section so the FB2 body never ends up empty.
+ *
+ * @param sections Output of splitIntoSections.
+ * @param fallbackTitle Title to use for the stub section when input
+ *   was empty.
+ * @returns Concatenated FB2 sections.
+ */
+export const renderSections = (
+  sections: readonly Section[],
+  fallbackTitle: string
+): string => {
+  const list =
+    sections.length === 0 ? [{ title: fallbackTitle, body: [] }] : sections
+  return list.map(renderSection).join('\n')
+}

--- a/src/features/newspaper/html-to-fb2/split-sections.ts
+++ b/src/features/newspaper/html-to-fb2/split-sections.ts
@@ -1,0 +1,65 @@
+import { renderBlock } from './render-block'
+import { renderInline } from './render-inline'
+
+/** A single FB2 <section>: title plus body paragraphs. */
+export interface Section {
+  readonly title: string
+  readonly body: readonly string[]
+}
+
+interface SplitState {
+  readonly sections: readonly Section[]
+  readonly current: Section
+}
+
+const headingTitle = (node: Element): string =>
+  Array.from(node.childNodes).map(renderInline).join('').trim()
+
+const isHeading = (el: Element): boolean => {
+  const tag = el.tagName.toLowerCase()
+  return tag === 'h1' || tag === 'h2'
+}
+
+const hasContent = (s: Section): boolean =>
+  s.title !== '' || s.body.length > 0
+
+const onHeading = (state: SplitState, node: Element): SplitState => ({
+  sections: hasContent(state.current)
+    ? [...state.sections, state.current]
+    : state.sections,
+  current: { title: headingTitle(node), body: [] },
+})
+
+const onBlock = (state: SplitState, node: Element): SplitState => {
+  const block = renderBlock(node)
+  return {
+    sections: state.sections,
+    current: {
+      title: state.current.title,
+      body:
+        block === '' ? state.current.body : [...state.current.body, block],
+    },
+  }
+}
+
+const advance = (state: SplitState, node: Element): SplitState =>
+  isHeading(node) ? onHeading(state, node) : onBlock(state, node)
+
+/**
+ * Walk the root element's children and group them into FB2
+ * sections. Every <h1>/<h2> starts a new section; everything else
+ * goes into the current section's body.
+ *
+ * @param root Element whose children carry the converted markup.
+ * @returns Sections in document order; an empty array when the
+ *   document had nothing renderable.
+ */
+export const splitIntoSections = (root: Element): readonly Section[] => {
+  const final = Array.from(root.children).reduce<SplitState>(advance, {
+    sections: [],
+    current: { title: '', body: [] },
+  })
+  return hasContent(final.current)
+    ? [...final.sections, final.current]
+    : final.sections
+}

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
 import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
+import Fb2Upload from '@/components/MarkdownEditor/Fb2Upload.vue'
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
 import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
 import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
@@ -54,7 +55,17 @@ const currentCover = (fm: Record<string, unknown>): string | undefined => {
   <DocxUpload
     v-if="isNewspaper(contentType)"
     :assets="assets"
-    @upload-docx="$emit('upload-asset', $event)"
+    :issue-title="(frontmatterData.title as string) ?? undefined"
+    :issue-lang="(frontmatterData.lang as string) ?? undefined"
+    :issue-description="(frontmatterData.description as string) ?? undefined"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <Fb2Upload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
   />
   <MarkdownEditorBody
     v-else-if="hasBodyEditor(contentType, slug)"


### PR DESCRIPTION
## Summary

Pairs with [public-website#73](https://github.com/communist-prometheus/public-website/pull/73).

Editor flagged that the .docx is the SOURCE format, not a reader-facing download. Refactor:

- **DocxUpload** now converts .docx → FB2 **client-side** (mammoth → HTML → DOMParser walker → FB2). Emits only the .fb2; the .docx never reaches the content repo.
- **New Fb2Upload** sibling — editors who already have a .fb2 from Calibre/scribus/hand-written can drop it directly.
- ContentEditMainBody renders both Docx + Fb2 uploads beneath PdfUpload, only for \`newspaper\` content type.
- html-to-fb2 transform lives in admin-website now (\`src/features/newspaper/html-to-fb2/\`), split into per-concern modules for the per-file/per-function line budgets.

## Test plan

- [x] \`bun run build\` clean (admin)
- [x] Pairs with public-website#73 (already merged) which drops the docx-passthrough