### PR TITLE
fix(deploy-detail): GH log API rejects Accept: text/plain — use vnd.github+json

### DIFF
--- a/src/composables/useDeployStatus/job-logs.ts
+++ b/src/composables/useDeployStatus/job-logs.ts
@@ -38,8 +38,18 @@ const fetchLogText = async (
   token: string
 ): Promise<JobLogResult> => {
   try {
+    /*
+     * GitHub's REST API rejects `Accept: text/plain` on the
+     * /actions/jobs/:id/logs endpoint with a 415 — even though the
+     * eventual blob storage redirect target serves plain text.
+     * Send the canonical GH API mime; the 302 to blob storage is
+     * followed transparently and the body comes back as plain text.
+     */
     const r = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}`, Accept: 'text/plain' },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
       cache: 'no-store',
     })
     return onHttp(r)


### PR DESCRIPTION
GH API responded `415 Unsupported 'Accept' header: 'text/plain'. Must accept 'application/json'`. Switched to canonical `application/vnd.github+json`. The 302 redirect to blob storage is followed transparently and the log body comes back as plain text the same way.

The error was visible only because #196 swapped the misleading 'token missing or job too young' fallback for the real upstream message — that work paid off the moment it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)