### PR TITLE
feat(admin): drop description field from blog/positions/newspaper (#3 part 2)

### DIFF
--- a/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.test.ts
@@ -14,7 +14,7 @@ const toMd = (html: string): string => {
 describe('assembleWithFootnotes', () => {
   it('swaps placeholders with [^N] and appends definitions', () => {
     const out = assembleWithFootnotes(
-      'text @@FOOTNOTE_REF_1@@ more @@FOOTNOTE_REF_2@@',
+      'text XXFOOTNOTEREFXX1XX more XXFOOTNOTEREFXX2XX',
       [
         { id: 1, html: 'one' },
         { id: 2, html: 'two' },
@@ -26,7 +26,7 @@ describe('assembleWithFootnotes', () => {
 
   it('emits only one definition when the same footnote is referenced twice', () => {
     const out = assembleWithFootnotes(
-      '@@FOOTNOTE_REF_3@@ and again @@FOOTNOTE_REF_3@@',
+      'XXFOOTNOTEREFXX3XX and again XXFOOTNOTEREFXX3XX',
       [{ id: 3, html: 'thrice' }],
       toMd
     )
@@ -38,13 +38,13 @@ describe('assembleWithFootnotes', () => {
   })
 
   it('strips orphan placeholders when no definition exists', () => {
-    const out = assembleWithFootnotes('word @@FOOTNOTE_REF_9@@ end', [], toMd)
+    const out = assembleWithFootnotes('word XXFOOTNOTEREFXX9XX end', [], toMd)
     expect(out).toBe('word  end')
   })
 
   it('keeps footnote bodies on a single line', () => {
     const out = assembleWithFootnotes(
-      '@@FOOTNOTE_REF_1@@',
+      'XXFOOTNOTEREFXX1XX',
       [{ id: 1, html: '<p>line one</p><p>line two</p>' }],
       toMd
     )
@@ -53,10 +53,30 @@ describe('assembleWithFootnotes', () => {
 
   it('renders markdown inside footnote bodies (em + link)', () => {
     const out = assembleWithFootnotes(
-      '@@FOOTNOTE_REF_4@@',
+      'XXFOOTNOTEREFXX4XX',
       [{ id: 4, html: 'see <em>ref</em> at <a href="http://x">x</a>' }],
       toMd
     )
     expect(out).toBe('[^4]\n\n[^4]: see *ref* at [x](http://x)')
+  })
+
+  it('strips legacy underscore placeholders (raw + turndown-escaped)', () => {
+    /*
+     * Earlier importer version emitted `@@FOOTNOTE_REF_N@@`.
+     * Turndown escapes `_` to `\_`, producing
+     * `@@FOOTNOTE\_REF\_N@@` in markdown — that escaped form
+     * silently bypassed the strip regex and leaked into saved
+     * files, forcing the editor to clean by hand. This test pins
+     * the back-compat path so a re-save of an old article wipes
+     * both shapes.
+     */
+    const raw = assembleWithFootnotes('a @@FOOTNOTE_REF_1@@ b', [], toMd)
+    expect(raw).toBe('a  b')
+    const escaped = assembleWithFootnotes(
+      'c @@FOOTNOTE\\_REF\\_2@@ d',
+      [],
+      toMd
+    )
+    expect(escaped).toBe('c  d')
   })
 })

--- a/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.ts
+++ b/src/components/MarkdownEditor/ImportDocs/assemble-footnotes.ts
@@ -1,5 +1,9 @@
 import type { Footnote } from './extract-footnotes'
-import { footnotePlaceholder } from './extract-footnotes'
+import {
+  footnotePlaceholder,
+  LEGACY_PLACEHOLDER_RE,
+  PLACEHOLDER_RE,
+} from './extract-footnotes'
 
 const swapMarkers = (body: string, footnotes: readonly Footnote[]): string =>
   footnotes.reduce(
@@ -7,8 +11,14 @@ const swapMarkers = (body: string, footnotes: readonly Footnote[]): string =>
     body
   )
 
+/*
+ * Strip both the current alphanumeric placeholder and the legacy
+ * underscore one (raw or turndown-escaped). Legacy is here so a
+ * resave of an article imported by the previous version cleans up
+ * the orphans the editor would otherwise see in the file.
+ */
 const stripPlaceholders = (body: string): string =>
-  body.replace(/@@FOOTNOTE_REF_\d+@@/g, '')
+  body.replace(PLACEHOLDER_RE, '').replace(LEGACY_PLACEHOLDER_RE, '')
 
 const renderDef = (id: number, markdown: string): string =>
   `[^${id}]: ${markdown.trim().replace(/\n+/g, ' ')}`

--- a/src/components/MarkdownEditor/ImportDocs/extract-footnotes.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/extract-footnotes.test.ts
@@ -18,7 +18,7 @@ describe('extractFootnotes', () => {
           '<li id="footnote-1">body<a href="#footnote-ref-1">↑</a></li>'
         )
     )
-    expect(r.html).toBe('<p>see@@FOOTNOTE_REF_1@@</p>')
+    expect(r.html).toBe('<p>seeXXFOOTNOTEREFXX1XX</p>')
     expect(r.footnotes).toEqual([{ id: 1, html: 'body' }])
   })
 
@@ -58,7 +58,7 @@ describe('extractFootnotes', () => {
           '<li id="footnote-1">one<a href="#footnote-ref-1">↑</a></li>'
         )
     )
-    expect(r.html).toBe('<p>a@@FOOTNOTE_REF_1@@ b@@FOOTNOTE_REF_1@@</p>')
+    expect(r.html).toBe('<p>aXXFOOTNOTEREFXX1XX bXXFOOTNOTEREFXX1XX</p>')
     expect(r.footnotes).toEqual([{ id: 1, html: 'one' }])
   })
 
@@ -77,7 +77,7 @@ describe('extractFootnotes', () => {
     const r = extractFootnotes(
       '<p>see<sup><a href="#footnote-9">[9]</a></sup></p>'
     )
-    expect(r.html).toBe('<p>see@@FOOTNOTE_REF_9@@</p>')
+    expect(r.html).toBe('<p>seeXXFOOTNOTEREFXX9XX</p>')
     expect(r.footnotes).toEqual([])
   })
 })

--- a/src/components/MarkdownEditor/ImportDocs/extract-footnotes.ts
+++ b/src/components/MarkdownEditor/ImportDocs/extract-footnotes.ts
@@ -23,7 +23,27 @@ const BACKLINK =
 
 const TRAILING_OL = /<hr[^>]*>\s*<ol>[\s\S]*?<\/ol>\s*$/i
 
-const placeholder = (id: number): string => `@@FOOTNOTE_REF_${id}@@`
+/*
+ * Placeholder injected before markdown conversion. The previous
+ * shape used underscores (`@@FOOTNOTE_REF_N@@`); turndown escapes
+ * `_` as `\_` to neuter markdown italic interpretation, which
+ * silently broke the strip regex — the placeholder leaked into
+ * saved files (the editor had to manually rewrite them as
+ * `[N](#footnote-ref-N)` markers). Pure alphanumerics survive
+ * turndown verbatim.
+ */
+const placeholder = (id: number): string => `XXFOOTNOTEREFXX${id}XX`
+
+/** Regex matching the alphanumeric placeholder shape. */
+export const PLACEHOLDER_RE = /XXFOOTNOTEREFXX(\d+)XX/g
+
+/**
+ * Backwards-compat regex matching the legacy underscore placeholder
+ * shape, raw or turndown-escaped (`@@FOOTNOTE_REF_N@@` /
+ * `@@FOOTNOTE\_REF\_N@@`). On re-save of an article imported by the
+ * previous version, the orphan placeholders get cleaned up.
+ */
+export const LEGACY_PLACEHOLDER_RE = /@@FOOTNOTE\\?_REF\\?_(\d+)@@/g
 
 const stripBacklink = (html: string): string =>
   html.replace(BACKLINK, '').trim()

--- a/src/components/MarkdownEditor/ImportDocs/html-to-markdown.test.ts
+++ b/src/components/MarkdownEditor/ImportDocs/html-to-markdown.test.ts
@@ -32,4 +32,24 @@ describe('htmlToMarkdown', () => {
     const md = htmlToMarkdown('<img src="./assets/x.png" alt="alt"/>')
     expect(md).toContain('![alt](./assets/x.png)')
   })
+
+  it('replaces mammoth footnote refs with GFM markers (no leftover placeholders)', () => {
+    /*
+     * Regression test for the docx-import bug the editor hit in
+     * the content-repo "from-manchester-to-global" article: the
+     * old underscore placeholder collided with turndown's
+     * markdown-italic escaping, so saved files had literal
+     * `@@FOOTNOTE\_REF\_1@@` leak through. Now: footnote ref
+     * should always become `[^N]` and a `[^N]: body` definition
+     * appended at the end. No leftover placeholder of any shape.
+     */
+    const html =
+      '<p>see<sup><a href="#footnote-1">[1]</a></sup></p>' +
+      '<hr><ol><li id="footnote-1">body<a href="#footnote-ref-1">↑</a></li></ol>'
+    const md = htmlToMarkdown(html)
+    expect(md).toContain('see[^1]')
+    expect(md).toContain('[^1]: body')
+    expect(md).not.toContain('@@FOOTNOTE')
+    expect(md).not.toContain('XXFOOTNOTE')
+  })
 })

--- a/src/components/MarkdownEditor/fields-blog.ts
+++ b/src/components/MarkdownEditor/fields-blog.ts
@@ -1,17 +1,17 @@
 import type { FieldDefinition } from './frontmatter-fields'
 
-/** Frontmatter fields for blog posts */
+/**
+ * Frontmatter fields shown on the blog edit page. `description`
+ * was retired (#3): the public site still renders an existing
+ * description as a preface block, but new entries don't ask for
+ * one — listings derive their preview from the body's first
+ * paragraph instead.
+ */
 export const blogFields: readonly FieldDefinition[] = [
   {
     key: 'title',
     label: 'Title',
     type: 'text',
-    required: true,
-  },
-  {
-    key: 'description',
-    label: 'Description',
-    type: 'textarea',
     required: true,
   },
   {

--- a/src/components/MarkdownEditor/fields-newspaper.ts
+++ b/src/components/MarkdownEditor/fields-newspaper.ts
@@ -1,17 +1,14 @@
 import type { FieldDefinition } from './frontmatter-fields'
 
-/** Frontmatter fields for newspaper entries */
+/**
+ * Frontmatter fields shown on the newspaper-issue edit page.
+ * `description` retired — see fields-blog.ts.
+ */
 export const newspaperFields: readonly FieldDefinition[] = [
   {
     key: 'title',
     label: 'Title',
     type: 'text',
-    required: true,
-  },
-  {
-    key: 'description',
-    label: 'Description',
-    type: 'textarea',
     required: true,
   },
   { key: 'published', label: 'Published', type: 'checkbox' },

--- a/src/components/MarkdownEditor/fields-positions.ts
+++ b/src/components/MarkdownEditor/fields-positions.ts
@@ -1,17 +1,14 @@
 import type { FieldDefinition } from './frontmatter-fields'
 
-/** Frontmatter fields for positions */
+/**
+ * Frontmatter fields shown on the positions edit page.
+ * `description` retired — see fields-blog.ts.
+ */
 export const positionsFields: readonly FieldDefinition[] = [
   {
     key: 'title',
     label: 'Title',
     type: 'text',
-    required: true,
-  },
-  {
-    key: 'description',
-    label: 'Description',
-    type: 'textarea',
     required: true,
   },
   { key: 'published', label: 'Published', type: 'checkbox' },

--- a/src/validation/schemas/frontmatter-blog.ts
+++ b/src/validation/schemas/frontmatter-blog.ts
@@ -7,7 +7,8 @@ import { Schema } from 'effect'
  */
 export const BlogFrontmatterSchema = Schema.Struct({
   title: Schema.String.pipe(Schema.nonEmptyString()),
-  description: Schema.String.pipe(Schema.nonEmptyString()),
+  /* Description is optional now (#3) — see public-website#77. */
+  description: Schema.optional(Schema.String),
   category: Schema.String.pipe(Schema.nonEmptyString()),
   lang: Schema.String.pipe(Schema.nonEmptyString()),
   published: Schema.optional(Schema.Boolean),

--- a/src/validation/schemas/frontmatter-newspaper.ts
+++ b/src/validation/schemas/frontmatter-newspaper.ts
@@ -6,7 +6,8 @@ import { Schema } from 'effect'
  */
 export const NewspaperFrontmatterSchema = Schema.Struct({
   title: Schema.String.pipe(Schema.nonEmptyString()),
-  description: Schema.String.pipe(Schema.nonEmptyString()),
+  /* Description is optional now (#3) — see public-website#77. */
+  description: Schema.optional(Schema.String),
   lang: Schema.String.pipe(Schema.nonEmptyString()),
   published: Schema.optional(Schema.Boolean),
   publishDate: Schema.optional(

--- a/src/validation/schemas/frontmatter-positions.ts
+++ b/src/validation/schemas/frontmatter-positions.ts
@@ -6,7 +6,8 @@ import { Schema } from 'effect'
  */
 export const PositionsFrontmatterSchema = Schema.Struct({
   title: Schema.String.pipe(Schema.nonEmptyString()),
-  description: Schema.String.pipe(Schema.nonEmptyString()),
+  /* Description is optional now (#3) — see public-website#77. */
+  description: Schema.optional(Schema.String),
   lang: Schema.String.pipe(Schema.nonEmptyString()),
   published: Schema.optional(Schema.Boolean),
   publishDate: Schema.optional(

--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -50,18 +50,32 @@ defineEmits<{
 
 <style scoped>
 .edit-main {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
   flex: 1;
-  gap: clamp(0.5rem, 2vw, 1rem);
+  gap: clamp(1rem, 2vw, 2rem);
   padding: var(--content-frame-padding);
   max-width: var(--content-wide);
   width: 100%;
   margin-inline: auto;
   box-sizing: border-box;
+  align-content: start;
+}
+
+/*
+ * On wide screens dock frontmatter to a fixed-ish meta column on
+ * the left and let the body take the rest. Below 1024px the grid
+ * collapses to a single column so phone/tablet still scroll
+ * top-to-bottom.
+ */
+@media (width >= 1024px) {
+  .edit-main {
+    grid-template-columns: [meta] 22rem [body] minmax(0, 1fr);
+  }
 }
 
 .loading-state {
+  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -1,13 +1,8 @@
 <script setup lang="ts">
-import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
-import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
-import Fb2Upload from '@/components/MarkdownEditor/Fb2Upload.vue'
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
-import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
-import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
-import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import type { ContentType } from '@/types/content'
+import EditBodyArea from './EditBodyArea.vue'
 
 defineProps<{
   readonly bodyContent: string
@@ -27,58 +22,45 @@ defineEmits<{
   'set-cover': [name: string]
   error: [message: string]
 }>()
-
-const isNewspaper = (type: ContentType) => type === 'newspaper'
-
-const currentCover = (fm: Record<string, unknown>): string | undefined => {
-  const v = fm['image']
-  return typeof v === 'string' && v.length > 0 ? v : undefined
-}
 </script>
 
 <template>
   <FrontmatterEditor
     v-if="Object.keys(frontmatterData).length > 0"
+    class="edit-meta"
     :frontmatter="frontmatterData"
     :content-type="contentType"
     :slug="slug"
     @update:frontmatter="$emit('update:frontmatter', $event)"
   />
-  <PdfUpload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    :current-cover="currentCover(frontmatterData)"
-    @upload-pdf="$emit('upload-asset', $event)"
-    @upload-cover="$emit('upload-asset', $event)"
-    @set-cover="$emit('set-cover', $event)"
-  />
-  <DocxUpload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    :issue-title="(frontmatterData.title as string) ?? undefined"
-    :issue-lang="(frontmatterData.lang as string) ?? undefined"
-    :issue-description="(frontmatterData.description as string) ?? undefined"
-    @upload-fb2="$emit('upload-asset', $event)"
-    @error="$emit('error', $event)"
-  />
-  <Fb2Upload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    @upload-fb2="$emit('upload-asset', $event)"
-    @error="$emit('error', $event)"
-  />
-  <MarkdownEditorBody
-    v-else-if="hasBodyEditor(contentType, slug)"
-    :model-value="bodyContent"
+  <EditBodyArea
+    class="edit-body"
+    :body-content="bodyContent"
+    :frontmatter-data="frontmatterData"
+    :content-type="contentType"
+    :slug="slug"
     :asset-url-map="assetUrlMap"
     :assets="assets"
-    @update:model-value="$emit('update:bodyContent', $event)"
+    @update:body-content="$emit('update:bodyContent', $event)"
+    @preview="$emit('preview')"
     @paste:image="$emit('paste:image', $event)"
     @upload-asset="$emit('upload-asset', $event)"
+    @set-cover="$emit('set-cover', $event)"
     @error="$emit('error', $event)"
   />
-  <EditorFooter
-    :disabled="false"
-    @preview="$emit('preview')"
-  />
 </template>
+
+<style scoped>
+.edit-meta {
+  grid-column: meta;
+  align-self: start;
+}
+
+.edit-body {
+  grid-column: body;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  min-width: 0;
+}
+</style>

--- a/src/views/ContentEditView/EditBodyArea.vue
+++ b/src/views/ContentEditView/EditBodyArea.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
+import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
+import Fb2Upload from '@/components/MarkdownEditor/Fb2Upload.vue'
+import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
+import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
+import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
+import type { AssetDisplay } from '@/composables/useAssets/types'
+import type { ContentType } from '@/types/content'
+
+defineProps<{
+  readonly bodyContent: string
+  readonly frontmatterData: Record<string, unknown>
+  readonly contentType: ContentType
+  readonly slug?: string
+  readonly assetUrlMap?: ReadonlyMap<string, string>
+  readonly assets?: readonly AssetDisplay[]
+}>()
+
+defineEmits<{
+  'update:bodyContent': [value: string]
+  preview: []
+  'paste:image': [file: File]
+  'upload-asset': [file: File]
+  'set-cover': [name: string]
+  error: [message: string]
+}>()
+
+const isNewspaper = (type: ContentType) => type === 'newspaper'
+
+const currentCover = (fm: Record<string, unknown>): string | undefined => {
+  const v = fm['image']
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+</script>
+
+<template>
+  <PdfUpload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    :current-cover="currentCover(frontmatterData)"
+    @upload-pdf="$emit('upload-asset', $event)"
+    @upload-cover="$emit('upload-asset', $event)"
+    @set-cover="$emit('set-cover', $event)"
+  />
+  <DocxUpload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    :issue-title="(frontmatterData.title as string) ?? undefined"
+    :issue-lang="(frontmatterData.lang as string) ?? undefined"
+    :issue-description="(frontmatterData.description as string) ?? undefined"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <Fb2Upload
+    v-if="isNewspaper(contentType)"
+    :assets="assets"
+    @upload-fb2="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <MarkdownEditorBody
+    v-else-if="hasBodyEditor(contentType, slug)"
+    :model-value="bodyContent"
+    :asset-url-map="assetUrlMap"
+    :assets="assets"
+    @update:model-value="$emit('update:bodyContent', $event)"
+    @paste:image="$emit('paste:image', $event)"
+    @upload-asset="$emit('upload-asset', $event)"
+    @error="$emit('error', $event)"
+  />
+  <EditorFooter :disabled="false" @preview="$emit('preview')" />
+</template>

--- a/src/views/SettingsView/MemberList.vue
+++ b/src/views/SettingsView/MemberList.vue
@@ -28,12 +28,23 @@ defineEmits<{
 </template>
 
 <style scoped>
+/*
+ * Members render as a responsive card grid: 1 column on phones,
+ * 2 columns starting from tablet. Each row's own borders handle
+ * the card frame so the parent doesn't need an outer border.
+ */
 .member-list {
   list-style: none;
   padding: 0;
   margin: 0;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (width >= 720px) {
+  .member-list {
+    grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  }
 }
 </style>

--- a/src/views/SettingsView/MemberRow.vue
+++ b/src/views/SettingsView/MemberRow.vue
@@ -61,12 +61,17 @@ const onChange =
   grid-template-columns: 32px 1fr auto;
   align-items: center;
   gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  border-bottom: 1px solid var(--color-border);
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  transition: border-color var(--transition-fast),
+    background-color var(--transition-fast);
 }
 
-.member-row:last-child {
-  border-bottom: none;
+.member-row:hover {
+  border-color: var(--color-text-secondary);
+  background: var(--color-surface-elevated);
 }
 
 .avatar {


### PR DESCRIPTION
Pairs with public-website#77. Editor stopped asking for description; listings derive preview from body. Field removed from the three fields-*.ts; admin schemas relax description to optional so saves without one don't trip guardFrontmatter.