### PR TITLE
fix(layout): metadata back on top in editor + center deploy list on home

### DIFF
--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -49,33 +49,26 @@ defineEmits<{
 </template>
 
 <style scoped>
+/*
+ * Single-column stack everywhere — frontmatter on top, body
+ * underneath. The earlier two-column grid (meta left, body right)
+ * was confusing once meta got long enough to scroll while body
+ * stayed put, and editors lost track of where they were on the
+ * page. Top-down scroll matches the public site's article shape.
+ */
 .edit-main {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: flex;
+  flex-direction: column;
   flex: 1;
   gap: clamp(1rem, 2vw, 2rem);
   padding: var(--content-frame-padding);
-  max-width: var(--content-wide);
+  max-width: var(--content-narrow);
   width: 100%;
   margin-inline: auto;
   box-sizing: border-box;
-  align-content: start;
-}
-
-/*
- * On wide screens dock frontmatter to a fixed-ish meta column on
- * the left and let the body take the rest. Below 1024px the grid
- * collapses to a single column so phone/tablet still scroll
- * top-to-bottom.
- */
-@media (width >= 1024px) {
-  .edit-main {
-    grid-template-columns: [meta] 22rem [body] minmax(0, 1fr);
-  }
 }
 
 .loading-state {
-  grid-column: 1 / -1;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -52,15 +52,15 @@ defineEmits<{
 
 <style scoped>
 .edit-meta {
-  grid-column: meta;
-  align-self: start;
+  align-self: stretch;
+  width: 100%;
 }
 
 .edit-body {
-  grid-column: body;
   display: flex;
   flex-direction: column;
   gap: clamp(0.75rem, 2vw, 1.25rem);
   min-width: 0;
+  width: 100%;
 }
 </style>

--- a/src/views/HomeView/DeployHistory/DeployList.vue
+++ b/src/views/HomeView/DeployHistory/DeployList.vue
@@ -32,6 +32,8 @@ defineProps<{
   gap: 0.5rem;
   padding: clamp(1rem, 3vw, 2rem);
   max-width: 48rem;
+  width: 100%;
+  margin-inline: auto;
   min-width: 0;
 }
 


### PR DESCRIPTION
Reverts #185's two-column edit-page grid and centers the home-page deploy list. Pure CSS, no behaviour change. 567/567 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)