### PR TITLE
fix(e2e): catch up to #187 (description retired) — unblock admin deploy

### DIFF
--- a/e2e/content/create-edit-roundtrip.spec.ts
+++ b/e2e/content/create-edit-roundtrip.spec.ts
@@ -63,8 +63,11 @@ test.describe('Content - create → edit round-trip', () => {
 
     // Verify each required blog field is bound in the form — the actual
     // regression was that the form rendered with empty values.
+    // Description retired from the FrontmatterEditor for blog in #187,
+    // so we don't probe `#fm-description` here. The create dialog still
+    // collects description and the field round-trips into the file body
+    // — checked via the file-content assertions below.
     await expect(page.locator('#fm-title')).toHaveValue(title)
-    await expect(page.locator('#fm-description')).toHaveValue(description)
     await expect(page.locator('#fm-category')).not.toHaveValue('')
 
     // Type a change into the body, then save. Use the editor-body

--- a/e2e/content/frontmatter-validation.spec.ts
+++ b/e2e/content/frontmatter-validation.spec.ts
@@ -37,20 +37,14 @@ test.describe('Frontmatter validation before save', () => {
     expect(commitFired).toBe(false)
   })
 
-  test('clearing the description blocks the save', async ({ page }) => {
-    await edit(page)
-    await page.locator('#fm-description').fill('')
-
-    let commitFired = false
-    page.on('response', r => {
-      if (r.url().includes('/api/github/commit')) commitFired = true
-    })
-
-    await saveAndConfirm(page, await openPreview(page))
-    await expectVisible(page, errorBanner(page))
-    await waitForCondition(page, async () => true)
-    expect(commitFired).toBe(false)
-  })
+  /*
+   * "clearing the description blocks the save" was retired with #187 —
+   * description is no longer a required field for blog (or any other
+   * collection). Listings derive a card preview from the body's first
+   * paragraph; the article page renders the description as a lead block
+   * only when an old entry still carries one. Title is now the sole
+   * mandatory text field — covered by the test above.
+   */
 
   test('valid frontmatter allows the save to complete', async ({ page }) => {
     await edit(page)

--- a/src/components/CreateContentDialog/CreateContentDialog.vue
+++ b/src/components/CreateContentDialog/CreateContentDialog.vue
@@ -77,8 +77,8 @@ watch(() => props.show, visible => {
       <label for="title" class="field-label">Title *</label>
       <input id="title" v-model="title" type="text" required placeholder="Article Title" class="field-input" />
       <template v-if="contentType === 'blog' || contentType === 'positions' || contentType === 'newspaper'">
-        <label for="description" class="field-label">Description *</label>
-        <textarea id="description" v-model="description" required placeholder="Brief description..." rows="3" class="field-input" />
+        <label for="description" class="field-label">Description (optional)</label>
+        <textarea id="description" v-model="description" placeholder="Optional — listings derive a preview from the body's first paragraph when blank." rows="3" class="field-input" />
       </template>
       <template v-if="contentType === 'blog'">
         <label for="category" class="field-label">Category *</label>


### PR DESCRIPTION
## Why

Admin master deploy has been **red since #187 merged** (a week ago). Two stale e2e tests + one stale dialog field were never updated when description was retired, and the deploy gate has been failing on them ever since:

- \`e2e/content/create-edit-roundtrip.spec.ts\` — asserted \`#fm-description\` on the FrontmatterEditor, which #187 removed.
- \`e2e/content/frontmatter-validation.spec.ts\` — \"clearing the description blocks the save\" was the exact validation rule #187 explicitly dropped.
- \`CreateContentDialog.vue\` — still rendered \`Description *\` with html5 \`required\`, contradicting the schema.

Net effect: the live admin still serves the **pre-#189 broken YAML serializer** because every deploy attempt is blocked by these stale tests, so editors keep committing invalid frontmatter and crashing prod (\`from-manchester\`, \`cyber-tool\`, \`about-the-manifesto\` regressions all happened **after** #189 was merged but never reached production admin).

## Changes

- Drop \`#fm-description\` assertion from create-edit roundtrip — file-content assertions further down still verify description round-trips from dialog → file body.
- Drop the \"clearing the description blocks the save\" test — assertion contradicts the post-#187 contract.
- Dialog: relabel as \`Description (optional)\`, drop html5 \`required\`. Placeholder explains the body-derived preview fallback so editors who skip it understand what they get.

## Tests
- [x] \`bun run validate\` clean
- [x] \`bun run test:unit\` 546/546 pass

## Unblocks
- admin#189 (yaml lib + pre-stage guard) reaches production admin
- admin#193 (fuzz) deploys
- admin#194 (describeError, no more 'An error has occurred')

🤖 Generated with [Claude Code](https://claude.com/claude-code)