### PR TITLE
feat(editor): GFM footnotes — toolbar button + preview support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "isomorphic-git": "^1.37.2",
         "mammoth": "^1.12.0",
         "marked": "^17.0.4",
+        "marked-footnote": "^1.4.0",
         "pinia": "^3.0.4",
         "turndown": "^7.2.4",
         "turndown-plugin-gfm": "^1.0.2",
@@ -1246,6 +1247,8 @@
     "mammoth": ["mammoth@1.12.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.6", "argparse": "~1.0.3", "base64-js": "^1.5.1", "bluebird": "~3.4.0", "dingbat-to-unicode": "^1.0.1", "jszip": "^3.7.1", "lop": "^0.4.2", "path-is-absolute": "^1.0.0", "underscore": "^1.13.1", "xmlbuilder": "^10.0.0" }, "bin": { "mammoth": "bin/mammoth" } }, "sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w=="],
 
     "marked": ["marked@17.0.6", "", { "bin": "bin/marked.js" }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
+
+    "marked-footnote": ["marked-footnote@1.4.0", "", { "peerDependencies": { "marked": ">=7.0.0" } }, "sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg=="],
 
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "isomorphic-git": "^1.37.2",
     "mammoth": "^1.12.0",
     "marked": "^17.0.4",
+    "marked-footnote": "^1.4.0",
     "pinia": "^3.0.4",
     "turndown": "^7.2.4",
     "turndown-plugin-gfm": "^1.0.2",

--- a/src/components/MarkdownEditor/CommandPanel.vue
+++ b/src/components/MarkdownEditor/CommandPanel.vue
@@ -14,6 +14,7 @@ const emit = defineEmits<{
   wrap: [pre: string, suf: string]
   block: [prefix: string]
   'insert-media': [tag: string]
+  'insert-footnote': []
   'upload-asset': [file: File]
 }>()
 
@@ -54,6 +55,12 @@ const onMedia = (a: AssetDisplay) => {
       label="―"
       title="Horizontal rule"
       @click="$emit('block', '---\n')"
+    />
+    <CmdButton
+      label="[†]"
+      title="Footnote (insert [^N] + definition)"
+      test-id="cmd-footnote"
+      @click="$emit('insert-footnote')"
     />
     <span
       v-if="assets"

--- a/src/components/MarkdownEditor/MarkdownEditorBody.vue
+++ b/src/components/MarkdownEditor/MarkdownEditorBody.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import CommandPanel from './CommandPanel.vue'
 import { createPasteDrop } from './editor-paste-drop'
+import { execFootnote } from './exec-footnote'
 import { handleKeyboard } from './handle-keyboard'
 import { insertUploadTag } from './handle-upload'
 import ImportDocsButton from './ImportDocs/ImportDocsButton.vue'
@@ -60,6 +61,7 @@ const handleImported = (markdown: string, images: readonly File[]) =>
       @wrap="wrap"
       @block="p => textareaRef && execBlock(textareaRef, p)"
       @insert-media="t => textareaRef && execMedia(textareaRef, t)"
+      @insert-footnote="textareaRef && execFootnote(textareaRef)"
       @upload-asset="handleUpload"
     />
     <textarea

--- a/src/components/MarkdownEditor/MarkdownPreview.vue
+++ b/src/components/MarkdownEditor/MarkdownPreview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { Marked } from 'marked'
+import markedFootnote from 'marked-footnote'
 import { computed } from 'vue'
 import { createAssetExtension } from './create-asset-renderer'
 
@@ -8,8 +9,17 @@ const props = defineProps<{
   readonly assetUrlMap?: ReadonlyMap<string, string>
 }>()
 
+/*
+ * GFM footnotes: `[^N]` in the body becomes a superscript link to
+ * `#user-content-fn-N`, and `[^N]: text` defines a list block at
+ * the bottom whose `↩` link goes back to the marker. The plugin
+ * generates matching `id` attributes so anchor navigation works
+ * inside this preview AND on the public site (Astro's remark-gfm
+ * emits the same shape, so the markdown round-trips identically).
+ */
 const html = computed(() => {
   const m = new Marked()
+  m.use(markedFootnote())
   if (props.assetUrlMap && props.assetUrlMap.size > 0) {
     m.use(createAssetExtension(props.assetUrlMap))
   }

--- a/src/components/MarkdownEditor/exec-footnote.test.ts
+++ b/src/components/MarkdownEditor/exec-footnote.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { nextFootnoteId } from './exec-footnote'
+
+describe('nextFootnoteId', () => {
+  it('returns 1 for an empty body', () => {
+    expect(nextFootnoteId('')).toBe(1)
+  })
+
+  it('returns 1 when no footnotes exist', () => {
+    expect(nextFootnoteId('lorem ipsum dolor sit')).toBe(1)
+  })
+
+  it('returns max + 1 when markers exist in the text', () => {
+    expect(nextFootnoteId('a [^1] b [^2] c [^5] d')).toBe(6)
+  })
+
+  it('reads ids out of definition lines too', () => {
+    expect(nextFootnoteId('text [^3]\n\n[^3]: definition')).toBe(4)
+  })
+
+  it('skips non-numeric ids without crashing', () => {
+    /*
+     * GFM allows word ids like `[^big-quote]` — they shouldn't
+     * raise the integer counter, only numeric markers do.
+     */
+    expect(nextFootnoteId('a [^manifest] b [^7] c')).toBe(8)
+  })
+})

--- a/src/components/MarkdownEditor/exec-footnote.ts
+++ b/src/components/MarkdownEditor/exec-footnote.ts
@@ -1,0 +1,48 @@
+const MARKER_RE = /\[\^(\d+)\]/g
+
+/**
+ * Find the next free numeric footnote id by scanning the body for
+ * existing `[^N]` markers and definitions and returning max + 1.
+ *
+ * @param body Current textarea content.
+ * @returns Next free integer footnote id (1 when none exist yet).
+ */
+export const nextFootnoteId = (body: string): number => {
+  const ids = [...body.matchAll(MARKER_RE)]
+    .map(m => Number(m[1]))
+    .filter(n => Number.isFinite(n))
+  return (ids.length === 0 ? 0 : Math.max(...ids)) + 1
+}
+
+/**
+ * Insert a GFM footnote at the cursor. The marker `[^N]` lands at
+ * the caret position; the empty definition `[^N]: ` is appended to
+ * the very end of the body so editors find it where it'll be
+ * rendered. After insertion the caret moves to the definition line
+ * so the editor can type the footnote text immediately.
+ *
+ * @param el Textarea element.
+ * @returns void
+ */
+export const execFootnote = (el: HTMLTextAreaElement): void => {
+  const id = nextFootnoteId(el.value)
+  const marker = `[^${id}]`
+  const def = `[^${id}]: `
+
+  el.focus()
+  document.execCommand('insertText', false, marker)
+
+  /*
+   * Append the empty definition at the end of the body. We move the
+   * caret there, write `\n\n[^N]: `, and leave the caret at the end
+   * of that line so the editor types the footnote text right away.
+   */
+  const end = el.value.length
+  const trailingNewlines = el.value.endsWith('\n\n')
+    ? ''
+    : el.value.endsWith('\n')
+      ? '\n'
+      : '\n\n'
+  el.setSelectionRange(end, end)
+  document.execCommand('insertText', false, `${trailingNewlines}${def}`)
+}


### PR DESCRIPTION
Adds a [†] button to the markdown command panel and `marked-footnote` to the preview pipeline so GFM footnotes work end-to-end in the admin.

Click the [†] button → `[^N]` lands at the caret + `[^N]: ` is appended at the end of the body with caret positioned to type the footnote text. N auto-increments based on existing markers.

Preview renders `[^N]` as a sup-link with anchor navigation to the matching definition block, mirroring Astro v5's remark-gfm output on the public site. Same shape both places, no surprises at deploy time.

The existing project convention (`[\[N\]](#footnote-X)` + numbered list with `[↑](#footnote-ref-X)`) doesn't actually resolve on prod (no matching ids in HTML — verified via curl). This PR ships the syntax that works; migrating old articles is a separate workstream.

Tests: 5 unit cases on `nextFootnoteId`, full suite 567/567 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)