### PR TITLE
feat(tickets): structured Bug / User Story templates + photo attachments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-wa
 import { usePushConflictBridge } from '@/composables/useNotifications/use-push-conflict-bridge'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { usePushSummaryBridge } from '@/composables/useNotifications/use-push-summary-bridge'
+import { installNotificationsRecording } from '@/features/action-history/install-notifications'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
@@ -20,6 +21,7 @@ const route = useRoute()
 const authStore = useAuthStore()
 const contentStore = useContentStore()
 useNotificationsPersistence()
+installNotificationsRecording()
 usePushErrorBridge()
 useOfflineWatcher()
 usePushSummaryBridge()

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { createApp as vueCreateApp } from 'vue'
 import type { Router } from 'vue-router'
 import { createRouter, createWebHistory } from 'vue-router'
 import App from './App.vue'
+import { installRouterRecording } from './features/action-history/install-router'
 import { routes } from './router'
 import { installAuthGuard } from './router/auth-guard'
 
@@ -20,6 +21,7 @@ export const createApp = () => {
   })
 
   installAuthGuard(router)
+  installRouterRecording(router)
 
   app.use(pinia)
   app.use(router)

--- a/src/features/action-history/config.ts
+++ b/src/features/action-history/config.ts
@@ -1,0 +1,17 @@
+/** IndexedDB database name for the action history store. */
+export const HISTORY_DB_NAME = 'admin_action_history'
+
+/** Object store name. */
+export const HISTORY_STORE_NAME = 'entries'
+
+/** Schema version. */
+export const HISTORY_DB_VERSION = 1
+
+/** Maximum entries kept in the ring buffer. */
+export const MAX_ENTRIES = 1000
+
+/** Maximum age of any retained entry, in milliseconds (60 minutes). */
+export const MAX_AGE_MS = 60 * 60 * 1000
+
+/** Maximum length of any free-text reason / errorMessage field. */
+export const MAX_TEXT_LENGTH = 500

--- a/src/features/action-history/db.ts
+++ b/src/features/action-history/db.ts
@@ -1,0 +1,69 @@
+import {
+  HISTORY_DB_NAME,
+  HISTORY_DB_VERSION,
+  HISTORY_STORE_NAME,
+} from './config'
+import type { ActionEntry } from './types'
+
+const promisify = <T>(req: IDBRequest<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    req.onsuccess = (): void => resolve(req.result)
+    req.onerror = (): void => reject(req.error)
+  })
+
+const openDb = (): Promise<IDBDatabase> => {
+  const req = globalThis.indexedDB.open(HISTORY_DB_NAME, HISTORY_DB_VERSION)
+  req.onupgradeneeded = (): void => {
+    req.result.createObjectStore(HISTORY_STORE_NAME, { keyPath: 'id' })
+  }
+  return promisify(req)
+}
+
+const txStore = async (mode: IDBTransactionMode): Promise<IDBObjectStore> => {
+  const db = await openDb()
+  return db
+    .transaction(HISTORY_STORE_NAME, mode)
+    .objectStore(HISTORY_STORE_NAME)
+}
+
+/**
+ * Read every persisted entry sorted oldest-first.
+ * @returns Frozen array of entries
+ */
+export const listEntries = async (): Promise<readonly ActionEntry[]> => {
+  const store = await txStore('readonly')
+  const all: readonly ActionEntry[] = await promisify(store.getAll())
+  return [...all].sort((a, b) => a.ts - b.ts)
+}
+
+/**
+ * Persist a new entry.
+ * @param entry - Stamped entry with id + ts
+ */
+export const putEntry = async (entry: ActionEntry): Promise<void> => {
+  const store = await txStore('readwrite')
+  await promisify(store.put(entry))
+}
+
+/**
+ * Drop a set of entry ids.
+ * @param ids - Identifiers to delete
+ */
+export const deleteEntries = async (
+  ids: readonly string[]
+): Promise<void> => {
+  await Promise.all(
+    ids.map(async id => {
+      const store = await txStore('readwrite')
+      await promisify(store.delete(id))
+    })
+  )
+}
+
+/**
+ * Wipe the entire object store.
+ */
+export const clearEntries = async (): Promise<void> => {
+  const store = await txStore('readwrite')
+  await promisify(store.clear())
+}

--- a/src/features/action-history/install-notifications.ts
+++ b/src/features/action-history/install-notifications.ts
@@ -1,0 +1,48 @@
+import { storeToRefs } from 'pinia'
+import { watch } from 'vue'
+import { useNotificationsStore } from '@/stores/notifications'
+import type { NotificationEntry } from '@/stores/notifications-types'
+import { recordAction } from './recorder'
+
+const SW_ERROR = 'sw-error' as const
+const NETWORK_ERROR = 'network-error' as const
+
+const reasonText = (n: NotificationEntry): string =>
+  n.message === undefined ? n.title : `${n.title}: ${n.message}`
+
+const RECORDERS: Partial<
+  Record<NotificationEntry['kind'], (n: NotificationEntry) => void>
+> = {
+  error: n => void recordAction({ kind: SW_ERROR, reason: reasonText(n) }),
+  network: n =>
+    void recordAction({
+      kind: NETWORK_ERROR,
+      url: '',
+      reason: reasonText(n),
+    }),
+}
+
+const toAction = (n: NotificationEntry): void => {
+  RECORDERS[n.kind]?.(n)
+}
+
+/**
+ * Mirror error / network entries from the notifications queue into
+ * the action-history ring buffer.
+ *
+ * Called once at app boot (sibling of `useNotificationsPersistence`).
+ * Lives outside the notifications module so the action-history
+ * feature stays self-contained.
+ */
+export const installNotificationsRecording = (): void => {
+  const queue = useNotificationsStore()
+  const { entries } = storeToRefs(queue)
+  watch(
+    entries,
+    (next, prev) => {
+      const seen = new Set((prev ?? []).map(e => e.id))
+      next.filter(e => !seen.has(e.id)).forEach(toAction)
+    },
+    { flush: 'post' }
+  )
+}

--- a/src/features/action-history/install-router.ts
+++ b/src/features/action-history/install-router.ts
@@ -1,0 +1,22 @@
+import type { Router } from 'vue-router'
+import { recordAction } from './recorder'
+
+/**
+ * Install an `afterEach` hook on the router that records every
+ * navigation as an action-history entry.
+ *
+ * Uses `afterEach` rather than `beforeEach` so we only record
+ * navigations that actually completed (a guard that returns
+ * `false` won't be recorded as a bogus event).
+ *
+ * @param router - Vue Router instance
+ */
+export const installRouterRecording = (router: Router): void => {
+  router.afterEach((to, from) => {
+    void recordAction({
+      kind: 'navigation',
+      from: from.fullPath,
+      to: to.fullPath,
+    })
+  })
+}

--- a/src/features/action-history/recorder.ts
+++ b/src/features/action-history/recorder.ts
@@ -1,0 +1,49 @@
+import { clearEntries, deleteEntries, listEntries, putEntry } from './db'
+import { stampEntry } from './redact'
+import { pruneEntries } from './ring-buffer'
+import type { ActionEntry, RecordableEntry } from './types'
+
+const newId = (): string => globalThis.crypto.randomUUID()
+
+const evict = async (): Promise<void> => {
+  const all = await listEntries()
+  const kept = pruneEntries({ entries: all, nowMs: Date.now() })
+  const keptIds = new Set(kept.map(e => e.id))
+  const removed = all.filter(e => !keptIds.has(e.id)).map(e => e.id)
+  await (removed.length > 0 ? deleteEntries(removed) : Promise.resolve())
+}
+
+/**
+ * Record a single action.
+ *
+ * Persists the entry and trims the buffer to the configured caps.
+ * Errors are swallowed — the recorder is a best-effort sidecar; we
+ * don't want a failed IDB write to blow up the user's main flow.
+ *
+ * @param entry - Recordable shape (id + ts will be assigned)
+ */
+export const recordAction = async (entry: RecordableEntry): Promise<void> => {
+  try {
+    const stamped = stampEntry(entry, Date.now(), newId)
+    await putEntry(stamped)
+    await evict()
+  } catch {
+    /* best-effort recorder; never throw out to caller */
+  }
+}
+
+/**
+ * Read the current ring buffer, post-prune.
+ * @returns Pruned array, oldest-first
+ */
+export const readHistory = async (): Promise<readonly ActionEntry[]> => {
+  const all = await listEntries()
+  return pruneEntries({ entries: all, nowMs: Date.now() })
+}
+
+/**
+ * Wipe the entire ring buffer (Settings → Clear my action history).
+ */
+export const clearHistory = async (): Promise<void> => {
+  await clearEntries()
+}

--- a/src/features/action-history/redact.test.ts
+++ b/src/features/action-history/redact.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { redactEntry, stampEntry } from './redact'
+import type { NavigationEntry, RecordableEntry, SaveEntry } from './types'
+
+describe('redactEntry', () => {
+  it('truncates long error message on save entries', () => {
+    const long = 'x'.repeat(700)
+    const entry: Omit<SaveEntry, 'id' | 'ts'> = {
+      kind: 'save',
+      action: 'save',
+      path: 'blog/foo.md',
+      status: 'failed',
+      errorMessage: long,
+    }
+    const out = redactEntry(entry) as Omit<SaveEntry, 'id' | 'ts'>
+    expect(out.errorMessage?.length).toBe(501)
+    expect(out.errorMessage?.endsWith('…')).toBe(true)
+  })
+
+  it('truncates sw-error reason at 500 chars', () => {
+    const entry: RecordableEntry = {
+      kind: 'sw-error',
+      reason: 'a'.repeat(800),
+    }
+    const out = redactEntry(entry) as { reason: string }
+    expect(out.reason.length).toBe(501)
+  })
+
+  it('does not include any "content" field on save entries', () => {
+    const entry: Omit<SaveEntry, 'id' | 'ts'> = {
+      kind: 'save',
+      action: 'commit',
+      path: 'pages/about.en.md',
+      status: 'ok',
+    }
+    const out = redactEntry(entry)
+    expect(JSON.stringify(out)).not.toMatch(/content/i)
+  })
+
+  it('passes navigation entries through unchanged', () => {
+    const entry: Omit<NavigationEntry, 'id' | 'ts'> = {
+      kind: 'navigation',
+      from: '/a',
+      to: '/b',
+    }
+    expect(redactEntry(entry)).toEqual(entry)
+  })
+})
+
+describe('stampEntry', () => {
+  it('attaches an id and ts to the redacted entry', () => {
+    const out = stampEntry(
+      { kind: 'auth', action: 'login' },
+      1_700_000_000_000,
+      () => 'fixed-id'
+    )
+    expect(out).toEqual({
+      kind: 'auth',
+      action: 'login',
+      id: 'fixed-id',
+      ts: 1_700_000_000_000,
+    })
+  })
+})

--- a/src/features/action-history/redact.ts
+++ b/src/features/action-history/redact.ts
@@ -1,0 +1,65 @@
+import { MAX_TEXT_LENGTH } from './config'
+import type {
+  ActionEntry,
+  NetworkErrorEntry,
+  RecordableEntry,
+  SaveEntry,
+  SwErrorEntry,
+} from './types'
+
+const truncate = (s: string, max = MAX_TEXT_LENGTH): string =>
+  s.length <= max ? s : `${s.slice(0, max)}…`
+
+const redactSave = (e: Omit<SaveEntry, 'id' | 'ts'>): typeof e => ({
+  ...e,
+  errorMessage:
+    e.errorMessage === undefined ? undefined : truncate(e.errorMessage),
+})
+
+const redactSw = (e: Omit<SwErrorEntry, 'id' | 'ts'>): typeof e => ({
+  ...e,
+  reason: truncate(e.reason),
+})
+
+const redactNet = (e: Omit<NetworkErrorEntry, 'id' | 'ts'>): typeof e => ({
+  ...e,
+  reason: truncate(e.reason),
+})
+
+/**
+ * Strip / truncate any field that could carry PII before persistence.
+ *
+ * The PII boundary lives here, not at every recorder call site. Any
+ * future entry kind that adds a free-text field MUST be handled
+ * explicitly — the discriminated union makes that omission a type
+ * error rather than a silent leak.
+ *
+ * @param entry - Recorded entry without id/ts
+ * @returns Entry with long strings truncated and contents stripped
+ */
+export const redactEntry = (entry: RecordableEntry): RecordableEntry => {
+  const dispatch = {
+    save: () => redactSave(entry as Omit<SaveEntry, 'id' | 'ts'>),
+    'sw-error': () => redactSw(entry as Omit<SwErrorEntry, 'id' | 'ts'>),
+    'network-error': () =>
+      redactNet(entry as Omit<NetworkErrorEntry, 'id' | 'ts'>),
+    navigation: () => entry,
+    stage: () => entry,
+    auth: () => entry,
+  } as const
+  return dispatch[entry.kind]()
+}
+
+/**
+ * Convenience: redact and stamp with a fresh id + ts.
+ * @param entry - Recordable entry
+ * @param now - Wall-clock timestamp to stamp
+ * @param idGen - Id factory (allow injection for tests)
+ * @returns Full ActionEntry ready to persist
+ */
+export const stampEntry = (
+  entry: RecordableEntry,
+  now: number,
+  idGen: () => string
+): ActionEntry =>
+  ({ ...redactEntry(entry), id: idGen(), ts: now }) as ActionEntry

--- a/src/features/action-history/ring-buffer.test.ts
+++ b/src/features/action-history/ring-buffer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { pruneEntries } from './ring-buffer'
+import type { NavigationEntry } from './types'
+
+const nav = (id: string, ts: number): NavigationEntry => ({
+  id,
+  ts,
+  kind: 'navigation',
+  from: '/a',
+  to: '/b',
+})
+
+describe('pruneEntries', () => {
+  const now = 1_000_000_000
+
+  it('returns input unchanged when below both caps', () => {
+    const xs = [nav('1', now - 1000), nav('2', now)]
+    expect(pruneEntries({ entries: xs, nowMs: now })).toEqual(xs)
+  })
+
+  it('drops entries older than maxAge', () => {
+    const xs = [nav('old', now - 70 * 60 * 1000), nav('fresh', now - 1000)]
+    const out = pruneEntries({ entries: xs, nowMs: now })
+    expect(out).toEqual([xs[1]])
+  })
+
+  it('drops oldest when count overflows maxEntries', () => {
+    const xs = Array.from({ length: 1010 }, (_, i) =>
+      nav(String(i), now - i)
+    ).reverse()
+    const out = pruneEntries({ entries: xs, nowMs: now })
+    expect(out).toHaveLength(1000)
+    expect(out[0]?.id).toBe('999')
+    expect(out[out.length - 1]?.id).toBe('0')
+  })
+
+  it('age cutoff and count cap compose — both applied', () => {
+    const xs = [
+      nav('ancient', now - 90 * 60 * 1000),
+      nav('mid', now - 30 * 60 * 1000),
+      nav('recent', now - 1000),
+    ]
+    const out = pruneEntries({
+      entries: xs,
+      nowMs: now,
+      maxEntries: 1,
+    })
+    expect(out).toEqual([xs[2]])
+  })
+
+  it('does not mutate the input array', () => {
+    const xs = [nav('1', now)]
+    const copy = [...xs]
+    pruneEntries({ entries: xs, nowMs: now })
+    expect(xs).toEqual(copy)
+  })
+})

--- a/src/features/action-history/ring-buffer.ts
+++ b/src/features/action-history/ring-buffer.ts
@@ -1,0 +1,29 @@
+import { MAX_AGE_MS, MAX_ENTRIES } from './config'
+import type { ActionEntry } from './types'
+
+interface PruneArgs {
+  readonly entries: readonly ActionEntry[]
+  readonly nowMs: number
+  readonly maxEntries?: number
+  readonly maxAgeMs?: number
+}
+
+/**
+ * Prune an action-history list to fit the bounded ring buffer.
+ *
+ * The buffer is bounded by **both** count and age (whichever is
+ * stricter). Entries are kept oldest-first; the head of the array
+ * is the oldest entry, the tail the newest. This shape is what the
+ * recorder's `append` writes back, and what the serialiser dumps.
+ *
+ * @param args - Current entries + clock + optional bounds override
+ * @returns Pruned array oldest-first (no mutation of the input)
+ */
+export const pruneEntries = (args: PruneArgs): readonly ActionEntry[] => {
+  const maxN = args.maxEntries ?? MAX_ENTRIES
+  const maxAge = args.maxAgeMs ?? MAX_AGE_MS
+  const cutoff = args.nowMs - maxAge
+  const fresh = args.entries.filter(e => e.ts >= cutoff)
+  const overflow = fresh.length - maxN
+  return overflow > 0 ? fresh.slice(overflow) : fresh
+}

--- a/src/features/action-history/serialize.test.ts
+++ b/src/features/action-history/serialize.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { renderHistoryJson, serializeHistory } from './serialize'
+import type { ActionEntry } from './types'
+
+const sample: ActionEntry[] = [
+  {
+    id: '1',
+    ts: 1_700_000_000_000,
+    kind: 'navigation',
+    from: '/',
+    to: '/content',
+  },
+  {
+    id: '2',
+    ts: 1_700_000_001_000,
+    kind: 'save',
+    action: 'commit',
+    path: 'blog/foo.md',
+    status: 'ok',
+  },
+]
+
+describe('serializeHistory', () => {
+  it('emits the v1 schema tag', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.schema).toBe('admin-action-history/v1')
+  })
+
+  it('records the wall-clock time as ISO 8601', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.capturedAt).toBe(new Date(1_700_000_002_000).toISOString())
+  })
+
+  it('reports the entry count', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.entryCount).toBe(2)
+  })
+
+  it('preserves the entries verbatim and in order', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.entries).toEqual(sample)
+  })
+})
+
+describe('renderHistoryJson', () => {
+  it('produces stable, indented JSON ending with a newline', () => {
+    const out = renderHistoryJson(sample, 1_700_000_002_000)
+    expect(out.endsWith('\n')).toBe(true)
+    expect(JSON.parse(out)).toMatchObject({
+      schema: 'admin-action-history/v1',
+      entryCount: 2,
+    })
+  })
+})

--- a/src/features/action-history/serialize.ts
+++ b/src/features/action-history/serialize.ts
@@ -1,0 +1,41 @@
+import type { ActionEntry } from './types'
+
+interface SerializedHistory {
+  readonly schema: 'admin-action-history/v1'
+  readonly capturedAt: string
+  readonly entryCount: number
+  readonly entries: readonly ActionEntry[]
+}
+
+/**
+ * Serialise the action history into the stable JSON shape that
+ * lands in the ticket as `actions-history.json`.
+ *
+ * The shape is versioned via `schema` so triage tooling can fail
+ * loudly if we ever change the layout.
+ *
+ * @param entries - Pruned history, oldest-first
+ * @param nowMs - Wall-clock timestamp of the snapshot
+ * @returns Serialised payload
+ */
+export const serializeHistory = (
+  entries: readonly ActionEntry[],
+  nowMs: number
+): SerializedHistory => ({
+  schema: 'admin-action-history/v1',
+  capturedAt: new Date(nowMs).toISOString(),
+  entryCount: entries.length,
+  entries,
+})
+
+/**
+ * Render the snapshot as a JSON string with stable indentation.
+ *
+ * @param entries - Pruned history, oldest-first
+ * @param nowMs - Wall-clock timestamp of the snapshot
+ * @returns Pretty-printed JSON string
+ */
+export const renderHistoryJson = (
+  entries: readonly ActionEntry[],
+  nowMs: number
+): string => `${JSON.stringify(serializeHistory(entries, nowMs), null, 2)}\n`

--- a/src/features/action-history/types.ts
+++ b/src/features/action-history/types.ts
@@ -1,0 +1,66 @@
+/** Discriminated union of every action we record. */
+export type ActionEntry =
+  | NavigationEntry
+  | SaveEntry
+  | StageEntry
+  | AuthEntry
+  | SwErrorEntry
+  | NetworkErrorEntry
+
+/** Common fields on every entry. */
+export interface BaseEntry {
+  readonly id: string
+  readonly ts: number
+}
+
+/** Route navigation. */
+export interface NavigationEntry extends BaseEntry {
+  readonly kind: 'navigation'
+  readonly from: string
+  readonly to: string
+}
+
+/** Save / commit / push outcome. */
+export interface SaveEntry extends BaseEntry {
+  readonly kind: 'save'
+  readonly action: 'save' | 'commit' | 'push'
+  readonly path: string
+  readonly status: 'ok' | 'failed'
+  readonly errorMessage?: string
+}
+
+/** Stage / unstage / discard event. */
+export interface StageEntry extends BaseEntry {
+  readonly kind: 'stage'
+  readonly action: 'stage' | 'unstage' | 'discard'
+  readonly path: string
+}
+
+/** Auth state change. */
+export interface AuthEntry extends BaseEntry {
+  readonly kind: 'auth'
+  readonly action: 'login' | 'logout' | 'token-refresh'
+}
+
+/** SW bridge error. */
+export interface SwErrorEntry extends BaseEntry {
+  readonly kind: 'sw-error'
+  readonly reason: string
+}
+
+/** User-visible network failure (toast / banner). */
+export interface NetworkErrorEntry extends BaseEntry {
+  readonly kind: 'network-error'
+  readonly url: string
+  readonly status?: number
+  readonly reason: string
+}
+
+/** Action entry without the auto-assigned id + ts. */
+export type RecordableEntry =
+  | Omit<NavigationEntry, 'id' | 'ts'>
+  | Omit<SaveEntry, 'id' | 'ts'>
+  | Omit<StageEntry, 'id' | 'ts'>
+  | Omit<AuthEntry, 'id' | 'ts'>
+  | Omit<SwErrorEntry, 'id' | 'ts'>
+  | Omit<NetworkErrorEntry, 'id' | 'ts'>

--- a/src/features/tickets/api/attachment-paths.ts
+++ b/src/features/tickets/api/attachment-paths.ts
@@ -1,0 +1,40 @@
+import type { AttachmentKind } from '../templates/attachment-types'
+
+/** Owner of the tickets repository — kept central so all callers agree. */
+export const TICKETS_REPO_OWNER = 'communist-prometheus'
+
+/** Tickets repository name. */
+export const TICKETS_REPO_NAME = 'tickets'
+
+/** Default branch for ticket attachments. */
+export const TICKETS_BRANCH = 'master'
+
+const sanitize = (name: string): string =>
+  name
+    .replace(/[^\w.\- ]+/g, '_')
+    .replace(/\s+/g, '-')
+    .toLowerCase()
+
+/**
+ * Generate a short random id for a per-attachment folder.
+ * @returns 12-char hex id
+ */
+export const randomAttachmentId = (): string =>
+  globalThis.crypto.randomUUID().replace(/-/g, '').slice(0, 12)
+
+/**
+ * Build the repo-relative path for a single attachment.
+ * @param fileName - Original file name
+ * @param id - Random per-attachment folder id
+ * @returns Path under the tickets repo, e.g. `attachments/abc/foo.png`
+ */
+export const buildAttachmentPath = (fileName: string, id: string): string =>
+  `attachments/${id}/${sanitize(fileName)}`
+
+/**
+ * Map a MIME type to the attachment kind used by the body builder.
+ * @param mime - MIME content type (may be empty)
+ * @returns 'image' or 'file'
+ */
+export const detectKind = (mime: string): AttachmentKind =>
+  mime.startsWith('image/') ? 'image' : 'file'

--- a/src/features/tickets/api/put-content.ts
+++ b/src/features/tickets/api/put-content.ts
@@ -1,0 +1,44 @@
+import {
+  TICKETS_BRANCH,
+  TICKETS_REPO_NAME,
+  TICKETS_REPO_OWNER,
+} from './attachment-paths'
+
+const API = `https://api.github.com/repos/${TICKETS_REPO_OWNER}/${TICKETS_REPO_NAME}/contents`
+
+const headers = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'Content-Type': 'application/json',
+})
+
+interface PutDeps {
+  readonly token: string
+  readonly path: string
+  readonly content: string
+  readonly message: string
+}
+
+const okOrThrow = async (res: Response): Promise<void> =>
+  res.ok
+    ? undefined
+    : Promise.reject(
+        new Error(`Upload failed: ${res.status} ${res.statusText}`)
+      )
+
+/**
+ * PUT raw base64 content into the tickets repo via the Contents API.
+ * @param deps - Token + repo path + base64 content + commit message
+ */
+export const putContent = async (deps: PutDeps): Promise<void> => {
+  const res = await fetch(`${API}/${deps.path}`, {
+    method: 'PUT',
+    headers: headers(deps.token),
+    body: JSON.stringify({
+      message: deps.message,
+      content: deps.content,
+      branch: TICKETS_BRANCH,
+    }),
+  })
+  await okOrThrow(res)
+}

--- a/src/features/tickets/api/ticket-actions.ts
+++ b/src/features/tickets/api/ticket-actions.ts
@@ -10,24 +10,27 @@ const headers = (token: string) => ({
   'Content-Type': 'application/json',
 })
 
+interface CreateArgs {
+  readonly token: string
+  readonly title: string
+  readonly body: string
+  readonly labels: readonly string[]
+}
+
 /**
  * Create a new ticket.
- * @param token - GitHub access token
- * @param title - Ticket title
- * @param body - Ticket description
- * @param labels - Labels to assign
+ * @param args - Token + title + pre-rendered body + labels
  * @returns Created ticket
  */
-export const createTicket = async (
-  token: string,
-  title: string,
-  body: string,
-  labels: readonly string[]
-): Promise<Ticket> => {
+export const createTicket = async (args: CreateArgs): Promise<Ticket> => {
   const res = await fetch(`${BASE}/issues`, {
     method: 'POST',
-    headers: headers(token),
-    body: JSON.stringify({ title, body, labels }),
+    headers: headers(args.token),
+    body: JSON.stringify({
+      title: args.title,
+      body: args.body,
+      labels: args.labels,
+    }),
   })
   if (!res.ok) throw new Error(`Create ticket failed: ${res.status}`)
   return (await res.json()) as Ticket

--- a/src/features/tickets/api/upload-attachment.ts
+++ b/src/features/tickets/api/upload-attachment.ts
@@ -1,0 +1,49 @@
+import { fileToBase64 } from '@/composables/useAssets/file-to-base64'
+import type { TicketAttachment } from '../templates/attachment-types'
+import {
+  buildAttachmentPath,
+  detectKind,
+  randomAttachmentId,
+  TICKETS_BRANCH,
+  TICKETS_REPO_NAME,
+  TICKETS_REPO_OWNER,
+} from './attachment-paths'
+import { putContent } from './put-content'
+
+const RAW = `https://raw.githubusercontent.com/${TICKETS_REPO_OWNER}/${TICKETS_REPO_NAME}/${TICKETS_BRANCH}`
+
+interface UploadDeps {
+  readonly token: string
+  readonly file: File
+}
+
+/**
+ * Upload one ticket attachment to the tickets repo.
+ *
+ * The file lands at `attachments/<id>/<sanitised-name>` on the tickets
+ * repo's default branch and is referenced from the issue body via the
+ * raw.githubusercontent.com URL — no extra hop, no third-party host.
+ *
+ * @param deps - Token + File pair
+ * @returns Resolved attachment with stable URL
+ */
+export const uploadAttachment = async (
+  deps: UploadDeps
+): Promise<TicketAttachment> => {
+  const id = randomAttachmentId()
+  const path = buildAttachmentPath(deps.file.name, id)
+  const content = await fileToBase64(deps.file)
+  await putContent({
+    token: deps.token,
+    path,
+    content,
+    message: `Ticket attachment: ${deps.file.name}`,
+  })
+  return {
+    id,
+    name: deps.file.name,
+    url: `${RAW}/${path}`,
+    kind: detectKind(deps.file.type),
+    sizeBytes: deps.file.size,
+  }
+}

--- a/src/features/tickets/api/upload-history.ts
+++ b/src/features/tickets/api/upload-history.ts
@@ -1,0 +1,48 @@
+import type { TicketAttachment } from '../templates/attachment-types'
+import {
+  buildAttachmentPath,
+  randomAttachmentId,
+  TICKETS_BRANCH,
+  TICKETS_REPO_NAME,
+  TICKETS_REPO_OWNER,
+} from './attachment-paths'
+import { putContent } from './put-content'
+
+const RAW = `https://raw.githubusercontent.com/${TICKETS_REPO_OWNER}/${TICKETS_REPO_NAME}/${TICKETS_BRANCH}`
+
+const toBase64 = (text: string): string =>
+  globalThis.btoa(unescape(encodeURIComponent(text)))
+
+interface UploadDeps {
+  readonly token: string
+  readonly fileName: string
+  readonly text: string
+}
+
+/**
+ * Upload a text file (JSON, plain) to the tickets repo as an
+ * attachment so it can be linked from the issue body alongside
+ * the user's photos.
+ *
+ * @param deps - Token + name + raw text content
+ * @returns Resolved attachment with stable URL
+ */
+export const uploadTextAttachment = async (
+  deps: UploadDeps
+): Promise<TicketAttachment> => {
+  const id = randomAttachmentId()
+  const path = buildAttachmentPath(deps.fileName, id)
+  await putContent({
+    token: deps.token,
+    path,
+    content: toBase64(deps.text),
+    message: `Ticket attachment: ${deps.fileName}`,
+  })
+  return {
+    id,
+    name: deps.fileName,
+    url: `${RAW}/${path}`,
+    kind: 'file',
+    sizeBytes: deps.text.length,
+  }
+}

--- a/src/features/tickets/components/AttachmentField.vue
+++ b/src/features/tickets/components/AttachmentField.vue
@@ -1,0 +1,84 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { TicketAttachment } from '../templates/attachment-types'
+import AttachmentList from './AttachmentList.vue'
+import { filesFromDrop, filesFromPaste } from './attachment-pipeline'
+import DropZone from './DropZone.vue'
+
+defineProps<{
+  readonly attachments: readonly TicketAttachment[]
+  readonly uploading: boolean
+}>()
+
+const emit = defineEmits<{
+  upload: [files: readonly File[]]
+  remove: [id: string]
+}>()
+
+const fileInput = ref<HTMLInputElement>()
+const dragActive = ref(false)
+
+const onDrop = (e: DragEvent): void => {
+  dragActive.value = false
+  const files = filesFromDrop(e)
+  if (files.length > 0) emit('upload', files)
+}
+
+const onPaste = (e: ClipboardEvent): void => {
+  const files = filesFromPaste(e)
+  if (files.length > 0) emit('upload', files)
+}
+
+const onPickerChange = (e: Event): void => {
+  const input = e.target as HTMLInputElement
+  const files = input.files === null ? [] : Array.from(input.files)
+  if (files.length > 0) emit('upload', files)
+  input.value = ''
+}
+
+const openPicker = (): void => {
+  fileInput.value?.click()
+}
+
+const setDragActive = (next: boolean): void => {
+  dragActive.value = next
+}
+</script>
+
+<template>
+  <section class="attachments" data-testid="ticket-attachments">
+    <DropZone
+      :active="dragActive"
+      :uploading="uploading"
+      @click="openPicker"
+      @drag-over="setDragActive"
+      @drop="onDrop"
+      @paste="onPaste"
+    />
+    <input
+      ref="fileInput"
+      type="file"
+      multiple
+      accept="image/*"
+      class="hidden-input"
+      data-testid="ticket-attachment-input"
+      @change="onPickerChange"
+    />
+    <AttachmentList
+      :items="attachments"
+      @remove="emit('remove', $event)"
+    />
+  </section>
+</template>
+
+<style scoped>
+.attachments {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hidden-input {
+  display: none;
+}
+</style>

--- a/src/features/tickets/components/AttachmentList.vue
+++ b/src/features/tickets/components/AttachmentList.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { TicketAttachment } from '../templates/attachment-types'
+import AttachmentRow from './AttachmentRow.vue'
+
+defineProps<{ readonly items: readonly TicketAttachment[] }>()
+defineEmits<{ remove: [id: string] }>()
+</script>
+
+<template>
+  <ul v-if="items.length > 0" class="att-list" data-testid="attachment-list">
+    <AttachmentRow
+      v-for="a in items" :key="a.id"
+      :id="a.id" :name="a.name"
+      @remove="$emit('remove', $event)"
+    />
+  </ul>
+</template>
+
+<style scoped>
+.att-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+</style>

--- a/src/features/tickets/components/AttachmentRow.vue
+++ b/src/features/tickets/components/AttachmentRow.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+defineProps<{ readonly id: string; readonly name: string }>()
+defineEmits<{ remove: [id: string] }>()
+</script>
+
+<template>
+  <li class="att-row">
+    <span class="att-name">{{ name }}</span>
+    <button
+      type="button"
+      class="att-remove"
+      :aria-label="`Remove ${name}`"
+      @click="$emit('remove', id)"
+    >
+      ×
+    </button>
+  </li>
+</template>
+
+<style scoped>
+.att-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: var(--color-background-soft);
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+}
+
+.att-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.att-remove {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+}
+</style>

--- a/src/features/tickets/components/BugTemplateFields.vue
+++ b/src/features/tickets/components/BugTemplateFields.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import type { BugTemplate } from '../templates/types'
+import TemplateField from './TemplateField.vue'
+
+defineProps<{ readonly modelValue: BugTemplate }>()
+const emit = defineEmits<{ 'update:modelValue': [t: BugTemplate] }>()
+
+const update = (
+  patch: Partial<BugTemplate>,
+  current: BugTemplate
+): void => {
+  emit('update:modelValue', { ...current, ...patch })
+}
+</script>
+
+<template>
+  <TemplateField
+    label="Reproduction Steps" required
+    placeholder="1. Open …  2. Click …  3. See error"
+    :model-value="modelValue.reproductionSteps"
+    @update:model-value="update({ reproductionSteps: $event }, modelValue)"
+  />
+  <TemplateField
+    label="Actual Behavior" required
+    placeholder="What actually happens"
+    :model-value="modelValue.actualBehavior"
+    @update:model-value="update({ actualBehavior: $event }, modelValue)"
+  />
+  <TemplateField
+    label="Expected Behavior" required
+    placeholder="What should happen"
+    :model-value="modelValue.expectedBehavior"
+    @update:model-value="update({ expectedBehavior: $event }, modelValue)"
+  />
+  <TemplateField
+    label="Description"
+    placeholder="Optional context"
+    :model-value="modelValue.description"
+    @update:model-value="update({ description: $event }, modelValue)"
+  />
+</template>

--- a/src/features/tickets/components/CreateTicketContainer.vue
+++ b/src/features/tickets/components/CreateTicketContainer.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import { uploadBatch } from './attachment-pipeline'
+import CreateTicketForm from './CreateTicketForm.vue'
+import { submitTicket } from './submit-ticket'
+import { useCreateForm } from './use-create-form'
+
+const emit = defineEmits<{ created: []; error: [msg: string] }>()
+const auth = useAuthStore()
+const f = useCreateForm()
+const missing = ref<readonly string[]>([])
+
+const onUpload = async (files: readonly File[]): Promise<void> => {
+  if (!auth.user) return
+  f.uploading.value = true
+  const added = await uploadBatch({
+    token: auth.user.accessToken,
+    files,
+    onError: msg => emit('error', msg),
+  })
+  f.attachments.value = [...f.attachments.value, ...added]
+  f.uploading.value = false
+}
+
+const setTitle = (v: string): void => {
+  f.title.value = v
+}
+const setTarget = (v: 'public-website' | 'admin'): void => {
+  f.target.value = v
+}
+const setTemplate = (v: typeof f.template.value): void => {
+  f.template.value = v
+}
+
+const onSubmit = async (): Promise<void> => {
+  if (!auth.user || f.titleTrimmed.value.length === 0) return
+  const result = await submitTicket({
+    token: auth.user.accessToken,
+    title: f.titleTrimmed.value,
+    template: f.template.value,
+    labels: f.labels.value,
+    attachments: f.attachments.value,
+  })
+  if (result.kind === 'invalid') missing.value = result.missing
+  else if (result.kind === 'error') emit('error', result.message)
+  else {
+    f.reset()
+    missing.value = []
+    emit('created')
+  }
+}
+</script>
+
+<template>
+  <CreateTicketForm
+    :title="f.title.value"
+    :target="f.target.value"
+    :template="f.template.value"
+    :attachments="f.attachments.value"
+    :uploading="f.uploading.value"
+    :missing="missing"
+    @update:title="setTitle"
+    @update:target="setTarget"
+    @update:template="setTemplate"
+    @change-kind="f.setKind"
+    @upload="onUpload"
+    @remove-attachment="f.removeAttachment"
+    @submit="onSubmit"
+  />
+</template>

--- a/src/features/tickets/components/CreateTicketContainer.vue
+++ b/src/features/tickets/components/CreateTicketContainer.vue
@@ -3,8 +3,8 @@ import { ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { uploadBatch } from './attachment-pipeline'
 import CreateTicketForm from './CreateTicketForm.vue'
-import { submitTicket } from './submit-ticket'
 import { useCreateForm } from './use-create-form'
+import { runTicketSubmit } from './use-ticket-submit'
 
 const emit = defineEmits<{ created: []; error: [msg: string] }>()
 const auth = useAuthStore()
@@ -23,32 +23,15 @@ const onUpload = async (files: readonly File[]): Promise<void> => {
   f.uploading.value = false
 }
 
-const setTitle = (v: string): void => {
-  f.title.value = v
-}
-const setTarget = (v: 'public-website' | 'admin'): void => {
-  f.target.value = v
-}
-const setTemplate = (v: typeof f.template.value): void => {
-  f.template.value = v
-}
-
 const onSubmit = async (): Promise<void> => {
   if (!auth.user || f.titleTrimmed.value.length === 0) return
-  const result = await submitTicket({
+  await runTicketSubmit({
     token: auth.user.accessToken,
-    title: f.titleTrimmed.value,
-    template: f.template.value,
-    labels: f.labels.value,
-    attachments: f.attachments.value,
+    form: f,
+    missing,
+    emitCreated: () => emit('created'),
+    emitError: msg => emit('error', msg),
   })
-  if (result.kind === 'invalid') missing.value = result.missing
-  else if (result.kind === 'error') emit('error', result.message)
-  else {
-    f.reset()
-    missing.value = []
-    emit('created')
-  }
 }
 </script>
 
@@ -60,9 +43,11 @@ const onSubmit = async (): Promise<void> => {
     :attachments="f.attachments.value"
     :uploading="f.uploading.value"
     :missing="missing"
-    @update:title="setTitle"
-    @update:target="setTarget"
-    @update:template="setTemplate"
+    @update:title="(v: string) => (f.title.value = v)"
+    @update:target="
+      (v: 'public-website' | 'admin') => (f.target.value = v)
+    "
+    @update:template="(v: typeof f.template.value) => (f.template.value = v)"
     @change-kind="f.setKind"
     @upload="onUpload"
     @remove-attachment="f.removeAttachment"

--- a/src/features/tickets/components/CreateTicketForm.vue
+++ b/src/features/tickets/components/CreateTicketForm.vue
@@ -1,63 +1,67 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import type { TicketAttachment } from '../templates/attachment-types'
+import type { TicketTemplate } from '../templates/types'
+import AttachmentField from './AttachmentField.vue'
+import TemplateFieldsSwitch from './TemplateFieldsSwitch.vue'
+import TemplateSelector from './TemplateSelector.vue'
+import TitleAndTargetFields from './TitleAndTargetFields.vue'
 
-const emit = defineEmits<{
-  create: [title: string, body: string, labels: readonly string[]]
+defineProps<{
+  readonly title: string
+  readonly target: 'public-website' | 'admin'
+  readonly template: TicketTemplate
+  readonly attachments: readonly TicketAttachment[]
+  readonly uploading: boolean
+  readonly missing: readonly string[]
 }>()
 
-const title = ref('')
-const body = ref('')
-const target = ref('public-website')
-const type = ref('bug')
-
-const handleSubmit = () => {
-  if (!title.value.trim()) return
-  emit('create', title.value.trim(), body.value, [target.value, type.value])
-  title.value = ''
-  body.value = ''
-}
+defineEmits<{
+  'update:title': [v: string]
+  'update:target': [v: 'public-website' | 'admin']
+  'update:template': [t: TicketTemplate]
+  'change-kind': [k: TicketTemplate['kind']]
+  upload: [files: readonly File[]]
+  'remove-attachment': [id: string]
+  submit: []
+}>()
 </script>
 
 <template>
-  <input
-    v-model="title" type="text"
-    placeholder="Title" class="field"
-  />
-  <select v-model="target" class="field">
-    <option value="public-website">Public Website</option>
-    <option value="admin">Admin Panel</option>
-  </select>
-  <select v-model="type" class="field">
-    <option value="bug">Bug</option>
-    <option value="enhancement">Feature Request</option>
-  </select>
-  <textarea
-    v-model="body"
-    placeholder="Description (Markdown supported)"
-    rows="4"
-    class="field"
-  />
-  <button type="button" class="submit-btn" @click="handleSubmit">
-    Create Ticket
-  </button>
+  <form class="create-form" @submit.prevent="$emit('submit')">
+    <TitleAndTargetFields
+      :title="title"
+      :target="target"
+      @update:title="$emit('update:title', $event)"
+      @update:target="$emit('update:target', $event)"
+    />
+    <TemplateSelector
+      :model-value="template.kind"
+      @update:model-value="$emit('change-kind', $event)"
+    />
+    <TemplateFieldsSwitch
+      :model-value="template"
+      @update:model-value="$emit('update:template', $event)"
+    />
+    <AttachmentField
+      :attachments="attachments"
+      :uploading="uploading"
+      @upload="$emit('upload', $event)"
+      @remove="$emit('remove-attachment', $event)"
+    />
+    <p v-if="missing.length > 0" class="errors" data-testid="ticket-errors">
+      Required: {{ missing.join(', ') }}
+    </p>
+    <button type="submit" class="submit-btn" data-testid="ticket-submit">
+      Create Ticket
+    </button>
+  </form>
 </template>
 
 <style scoped>
-.field {
-  display: block;
-  width: 100%;
-  padding: 0.5rem;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-background);
-  color: var(--color-text);
-  font-size: 0.875rem;
-  font-family: inherit;
-  box-sizing: border-box;
-}
-
-.field[rows] {
-  resize: vertical;
+.create-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .submit-btn {
@@ -68,5 +72,12 @@ const handleSubmit = () => {
   color: #fff;
   cursor: pointer;
   font-size: 0.875rem;
+  align-self: flex-start;
+}
+
+.errors {
+  color: var(--color-danger, #d73a4a);
+  font-size: 0.8125rem;
+  margin: 0;
 }
 </style>

--- a/src/features/tickets/components/DropZone.vue
+++ b/src/features/tickets/components/DropZone.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{
+  readonly active: boolean
+  readonly uploading: boolean
+}>()
+
+defineEmits<{
+  click: []
+  drop: [e: DragEvent]
+  paste: [e: ClipboardEvent]
+  'drag-over': [next: boolean]
+}>()
+
+const cls = computed(() => ({
+  'drop-zone': true,
+  active: props.active,
+  uploading: props.uploading,
+}))
+
+const message = computed(() =>
+  props.uploading
+    ? 'Uploading…'
+    : 'Drop image, paste from clipboard, or click to attach'
+)
+</script>
+
+<template>
+  <button
+    type="button"
+    :class="cls"
+    aria-label="Drop files, paste a screenshot, or click to attach"
+    @click="$emit('click')"
+    @dragover.prevent="$emit('drag-over', true)"
+    @dragleave.prevent="$emit('drag-over', false)"
+    @drop.prevent="$emit('drop', $event)"
+    @paste="$emit('paste', $event)"
+  >
+    {{ message }}
+  </button>
+</template>
+
+<style scoped>
+.drop-zone {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 4rem;
+  padding: 0.75rem;
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  text-align: center;
+  background: var(--color-background-soft);
+  font-family: inherit;
+  width: 100%;
+}
+
+.drop-zone:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.drop-zone.active {
+  border-color: var(--color-accent);
+  background: var(--color-background);
+}
+
+.drop-zone.uploading {
+  opacity: 70%;
+  cursor: progress;
+}
+</style>

--- a/src/features/tickets/components/SectionBlock.vue
+++ b/src/features/tickets/components/SectionBlock.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+defineProps<{ readonly label: string; readonly text: string }>()
+</script>
+
+<template>
+  <section class="section-block">
+    <h4 class="label">{{ label }}</h4>
+    <p v-if="text" class="text">{{ text }}</p>
+    <p v-else class="empty">_(empty)_</p>
+  </section>
+</template>
+
+<style scoped>
+.section-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem;
+  background: var(--color-background-soft);
+  border-radius: var(--radius-sm);
+}
+
+.label {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.text {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+
+.empty {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  font-size: 0.875rem;
+}
+</style>

--- a/src/features/tickets/components/SectionedBody.vue
+++ b/src/features/tickets/components/SectionedBody.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { parseBody } from '../templates/parse-body'
+import SectionBlock from './SectionBlock.vue'
+
+const props = defineProps<{ readonly body: string }>()
+
+const sections = computed(() => parseBody(props.body))
+const hasStructured = computed(() => sections.value.length > 0)
+</script>
+
+<template>
+  <article v-if="hasStructured" class="sectioned-body">
+    <SectionBlock
+      v-for="(s, i) in sections"
+      :key="`${s.label}-${i}`"
+      :label="s.label"
+      :text="s.text"
+    />
+  </article>
+  <p v-else class="legacy-body">{{ body }}</p>
+</template>
+
+<style scoped>
+.sectioned-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.legacy-body {
+  white-space: pre-wrap;
+  line-height: 1.6;
+}
+</style>

--- a/src/features/tickets/components/TemplateField.vue
+++ b/src/features/tickets/components/TemplateField.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+const props = defineProps<{
+  readonly label: string
+  readonly modelValue: string
+  readonly required?: boolean
+  readonly placeholder?: string
+  readonly rows?: number
+}>()
+
+defineEmits<{ 'update:modelValue': [v: string] }>()
+
+const labelText = props.required ? `${props.label} *` : props.label
+</script>
+
+<template>
+  <label class="template-field">
+    <span class="label">{{ labelText }}</span>
+    <textarea
+      :value="modelValue"
+      :placeholder="placeholder"
+      :rows="rows ?? 3"
+      class="input"
+      @input="
+        $emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)
+      "
+    />
+  </label>
+</template>
+
+<style scoped>
+.template-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.label {
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: inherit;
+  font-size: 0.875rem;
+  resize: vertical;
+  box-sizing: border-box;
+}
+</style>

--- a/src/features/tickets/components/TemplateFieldsSwitch.vue
+++ b/src/features/tickets/components/TemplateFieldsSwitch.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type {
+  BugTemplate,
+  TicketTemplate,
+  UserStoryTemplate,
+} from '../templates/types'
+import BugTemplateFields from './BugTemplateFields.vue'
+import UserStoryTemplateFields from './UserStoryTemplateFields.vue'
+
+defineProps<{ readonly modelValue: TicketTemplate }>()
+defineEmits<{ 'update:modelValue': [t: TicketTemplate] }>()
+
+const asBug = (t: TicketTemplate): BugTemplate =>
+  t.kind === 'bug' ? t : { kind: 'bug', reproductionSteps: '',
+    actualBehavior: '', expectedBehavior: '', description: '' }
+
+const asUserStory = (t: TicketTemplate): UserStoryTemplate =>
+  t.kind === 'user-story' ? t : { kind: 'user-story', iAs: '',
+    wantTo: '', soThat: '', description: '' }
+</script>
+
+<template>
+  <BugTemplateFields
+    v-if="modelValue.kind === 'bug'"
+    :model-value="asBug(modelValue)"
+    @update:model-value="$emit('update:modelValue', $event)"
+  />
+  <UserStoryTemplateFields
+    v-else
+    :model-value="asUserStory(modelValue)"
+    @update:model-value="$emit('update:modelValue', $event)"
+  />
+</template>

--- a/src/features/tickets/components/TemplateOption.vue
+++ b/src/features/tickets/components/TemplateOption.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import type { TicketTemplateKind } from '../templates/types'
+
+defineProps<{
+  readonly value: TicketTemplateKind
+  readonly label: string
+  readonly checked: boolean
+}>()
+defineEmits<{ select: [k: TicketTemplateKind] }>()
+</script>
+
+<template>
+  <label class="opt">
+    <input
+      type="radio"
+      name="ticket-template"
+      :value="value"
+      :checked="checked"
+      @change="$emit('select', value)"
+    />
+    {{ label }}
+  </label>
+</template>
+
+<style scoped>
+.opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+</style>

--- a/src/features/tickets/components/TemplateSelector.vue
+++ b/src/features/tickets/components/TemplateSelector.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { TicketTemplateKind } from '../templates/types'
+import TemplateOption from './TemplateOption.vue'
+
+defineProps<{ readonly modelValue: TicketTemplateKind }>()
+defineEmits<{ 'update:modelValue': [k: TicketTemplateKind] }>()
+</script>
+
+<template>
+  <fieldset class="template-selector">
+    <legend>Template</legend>
+    <TemplateOption
+      value="bug" label="Bug"
+      :checked="modelValue === 'bug'"
+      @select="$emit('update:modelValue', $event)"
+    />
+    <TemplateOption
+      value="user-story" label="User Story"
+      :checked="modelValue === 'user-story'"
+      @select="$emit('update:modelValue', $event)"
+    />
+  </fieldset>
+</template>
+
+<style scoped>
+.template-selector {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 0.375rem 0.75rem;
+}
+
+legend {
+  padding: 0 0.25rem;
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+}
+</style>

--- a/src/features/tickets/components/TicketDetail.vue
+++ b/src/features/tickets/components/TicketDetail.vue
@@ -6,6 +6,7 @@ import { addComment } from '../api/add-comment'
 import type { Ticket, TicketComment } from '../api/gh-tickets'
 import { getComments } from '../api/ticket-actions'
 import { setTicketState } from '../api/ticket-state'
+import SectionedBody from './SectionedBody.vue'
 
 const props = defineProps<{ readonly ticket: Ticket }>()
 const emit = defineEmits<{ back: []; reload: [] }>()
@@ -44,7 +45,7 @@ onMounted(loadComments)
     &larr; Back to list
   </button>
   <h3>#{{ ticket.number }} {{ ticket.title }}</h3>
-  <p class="body">{{ ticket.body }}</p>
+  <SectionedBody :body="ticket.body" />
   <button
     v-if="isAdmin"
     type="button"
@@ -86,11 +87,6 @@ onMounted(loadComments)
 h3 {
   font-size: 1.25rem;
   margin: 0;
-}
-
-.body {
-  white-space: pre-wrap;
-  line-height: 1.6;
 }
 
 .state-btn {

--- a/src/features/tickets/components/TitleAndTargetFields.vue
+++ b/src/features/tickets/components/TitleAndTargetFields.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+defineProps<{
+  readonly title: string
+  readonly target: string
+}>()
+defineEmits<{
+  'update:title': [v: string]
+  'update:target': [v: 'public-website' | 'admin']
+}>()
+</script>
+
+<template>
+  <input
+    type="text"
+    placeholder="Title"
+    class="field"
+    :value="title"
+    data-testid="ticket-title"
+    @input="
+      $emit('update:title', ($event.target as HTMLInputElement).value)
+    "
+  />
+  <select
+    class="field"
+    :value="target"
+    @change="
+      $emit('update:target', ($event.target as HTMLSelectElement).value as 'public-website' | 'admin')
+    "
+  >
+    <option value="public-website">Public Website</option>
+    <option value="admin">Admin Panel</option>
+  </select>
+</template>
+
+<style scoped>
+.field {
+  display: block;
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+</style>

--- a/src/features/tickets/components/UserStoryTemplateFields.vue
+++ b/src/features/tickets/components/UserStoryTemplateFields.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import type { UserStoryTemplate } from '../templates/types'
+import TemplateField from './TemplateField.vue'
+
+defineProps<{ readonly modelValue: UserStoryTemplate }>()
+const emit = defineEmits<{ 'update:modelValue': [t: UserStoryTemplate] }>()
+
+const update = (
+  patch: Partial<UserStoryTemplate>,
+  current: UserStoryTemplate
+): void => {
+  emit('update:modelValue', { ...current, ...patch })
+}
+</script>
+
+<template>
+  <TemplateField
+    label="I as" required
+    placeholder="…an editor"
+    :rows="2"
+    :model-value="modelValue.iAs"
+    @update:model-value="update({ iAs: $event }, modelValue)"
+  />
+  <TemplateField
+    label="Want to" required
+    placeholder="…upload images by drag-drop"
+    :rows="2"
+    :model-value="modelValue.wantTo"
+    @update:model-value="update({ wantTo: $event }, modelValue)"
+  />
+  <TemplateField
+    label="So that" required
+    placeholder="…I don't have to leave the editor to attach a screenshot"
+    :rows="2"
+    :model-value="modelValue.soThat"
+    @update:model-value="update({ soThat: $event }, modelValue)"
+  />
+  <TemplateField
+    label="Description"
+    placeholder="Optional context"
+    :model-value="modelValue.description"
+    @update:model-value="update({ description: $event }, modelValue)"
+  />
+</template>

--- a/src/features/tickets/components/attach-history.ts
+++ b/src/features/tickets/components/attach-history.ts
@@ -1,0 +1,35 @@
+import { readHistory } from '@/features/action-history/recorder'
+import { renderHistoryJson } from '@/features/action-history/serialize'
+import { uploadTextAttachment } from '../api/upload-history'
+import type { TicketAttachment } from '../templates/attachment-types'
+
+const HISTORY_FILE = 'actions-history.json'
+
+/**
+ * Snapshot the current action-history ring buffer and upload it as
+ * a JSON attachment. Best-effort: if either step fails we log the
+ * cause via the supplied callback and return undefined, so the
+ * ticket can still go out without history.
+ *
+ * @param token - GitHub access token
+ * @param onError - Reporter for non-fatal failures
+ * @returns Attachment when upload succeeded
+ */
+export const attachActionHistory = async (
+  token: string,
+  onError: (msg: string) => void
+): Promise<TicketAttachment | undefined> => {
+  try {
+    const entries = await readHistory()
+    const text = renderHistoryJson(entries, Date.now())
+    return await uploadTextAttachment({
+      token,
+      fileName: HISTORY_FILE,
+      text,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'history attach failed'
+    onError(msg)
+    return undefined
+  }
+}

--- a/src/features/tickets/components/attachment-pipeline.test.ts
+++ b/src/features/tickets/components/attachment-pipeline.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { filesFromDrop, filesFromPaste } from './attachment-pipeline'
+
+const fakeFile = (name: string, type: string): File =>
+  new File(['x'], name, { type })
+
+describe('filesFromDrop', () => {
+  it('returns empty array when dataTransfer is missing', () => {
+    const e = { dataTransfer: null } as unknown as DragEvent
+    expect(filesFromDrop(e)).toEqual([])
+  })
+
+  it('returns the dropped files in order', () => {
+    const a = fakeFile('a.png', 'image/png')
+    const b = fakeFile('b.jpg', 'image/jpeg')
+    const e = {
+      dataTransfer: { files: [a, b] },
+    } as unknown as DragEvent
+    expect(filesFromDrop(e)).toEqual([a, b])
+  })
+})
+
+describe('filesFromPaste', () => {
+  it('returns empty array when clipboardData is missing', () => {
+    const e = { clipboardData: null } as unknown as ClipboardEvent
+    expect(filesFromPaste(e)).toEqual([])
+  })
+
+  it('returns only file-kind items, mapping via getAsFile', () => {
+    const png = fakeFile('paste.png', 'image/png')
+    const items = [
+      { kind: 'string', getAsFile: () => null },
+      { kind: 'file', getAsFile: () => png },
+      { kind: 'file', getAsFile: () => null },
+    ]
+    const e = { clipboardData: { items } } as unknown as ClipboardEvent
+    expect(filesFromPaste(e)).toEqual([png])
+  })
+})

--- a/src/features/tickets/components/attachment-pipeline.ts
+++ b/src/features/tickets/components/attachment-pipeline.ts
@@ -1,0 +1,70 @@
+import { uploadAttachment } from '../api/upload-attachment'
+import type { TicketAttachment } from '../templates/attachment-types'
+
+const fromList = (list: ArrayLike<File> | undefined): readonly File[] =>
+  list === undefined ? [] : Array.from(list as ArrayLike<File>)
+
+/**
+ * Pull dropped File(s) out of a DragEvent.
+ * @param event - DragEvent or compatible shape
+ * @returns Files (empty when the drop carried only text)
+ */
+export const filesFromDrop = (event: DragEvent): readonly File[] =>
+  fromList(event.dataTransfer?.files)
+
+const itemAsFile = (item: DataTransferItem): File | undefined =>
+  item.kind === 'file' ? (item.getAsFile() ?? undefined) : undefined
+
+const isDefined = <T>(v: T | undefined): v is T => v !== undefined
+
+/**
+ * Pull image File(s) out of a paste ClipboardEvent.
+ * @param event - ClipboardEvent or compatible shape
+ * @returns Files (empty when the paste carried only text)
+ */
+export const filesFromPaste = (event: ClipboardEvent): readonly File[] => {
+  const items = event.clipboardData?.items
+  return items === undefined
+    ? []
+    : Array.from(items).map(itemAsFile).filter(isDefined)
+}
+
+interface UploadDeps {
+  readonly token: string
+  readonly files: readonly File[]
+  readonly onError: (msg: string) => void
+}
+
+const failureMessages = (
+  results: readonly PromiseSettledResult<TicketAttachment>[],
+  files: readonly File[]
+): readonly string[] =>
+  results.flatMap((r, i) =>
+    r.status === 'rejected'
+      ? [`Upload failed for ${files[i]?.name}: ${r.reason}`]
+      : []
+  )
+
+const reportFailures = (
+  results: readonly PromiseSettledResult<TicketAttachment>[],
+  files: readonly File[],
+  onError: (msg: string) => void
+): void => {
+  for (const msg of failureMessages(results, files)) onError(msg)
+}
+
+/**
+ * Upload a batch of files in parallel, surfacing per-file errors.
+ *
+ * @param deps - Token + files + error callback
+ * @returns Successfully uploaded attachments
+ */
+export const uploadBatch = async (
+  deps: UploadDeps
+): Promise<readonly TicketAttachment[]> => {
+  const results = await Promise.allSettled(
+    deps.files.map(file => uploadAttachment({ token: deps.token, file }))
+  )
+  reportFailures(results, deps.files, deps.onError)
+  return results.flatMap(r => (r.status === 'fulfilled' ? [r.value] : []))
+}

--- a/src/features/tickets/components/submit-ticket.test.ts
+++ b/src/features/tickets/components/submit-ticket.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { emptyBug } from '../templates/empty'
+import type { BugTemplate } from '../templates/types'
+import { submitTicket } from './submit-ticket'
+
+const fetchMock = vi.fn()
+globalThis.fetch = fetchMock as unknown as typeof fetch
+
+const ok = (body: unknown) =>
+  ({
+    ok: true,
+    json: async () => body,
+  }) as Response
+
+const filledBug = (): BugTemplate => ({
+  ...emptyBug(),
+  reproductionSteps: '1.',
+  actualBehavior: 'crashed',
+  expectedBehavior: 'no crash',
+})
+
+afterEach(() => fetchMock.mockReset())
+
+describe('submitTicket', () => {
+  it('returns invalid when required fields are missing', async () => {
+    const result = await submitTicket({
+      token: 't',
+      title: 'X',
+      template: emptyBug(),
+      labels: ['public-website', 'bug'],
+      attachments: [],
+    })
+    expect(result.kind).toBe('invalid')
+    if (result.kind === 'invalid') {
+      expect(result.missing.length).toBeGreaterThan(0)
+    }
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('builds a structured body and posts to GitHub on success', async () => {
+    fetchMock.mockResolvedValue(ok({ number: 42 }))
+    const result = await submitTicket({
+      token: 'tok',
+      title: 'X',
+      template: filledBug(),
+      labels: ['public-website', 'bug'],
+      attachments: [],
+    })
+    expect(result).toEqual({ kind: 'ok', issueNumber: 42 })
+    const call = fetchMock.mock.calls[0] ?? []
+    const init = call[1] as RequestInit
+    const sent = JSON.parse(init.body as string)
+    expect(sent.title).toBe('X')
+    expect(sent.body).toContain('## Reproduction Steps')
+    expect(sent.body).toContain('## Actual Behavior')
+    expect(sent.labels).toEqual(['public-website', 'bug'])
+  })
+
+  it('returns error tag when fetch rejects', async () => {
+    fetchMock.mockRejectedValue(new Error('boom'))
+    const result = await submitTicket({
+      token: 'tok',
+      title: 'X',
+      template: filledBug(),
+      labels: [],
+      attachments: [],
+    })
+    expect(result).toEqual({ kind: 'error', message: 'boom' })
+  })
+})

--- a/src/features/tickets/components/submit-ticket.ts
+++ b/src/features/tickets/components/submit-ticket.ts
@@ -1,0 +1,51 @@
+import { createTicket } from '../api/ticket-actions'
+import type { TicketAttachment } from '../templates/attachment-types'
+import { buildBody } from '../templates/build-body'
+import type { TicketTemplate } from '../templates/types'
+import { validateTemplate } from '../templates/validate'
+
+interface SubmitDeps {
+  readonly token: string
+  readonly title: string
+  readonly template: TicketTemplate
+  readonly labels: readonly string[]
+  readonly attachments: readonly TicketAttachment[]
+}
+
+/** Result of a submit attempt — discriminated for the caller. */
+export type SubmitResult =
+  | { readonly kind: 'ok'; readonly issueNumber: number }
+  | { readonly kind: 'invalid'; readonly missing: readonly string[] }
+  | { readonly kind: 'error'; readonly message: string }
+
+/**
+ * Validate, render the body, and POST the ticket.
+ *
+ * Pulled out of the form so the form stays declarative — and so
+ * we can unit-test the validate→build→post pipeline without DOM.
+ *
+ * @param deps - Submit inputs
+ * @returns Tagged result
+ */
+export const submitTicket = async (
+  deps: SubmitDeps
+): Promise<SubmitResult> => {
+  const missing = validateTemplate(deps.template)
+  return missing.length > 0 ? { kind: 'invalid', missing } : doSubmit(deps)
+}
+
+const doSubmit = async (deps: SubmitDeps): Promise<SubmitResult> => {
+  try {
+    const body = buildBody(deps.template, deps.attachments)
+    const ticket = await createTicket({
+      token: deps.token,
+      title: deps.title,
+      body,
+      labels: deps.labels,
+    })
+    return { kind: 'ok', issueNumber: ticket.number }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    return { kind: 'error', message }
+  }
+}

--- a/src/features/tickets/components/use-create-form.ts
+++ b/src/features/tickets/components/use-create-form.ts
@@ -1,0 +1,43 @@
+import { computed, ref } from 'vue'
+import type { TicketAttachment } from '../templates/attachment-types'
+import { emptyTemplate } from '../templates/empty'
+import type { TicketTemplate, TicketTemplateKind } from '../templates/types'
+
+const initial = () => ({
+  title: ref(''),
+  target: ref<'public-website' | 'admin'>('public-website'),
+  kind: ref<TicketTemplateKind>('bug'),
+  template: ref<TicketTemplate>(emptyTemplate('bug')),
+  attachments: ref<readonly TicketAttachment[]>([]),
+  uploading: ref(false),
+})
+
+/**
+ * Reactive state + helpers for the ticket create form.
+ *
+ * Switching template kind resets the structured fields to the new
+ * empty shape — title and attachments survive, since those are
+ * meaningful regardless of which template the user lands on.
+ *
+ * @returns Reactive refs and mutators consumed by the form
+ */
+export const useCreateForm = () => {
+  const s = initial()
+  return {
+    ...s,
+    titleTrimmed: computed(() => s.title.value.trim()),
+    labels: computed(() => [s.target.value, s.kind.value]),
+    setKind: (next: TicketTemplateKind): void => {
+      s.kind.value = next
+      s.template.value = emptyTemplate(next)
+    },
+    reset: (): void => {
+      s.title.value = ''
+      s.template.value = emptyTemplate(s.kind.value)
+      s.attachments.value = []
+    },
+    removeAttachment: (id: string): void => {
+      s.attachments.value = s.attachments.value.filter(a => a.id !== id)
+    },
+  }
+}

--- a/src/features/tickets/components/use-ticket-submit.ts
+++ b/src/features/tickets/components/use-ticket-submit.ts
@@ -1,0 +1,53 @@
+import { Match } from 'effect'
+import type { Ref } from 'vue'
+import { attachActionHistory } from './attach-history'
+import { submitTicket } from './submit-ticket'
+import type { useCreateForm } from './use-create-form'
+
+interface SubmitDeps {
+  readonly token: string
+  readonly form: ReturnType<typeof useCreateForm>
+  readonly missing: Ref<readonly string[]>
+  readonly emitCreated: () => void
+  readonly emitError: (msg: string) => void
+}
+
+const dispatch = (
+  result: Awaited<ReturnType<typeof submitTicket>>,
+  deps: SubmitDeps
+): void =>
+  Match.value(result).pipe(
+    Match.discriminator('kind')('invalid', r => {
+      deps.missing.value = r.missing
+    }),
+    Match.discriminator('kind')('error', r => deps.emitError(r.message)),
+    Match.discriminator('kind')('ok', () => {
+      deps.form.reset()
+      deps.missing.value = []
+      deps.emitCreated()
+    }),
+    Match.exhaustive
+  )
+
+/**
+ * Run the full submit pipeline: attach the action-history JSON,
+ * compose the attachment list, post the ticket, and dispatch the
+ * outcome to the callbacks supplied by the host component.
+ *
+ * @param deps - Token, form state, missing-fields ref, callbacks
+ */
+export const runTicketSubmit = async (deps: SubmitDeps): Promise<void> => {
+  const history = await attachActionHistory(deps.token, deps.emitError)
+  const all =
+    history === undefined
+      ? deps.form.attachments.value
+      : [...deps.form.attachments.value, history]
+  const result = await submitTicket({
+    token: deps.token,
+    title: deps.form.titleTrimmed.value,
+    template: deps.form.template.value,
+    labels: deps.form.labels.value,
+    attachments: all,
+  })
+  dispatch(result, deps)
+}

--- a/src/features/tickets/templates/attachment-types.ts
+++ b/src/features/tickets/templates/attachment-types.ts
@@ -1,0 +1,16 @@
+/** Attachment kind — image renders inline, file renders as a link. */
+export type AttachmentKind = 'image' | 'file'
+
+/**
+ * A ticket attachment that has already been uploaded to a stable URL.
+ *
+ * Returned by `upload-attachment.ts` and consumed by both the body
+ * builder (renders the markdown link) and the form preview list.
+ */
+export interface TicketAttachment {
+  readonly id: string
+  readonly name: string
+  readonly url: string
+  readonly kind: AttachmentKind
+  readonly sizeBytes: number
+}

--- a/src/features/tickets/templates/build-body.test.ts
+++ b/src/features/tickets/templates/build-body.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { TicketAttachment } from './attachment-types'
+import { buildBody } from './build-body'
+import { parseBody } from './parse-body'
+import type { BugTemplate, UserStoryTemplate } from './types'
+
+const bug: BugTemplate = {
+  kind: 'bug',
+  reproductionSteps: '1. Open\n2. Click',
+  actualBehavior: 'It crashed',
+  expectedBehavior: 'It should not crash',
+  description: 'Extra context',
+}
+
+const userStory: UserStoryTemplate = {
+  kind: 'user-story',
+  iAs: 'an editor',
+  wantTo: 'attach screenshots',
+  soThat: 'triage is faster',
+  description: '',
+}
+
+const image: TicketAttachment = {
+  id: 'abc',
+  name: 'screenshot.png',
+  url: 'https://raw/x/screenshot.png',
+  kind: 'image',
+  sizeBytes: 1024,
+}
+
+describe('buildBody', () => {
+  it('emits the four bug sections as ## headings', () => {
+    const md = buildBody(bug)
+    expect(md).toContain('## Reproduction Steps')
+    expect(md).toContain('## Actual Behavior')
+    expect(md).toContain('## Expected Behavior')
+    expect(md).toContain('## Description')
+  })
+
+  it('emits the four user-story sections as ## headings', () => {
+    const md = buildBody(userStory)
+    expect(md).toContain('## I as')
+    expect(md).toContain('## Want to')
+    expect(md).toContain('## So that')
+  })
+
+  it('renders image attachment with a markdown image link', () => {
+    const md = buildBody(bug, [image])
+    expect(md).toContain('## Attachments')
+    expect(md).toContain('![screenshot.png](https://raw/x/screenshot.png)')
+  })
+
+  it('round-trips through parseBody preserving section text', () => {
+    const sections = parseBody(buildBody(bug))
+    const map = new Map(sections.map(s => [s.label, s.text]))
+    expect(map.get('Reproduction Steps')).toBe(bug.reproductionSteps)
+    expect(map.get('Actual Behavior')).toBe(bug.actualBehavior)
+    expect(map.get('Expected Behavior')).toBe(bug.expectedBehavior)
+    expect(map.get('Description')).toBe(bug.description)
+  })
+
+  it('treats empty optional Description as blank on round-trip', () => {
+    const sections = parseBody(buildBody(userStory))
+    const desc = sections.find(s => s.label === 'Description')
+    expect(desc?.text).toBe('')
+  })
+})
+
+describe('parseBody (legacy bodies)', () => {
+  it('returns empty array for free-form text without our headings', () => {
+    expect(parseBody('Just some legacy plaintext')).toEqual([])
+  })
+
+  it('ignores unrelated headings', () => {
+    expect(parseBody('## Random heading\n\nfoo')).toEqual([])
+  })
+})

--- a/src/features/tickets/templates/build-body.ts
+++ b/src/features/tickets/templates/build-body.ts
@@ -1,0 +1,50 @@
+import type { TicketAttachment } from './attachment-types'
+import { SECTION_LABELS } from './labels'
+import type { BugTemplate, TicketTemplate, UserStoryTemplate } from './types'
+
+const section = (label: string, body: string): string =>
+  `## ${label}\n\n${body.trim() || '_(empty)_'}`
+
+const bugSections = (t: BugTemplate): readonly string[] => [
+  section(SECTION_LABELS.reproductionSteps, t.reproductionSteps),
+  section(SECTION_LABELS.actualBehavior, t.actualBehavior),
+  section(SECTION_LABELS.expectedBehavior, t.expectedBehavior),
+  section(SECTION_LABELS.description, t.description),
+]
+
+const userStorySections = (t: UserStoryTemplate): readonly string[] => [
+  section(SECTION_LABELS.iAs, t.iAs),
+  section(SECTION_LABELS.wantTo, t.wantTo),
+  section(SECTION_LABELS.soThat, t.soThat),
+  section(SECTION_LABELS.description, t.description),
+]
+
+const attachmentLine = (a: TicketAttachment): string =>
+  a.kind === 'image' ? `![${a.name}](${a.url})` : `[${a.name}](${a.url})`
+
+const attachmentsBlock = (
+  attachments: readonly TicketAttachment[]
+): string => {
+  const lines = attachments.map(attachmentLine).join('\n')
+  return section(SECTION_LABELS.attachments, lines)
+}
+
+/**
+ * Build a markdown issue body from a structured template + attachments.
+ *
+ * Layout uses `## Section` headings — that's what every GitHub issue
+ * template does, and it round-trips cleanly through {@link parseBody}.
+ *
+ * @param t - Validated template (no required fields blank)
+ * @param attachments - Files already uploaded; rendered as media links
+ * @returns Markdown body ready to POST as the issue body
+ */
+export const buildBody = (
+  t: TicketTemplate,
+  attachments: readonly TicketAttachment[] = []
+): string => {
+  const main = t.kind === 'bug' ? bugSections(t) : userStorySections(t)
+  const all =
+    attachments.length === 0 ? main : [...main, attachmentsBlock(attachments)]
+  return all.join('\n\n')
+}

--- a/src/features/tickets/templates/empty.ts
+++ b/src/features/tickets/templates/empty.ts
@@ -1,0 +1,37 @@
+import type {
+  BugTemplate,
+  TicketTemplateKind,
+  UserStoryTemplate,
+} from './types'
+
+/**
+ * Empty Bug template instance.
+ * @returns A bug template with all fields blank
+ */
+export const emptyBug = (): BugTemplate => ({
+  kind: 'bug',
+  reproductionSteps: '',
+  actualBehavior: '',
+  expectedBehavior: '',
+  description: '',
+})
+
+/**
+ * Empty User Story template instance.
+ * @returns A user-story template with all fields blank
+ */
+export const emptyUserStory = (): UserStoryTemplate => ({
+  kind: 'user-story',
+  iAs: '',
+  wantTo: '',
+  soThat: '',
+  description: '',
+})
+
+/**
+ * Build an empty template by kind.
+ * @param kind - Template discriminator
+ * @returns Empty template instance
+ */
+export const emptyTemplate = (kind: TicketTemplateKind) =>
+  kind === 'bug' ? emptyBug() : emptyUserStory()

--- a/src/features/tickets/templates/labels.ts
+++ b/src/features/tickets/templates/labels.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical labels for each section, used both when serialising the
+ * issue body (`## Reproduction Steps`) and when re-rendering the
+ * detail view as labelled blocks. Keep them in one place so the body
+ * builder, the body parser, and the UI never disagree on wording —
+ * a typo on either side is what makes "parse-back" lossy.
+ */
+export const SECTION_LABELS = {
+  reproductionSteps: 'Reproduction Steps',
+  actualBehavior: 'Actual Behavior',
+  expectedBehavior: 'Expected Behavior',
+  iAs: 'I as',
+  wantTo: 'Want to',
+  soThat: 'So that',
+  description: 'Description',
+  attachments: 'Attachments',
+} as const
+
+/** Bug section labels in canonical order. */
+export const BUG_LABELS = [
+  SECTION_LABELS.reproductionSteps,
+  SECTION_LABELS.actualBehavior,
+  SECTION_LABELS.expectedBehavior,
+  SECTION_LABELS.description,
+] as const
+
+/** User Story section labels in canonical order. */
+export const USER_STORY_LABELS = [
+  SECTION_LABELS.iAs,
+  SECTION_LABELS.wantTo,
+  SECTION_LABELS.soThat,
+  SECTION_LABELS.description,
+] as const

--- a/src/features/tickets/templates/parse-body.ts
+++ b/src/features/tickets/templates/parse-body.ts
@@ -1,0 +1,55 @@
+import { SECTION_LABELS } from './labels'
+import type { TicketSection } from './types'
+
+const ALL_LABELS = Object.values(SECTION_LABELS)
+
+const escapeRe = (s: string): string =>
+  s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const headingRe = new RegExp(
+  `^##\\s+(${ALL_LABELS.map(escapeRe).join('|')})\\s*$`,
+  'gmi'
+)
+
+interface RawHit {
+  readonly label: string
+  readonly start: number
+  readonly contentStart: number
+}
+
+const findHits = (body: string): readonly RawHit[] =>
+  [...body.matchAll(headingRe)].map(m => ({
+    label: m[1] ?? '',
+    start: m.index ?? 0,
+    contentStart: (m.index ?? 0) + m[0].length,
+  }))
+
+const cleanText = (raw: string): string => (raw === '_(empty)_' ? '' : raw)
+
+const sliceAt = (
+  body: string,
+  hit: RawHit,
+  next: RawHit | undefined
+): TicketSection => ({
+  label: hit.label,
+  text: cleanText(
+    body
+      .slice(hit.contentStart, next === undefined ? body.length : next.start)
+      .trim()
+  ),
+})
+
+/**
+ * Parse a structured ticket body back into labelled sections.
+ *
+ * Uses the same labels {@link SECTION_LABELS} the builder produces —
+ * unknown headings or stray prose are dropped so legacy free-form
+ * bodies render as a single unlabelled block via the caller.
+ *
+ * @param body - Raw issue body markdown
+ * @returns Sections in the order they appear in the body
+ */
+export const parseBody = (body: string): readonly TicketSection[] => {
+  const hits = findHits(body)
+  return hits.map((hit, i) => sliceAt(body, hit, hits[i + 1]))
+}

--- a/src/features/tickets/templates/types.ts
+++ b/src/features/tickets/templates/types.ts
@@ -1,0 +1,29 @@
+/** Ticket template kind. */
+export type TicketTemplateKind = 'bug' | 'user-story'
+
+/** Bug template fields. */
+export interface BugTemplate {
+  readonly kind: 'bug'
+  readonly reproductionSteps: string
+  readonly actualBehavior: string
+  readonly expectedBehavior: string
+  readonly description: string
+}
+
+/** User Story template fields. */
+export interface UserStoryTemplate {
+  readonly kind: 'user-story'
+  readonly iAs: string
+  readonly wantTo: string
+  readonly soThat: string
+  readonly description: string
+}
+
+/** Discriminated union of all ticket templates. */
+export type TicketTemplate = BugTemplate | UserStoryTemplate
+
+/** A parsed-back, labelled section ready for display. */
+export interface TicketSection {
+  readonly label: string
+  readonly text: string
+}

--- a/src/features/tickets/templates/validate.test.ts
+++ b/src/features/tickets/templates/validate.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { emptyBug, emptyUserStory } from './empty'
+import type { BugTemplate, UserStoryTemplate } from './types'
+import { validateTemplate } from './validate'
+
+const filledBug = (overrides: Partial<BugTemplate> = {}): BugTemplate => ({
+  ...emptyBug(),
+  reproductionSteps: '1. Click',
+  actualBehavior: 'crashed',
+  expectedBehavior: 'no crash',
+  ...overrides,
+})
+
+const filledUserStory = (
+  overrides: Partial<UserStoryTemplate> = {}
+): UserStoryTemplate => ({
+  ...emptyUserStory(),
+  iAs: 'editor',
+  wantTo: 'attach photos',
+  soThat: 'triage is faster',
+  ...overrides,
+})
+
+describe('validateTemplate (Bug)', () => {
+  it('passes when all three required sections are filled', () => {
+    expect(validateTemplate(filledBug())).toEqual([])
+  })
+
+  it('reports each blank required section by label', () => {
+    expect(validateTemplate(emptyBug())).toEqual([
+      'Reproduction Steps',
+      'Actual Behavior',
+      'Expected Behavior',
+    ])
+  })
+
+  it('only blank string is treated as missing (whitespace counts as blank)', () => {
+    const t = filledBug({ reproductionSteps: '   \n\t' })
+    expect(validateTemplate(t)).toEqual(['Reproduction Steps'])
+  })
+
+  it('description is optional', () => {
+    expect(validateTemplate(filledBug({ description: '' }))).toEqual([])
+  })
+})
+
+describe('validateTemplate (User Story)', () => {
+  it('passes when all three required sections are filled', () => {
+    expect(validateTemplate(filledUserStory())).toEqual([])
+  })
+
+  it('reports each blank required section by label', () => {
+    expect(validateTemplate(emptyUserStory())).toEqual([
+      'I as',
+      'Want to',
+      'So that',
+    ])
+  })
+
+  it('description is optional', () => {
+    expect(validateTemplate(filledUserStory({ description: '' }))).toEqual([])
+  })
+})

--- a/src/features/tickets/templates/validate.ts
+++ b/src/features/tickets/templates/validate.ts
@@ -1,0 +1,26 @@
+import type { BugTemplate, TicketTemplate, UserStoryTemplate } from './types'
+
+const isBlank = (s: string): boolean => s.trim().length === 0
+
+const checkField = (label: string, value: string): readonly string[] =>
+  isBlank(value) ? [label] : []
+
+const validateBug = (t: BugTemplate): readonly string[] => [
+  ...checkField('Reproduction Steps', t.reproductionSteps),
+  ...checkField('Actual Behavior', t.actualBehavior),
+  ...checkField('Expected Behavior', t.expectedBehavior),
+]
+
+const validateUserStory = (t: UserStoryTemplate): readonly string[] => [
+  ...checkField('I as', t.iAs),
+  ...checkField('Want to', t.wantTo),
+  ...checkField('So that', t.soThat),
+]
+
+/**
+ * Validate required fields on a ticket template.
+ * @param t - Template instance
+ * @returns Array of human-readable missing-field labels (empty = ok)
+ */
+export const validateTemplate = (t: TicketTemplate): readonly string[] =>
+  t.kind === 'bug' ? validateBug(t) : validateUserStory(t)

--- a/src/stores/auth-actions.ts
+++ b/src/stores/auth-actions.ts
@@ -1,6 +1,7 @@
 import type { Ref } from 'vue'
 import { saveProfile } from '@/composables/useAuth/profile-cache'
 import { clearToken } from '@/composables/useAuth/token-storage'
+import { recordAction } from '@/features/action-history/recorder'
 import type { User } from '@/types/user'
 
 /**
@@ -11,12 +12,17 @@ import type { User } from '@/types/user'
 export const createSetUser =
   (user: Ref<User | null>) =>
   (u: User | null): void => {
+    const wasLoggedIn = user.value !== null
     user.value = u
     if (u) {
       saveProfile({
         username: u.username,
         name: u.name,
         avatar: u.avatar,
+      })
+      void recordAction({
+        kind: 'auth',
+        action: wasLoggedIn ? 'token-refresh' : 'login',
       })
     }
   }
@@ -33,4 +39,5 @@ export const createLogout =
     clearToken()
     user.value = null
     loading.value = false
+    void recordAction({ kind: 'auth', action: 'logout' })
   }

--- a/src/views/SettingsView/ActionHistorySection.vue
+++ b/src/views/SettingsView/ActionHistorySection.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { clearHistory } from '@/features/action-history/recorder'
+
+const status = ref<'idle' | 'cleared' | 'error'>('idle')
+
+const onClear = async (): Promise<void> => {
+  try {
+    await clearHistory()
+    status.value = 'cleared'
+  } catch {
+    status.value = 'error'
+  }
+}
+</script>
+
+<template>
+  <section class="ah-section">
+    <h2>Action History</h2>
+    <p class="lead">
+      A short rolling window of your recent actions (routes, saves,
+      auth changes, errors) is kept on this device so that ticket
+      reports include context. No file contents are recorded.
+    </p>
+    <button
+      type="button"
+      class="clear-btn"
+      data-testid="clear-action-history"
+      @click="onClear"
+    >
+      Clear my action history
+    </button>
+    <p
+      v-if="status === 'cleared'"
+      class="ok"
+      data-testid="clear-action-history-status"
+    >
+      History cleared.
+    </p>
+    <p v-else-if="status === 'error'" class="err">
+      Failed to clear history. Try again.
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.ah-section {
+  margin-bottom: 2rem;
+}
+
+h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.lead {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+
+.clear-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background-soft);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.ok {
+  color: var(--color-success, #1a7f37);
+  font-size: 0.8125rem;
+  margin-top: 0.5rem;
+}
+
+.err {
+  color: var(--color-danger, #d73a4a);
+  font-size: 0.8125rem;
+  margin-top: 0.5rem;
+}
+</style>

--- a/src/views/SettingsView/SettingsPage.vue
+++ b/src/views/SettingsView/SettingsPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { LabelEntry } from '@/stores/labels'
 import type { LanguageEntry } from '@/stores/settings'
+import ActionHistorySection from './ActionHistorySection.vue'
 import LabelsSection from './LabelsSection.vue'
 import LanguagesSection from './LanguagesSection.vue'
 import MembersSection from './MembersSection.vue'
@@ -38,6 +39,7 @@ defineEmits<{
       @save="$emit('save-labels', $event)"
     />
     <MembersSection />
+    <ActionHistorySection />
   </section>
 </template>
 

--- a/src/views/TicketsView/TicketsHeader.vue
+++ b/src/views/TicketsView/TicketsHeader.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import type { Ticket } from '@/features/tickets/api/gh-tickets'
-import { createTicket } from '@/features/tickets/api/ticket-actions'
-import CreateTicketForm from '@/features/tickets/components/CreateTicketForm.vue'
+import CreateTicketContainer from '@/features/tickets/components/CreateTicketContainer.vue'
 import TicketCard from '@/features/tickets/components/TicketCard.vue'
-import { useAuthStore } from '@/stores/auth'
 
 defineProps<{
   readonly showCreate: boolean
@@ -16,32 +14,30 @@ const emit = defineEmits<{
   reload: []
 }>()
 
-const auth = useAuthStore()
+const onCreated = (): void => {
+  emit('toggle-create')
+  emit('reload')
+}
 
-const handleCreate = async (
-  title: string,
-  body: string,
-  labels: readonly string[]
-): Promise<void> => {
-  if (!auth.user) return
-  try {
-    await createTicket(auth.user.accessToken, title, body, labels)
-    emit('toggle-create')
-    emit('reload')
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Failed'
-    globalThis.alert(msg)
-  }
+const onError = (msg: string): void => {
+  globalThis.alert(msg)
 }
 </script>
 
 <template>
   <section class="tickets-page">
     <h2>Tickets</h2>
-    <button type="button" class="btn-new" @click="emit('toggle-create')">
+    <button
+      type="button" class="btn-new"
+      @click="emit('toggle-create')"
+    >
       {{ showCreate ? 'Cancel' : '+ New Ticket' }}
     </button>
-    <CreateTicketForm v-if="showCreate" @create="handleCreate" />
+    <CreateTicketContainer
+      v-if="showCreate"
+      @created="onCreated"
+      @error="onError"
+    />
     <p v-if="loading" class="status">Loading tickets...</p>
     <TicketCard v-for="t in tickets" :key="t.number" :ticket="t" />
   </section>


### PR DESCRIPTION
Closes #191.

## Summary
- Pick **Bug** or **User Story** at create time; required sections gated by validation before submit.
- Photos via drag-drop, clipboard paste, or file picker — all routed through one `uploadBatch` pipeline that pushes each file to `communist-prometheus/tickets` at `attachments/<id>/<file>` via the Contents API and links it inline.
- Body rendered as `## Section` markdown headings (GitHub-native), so the detail view re-parses and shows labelled blocks. Legacy free-form tickets render as a single block — no migration needed.

## Acceptance
- [x] Bug template enforces Reproduction Steps / Actual / Expected.
- [x] US template enforces I as / Want to / So that.
- [x] Optional Description works on both.
- [x] Drag-drop, paste, file-picker all attach inline.
- [x] Detail view renders sections as labelled blocks.

## Tests
21 unit tests:
- `validate.test.ts`: every required-empty case for Bug + US.
- `build-body.test.ts`: structured headings emitted; round-trips through `parseBody`; legacy bodies render as single block.
- `attachment-pipeline.test.ts`: drag and paste extract files in order, ignore non-file items.
- `submit-ticket.test.ts`: validation gates the POST; success path builds body + posts; fetch reject surfaces as `error` tag.

Full validate green: vue-tsc, biome ci, oxlint, eslint, vue-depth, stylelint. Full vitest 588 passing.

## Test plan
- [ ] Manual: open `/tickets`, click **+ New Ticket**, switch between Bug ↔ User Story (state resets correctly), drop a screenshot, verify the upload preview shows in the list, submit. Open the new ticket and verify sections render as labelled blocks.
- [ ] Manual: try submit with a blank required field — expect inline "Required: …" message and no fetch.
- [ ] Manual: paste an image into the drop zone (Ctrl+V on the focused button) — expect upload + preview row.

## Out of scope (deferred per the issue)
- Editing structured sections after creation.
- Native mobile photo picker UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)