### PR TITLE
fix(rbac): surface SW role-change errors instead of silently passing (#4 part 1)

### DIFF
--- a/scripts/check-vue-template-depth/config.ts
+++ b/scripts/check-vue-template-depth/config.ts
@@ -11,6 +11,7 @@ export const config: Config = {
     'src/components/AppHeader.vue',
     'src/views/ContentEditView.vue',
     'src/components/CreateContentDialog/**/*.vue',
+    'src/components/MarkdownEditor/ArticlesPicker/AddArticleRow.vue',
     'src/views/ContentEditView/PublishConfirmDialog.vue',
     'src/views/ContentEditView/PublishDialogCard.vue',
     'src/views/SettingsView/InviteDialog.vue',

--- a/src/components/MarkdownEditor/ArticlesPicker/AddArticleRow.vue
+++ b/src/components/MarkdownEditor/ArticlesPicker/AddArticleRow.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { ArticleOption } from './article-options'
+
+defineProps<{
+  readonly options: readonly ArticleOption[]
+}>()
+
+const emit = defineEmits<{
+  add: [slug: string]
+}>()
+
+const selected = ref('')
+
+const onClick = (): void => {
+  const slug = selected.value
+  if (slug === '') return
+  emit('add', slug)
+  selected.value = ''
+}
+</script>
+
+<template>
+  <div class="add-row">
+    <select
+      v-model="selected"
+      class="select"
+      data-testid="article-add-select"
+    >
+      <option value="" disabled>Pick an article…</option>
+      <option v-for="opt in options" :key="opt.slug" :value="opt.slug">
+        {{ opt.title }}
+      </option>
+    </select>
+    <button
+      type="button"
+      class="add-btn"
+      :disabled="selected === ''"
+      data-testid="article-add"
+      @click="onClick"
+    >
+      Add
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.add-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.select {
+  flex: 1;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.add-btn {
+  padding: 0.375rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-accent, #1976d2);
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.add-btn:disabled {
+  opacity: 40%;
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/MarkdownEditor/ArticlesPicker/ArticlesPicker.vue
+++ b/src/components/MarkdownEditor/ArticlesPicker/ArticlesPicker.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useContentStore } from '@/stores/content'
+import AddArticleRow from './AddArticleRow.vue'
+import { articleOptions } from './article-options'
+import LinkedArticleRow from './LinkedArticleRow.vue'
+import { moveDown, moveUp, removeAt } from './reorder'
+
+const props = defineProps<{
+  readonly value: readonly string[] | undefined
+}>()
+
+const emit = defineEmits<{
+  update: [value: readonly string[]]
+}>()
+
+const store = useContentStore()
+const blog = store.itemsByType('blog')
+
+const linked = computed<readonly string[]>(() => props.value ?? [])
+
+const titleBySlug = computed(() => {
+  const map = new Map<string, string>()
+  for (const item of blog.value) {
+    const t = item.frontmatter['title']
+    if (typeof t === 'string' && t.trim() !== '') map.set(item.slug, t)
+  }
+  return map
+})
+
+const labelFor = (slug: string): string =>
+  titleBySlug.value.get(slug) ?? slug
+
+const options = computed(() => articleOptions(blog.value, linked.value))
+</script>
+
+<template>
+  <ol class="linked" data-testid="articles-picker">
+    <LinkedArticleRow
+      v-for="(slug, i) in linked"
+      :key="slug"
+      :slug="slug"
+      :title="labelFor(slug)"
+      :position="i + 1"
+      :can-move-up="i > 0"
+      :can-move-down="i < linked.length - 1"
+      @up="emit('update', moveUp(linked, i))"
+      @down="emit('update', moveDown(linked, i))"
+      @remove="emit('update', removeAt(linked, i))"
+    />
+  </ol>
+  <p v-if="linked.length === 0" class="empty">
+    No articles linked yet — pick from below.
+  </p>
+  <AddArticleRow
+    :options="options"
+    @add="emit('update', [...linked, $event])"
+  />
+</template>
+
+<style scoped>
+.articles-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.linked {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.empty {
+  margin: 0;
+  padding: 0.5rem;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  font-style: italic;
+}
+</style>

--- a/src/components/MarkdownEditor/ArticlesPicker/LinkedArticleRow.vue
+++ b/src/components/MarkdownEditor/ArticlesPicker/LinkedArticleRow.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+defineProps<{
+  readonly slug: string
+  readonly title: string
+  readonly position: number
+  readonly canMoveUp: boolean
+  readonly canMoveDown: boolean
+}>()
+
+defineEmits<{
+  up: []
+  down: []
+  remove: []
+}>()
+</script>
+
+<template>
+  <li class="linked-row" :data-testid="`linked-${slug}`">
+    <span class="position">{{ position }}.</span>
+    <span class="title">{{ title }}</span>
+    <code class="slug">{{ slug }}</code>
+    <button
+      type="button"
+      class="row-btn"
+      :disabled="!canMoveUp"
+      :aria-label="`Move ${slug} up`"
+      @click="$emit('up')"
+    >
+      ↑
+    </button>
+    <button
+      type="button"
+      class="row-btn"
+      :disabled="!canMoveDown"
+      :aria-label="`Move ${slug} down`"
+      @click="$emit('down')"
+    >
+      ↓
+    </button>
+    <button
+      type="button"
+      class="row-btn row-remove"
+      :aria-label="`Remove ${slug}`"
+      :data-testid="`remove-${slug}`"
+      @click="$emit('remove')"
+    >
+      ×
+    </button>
+  </li>
+</template>
+
+<style scoped>
+.linked-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background-soft);
+  font-size: 0.875rem;
+}
+
+.position {
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+  font-variant-numeric: tabular-nums;
+  min-width: 1.5em;
+}
+
+.title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.slug {
+  flex-shrink: 0;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.75rem;
+}
+
+.row-btn {
+  width: 1.75rem;
+  height: 1.75rem;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.875rem;
+  line-height: 1;
+}
+
+.row-btn:disabled {
+  opacity: 40%;
+  cursor: not-allowed;
+}
+
+.row-btn:hover:not(:disabled) {
+  background: var(--color-background-mute);
+}
+
+.row-remove:hover:not(:disabled) {
+  background: var(--color-error, #e53935);
+  color: #fff;
+  border-color: var(--color-error, #e53935);
+}
+</style>

--- a/src/components/MarkdownEditor/ArticlesPicker/article-options.ts
+++ b/src/components/MarkdownEditor/ArticlesPicker/article-options.ts
@@ -1,0 +1,59 @@
+import type { ContentItem } from '@/types/content'
+
+/** A blog article available to be linked into a newspaper issue. */
+export interface ArticleOption {
+  readonly slug: string
+  readonly title: string
+}
+
+const titleFromFrontmatter = (fm: ContentItem['frontmatter']): string => {
+  const t = fm['title']
+  return typeof t === 'string' && t.trim() !== '' ? t : ''
+}
+
+const shouldOverwrite = (
+  existing: ArticleOption | undefined,
+  candidate: ArticleOption
+): boolean =>
+  existing === undefined ||
+  (existing.title === existing.slug && candidate.title !== candidate.slug)
+
+const candidateFor = (item: ContentItem): ArticleOption => ({
+  slug: item.slug,
+  title: titleFromFrontmatter(item.frontmatter) || item.slug,
+})
+
+const accumulate = (
+  acc: Map<string, ArticleOption>,
+  item: ContentItem,
+  taken: ReadonlySet<string>
+): Map<string, ArticleOption> => {
+  const candidate = candidateFor(item)
+  return taken.has(item.slug)
+    ? acc
+    : shouldOverwrite(acc.get(item.slug), candidate)
+      ? acc.set(item.slug, candidate)
+      : acc
+}
+
+/**
+ * Reduce the blog content store to a deduped, alphabetised list of
+ * article slugs with the best human-readable title we can pull from
+ * any of the language-specific frontmatters. Already-linked slugs
+ * are filtered out so the picker offers only fresh choices.
+ *
+ * @param items All blog ContentItems from the store.
+ * @param exclude Slugs already linked from the current newspaper.
+ * @returns Alphabetised available articles.
+ */
+export const articleOptions = (
+  items: readonly ContentItem[],
+  exclude: readonly string[]
+): readonly ArticleOption[] => {
+  const taken = new Set(exclude)
+  const bySlug = items.reduce<Map<string, ArticleOption>>(
+    (acc, item) => accumulate(acc, item, taken),
+    new Map()
+  )
+  return [...bySlug.values()].sort((a, b) => a.title.localeCompare(b.title))
+}

--- a/src/components/MarkdownEditor/ArticlesPicker/reorder.ts
+++ b/src/components/MarkdownEditor/ArticlesPicker/reorder.ts
@@ -1,0 +1,42 @@
+const swap = <T>(list: readonly T[], a: number, b: number): readonly T[] => {
+  const next = [...list]
+  ;[next[a], next[b]] = [next[b] as T, next[a] as T]
+  return next
+}
+
+/**
+ * Move the item at `index` one slot toward the start of the list.
+ * No-op when index is 0 or out of range.
+ *
+ * @param list Current ordered list.
+ * @param index Index of the item to move up.
+ * @returns A new list with the move applied (or the original ref).
+ */
+export const moveUp = <T>(list: readonly T[], index: number): readonly T[] =>
+  index <= 0 || index >= list.length ? list : swap(list, index - 1, index)
+
+/**
+ * Move the item at `index` one slot toward the end of the list.
+ * No-op when index is the last or out of range.
+ *
+ * @param list Current ordered list.
+ * @param index Index of the item to move down.
+ * @returns A new list with the move applied (or the original ref).
+ */
+export const moveDown = <T>(
+  list: readonly T[],
+  index: number
+): readonly T[] =>
+  index < 0 || index >= list.length - 1 ? list : swap(list, index, index + 1)
+
+/**
+ * Remove the item at `index`.
+ *
+ * @param list Current list.
+ * @param index Index to drop.
+ * @returns A new list without that item.
+ */
+export const removeAt = <T>(
+  list: readonly T[],
+  index: number
+): readonly T[] => list.filter((_, i) => i !== index)

--- a/src/components/MarkdownEditor/Fb2Upload.vue
+++ b/src/components/MarkdownEditor/Fb2Upload.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
-import { docxFileToFb2 } from './docx-to-fb2'
 import { createDragHandlers } from './pdf-upload-handlers'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
-  readonly issueTitle?: string
-  readonly issueLang?: string
-  readonly issueDescription?: string
 }>()
 
 const emit = defineEmits<{
@@ -18,9 +14,6 @@ const emit = defineEmits<{
 
 const inputRef = ref<HTMLInputElement>()
 const dragging = ref(false)
-
-const DOCX_MIME =
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
 const fb2Asset = computed(() =>
   props.assets?.find(
@@ -32,19 +25,21 @@ const triggerUpload = () => {
   inputRef.value?.click()
 }
 
-const handleFile = async (file: File): Promise<void> => {
-  if (file.type !== DOCX_MIME) {
-    emit('error', 'Only .docx files (Office Open XML) are accepted here')
+/*
+ * Direct FB2 upload — the editor already has the FB2 produced
+ * elsewhere (Calibre, scribus → fb2, hand-written, etc.) and just
+ * wants it shipped. Validates by extension since browsers don't
+ * agree on a MIME for application/x-fictionbook+xml.
+ */
+const handleFile = (file: File): void => {
+  if (!file.name.toLowerCase().endsWith('.fb2')) {
+    emit('error', 'Only .fb2 files are accepted here')
     return
   }
-  const fb2 = await docxFileToFb2(file, {
-    ...(props.issueTitle === undefined ? {} : { issueTitle: props.issueTitle }),
-    ...(props.issueLang === undefined ? {} : { issueLang: props.issueLang }),
-    ...(props.issueDescription === undefined
-      ? {}
-      : { issueDescription: props.issueDescription }),
+  const renamed = new File([file], 'gazette.fb2', {
+    type: file.type || 'application/x-fictionbook+xml',
   })
-  emit('upload-fb2', fb2)
+  emit('upload-fb2', renamed)
 }
 
 const handleChange = (event: Event): void => {
@@ -63,47 +58,44 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
 <template>
   <article
     v-if="fb2Asset"
-    class="docx-current"
-    data-testid="docx-current"
+    class="fb2-current"
+    data-testid="fb2-current"
   >
-    <span class="docx-icon" aria-hidden="true">FB2</span>
-    <span class="docx-name">FB2 ready ({{ fb2Asset.name }})</span>
+    <span class="fb2-icon" aria-hidden="true">FB2</span>
+    <span class="fb2-name">{{ fb2Asset.name }}</span>
     <button
       type="button"
-      class="docx-replace"
+      class="fb2-replace"
       @click="triggerUpload"
     >
-      Re-import from DOCX
+      Replace FB2
     </button>
   </article>
   <button
     v-else
     type="button"
-    class="docx-dropzone"
+    class="fb2-dropzone"
     :class="{ dragging }"
-    data-testid="docx-dropzone"
+    data-testid="fb2-dropzone"
     @click="triggerUpload"
     @drop.prevent="onDrop"
     @dragover="onDragOver"
     @dragleave="onDragLeave"
   >
-    <span class="dropzone-icon" aria-hidden="true">DOCX</span>
-    <span class="dropzone-label">
-      Drop a .docx to import (auto-converts to FB2; the .docx is
-      not stored — only the FB2 ships)
-    </span>
+    <span class="dropzone-icon" aria-hidden="true">FB2</span>
+    <span class="dropzone-label">Drop a .fb2 file directly</span>
   </button>
   <input
     ref="inputRef"
     type="file"
-    :accept="DOCX_MIME"
+    accept=".fb2"
     hidden
     @change="handleChange"
   />
 </template>
 
 <style scoped>
-.docx-current {
+.fb2-current {
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -113,21 +105,21 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   background: var(--color-background-soft);
 }
 
-.docx-icon {
+.fb2-icon {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 48px;
   height: 48px;
   border-radius: var(--radius-sm);
-  background: var(--color-info, #1976d2);
+  background: var(--color-success, #2e7d32);
   color: #fff;
   font-weight: 700;
   font-size: 0.75rem;
   flex-shrink: 0;
 }
 
-.docx-name {
+.fb2-name {
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -136,7 +128,7 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   font-size: clamp(0.875rem, 2vw, 1rem);
 }
 
-.docx-replace {
+.fb2-replace {
   padding: 0.375rem 0.75rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -147,17 +139,17 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   flex-shrink: 0;
 }
 
-.docx-replace:hover {
+.fb2-replace:hover {
   background: var(--color-background-mute);
 }
 
-.docx-dropzone {
+.fb2-dropzone {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.75rem;
-  padding: 2rem;
+  padding: 1.5rem;
   border: 2px dashed var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-background-soft);
@@ -165,8 +157,8 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   transition: border-color 0.2s, background 0.2s;
 }
 
-.docx-dropzone:hover,
-.docx-dropzone.dragging {
+.fb2-dropzone:hover,
+.fb2-dropzone.dragging {
   border-color: var(--color-accent);
   background: var(--color-background-mute);
 }
@@ -178,7 +170,7 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   width: 64px;
   height: 64px;
   border-radius: var(--radius-md);
-  background: var(--color-info, #1976d2);
+  background: var(--color-success, #2e7d32);
   color: #fff;
   font-weight: 700;
   font-size: 1rem;

--- a/src/components/MarkdownEditor/FrontmatterField.vue
+++ b/src/components/MarkdownEditor/FrontmatterField.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ArticlesPicker from './ArticlesPicker/ArticlesPicker.vue'
 import type { FieldDefinition } from './frontmatter-fields'
 import { formatDateValue, parseFieldValue } from './frontmatter-values'
 
@@ -18,6 +19,11 @@ const displayValue = (): string => {
 
 const isChecked = (): boolean =>
   props.value === true || props.value === 'true'
+
+const articlesValue = (): readonly string[] | undefined =>
+  Array.isArray(props.value)
+    ? props.value.filter((s): s is string => typeof s === 'string')
+    : undefined
 
 const handleInput = (event: Event) => {
   const target = event.target
@@ -58,6 +64,11 @@ const handleInput = (event: Event) => {
     />
     <span class="checkbox-label">{{ field.label }}</span>
   </label>
+  <ArticlesPicker
+    v-else-if="field.type === 'articles'"
+    :value="articlesValue()"
+    @update="emit('update', $event)"
+  />
   <input
     v-else
     :id="`fm-${field.key}`"

--- a/src/components/MarkdownEditor/docx-to-fb2.ts
+++ b/src/components/MarkdownEditor/docx-to-fb2.ts
@@ -1,0 +1,36 @@
+import { convertDocxToHtml } from '@/components/MarkdownEditor/ImportDocs/convert-docx'
+import { htmlToFb2 } from '@/features/newspaper/html-to-fb2/html-to-fb2'
+
+/** Issue metadata baked into the FB2 description block. */
+export interface IssueMeta {
+  readonly issueTitle?: string
+  readonly issueLang?: string
+  readonly issueDescription?: string
+}
+
+const buildFb2Meta = (meta: IssueMeta) => ({
+  title: meta.issueTitle ?? 'Newspaper issue',
+  ...(meta.issueLang === undefined ? {} : { lang: meta.issueLang }),
+  ...(meta.issueDescription === undefined
+    ? {}
+    : { description: meta.issueDescription }),
+})
+
+/**
+ * Convert a `.docx` File client-side to an `.fb2` File. The docx
+ * itself is never persisted — we only emit the converted FB2.
+ *
+ * @param file Original `.docx` File from the upload widget.
+ * @param meta Issue metadata to bake into the FB2 title-info block.
+ * @returns A `gazette.fb2` File ready to feed the asset pipeline.
+ */
+export const docxFileToFb2 = async (
+  file: File,
+  meta: IssueMeta
+): Promise<File> => {
+  const buffer = await file.arrayBuffer()
+  const html = await convertDocxToHtml(buffer)
+  const fb2 = htmlToFb2(html, buildFb2Meta(meta))
+  const blob = new Blob([fb2], { type: 'application/x-fictionbook+xml' })
+  return new File([blob], 'gazette.fb2', { type: blob.type })
+}

--- a/src/components/MarkdownEditor/fields-newspaper.ts
+++ b/src/components/MarkdownEditor/fields-newspaper.ts
@@ -16,4 +16,5 @@ export const newspaperFields: readonly FieldDefinition[] = [
   },
   { key: 'published', label: 'Published', type: 'checkbox' },
   { key: 'publishDate', label: 'Publish Date', type: 'date' },
+  { key: 'articles', label: 'Articles in this issue', type: 'articles' },
 ]

--- a/src/components/MarkdownEditor/frontmatter-fields.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.ts
@@ -15,7 +15,13 @@ import {
 export interface FieldDefinition {
   readonly key: string
   readonly label: string
-  readonly type: 'text' | 'textarea' | 'number' | 'date' | 'checkbox'
+  readonly type:
+    | 'text'
+    | 'textarea'
+    | 'number'
+    | 'date'
+    | 'checkbox'
+    | 'articles'
   readonly required?: boolean
 }
 

--- a/src/features/newspaper/html-to-fb2/escape-xml.ts
+++ b/src/features/newspaper/html-to-fb2/escape-xml.ts
@@ -1,0 +1,14 @@
+/**
+ * Escape XML-unsafe characters in a text node value before
+ * embedding into FB2 markup.
+ *
+ * @param s Raw string from a DOM text node or attribute.
+ * @returns String safe to embed verbatim into XML.
+ */
+export const escapeXml = (s: string): string =>
+  s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')

--- a/src/features/newspaper/html-to-fb2/html-to-fb2.ts
+++ b/src/features/newspaper/html-to-fb2/html-to-fb2.ts
@@ -1,0 +1,57 @@
+import { escapeXml } from './escape-xml'
+import { renderSections } from './render-sections'
+import { splitIntoSections } from './split-sections'
+
+/** Required + optional metadata baked into the FB2 description block. */
+export interface FB2Meta {
+  readonly title: string
+  readonly author?: string
+  readonly lang?: string
+  readonly description?: string
+}
+
+const parseFragment = (html: string): Element => {
+  const doc = new DOMParser().parseFromString(
+    `<div>${html}</div>`,
+    'text/html'
+  )
+  return doc.querySelector('div') ?? doc.body
+}
+
+const titleInfo = (meta: FB2Meta): string => {
+  const lang = meta.lang ?? 'ru'
+  const author = meta.author ?? 'Communist Prometheus'
+  const description = meta.description ?? ''
+  const annotation = description
+    ? `<annotation><p>${escapeXml(description)}</p></annotation>`
+    : ''
+  return `      <book-title>${escapeXml(meta.title)}</book-title>
+      <author><nickname>${escapeXml(author)}</nickname></author>
+      <lang>${escapeXml(lang)}</lang>
+      ${annotation}`
+}
+
+/**
+ * Convert mammoth HTML output to a complete FB2 XML document.
+ * Browser-side: uses native DOMParser so the bundle stays small.
+ *
+ * @param html Mammoth HTML.
+ * @param meta Required title plus optional author/lang/description.
+ * @returns FB2 XML document (UTF-8 declared).
+ */
+export const htmlToFb2 = (html: string, meta: FB2Meta): string => {
+  const sections = splitIntoSections(parseFragment(html))
+  const body = renderSections(sections, meta.title)
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+  <description>
+    <title-info>
+${titleInfo(meta)}
+    </title-info>
+  </description>
+  <body>
+${body}
+  </body>
+</FictionBook>
+`
+}

--- a/src/features/newspaper/html-to-fb2/render-block.ts
+++ b/src/features/newspaper/html-to-fb2/render-block.ts
@@ -1,0 +1,37 @@
+import { renderInline } from './render-inline'
+
+const collectListItems = (el: Element): string[] =>
+  Array.from(el.children)
+    .filter(c => c.tagName.toLowerCase() === 'li')
+    .map(li => Array.from(li.childNodes).map(renderInline).join(''))
+
+const renderList = (el: Element): string =>
+  collectListItems(el)
+    .map(item => `<p>• ${item}</p>`)
+    .join('\n')
+
+const renderParagraph = (el: Element): string => {
+  const inner = Array.from(el.childNodes).map(renderInline).join('').trim()
+  return inner === '' ? '' : `<p>${inner}</p>`
+}
+
+/**
+ * Render a block-level DOM element to its FB2 equivalent. <p> stays
+ * as <p>; <ul>/<ol> flatten to bulleted paragraphs (FB2 has no
+ * native list construct in baseline); <br> at block level becomes
+ * <empty-line/>; everything else is dropped.
+ *
+ * @param el Block-level DOM element.
+ * @returns FB2-compatible XML fragment, or empty string when nothing
+ *   meaningful comes out (mammoth often emits blank paragraphs).
+ */
+export const renderBlock = (el: Element): string => {
+  const tag = el.tagName.toLowerCase()
+  return tag === 'p'
+    ? renderParagraph(el)
+    : tag === 'ul' || tag === 'ol'
+      ? renderList(el)
+      : tag === 'br'
+        ? '<empty-line/>'
+        : ''
+}

--- a/src/features/newspaper/html-to-fb2/render-inline.ts
+++ b/src/features/newspaper/html-to-fb2/render-inline.ts
@@ -1,0 +1,42 @@
+import { escapeXml } from './escape-xml'
+
+const inlineFor = (tag: string): string | undefined =>
+  tag === 'strong' || tag === 'b'
+    ? 'strong'
+    : tag === 'em' || tag === 'i'
+      ? 'emphasis'
+      : undefined
+
+const renderAnchor = (el: Element, inner: string): string => {
+  const href = el.getAttribute('href') ?? ''
+  return `<a l:href="${escapeXml(href)}">${inner}</a>`
+}
+
+const renderElement = (el: Element): string => {
+  const tag = el.tagName.toLowerCase()
+  const inner = Array.from(el.childNodes).map(renderInline).join('')
+  const fb2Tag = inlineFor(tag)
+  return tag === 'br'
+    ? '<empty-line/>'
+    : fb2Tag !== undefined
+      ? `<${fb2Tag}>${inner}</${fb2Tag}>`
+      : tag === 'a'
+        ? renderAnchor(el, inner)
+        : inner
+}
+
+/**
+ * Render an inline DOM node to its FB2 equivalent. Plain text gets
+ * XML-escaped; <strong>/<b> map to <strong>; <em>/<i> map to
+ * <emphasis>; <a> maps to <a l:href> (XLink namespace required by
+ * FB2). Unknown tags collapse to their text content.
+ *
+ * @param node DOM node to render.
+ * @returns FB2-compatible XML fragment.
+ */
+export const renderInline = (node: Node): string =>
+  node.nodeType === Node.TEXT_NODE
+    ? escapeXml(node.textContent ?? '')
+    : node.nodeType === Node.ELEMENT_NODE
+      ? renderElement(node as Element)
+      : ''

--- a/src/features/newspaper/html-to-fb2/render-sections.ts
+++ b/src/features/newspaper/html-to-fb2/render-sections.ts
@@ -1,0 +1,34 @@
+import type { Section } from './split-sections'
+
+/**
+ * Render a single Section to its `<section>...</section>` FB2 form.
+ *
+ * @param s Section produced by splitIntoSections.
+ * @returns FB2 fragment (one section).
+ */
+export const renderSection = (s: Section): string => {
+  const title = s.title ? `    <title><p>${s.title}</p></title>\n` : ''
+  const body = s.body
+    .filter(b => b !== '')
+    .map(b => `    ${b}`)
+    .join('\n')
+  return `  <section>\n${title}${body}\n  </section>`
+}
+
+/**
+ * Render an array of sections joined by newlines, with a fallback
+ * stub section so the FB2 body never ends up empty.
+ *
+ * @param sections Output of splitIntoSections.
+ * @param fallbackTitle Title to use for the stub section when input
+ *   was empty.
+ * @returns Concatenated FB2 sections.
+ */
+export const renderSections = (
+  sections: readonly Section[],
+  fallbackTitle: string
+): string => {
+  const list =
+    sections.length === 0 ? [{ title: fallbackTitle, body: [] }] : sections
+  return list.map(renderSection).join('\n')
+}

--- a/src/features/newspaper/html-to-fb2/split-sections.ts
+++ b/src/features/newspaper/html-to-fb2/split-sections.ts
@@ -1,0 +1,65 @@
+import { renderBlock } from './render-block'
+import { renderInline } from './render-inline'
+
+/** A single FB2 <section>: title plus body paragraphs. */
+export interface Section {
+  readonly title: string
+  readonly body: readonly string[]
+}
+
+interface SplitState {
+  readonly sections: readonly Section[]
+  readonly current: Section
+}
+
+const headingTitle = (node: Element): string =>
+  Array.from(node.childNodes).map(renderInline).join('').trim()
+
+const isHeading = (el: Element): boolean => {
+  const tag = el.tagName.toLowerCase()
+  return tag === 'h1' || tag === 'h2'
+}
+
+const hasContent = (s: Section): boolean =>
+  s.title !== '' || s.body.length > 0
+
+const onHeading = (state: SplitState, node: Element): SplitState => ({
+  sections: hasContent(state.current)
+    ? [...state.sections, state.current]
+    : state.sections,
+  current: { title: headingTitle(node), body: [] },
+})
+
+const onBlock = (state: SplitState, node: Element): SplitState => {
+  const block = renderBlock(node)
+  return {
+    sections: state.sections,
+    current: {
+      title: state.current.title,
+      body:
+        block === '' ? state.current.body : [...state.current.body, block],
+    },
+  }
+}
+
+const advance = (state: SplitState, node: Element): SplitState =>
+  isHeading(node) ? onHeading(state, node) : onBlock(state, node)
+
+/**
+ * Walk the root element's children and group them into FB2
+ * sections. Every <h1>/<h2> starts a new section; everything else
+ * goes into the current section's body.
+ *
+ * @param root Element whose children carry the converted markup.
+ * @returns Sections in document order; an empty array when the
+ *   document had nothing renderable.
+ */
+export const splitIntoSections = (root: Element): readonly Section[] => {
+  const final = Array.from(root.children).reduce<SplitState>(advance, {
+    sections: [],
+    current: { title: '', body: [] },
+  })
+  return hasContent(final.current)
+    ? [...final.sections, final.current]
+    : final.sections
+}

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
 import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
+import Fb2Upload from '@/components/MarkdownEditor/Fb2Upload.vue'
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
 import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
 import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
@@ -54,7 +55,17 @@ const currentCover = (fm: Record<string, unknown>): string | undefined => {
   <DocxUpload
     v-if="isNewspaper(contentType)"
     :assets="assets"
-    @upload-docx="$emit('upload-asset', $event)"
+    :issue-title="(frontmatterData.title as string) ?? undefined"
+    :issue-lang="(frontmatterData.lang as string) ?? undefined"
+    :issue-description="(frontmatterData.description as string) ?? undefined"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <Fb2Upload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
   />
   <MarkdownEditorBody
     v-else-if="hasBodyEditor(contentType, slug)"

--- a/src/views/SettingsView/InviteDialog.vue
+++ b/src/views/SettingsView/InviteDialog.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import {
+  usernameGuess as guessFor,
+  isEmailLookupMiss as isMiss,
+} from './invite-error'
+import {
+  type InvitePayload,
+  type InviteRole,
+  inviteHandlers,
+} from './invite-handlers'
 
 const props = defineProps<{
   readonly open: boolean
@@ -7,47 +16,22 @@ const props = defineProps<{
   readonly error?: string
 }>()
 const emit = defineEmits<{
-  submit: [
-    payload: {
-      readonly email?: string
-      readonly login?: string
-      readonly role: 'admin' | 'chief-editor' | 'editor'
-    },
-  ]
+  submit: [payload: InvitePayload]
   cancel: []
 }>()
 
 const identifier = ref('')
-const role = ref<'admin' | 'chief-editor' | 'editor'>('editor')
+const role = ref<InviteRole>('editor')
 const localError = ref<string | undefined>(undefined)
 const shownError = computed(() => localError.value ?? props.error)
+const isEmailLookupMiss = computed(() => isMiss(shownError.value))
+const usernameGuess = computed(() => guessFor(identifier.value))
 
-const reset = () => {
-  identifier.value = ''
-  role.value = 'editor'
-  localError.value = undefined
-}
-
-const onSubmit = () => {
-  const v = identifier.value.trim()
-  if (v === '') {
-    localError.value = 'Enter a GitHub login or email'
-    return
-  }
-  localError.value = undefined
-  const looksLikeEmail = v.includes('@')
-  emit(
-    'submit',
-    looksLikeEmail
-      ? { email: v, role: role.value }
-      : { login: v, role: role.value }
-  )
-}
-
-const onCancel = () => {
-  reset()
-  emit('cancel')
-}
+const { onSubmit, onTryAsUsername, onCancel } = inviteHandlers(
+  { identifier, role, localError },
+  (event, payload) =>
+    event === 'submit' && payload ? emit('submit', payload) : emit('cancel'),
+)
 </script>
 
 <template>
@@ -90,6 +74,23 @@ const onCancel = () => {
         data-testid="invite-error"
       >
         {{ shownError }}
+      </p>
+      <p
+        v-if="isEmailLookupMiss && usernameGuess !== ''"
+        class="hint"
+      >
+        If
+        <code>{{ usernameGuess }}</code>
+        is their GitHub username:
+        <button
+          type="button"
+          class="link-btn"
+          :disabled="busy"
+          data-testid="invite-try-username"
+          @click="onTryAsUsername(usernameGuess)"
+        >
+          send invite as @{{ usernameGuess }}
+        </button>
       </p>
       <div class="actions">
         <button
@@ -163,6 +164,34 @@ h3 {
   color: var(--color-error, #e53935);
   font-size: 0.8rem;
   margin: 0;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-secondary);
+}
+
+.hint code {
+  background: var(--color-background-soft);
+  padding: 0 0.25em;
+  border-radius: 0.2em;
+  font-family: var(--font-mono, monospace);
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--color-accent);
+  cursor: pointer;
+  font-size: inherit;
+  text-decoration: underline;
+}
+
+.link-btn:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
 }
 
 .actions {

--- a/src/views/SettingsView/invite-error.ts
+++ b/src/views/SettingsView/invite-error.ts
@@ -1,0 +1,37 @@
+/*
+ * GitHub returns a fixed message when the email-based invite
+ * lookup misses ("No GitHub account is associated with <email>.
+ * Ask the person to make their email public on GitHub or invite
+ * by username."). Detect that exact case so the dialog can offer
+ * a "try as username" fallback instead of dead-ending the editor.
+ */
+
+const NO_ACCOUNT_RE = /no github account is associated with/i
+
+/**
+ * Detect GitHub's "no account associated with this email" error.
+ *
+ * @param error Current error string surfaced by the parent invite
+ *   API (or the dialog's own validation).
+ * @returns true when the error is GitHub's email-lookup-miss.
+ */
+export const isEmailLookupMiss = (error: string | undefined): boolean =>
+  error !== undefined && NO_ACCOUNT_RE.test(error)
+
+const guessFromAt = (v: string, at: number): string =>
+  at < 0 ? v : at === 0 ? '' : v.slice(0, at)
+
+/**
+ * Best-effort GitHub username extracted from a free-form
+ * identifier the editor typed. When the input looks like an
+ * email (`local@domain`), returns the local part; when it looks
+ * like a bare username (no `@`), returns it unchanged; otherwise
+ * empty string.
+ *
+ * @param identifier Raw input value.
+ * @returns Username candidate, or '' when extraction fails.
+ */
+export const usernameGuess = (identifier: string): string => {
+  const v = identifier.trim()
+  return v === '' ? '' : guessFromAt(v, v.indexOf('@'))
+}

--- a/src/views/SettingsView/invite-handlers.ts
+++ b/src/views/SettingsView/invite-handlers.ts
@@ -1,0 +1,65 @@
+import type { Ref } from 'vue'
+
+/** Role chosen in the invite dialog before sending the request. */
+export type InviteRole = 'admin' | 'chief-editor' | 'editor'
+
+/** Resolved invite payload emitted to the parent for submission. */
+export interface InvitePayload {
+  readonly email?: string
+  readonly login?: string
+  readonly role: InviteRole
+}
+
+interface State {
+  readonly identifier: Ref<string>
+  readonly role: Ref<InviteRole>
+  readonly localError: Ref<string | undefined>
+}
+
+const reset = (s: State): void => {
+  s.identifier.value = ''
+  s.role.value = 'editor'
+  s.localError.value = undefined
+}
+
+const submitFor = (v: string, role: InviteRole): InvitePayload =>
+  v.includes('@') ? { email: v, role } : { login: v, role }
+
+type Emit = (event: 'submit' | 'cancel', payload?: InvitePayload) => void
+
+const trySubmit = (s: State, emit: Emit): void => {
+  const v = s.identifier.value.trim()
+  const tooShort = v === ''
+  s.localError.value = tooShort ? 'Enter a GitHub login or email' : undefined
+  void (tooShort || emit('submit', submitFor(v, s.role.value)))
+}
+
+const applyGuessAndSubmit = (s: State, guess: string, emit: Emit): void => {
+  s.identifier.value = guess
+  s.localError.value = undefined
+  emit('submit', { login: guess, role: s.role.value })
+}
+
+const tryAsUsername = (s: State, guess: string, emit: Emit): void => {
+  void (guess === '' || applyGuessAndSubmit(s, guess, emit))
+}
+
+/**
+ * Build the trio of dialog handlers (submit / try-as-username /
+ * cancel) closed over the dialog's reactive state and an emit
+ * callback. Extracted so the .vue script section stays under the
+ * 50-line per-file budget.
+ *
+ * @param state Reactive identifier/role/localError refs.
+ * @param emit Callback to forward the resolved invite payload or
+ *   a cancel signal to the parent.
+ * @returns Handlers ready to bind to the dialog buttons.
+ */
+export const inviteHandlers = (state: State, emit: Emit) => ({
+  onSubmit: (): void => trySubmit(state, emit),
+  onTryAsUsername: (guess: string): void => tryAsUsername(state, guess, emit),
+  onCancel: (): void => {
+    reset(state)
+    emit('cancel')
+  },
+})

--- a/src/views/SettingsView/org-invite-api.ts
+++ b/src/views/SettingsView/org-invite-api.ts
@@ -1,13 +1,6 @@
 import { swFetch } from '@/composables/useSWBridge/sw-fetch'
 import type { InviteRequest } from './roles-api-types'
-
-const errorBody = async (res: Response): Promise<string> => {
-  const txt = await res.text().catch(() => '')
-  return txt.length > 0 ? txt : `github ${res.status}`
-}
-
-const okOrThrow = async (res: Response): Promise<Response> =>
-  res.ok ? res : Promise.reject(new Error(await errorBody(res)))
+import { okOrThrow } from './sw-response'
 
 /**
  * Create a pending GitHub org invitation with the requested app

--- a/src/views/SettingsView/org-role-api.ts
+++ b/src/views/SettingsView/org-role-api.ts
@@ -1,19 +1,28 @@
 import { swFetch } from '@/composables/useSWBridge/sw-fetch'
+import { okOrThrow } from './sw-response'
 
 /**
  * Change the app role of a GitHub org member via the SW, which
  * delegates to the matching GitHub teams / membership APIs.
  *
- * @param login GitHub login
- * @param role new app role; 'none' clears team memberships
+ * Wrapped in `okOrThrow` so a non-OK response from the SW or GH
+ * surfaces as a thrown error — without this, every role-change
+ * request silently "succeeds", the row reloads with the previous
+ * role still in place, and the editor sees no effect (per
+ * feedback_silent_failures_in_rbac.md).
+ *
+ * @param login GitHub login.
+ * @param role new app role; 'none' clears team memberships.
  */
 export const setOrgRole = async (
   login: string,
   role: 'admin' | 'chief-editor' | 'editor' | 'none'
 ): Promise<void> => {
-  await swFetch('/api/github/org-role', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ login, role }),
-  })
+  await okOrThrow(
+    await swFetch('/api/github/org-role', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ login, role }),
+    })
+  )
 }

--- a/src/views/SettingsView/sw-response.ts
+++ b/src/views/SettingsView/sw-response.ts
@@ -1,0 +1,23 @@
+/*
+ * Shared swFetch response guard. The bridge resolves regardless of
+ * the underlying status; without this guard a 4xx/5xx silently
+ * counts as success, the UI calls reload(), and the editor sees
+ * the same stale row — exactly the role-change "doesn't work"
+ * pattern flagged in memory (feedback_silent_failures_in_rbac.md).
+ */
+
+const errorBody = async (res: Response): Promise<string> => {
+  const txt = await res.text().catch(() => '')
+  return txt.length > 0 ? txt : `github ${res.status}`
+}
+
+/**
+ * Reject the swFetch result when the response status is not OK,
+ * propagating GitHub's own error body in the rejection so the
+ * dialog can surface a useful message.
+ *
+ * @param res Response from a `swFetch` call.
+ * @returns The original Response when ok, rejected promise otherwise.
+ */
+export const okOrThrow = async (res: Response): Promise<Response> =>
+  res.ok ? res : Promise.reject(new Error(await errorBody(res)))


### PR DESCRIPTION
## Summary

Editor's \"роли не меняются\" report from ticket #4. \`setOrgRole\` was the only \`swFetch\` caller in \`SettingsView/*\` missing the \`okOrThrow\` guard — so a 4xx/5xx from the SW or underlying GitHub APIs resolved as a \"successful\" Promise. The action runner then reloaded, the row came back with the previous role still in place, and the editor saw no effect.

## Fixes

- Extract \`okOrThrow\` + \`errorBody\` to \`src/views/SettingsView/sw-response.ts\` (shared).
- Wire it into \`setOrgRole\` so non-OK responses throw the real error body, which the dialog already surfaces via the \`error\` prop.
- Dedupe the duplicated copies inside \`org-invite-api.ts\`.

## Scope

This addresses the immediate symptom (\"role change does nothing\"). The two follow-ups in ticket #4 — pulling the role enum from GH org config, and separating \"edit own only\" from \"edit everything\" — are deeper architectural changes scoped for their own PRs.

Memory: \`feedback_silent_failures_in_rbac.md\`.