### PR TITLE
feat(blog): newspaper-issue picker on the blog edit page

### DIFF
--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -19,6 +19,20 @@
   --radius-md: 0.75rem;
   --radius-lg: 1rem;
 
+  /*
+   * Content-frame tokens — the bounded container width every top
+   * level view sits inside so cards, lists and forms stop
+   * stretching to whatever the viewport is on a wide monitor.
+   *
+   *   --content-narrow  prose / forms / single-column dialogs.
+   *   --content-medium  lists / dashboards / mixed content.
+   *   --content-wide    editor + preview, two-up layouts.
+   */
+  --content-narrow: 56rem;
+  --content-medium: 72rem;
+  --content-wide: 90rem;
+  --content-frame-padding: clamp(1rem, 3vw, 2rem);
+
   --border-width: 1px;
 
   --font-sans: system-ui, -apple-system, sans-serif;

--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -8,8 +8,20 @@
 
 <style scoped>
 .app-main {
-  display: block;
+  display: flex;
+  flex-direction: column;
   min-width: 0;
+
+  /*
+   * Cap the wide-screen content width so cards, lists and forms
+   * stop running the full width of a 27" or ultrawide monitor.
+   * Per-view inner containers still impose tighter caps where
+   * single-column reading or narrow forms are appropriate
+   * (Settings 800px, conflicts 720px, etc).
+   */
+  max-width: var(--content-wide);
+  width: 100%;
+  margin-inline: auto;
   color: var(--color-text);
 }
 </style>

--- a/src/components/MarkdownEditor/FrontmatterField.vue
+++ b/src/components/MarkdownEditor/FrontmatterField.vue
@@ -2,6 +2,7 @@
 import ArticlesPicker from './ArticlesPicker/ArticlesPicker.vue'
 import type { FieldDefinition } from './frontmatter-fields'
 import { formatDateValue, parseFieldValue } from './frontmatter-values'
+import IssuePicker from './IssuePicker/IssuePicker.vue'
 
 const props = defineProps<{
   readonly field: FieldDefinition
@@ -23,6 +24,11 @@ const isChecked = (): boolean =>
 const articlesValue = (): readonly string[] | undefined =>
   Array.isArray(props.value)
     ? props.value.filter((s): s is string => typeof s === 'string')
+    : undefined
+
+const issueValue = (): string | undefined =>
+  typeof props.value === 'string' && props.value !== ''
+    ? props.value
     : undefined
 
 const handleInput = (event: Event) => {
@@ -67,6 +73,11 @@ const handleInput = (event: Event) => {
   <ArticlesPicker
     v-else-if="field.type === 'articles'"
     :value="articlesValue()"
+    @update="emit('update', $event)"
+  />
+  <IssuePicker
+    v-else-if="field.type === 'issue'"
+    :value="issueValue()"
     @update="emit('update', $event)"
   />
   <input

--- a/src/components/MarkdownEditor/IssuePicker/IssuePicker.vue
+++ b/src/components/MarkdownEditor/IssuePicker/IssuePicker.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useContentStore } from '@/stores/content'
+import { issueOptions } from './issue-options'
+
+const props = defineProps<{
+  readonly value: string | undefined
+}>()
+
+const emit = defineEmits<{
+  update: [value: string | undefined]
+}>()
+
+const store = useContentStore()
+const newspaper = store.itemsByType('newspaper')
+
+const options = computed(() => issueOptions(newspaper.value))
+
+const onChange = (e: Event): void => {
+  const raw = (e.target as HTMLSelectElement).value
+  emit('update', raw === '' ? undefined : raw)
+}
+</script>
+
+<template>
+  <select
+    class="issue-select"
+    :value="props.value ?? ''"
+    data-testid="issue-picker"
+    @change="onChange"
+  >
+    <option value="">— not in any issue —</option>
+    <option v-for="opt in options" :key="opt.slug" :value="opt.slug">
+      {{ opt.title }}
+    </option>
+  </select>
+</template>
+
+<style scoped>
+.issue-select {
+  width: 100%;
+  padding: clamp(0.375rem, 1vw, 0.5rem);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+}
+
+.issue-select:focus {
+  outline: none;
+  border-color: var(--color-heading);
+}
+</style>

--- a/src/components/MarkdownEditor/IssuePicker/issue-options.ts
+++ b/src/components/MarkdownEditor/IssuePicker/issue-options.ts
@@ -1,0 +1,51 @@
+import type { ContentItem } from '@/types/content'
+
+/** A newspaper issue available to link a blog post to. */
+export interface IssueOption {
+  readonly slug: string
+  readonly title: string
+}
+
+const titleFromFrontmatter = (fm: ContentItem['frontmatter']): string => {
+  const t = fm['title']
+  return typeof t === 'string' && t.trim() !== '' ? t : ''
+}
+
+const candidateFor = (item: ContentItem): IssueOption => ({
+  slug: item.slug,
+  title: titleFromFrontmatter(item.frontmatter) || item.slug,
+})
+
+const shouldOverwrite = (
+  existing: IssueOption | undefined,
+  candidate: IssueOption
+): boolean =>
+  existing === undefined ||
+  (existing.title === existing.slug && candidate.title !== candidate.slug)
+
+const accumulate = (
+  acc: Map<string, IssueOption>,
+  item: ContentItem
+): Map<string, IssueOption> => {
+  const candidate = candidateFor(item)
+  return shouldOverwrite(acc.get(item.slug), candidate)
+    ? acc.set(item.slug, candidate)
+    : acc
+}
+
+/**
+ * Reduce the newspaper content store to a deduped, alphabetised
+ * list of issues with the best human-readable title pulled from
+ * any language-specific frontmatter. The blog-side picker uses
+ * this so editors choose the issue from the same set the
+ * newspaper TOC will then echo.
+ *
+ * @param items All newspaper ContentItems from the store.
+ * @returns Alphabetised available issues.
+ */
+export const issueOptions = (
+  items: readonly ContentItem[]
+): readonly IssueOption[] => {
+  const bySlug = items.reduce<Map<string, IssueOption>>(accumulate, new Map())
+  return [...bySlug.values()].sort((a, b) => a.title.localeCompare(b.title))
+}

--- a/src/components/MarkdownEditor/fields-blog.ts
+++ b/src/components/MarkdownEditor/fields-blog.ts
@@ -22,4 +22,9 @@ export const blogFields: readonly FieldDefinition[] = [
   },
   { key: 'published', label: 'Published', type: 'checkbox' },
   { key: 'publishDate', label: 'Publish Date', type: 'date' },
+  {
+    key: 'newspaper',
+    label: 'Newspaper issue (optional)',
+    type: 'issue',
+  },
 ]

--- a/src/components/MarkdownEditor/frontmatter-fields.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.ts
@@ -22,6 +22,7 @@ export interface FieldDefinition {
     | 'date'
     | 'checkbox'
     | 'articles'
+    | 'issue'
   readonly required?: boolean
 }
 

--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -54,7 +54,11 @@ defineEmits<{
   flex-direction: column;
   flex: 1;
   gap: clamp(0.5rem, 2vw, 1rem);
-  padding: clamp(1rem, 3vw, 2rem);
+  padding: var(--content-frame-padding);
+  max-width: var(--content-wide);
+  width: 100%;
+  margin-inline: auto;
+  box-sizing: border-box;
 }
 
 .loading-state {

--- a/src/views/ContentView/ContentViewMain.vue
+++ b/src/views/ContentView/ContentViewMain.vue
@@ -53,7 +53,10 @@ const emit = defineEmits<{
 
 <style scoped>
 .view-content {
-  padding: clamp(1rem, 3vw, 2rem);
+  padding: var(--content-frame-padding);
+  max-width: var(--content-medium);
+  width: 100%;
+  margin-inline: auto;
   flex: 1;
   overflow: auto;
 }


### PR DESCRIPTION
Editor couldn't see how to link articles to a newspaper issue from the article side — only the newspaper side had a UI (admin#181). This adds the symmetric picker so either side works. Plus included the layout-frame tokens + AppMain max-width + ContentView/ContentEditView width caps as a first pass on the layout audit; a deeper redesign follows in another PR.