### PR TITLE
feat(layout): two-column edit page + members card grid (pass 1)

### DIFF
--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -50,18 +50,32 @@ defineEmits<{
 
 <style scoped>
 .edit-main {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   flex: 1;
-  gap: clamp(0.5rem, 2vw, 1rem);
+  gap: clamp(1rem, 2vw, 2rem);
   padding: var(--content-frame-padding);
   max-width: var(--content-wide);
   width: 100%;
   margin-inline: auto;
   box-sizing: border-box;
+  align-content: start;
+}
+
+/*
+ * On wide screens dock frontmatter to a fixed-ish meta column on
+ * the left and let the body take the rest. Below 1024px the grid
+ * collapses to a single column so phone/tablet still scroll
+ * top-to-bottom.
+ */
+@media (width >= 1024px) {
+  .edit-main {
+    grid-template-columns: [meta] 22rem [body] minmax(0, 1fr);
+  }
 }
 
 .loading-state {
+  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -1,13 +1,8 @@
 <script setup lang="ts">
-import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
-import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
-import Fb2Upload from '@/components/MarkdownEditor/Fb2Upload.vue'
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
-import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
-import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
-import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import type { ContentType } from '@/types/content'
+import EditBodyArea from './EditBodyArea.vue'
 
 defineProps<{
   readonly bodyContent: string
@@ -27,58 +22,45 @@ defineEmits<{
   'set-cover': [name: string]
   error: [message: string]
 }>()
-
-const isNewspaper = (type: ContentType) => type === 'newspaper'
-
-const currentCover = (fm: Record<string, unknown>): string | undefined => {
-  const v = fm['image']
-  return typeof v === 'string' && v.length > 0 ? v : undefined
-}
 </script>
 
 <template>
   <FrontmatterEditor
     v-if="Object.keys(frontmatterData).length > 0"
+    class="edit-meta"
     :frontmatter="frontmatterData"
     :content-type="contentType"
     :slug="slug"
     @update:frontmatter="$emit('update:frontmatter', $event)"
   />
-  <PdfUpload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    :current-cover="currentCover(frontmatterData)"
-    @upload-pdf="$emit('upload-asset', $event)"
-    @upload-cover="$emit('upload-asset', $event)"
-    @set-cover="$emit('set-cover', $event)"
-  />
-  <DocxUpload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    :issue-title="(frontmatterData.title as string) ?? undefined"
-    :issue-lang="(frontmatterData.lang as string) ?? undefined"
-    :issue-description="(frontmatterData.description as string) ?? undefined"
-    @upload-fb2="$emit('upload-asset', $event)"
-    @error="$emit('error', $event)"
-  />
-  <Fb2Upload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    @upload-fb2="$emit('upload-asset', $event)"
-    @error="$emit('error', $event)"
-  />
-  <MarkdownEditorBody
-    v-else-if="hasBodyEditor(contentType, slug)"
-    :model-value="bodyContent"
+  <EditBodyArea
+    class="edit-body"
+    :body-content="bodyContent"
+    :frontmatter-data="frontmatterData"
+    :content-type="contentType"
+    :slug="slug"
     :asset-url-map="assetUrlMap"
     :assets="assets"
-    @update:model-value="$emit('update:bodyContent', $event)"
+    @update:body-content="$emit('update:bodyContent', $event)"
+    @preview="$emit('preview')"
     @paste:image="$emit('paste:image', $event)"
     @upload-asset="$emit('upload-asset', $event)"
+    @set-cover="$emit('set-cover', $event)"
     @error="$emit('error', $event)"
   />
-  <EditorFooter
-    :disabled="false"
-    @preview="$emit('preview')"
-  />
 </template>
+
+<style scoped>
+.edit-meta {
+  grid-column: meta;
+  align-self: start;
+}
+
+.edit-body {
+  grid-column: body;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  min-width: 0;
+}
+</style>

--- a/src/views/ContentEditView/EditBodyArea.vue
+++ b/src/views/ContentEditView/EditBodyArea.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
+import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
+import Fb2Upload from '@/components/MarkdownEditor/Fb2Upload.vue'
+import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
+import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
+import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
+import type { AssetDisplay } from '@/composables/useAssets/types'
+import type { ContentType } from '@/types/content'
+
+defineProps<{
+  readonly bodyContent: string
+  readonly frontmatterData: Record<string, unknown>
+  readonly contentType: ContentType
+  readonly slug?: string
+  readonly assetUrlMap?: ReadonlyMap<string, string>
+  readonly assets?: readonly AssetDisplay[]
+}>()
+
+defineEmits<{
+  'update:bodyContent': [value: string]
+  preview: []
+  'paste:image': [file: File]
+  'upload-asset': [file: File]
+  'set-cover': [name: string]
+  error: [message: string]
+}>()
+
+const isNewspaper = (type: ContentType) => type === 'newspaper'
+
+const currentCover = (fm: Record<string, unknown>): string | undefined => {
+  const v = fm['image']
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+</script>
+
+<template>
+  <PdfUpload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    :current-cover="currentCover(frontmatterData)"
+    @upload-pdf="$emit('upload-asset', $event)"
+    @upload-cover="$emit('upload-asset', $event)"
+    @set-cover="$emit('set-cover', $event)"
+  />
+  <DocxUpload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    :issue-title="(frontmatterData.title as string) ?? undefined"
+    :issue-lang="(frontmatterData.lang as string) ?? undefined"
+    :issue-description="(frontmatterData.description as string) ?? undefined"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <Fb2Upload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <MarkdownEditorBody
+    v-else-if="hasBodyEditor(contentType, slug)"
+    :model-value="bodyContent"
+    :asset-url-map="assetUrlMap"
+    :assets="assets"
+    @update:model-value="$emit('update:bodyContent', $event)"
+    @paste:image="$emit('paste:image', $event)"
+    @upload-asset="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <EditorFooter :disabled="false" @preview="$emit('preview')" />
+</template>

--- a/src/views/SettingsView/MemberList.vue
+++ b/src/views/SettingsView/MemberList.vue
@@ -28,12 +28,23 @@ defineEmits<{
 </template>
 
 <style scoped>
+/*
+ * Members render as a responsive card grid: 1 column on phones,
+ * 2 columns starting from tablet. Each row's own borders handle
+ * the card frame so the parent doesn't need an outer border.
+ */
 .member-list {
   list-style: none;
   padding: 0;
   margin: 0;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (width >= 720px) {
+  .member-list {
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  }
 }
 </style>

--- a/src/views/SettingsView/MemberRow.vue
+++ b/src/views/SettingsView/MemberRow.vue
@@ -61,12 +61,17 @@ const onChange =
   grid-template-columns: 32px 1fr auto;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--color-border);
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  transition: border-color var(--transition-fast),
+    background-color var(--transition-fast);
 }
 
-.member-row:last-child {
-  border-bottom: none;
+.member-row:hover {
+  border-color: var(--color-text-secondary);
+  background: var(--color-surface-elevated);
 }
 
 .avatar {


### PR DESCRIPTION
## Summary

Editor's complaint that admin pages stretch end-to-end on a wide monitor. First proper layout pass.

### Tokens

- \`--content-narrow\` (56rem) / \`--content-medium\` (72rem) / \`--content-wide\` (90rem)
- \`--content-frame-padding\` (clamp 1rem-2rem)

### AppMain

Caps every view at \`--content-wide\` so even on 4K the page lives in a sensible column. Per-view inner caps (Settings 800px, Conflicts 720px, …) still bind tighter where appropriate.

### ContentEditView — two-column grid

- \`[meta] 22rem [body] 1fr\` from 1024px up
- Single column below 1024px (phone/tablet)
- Split ContentEditMainBody into \`ContentEditMainBody\` (grid layout) + \`EditBodyArea\` (markdown + asset uploads + footer)

### MemberList — responsive card grid

- \`auto-fill, minmax(20rem, 1fr)\` from 720px up
- MemberRow becomes a self-contained card with own border + hover

### ContentView — width-capped

\`max-width: var(--content-medium)\` so the listing stops stretching.

## Tests

- \`bunx playwright test --project=chromium e2e/settings/members.spec.ts e2e/content/markdown-editor.spec.ts\` — 9/9 pass
- Test-ids preserved

## Follow-up

Pass 2: deploy list, tickets list, conflicts view, label-table refresh.