### PR TITLE
fix(content): 'Delete only X' did nothing — stale lang in closure + last-lang promotion

### DIFF
--- a/src/views/ContentView.vue
+++ b/src/views/ContentView.vue
@@ -27,7 +27,13 @@ const labelsStore = useLabelsStore()
 onMounted(() => labelsStore.ensureLoaded())
 const handleSelect = createSelectHandler(router, typeRef)
 const pushAndTrack = usePushAndTrack()
-const del = createDeleteState(typeRef, selectedLang, reloadContent, pushAndTrack)
+const del = createDeleteState({
+  contentType: typeRef,
+  selectedLang,
+  listItems: items,
+  reload: reloadContent,
+  pushAndTrack,
+})
 
 const handleCreate = (data: CreateContentData) => {
   setNewContentDraft(data)

--- a/src/views/ContentView/build-delete-handlers.ts
+++ b/src/views/ContentView/build-delete-handlers.ts
@@ -1,0 +1,28 @@
+import type { Ref } from 'vue'
+import type { ContentItem, ContentType, Language } from '@/types/content'
+import { createDeleteHandlers } from './create-delete-handlers'
+
+interface CreateDeps {
+  readonly contentType: Ref<ContentType>
+  readonly selectedLang: Ref<Language>
+  readonly listItems: Ref<readonly ContentItem[]>
+  readonly reload: () => Promise<void>
+  readonly pushAndTrack: (message: string) => Promise<string>
+}
+
+/**
+ * Wire reactive refs to `createDeleteHandlers` getters so the
+ * handlers always read the current selection on each invocation.
+ *
+ * @param d - Reactive deps
+ * @returns Raw delete handlers (deleteAll, deleteLang)
+ */
+export const buildDeleteHandlers = (d: CreateDeps) =>
+  createDeleteHandlers({
+    contentType: () => d.contentType.value,
+    selectedLang: () => d.selectedLang.value,
+    listItems: () => d.listItems.value,
+    reload: d.reload,
+    clearTarget: () => undefined,
+    pushAndTrack: d.pushAndTrack,
+  })

--- a/src/views/ContentView/create-delete-handlers.ts
+++ b/src/views/ContentView/create-delete-handlers.ts
@@ -3,35 +3,68 @@ import {
   deleteSingleVersion,
 } from '@/composables/useGitHubApi/delete-content'
 import type { ContentItem, Language } from '@/types/content'
+import { getAvailableLanguages } from '@/utils/available-languages'
 
 interface DeleteDeps {
-  readonly contentType: string
-  readonly selectedLang: Language
+  /*
+   * Read at call time, not at init time. Earlier we captured
+   * `.value` once when `createDeleteHandlers` was constructed —
+   * after the editor switched language the handler kept sending
+   * DELETE for the original lang, the file didn't exist, and
+   * "Delete only X" looked like a no-op.
+   */
+  readonly contentType: () => string
+  readonly selectedLang: () => Language
+  readonly listItems: () => readonly ContentItem[]
   readonly reload: () => Promise<void>
   readonly clearTarget: () => void
   readonly pushAndTrack: (message: string) => Promise<string>
 }
 
+const isLastLang = (
+  items: readonly ContentItem[],
+  slug: string,
+  lang: Language
+): boolean => {
+  const langs = getAvailableLanguages(items, slug)
+  return langs.size === 1 && langs.has(lang)
+}
+
 /**
  * Create delete handlers for content list.
  * Stages deletion, then commits+pushes via unified pushAndTrack.
- * @param deps - Dependencies
+ * `contentType` and `selectedLang` are getters so the handlers
+ * pick up the latest selection on each click — capturing them by
+ * value at construction time was the bug behind "Delete only X
+ * does nothing" (the closure kept a stale lang).
+ *
+ * "Delete only X" promotes to delete-all when X is the only
+ * translation that exists for the slug — otherwise we'd leave the
+ * slug folder around with just `assets/` orphans.
+ *
+ * @param deps - Dependencies (getters + callbacks)
  * @returns Handlers for delete-all and delete-lang
  */
 export const createDeleteHandlers = (deps: DeleteDeps) => ({
   deleteAll: async (item: ContentItem) => {
-    await deleteAllVersions(deps.contentType, item.slug)
-    await deps.pushAndTrack(
-      `Delete all versions of ${deps.contentType}/${item.slug}`
-    )
+    const type = deps.contentType()
+    await deleteAllVersions(type, item.slug)
+    await deps.pushAndTrack(`Delete all versions of ${type}/${item.slug}`)
     deps.clearTarget()
     await deps.reload()
   },
   deleteLang: async (item: ContentItem) => {
-    await deleteSingleVersion(deps.contentType, item.slug, deps.selectedLang)
-    await deps.pushAndTrack(
-      `Delete ${deps.contentType}/${item.slug}.${deps.selectedLang}.md`
-    )
+    const type = deps.contentType()
+    const lang = deps.selectedLang()
+    const promote = isLastLang(deps.listItems(), item.slug, lang)
+    const action = promote
+      ? () => deleteAllVersions(type, item.slug)
+      : () => deleteSingleVersion(type, item.slug, lang)
+    const message = promote
+      ? `Delete all versions of ${type}/${item.slug}`
+      : `Delete ${type}/${item.slug}.${lang}.md`
+    await action()
+    await deps.pushAndTrack(message)
     deps.clearTarget()
     await deps.reload()
   },

--- a/src/views/ContentView/delete-state.ts
+++ b/src/views/ContentView/delete-state.ts
@@ -1,6 +1,7 @@
 import { computed, type Ref, ref } from 'vue'
 import type { ContentItem, ContentType, Language } from '@/types/content'
-import { createDeleteHandlers } from './create-delete-handlers'
+import { buildDeleteHandlers } from './build-delete-handlers'
+import type { createDeleteHandlers } from './create-delete-handlers'
 import { createDeletingState, type DeletingState } from './deleting-state'
 import { runOptimisticDelete } from './run-optimistic-delete'
 
@@ -16,34 +17,28 @@ const buildOptimistic = (
     runOptimisticDelete({ target, deleting, clear }, raw.deleteLang),
 })
 
+interface CreateArgs {
+  readonly contentType: Ref<ContentType>
+  readonly selectedLang: Ref<Language>
+  readonly listItems: Ref<readonly ContentItem[]>
+  readonly reload: () => Promise<void>
+  readonly pushAndTrack: (message: string) => Promise<string>
+}
+
 /**
  * Create delete-related state and handlers.
- * @param contentType - Content type
- * @param selectedLang - Current selected language
- * @param reload - Reload callback
- * @param pushAndTrack - Unified push+track function
+ *
+ * @param args - Reactive deps and callbacks
  * @returns Delete state + handlers + a reactive set of slugs that
- * are currently animating their delete (drives the fade CSS on
- * ContentListItem).
+ * are currently animating their delete.
  */
-export const createDeleteState = (
-  contentType: Ref<ContentType>,
-  selectedLang: Ref<Language>,
-  reload: () => Promise<void>,
-  pushAndTrack: (message: string) => Promise<string>
-) => {
+export const createDeleteState = (args: CreateArgs) => {
   const deleteTarget = ref<ContentItem | undefined>()
   const deleting = createDeletingState()
   const clear = (): void => {
     deleteTarget.value = undefined
   }
-  const raw = createDeleteHandlers({
-    contentType: contentType.value,
-    selectedLang: selectedLang.value,
-    reload,
-    clearTarget: () => undefined,
-    pushAndTrack,
-  })
+  const raw = buildDeleteHandlers(args)
   return {
     deleteTarget,
     showDeleteDialog: computed(() => deleteTarget.value !== undefined),


### PR DESCRIPTION
Two bugs:

1. `createDeleteHandlers` captured `selectedLang.value` at init time, not on each call. After the editor switched language and clicked 'Delete only ru', the handler still sent DELETE for the previously-selected lang. The file didn't exist, the request 404'd quietly, and the dialog closed with nothing happening visibly.
2. Even with the right lang, deleting the only translation a slug had left the folder around with just `assets/` orphans.

Fixes:
- Switch `contentType` / `selectedLang` / `listItems` to getter callbacks read on each invocation.
- When the deleted lang is the only one for the slug, promote to delete-all so the folder is fully removed.

Tests: 567/567 unit suite green, validate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)