### PR TITLE
fix(sw): surface real error cause — no more 'Commit failed: An error has occurred'

### DIFF
--- a/src/sw/handlers/file/create.ts
+++ b/src/sw/handlers/file/create.ts
@@ -1,6 +1,7 @@
 import { computeBlobSha } from '../../git/blob-sha'
 import { writeAndStage } from '../../git/io/write-file'
 import { log } from '../../logging/logger'
+import { describeError } from '../shared/describe-error'
 import { errorResponse, jsonResponse } from '../shared/json-response'
 
 interface CreateFileBody {
@@ -34,7 +35,7 @@ export const handleFileCreate = async (
       staged: true,
     })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     log('error', 'cache', `file create failed for ${path}: ${msg}`)
     return errorResponse(`Failed to create file: ${msg}`, 500)
   }

--- a/src/sw/handlers/file/update.ts
+++ b/src/sw/handlers/file/update.ts
@@ -2,6 +2,7 @@ import { computeBlobSha } from '../../git/blob-sha'
 import { writeAndStage } from '../../git/io/write-file'
 import { commitAndPush } from '../../git/remote/commit-and-push'
 import { log } from '../../logging/logger'
+import { describeError } from '../shared/describe-error'
 import { errorResponse, jsonResponse } from '../shared/json-response'
 
 interface UpdateFileBody {
@@ -47,7 +48,7 @@ export const handleFileUpdate = async (
       commit: { sha: commitSha },
     })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
+    const msg = describeError(err)
     log('error', 'cache', `file update failed for ${path}: ${msg}`)
     return errorResponse(`Failed to update file: ${msg}`, 500)
   }

--- a/src/sw/handlers/repo/commit.ts
+++ b/src/sw/handlers/repo/commit.ts
@@ -1,4 +1,5 @@
 import { commitAndPush } from '../../git/remote/commit-and-push'
+import { describeError } from '../shared/describe-error'
 import { errorResponse, jsonResponse } from '../shared/json-response'
 
 /**
@@ -14,7 +15,6 @@ export const handleCommit = async (request: Request): Promise<Response> => {
     const sha = await commitAndPush(message)
     return jsonResponse({ success: true, sha })
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err)
-    return errorResponse(`Commit failed: ${msg}`, 500)
+    return errorResponse(`Commit failed: ${describeError(err)}`, 500)
   }
 }

--- a/src/sw/handlers/route.ts
+++ b/src/sw/handlers/route.ts
@@ -5,6 +5,7 @@ import { routeContentRequest } from './content/route'
 import { routeFileRequest } from './file/route'
 import { recoverAndRetry } from './recover-and-retry'
 import { matchRbacRoute } from './route-rbac'
+import { describeError } from './shared/describe-error'
 import type { RouteHandler } from './shared/first-match'
 import { firstMatch } from './shared/first-match'
 import { errorResponse } from './shared/json-response'
@@ -21,9 +22,6 @@ const routes: readonly RouteHandler[] = [
   routeAssetRequest,
   routeContentRequest,
 ]
-
-const toMessage = (err: unknown): string =>
-  err instanceof Error ? err.message : String(err)
 
 const exec = (request: Request): Promise<Response> =>
   pipe(
@@ -43,7 +41,7 @@ const exec = (request: Request): Promise<Response> =>
 export const routeRequest = async (request: Request): Promise<Response> => {
   const replay = request.clone()
   return exec(request).catch(err => {
-    log('error', 'cache', `Handler error: ${toMessage(err)}`)
+    log('error', 'cache', `Handler error: ${describeError(err)}`)
     return recoverAndRetry(replay, exec)
   })
 }

--- a/src/sw/handlers/shared/describe-error.test.ts
+++ b/src/sw/handlers/shared/describe-error.test.ts
@@ -1,0 +1,50 @@
+import { Data } from 'effect'
+import { describe, expect, it } from 'vitest'
+import { describeError } from './describe-error'
+
+class TaglessTaggedError extends Data.TaggedError('ConfigMissingError')<
+  Record<string, never>
+> {}
+
+class WithCause extends Data.TaggedError('GitError')<{
+  readonly operation: string
+  readonly cause: unknown
+}> {}
+
+describe('describeError', () => {
+  it('returns the message of a regular Error', () => {
+    expect(describeError(new Error('boom'))).toBe('boom')
+  })
+
+  it('returns the literal when a string is thrown', () => {
+    expect(describeError('boom')).toBe('boom')
+  })
+
+  /*
+   * The opaque-error regression: Effect's TaggedError without a
+   * message field made the runtime fall back to "An error has
+   * occurred" — and the editor saw that string with no clue what
+   * actually went wrong.
+   */
+  it('uses _tag when an Effect TaggedError has no message field', () => {
+    expect(describeError(new TaglessTaggedError({}))).toBe(
+      'ConfigMissingError'
+    )
+  })
+
+  it('combines _tag with the inner cause for nested Effect errors', () => {
+    const cause = new Error('mkdir EEXIST')
+    expect(
+      describeError(
+        new WithCause({
+          operation: 'init',
+          cause,
+        })
+      )
+    ).toBe('GitError: mkdir EEXIST')
+  })
+
+  it('falls back to JSON when the value has no usable fields', () => {
+    expect(describeError({ a: 1, b: 'two' })).toBe('{"a":1,"b":"two"}')
+  })
+})

--- a/src/sw/handlers/shared/describe-error.ts
+++ b/src/sw/handlers/shared/describe-error.ts
@@ -1,0 +1,67 @@
+/*
+ * Build a human-readable message out of whatever the SW just
+ * threw. The previous catch in handleCommit unconditionally read
+ * `err.message` — but Effect's `Data.TaggedError`, when
+ * constructed without a `message` field, leaves the runtime to
+ * fall back to its generic string "An error has occurred". The
+ * editor then saw `Commit failed: An error has occurred` with
+ * zero hint at what actually went wrong.
+ *
+ * Here we walk the structure: prefer an explicit `.message`,
+ * otherwise the `_tag` of the Effect error (so at least the
+ * editor sees `Commit failed: ConfigMissingError`), otherwise
+ * the cause chain, otherwise the JSON of the error object so
+ * something useful surfaces every time.
+ */
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null
+
+const tagOf = (err: Record<string, unknown>): string | undefined => {
+  const tag = err['_tag']
+  return typeof tag === 'string' ? tag : undefined
+}
+
+const messageOf = (err: Record<string, unknown>): string | undefined => {
+  const m = err['message']
+  return typeof m === 'string' && m.length > 0 ? m : undefined
+}
+
+const causeOf = (err: Record<string, unknown>): unknown => err['cause']
+
+/*
+ * `tag: cause-message` is the most informative shape — the editor
+ * sees both the category (ConfigMissingError, GitError) and the
+ * underlying reason (mkdir EEXIST, etc).
+ */
+const compose = (
+  tag: string | undefined,
+  message: string | undefined,
+  causeMsg: string | undefined,
+  fallback: string
+): string =>
+  tag && causeMsg
+    ? `${tag}: ${causeMsg}`
+    : (tag ?? message ?? causeMsg ?? fallback)
+
+const describeObject = (err: Record<string, unknown>): string => {
+  const cause = causeOf(err)
+  const causeMsg =
+    cause === undefined || cause === null ? undefined : describeError(cause)
+  return compose(tagOf(err), messageOf(err), causeMsg, JSON.stringify(err))
+}
+
+/**
+ * Coerce any thrown value into a non-empty user-visible string.
+ * Preference order: explicit message → tag + cause → JSON dump.
+ *
+ * @param err Anything thrown / rejected.
+ * @returns Description suitable for an error response.
+ */
+export const describeError = (err: unknown): string =>
+  err instanceof Error && err.message.length > 0
+    ? err.message
+    : typeof err === 'string'
+      ? err
+      : isObject(err)
+        ? describeObject(err)
+        : String(err)


### PR DESCRIPTION
## What you saw

> ![Error: Commit failed: An error has occurred](docs)

Zero hint at the actual cause. The editor had no way to tell whether it was a network drop, a missing config, a YAML parse failure, or the GitHub token being expired.

## Root cause

Effect's \`Data.TaggedError\` is constructed without a \`message\` field by default (see \`src/sw/errors/index.ts\` — \`ConfigMissingError\`, \`NotFoundError\`, etc.). When such an error bubbles into Effect's runtime to be presented as a regular JS Error, the runtime synthesises a FiberFailure whose \`.message\` falls back to the literal string \"An error has occurred\" (\`node_modules/effect/dist/.../runtime.js: super(head?.message || \"An error has occurred\")\`). The catches in the handlers then read \`err.message\` and forwarded that opaque text up to the toast.

## Fix

\`describeError(err)\` walks the structure:
1. explicit \`.message\` (a regular Error → use it)
2. Effect \`_tag\` + inner \`.cause\` composed → \`\"GitError: mkdir EEXIST\"\`
3. just the \`_tag\` if there is no cause → \`\"ConfigMissingError\"\`
4. \`JSON.stringify\` as last resort

Applied at every catch site that previously emitted the opaque message:
- \`sw/handlers/repo/commit.ts\` — \"Commit failed\"
- \`sw/handlers/file/create.ts\` — \"Failed to create file\"
- \`sw/handlers/file/update.ts\` — \"Failed to update file\"
- \`sw/handlers/route.ts\` — top-level handler log

## Test plan
- [x] \`describeError\` unit tests: 5/5 pass — Error with message, plain string, tagless TaggedError, tagged with cause, opaque object → JSON.
- [x] Full unit suite: 557/557 pass.
- [x] \`bun run validate\` clean.

## Pairs with
- #189 (merged) — closes the YAML hole at the source
- #193 — property-based fuzz proves admin's output is build-safe by construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)