### PR TITLE
feat(admin): compact newspaper source uploads + tighter cover slot (#7)

### DIFF
--- a/src/components/AssetManager/CoverEmpty.vue
+++ b/src/components/AssetManager/CoverEmpty.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { COVER_UPLOAD_ID } from './test-ids'
+import UploadButton from './UploadButton.vue'
+
+defineEmits<{
+  upload: [file: File]
+}>()
+</script>
+
+<template>
+  <aside class="no-cover">
+    <p class="no-cover-text">No cover image yet</p>
+    <UploadButton
+      label="Upload cover"
+      accept="image/*,video/*"
+      :test-id="COVER_UPLOAD_ID"
+      @upload="$emit('upload', $event)"
+    />
+  </aside>
+</template>
+
+<style scoped>
+.no-cover {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-secondary);
+}
+
+.no-cover-text {
+  font-size: 0.8125rem;
+  margin: 0;
+}
+</style>

--- a/src/components/AssetManager/CoverImage.vue
+++ b/src/components/AssetManager/CoverImage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import CoverEmpty from './CoverEmpty.vue'
 import CoverOverlay from './CoverOverlay.vue'
 import { COVER_IMAGE_ID } from './test-ids'
 
@@ -22,8 +23,9 @@ defineEmits<{
       :src="coverUrl"
       alt="Article cover"
     />
-    <p v-else class="no-cover">No cover image</p>
+    <CoverEmpty v-else @upload="$emit('upload-cover', $event)" />
     <CoverOverlay
+      v-if="coverUrl"
       @delete="$emit('delete-cover')"
       @upload="$emit('upload-cover', $event)"
     />
@@ -36,23 +38,19 @@ defineEmits<{
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;
-  margin: 0;
+  margin: 0 auto;
+  max-width: 32rem;
+  width: 100%;
   background: var(--color-background-soft);
 }
 
 img {
   width: 100%;
-  max-height: 200px;
+  max-height: 16rem;
   display: block;
   object-fit: contain;
 }
 
-.no-cover {
-  padding: 2rem;
-  text-align: center;
-  color: var(--color-text-secondary);
-  margin: 0;
-}
 </style>
 
 <style>

--- a/src/components/MarkdownEditor/DocxUpload.vue
+++ b/src/components/MarkdownEditor/DocxUpload.vue
@@ -89,8 +89,7 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   >
     <span class="dropzone-icon" aria-hidden="true">DOCX</span>
     <span class="dropzone-label">
-      Drop a .docx to import (auto-converts to FB2; the .docx is
-      not stored — only the FB2 ships)
+      Drop a .docx — auto-converts to FB2 (only the FB2 ships)
     </span>
   </button>
   <input
@@ -153,15 +152,14 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
 
 .docx-dropzone {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 0.75rem;
-  padding: 2rem;
-  border: 2px dashed var(--color-border);
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-background-soft);
   cursor: pointer;
+  text-align: left;
   transition: border-color 0.2s, background 0.2s;
 }
 
@@ -175,18 +173,19 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 64px;
-  height: 64px;
-  border-radius: var(--radius-md);
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
   background: var(--color-info, #1976d2);
   color: #fff;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 0.6875rem;
+  flex-shrink: 0;
 }
 
 .dropzone-label {
   color: var(--color-text-secondary);
-  font-size: clamp(0.875rem, 2vw, 1rem);
-  text-align: center;
+  font-size: 0.8125rem;
+  line-height: 1.3;
 }
 </style>

--- a/src/components/MarkdownEditor/Fb2Upload.vue
+++ b/src/components/MarkdownEditor/Fb2Upload.vue
@@ -145,15 +145,14 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
 
 .fb2-dropzone {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 0.75rem;
-  padding: 1.5rem;
-  border: 2px dashed var(--color-border);
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-background-soft);
   cursor: pointer;
+  text-align: left;
   transition: border-color 0.2s, background 0.2s;
 }
 
@@ -167,18 +166,19 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 64px;
-  height: 64px;
-  border-radius: var(--radius-md);
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
   background: var(--color-success, #2e7d32);
   color: #fff;
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 0.75rem;
+  flex-shrink: 0;
 }
 
 .dropzone-label {
   color: var(--color-text-secondary);
-  font-size: clamp(0.875rem, 2vw, 1rem);
-  text-align: center;
+  font-size: 0.8125rem;
+  line-height: 1.3;
 }
 </style>

--- a/src/components/MarkdownEditor/FrontmatterEditor.test.ts
+++ b/src/components/MarkdownEditor/FrontmatterEditor.test.ts
@@ -1,5 +1,14 @@
 import { mount } from '@vue/test-utils'
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest'
 import FrontmatterEditor from './FrontmatterEditor.vue'
 
 const TODAY = '2026-04-23'
@@ -7,6 +16,7 @@ const TODAY = '2026-04-23'
 const mountEditor = (frontmatter: Record<string, unknown>) =>
   mount(FrontmatterEditor, {
     props: { frontmatter, contentType: 'blog' as const },
+    global: { plugins: [createPinia()] },
   })
 
 const lastEmit = (
@@ -21,6 +31,10 @@ describe('FrontmatterEditor — publishDate auto-fill', () => {
   beforeAll(() => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(`${TODAY}T12:00:00Z`))
+  })
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
   })
 
   afterAll(() => {

--- a/src/components/MarkdownEditor/NewspaperSourceUploads.vue
+++ b/src/components/MarkdownEditor/NewspaperSourceUploads.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import type { AssetDisplay } from '@/composables/useAssets/types'
+import DocxUpload from './DocxUpload.vue'
+import Fb2Upload from './Fb2Upload.vue'
+import PdfUpload from './PdfUpload.vue'
+import SourceUploadsHeader from './SourceUploadsHeader.vue'
+
+defineProps<{
+  readonly assets?: readonly AssetDisplay[]
+  readonly currentCover?: string
+  readonly issueTitle?: string
+  readonly issueLang?: string
+}>()
+
+defineEmits<{
+  'upload-asset': [file: File]
+  'set-cover': [name: string]
+  error: [message: string]
+}>()
+
+const HINT =
+  'PDF (the printed issue) and FB2 (the readable text) — pick whichever ' +
+  'you have. DOCX is auto-converted to FB2 on import.'
+</script>
+
+<template>
+  <section class="source-uploads" data-testid="newspaper-source-uploads">
+    <SourceUploadsHeader title="Source files" :hint="HINT" />
+    <PdfUpload
+      :assets="assets"
+      :current-cover="currentCover"
+      @upload-pdf="$emit('upload-asset', $event)"
+      @upload-cover="$emit('upload-asset', $event)"
+      @set-cover="$emit('set-cover', $event)"
+    />
+    <DocxUpload
+      :assets="assets"
+      :issue-title="issueTitle"
+      :issue-lang="issueLang"
+      @upload-fb2="$emit('upload-asset', $event)"
+      @error="$emit('error', $event)"
+    />
+    <Fb2Upload
+      :assets="assets"
+      @upload-fb2="$emit('upload-asset', $event)"
+      @error="$emit('error', $event)"
+    />
+  </section>
+</template>
+
+<style scoped>
+.source-uploads {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+}
+
+.source-uploads > :first-child {
+  grid-column: 1 / -1;
+  margin-bottom: 0.25rem;
+}
+
+@media (width >= 720px) {
+  .source-uploads {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+</style>

--- a/src/components/MarkdownEditor/PdfUpload.vue
+++ b/src/components/MarkdownEditor/PdfUpload.vue
@@ -76,9 +76,7 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(dragging, handleF
     @dragleave="onDragLeave"
   >
     <span class="dropzone-icon" aria-hidden="true">PDF</span>
-    <span class="dropzone-label">
-      Drop PDF file here or click to upload
-    </span>
+    <span class="dropzone-label">Drop PDF here or click to upload</span>
   </button>
   <input
     ref="inputRef"
@@ -140,15 +138,14 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(dragging, handleF
 
 .pdf-dropzone {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  justify-content: center;
   gap: 0.75rem;
-  padding: 2rem;
-  border: 2px dashed var(--color-border);
+  padding: 0.75rem 1rem;
+  border: 1px dashed var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-background-soft);
   cursor: pointer;
+  text-align: left;
   transition: border-color 0.2s, background 0.2s;
 }
 
@@ -162,17 +159,19 @@ const { onDrop, onDragOver, onDragLeave } = createDragHandlers(dragging, handleF
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 64px;
-  height: 64px;
-  border-radius: var(--radius-md);
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
   background: var(--color-error, #e53935);
   color: #fff;
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 0.75rem;
+  flex-shrink: 0;
 }
 
 .dropzone-label {
   color: var(--color-text-secondary);
-  font-size: clamp(0.875rem, 2vw, 1rem);
+  font-size: 0.8125rem;
+  line-height: 1.3;
 }
 </style>

--- a/src/components/MarkdownEditor/SourceUploadsHeader.vue
+++ b/src/components/MarkdownEditor/SourceUploadsHeader.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+defineProps<{
+  readonly title: string
+  readonly hint: string
+}>()
+</script>
+
+<template>
+  <header class="source-uploads-header">
+    <h2 class="source-uploads-title">{{ title }}</h2>
+    <p class="source-uploads-hint">{{ hint }}</p>
+  </header>
+</template>
+
+<style scoped>
+.source-uploads-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.source-uploads-title {
+  font-size: 0.875rem;
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.source-uploads-hint {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: 1.4;
+}
+</style>

--- a/src/components/MarkdownEditor/frontmatter-fields.test.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.test.ts
@@ -8,10 +8,10 @@ describe('getFields', () => {
       const keys = fields.map(f => f.key)
       expect(keys).toEqual([
         'title',
-        'description',
         'category',
         'published',
         'publishDate',
+        'newspaper',
       ])
     })
   })
@@ -20,12 +20,7 @@ describe('getFields', () => {
     it('returns positions fields', () => {
       const fields = getFields('positions')
       const keys = fields.map(f => f.key)
-      expect(keys).toEqual([
-        'title',
-        'description',
-        'published',
-        'publishDate',
-      ])
+      expect(keys).toEqual(['title', 'published', 'publishDate'])
     })
   })
 

--- a/src/validation/schemas/frontmatter.test.ts
+++ b/src/validation/schemas/frontmatter.test.ts
@@ -28,11 +28,16 @@ describe('validateFrontmatter', () => {
     expect(Either.isLeft(r)).toBe(true)
   })
 
-  it('rejects a positions missing description', () => {
+  it('accepts a positions without description (#3)', () => {
     const r = validateFrontmatter('positions', {
       title: 'T',
       lang: 'en',
     })
+    expect(Either.isRight(r)).toBe(true)
+  })
+
+  it('rejects a positions missing title', () => {
+    const r = validateFrontmatter('positions', { lang: 'en' })
     expect(Either.isLeft(r)).toBe(true)
   })
 

--- a/src/views/ContentEditView/EditBodyArea.vue
+++ b/src/views/ContentEditView/EditBodyArea.vue
@@ -1,14 +1,12 @@
 <script setup lang="ts">
-import DocxUpload from '@/components/MarkdownEditor/DocxUpload.vue'
 import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
-import Fb2Upload from '@/components/MarkdownEditor/Fb2Upload.vue'
 import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
-import PdfUpload from '@/components/MarkdownEditor/PdfUpload.vue'
+import NewspaperSourceUploads from '@/components/MarkdownEditor/NewspaperSourceUploads.vue'
 import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import type { ContentType } from '@/types/content'
 
-defineProps<{
+const props = defineProps<{
   readonly bodyContent: string
   readonly frontmatterData: Record<string, unknown>
   readonly contentType: ContentType
@@ -28,45 +26,43 @@ defineEmits<{
 
 const isNewspaper = (type: ContentType) => type === 'newspaper'
 
-const currentCover = (fm: Record<string, unknown>): string | undefined => {
-  const v = fm['image']
+const fmString = (key: string): string | undefined => {
+  const v = props.frontmatterData[key]
   return typeof v === 'string' && v.length > 0 ? v : undefined
 }
 </script>
 
 <template>
-  <PdfUpload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    :current-cover="currentCover(frontmatterData)"
-    @upload-pdf="$emit('upload-asset', $event)"
-    @upload-cover="$emit('upload-asset', $event)"
-    @set-cover="$emit('set-cover', $event)"
-  />
-  <DocxUpload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    :issue-title="(frontmatterData.title as string) ?? undefined"
-    :issue-lang="(frontmatterData.lang as string) ?? undefined"
-    :issue-description="(frontmatterData.description as string) ?? undefined"
-    @upload-fb2="$emit('upload-asset', $event)"
-    @error="$emit('error', $event)"
-  />
-  <Fb2Upload
-    v-if="isNewspaper(contentType)"
-    :assets="assets"
-    @upload-fb2="$emit('upload-asset', $event)"
-    @error="$emit('error', $event)"
-  />
-  <MarkdownEditorBody
-    v-else-if="hasBodyEditor(contentType, slug)"
-    :model-value="bodyContent"
-    :asset-url-map="assetUrlMap"
-    :assets="assets"
-    @update:model-value="$emit('update:bodyContent', $event)"
-    @paste:image="$emit('paste:image', $event)"
-    @upload-asset="$emit('upload-asset', $event)"
-    @error="$emit('error', $event)"
-  />
-  <EditorFooter :disabled="false" @preview="$emit('preview')" />
+  <section class="edit-body-area">
+    <NewspaperSourceUploads
+      v-if="isNewspaper(contentType)"
+      :assets="assets"
+      :current-cover="fmString('image')"
+      :issue-title="fmString('title')"
+      :issue-lang="fmString('lang')"
+      @upload-asset="$emit('upload-asset', $event)"
+      @set-cover="$emit('set-cover', $event)"
+      @error="$emit('error', $event)"
+    />
+    <MarkdownEditorBody
+      v-else-if="hasBodyEditor(contentType, slug)"
+      :model-value="bodyContent"
+      :asset-url-map="assetUrlMap"
+      :assets="assets"
+      @update:model-value="$emit('update:bodyContent', $event)"
+      @paste:image="$emit('paste:image', $event)"
+      @upload-asset="$emit('upload-asset', $event)"
+      @error="$emit('error', $event)"
+    />
+    <EditorFooter :disabled="false" @preview="$emit('preview')" />
+  </section>
 </template>
+
+<style scoped>
+.edit-body-area {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  min-width: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- Replaces 3 stacked, full-width source-upload widgets on the newspaper edit page with a compact 3-column grid (PDF / DOCX / FB2). Each dropzone shrinks to ~40px icon + horizontal label, so all three fit in one editor row instead of three screen-fulls.
- Wraps `EditBodyArea` in a single root so `class="edit-body"` from the parent grid actually applies — without it the source-uploads section was landing in the narrow meta column on wide viewports.
- Caps the cover slot at 32rem max-width (was full --content-wide) and replaces the "No cover image" placeholder with a clear "Upload cover" CTA in `CoverEmpty.vue`. The hover delete/replace overlay still applies for the filled state.
- Catches up two stale unit tests that were already red on master after #187 (description field retired) and #184 (Pinia + IssuePicker).

Closes part of #7.

## Visual proof
| state | result |
| --- | --- |
| Newspaper edit (empty) — desktop | compact cover + 3-col uploads |
| Newspaper edit (empty) — mobile | cover + uploads stacked |
| Blog edit (with cover) | cover at 32rem, two-column meta+body unchanged |

## Test plan
- [x] `bun run validate` — type-check + biome + oxlint + eslint + vue-depth + stylelint all green
- [x] `bun run test:unit -- --run` — 102/102 files, 519/519 tests pass
- [x] `e2e/content/asset-cover.spec.ts` — 8/8 pass on chromium + mobile
- [x] `e2e/content/markdown-editor.spec.ts` — 4/4 pass
- [x] Manual smoke: `/content/newspaper/edit/test` — cover, source-uploads grid, mobile collapse, blog edit unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)