### PR TITLE
feat(action-history): IDB ring buffer + auto-attach on ticket submit

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,6 +13,7 @@ import { useOfflineWatcher } from '@/composables/useNotifications/use-offline-wa
 import { usePushConflictBridge } from '@/composables/useNotifications/use-push-conflict-bridge'
 import { usePushErrorBridge } from '@/composables/useNotifications/use-push-error-bridge'
 import { usePushSummaryBridge } from '@/composables/useNotifications/use-push-summary-bridge'
+import { installNotificationsRecording } from '@/features/action-history/install-notifications'
 import { useAuthStore } from '@/stores/auth'
 import { useContentStore } from '@/stores/content'
 
@@ -20,6 +21,7 @@ const route = useRoute()
 const authStore = useAuthStore()
 const contentStore = useContentStore()
 useNotificationsPersistence()
+installNotificationsRecording()
 usePushErrorBridge()
 useOfflineWatcher()
 usePushSummaryBridge()

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import { createApp as vueCreateApp } from 'vue'
 import type { Router } from 'vue-router'
 import { createRouter, createWebHistory } from 'vue-router'
 import App from './App.vue'
+import { installRouterRecording } from './features/action-history/install-router'
 import { routes } from './router'
 import { installAuthGuard } from './router/auth-guard'
 
@@ -20,6 +21,7 @@ export const createApp = () => {
   })
 
   installAuthGuard(router)
+  installRouterRecording(router)
 
   app.use(pinia)
   app.use(router)

--- a/src/features/action-history/config.ts
+++ b/src/features/action-history/config.ts
@@ -1,0 +1,17 @@
+/** IndexedDB database name for the action history store. */
+export const HISTORY_DB_NAME = 'admin_action_history'
+
+/** Object store name. */
+export const HISTORY_STORE_NAME = 'entries'
+
+/** Schema version. */
+export const HISTORY_DB_VERSION = 1
+
+/** Maximum entries kept in the ring buffer. */
+export const MAX_ENTRIES = 1000
+
+/** Maximum age of any retained entry, in milliseconds (60 minutes). */
+export const MAX_AGE_MS = 60 * 60 * 1000
+
+/** Maximum length of any free-text reason / errorMessage field. */
+export const MAX_TEXT_LENGTH = 500

--- a/src/features/action-history/db.ts
+++ b/src/features/action-history/db.ts
@@ -1,0 +1,69 @@
+import {
+  HISTORY_DB_NAME,
+  HISTORY_DB_VERSION,
+  HISTORY_STORE_NAME,
+} from './config'
+import type { ActionEntry } from './types'
+
+const promisify = <T>(req: IDBRequest<T>): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    req.onsuccess = (): void => resolve(req.result)
+    req.onerror = (): void => reject(req.error)
+  })
+
+const openDb = (): Promise<IDBDatabase> => {
+  const req = globalThis.indexedDB.open(HISTORY_DB_NAME, HISTORY_DB_VERSION)
+  req.onupgradeneeded = (): void => {
+    req.result.createObjectStore(HISTORY_STORE_NAME, { keyPath: 'id' })
+  }
+  return promisify(req)
+}
+
+const txStore = async (mode: IDBTransactionMode): Promise<IDBObjectStore> => {
+  const db = await openDb()
+  return db
+    .transaction(HISTORY_STORE_NAME, mode)
+    .objectStore(HISTORY_STORE_NAME)
+}
+
+/**
+ * Read every persisted entry sorted oldest-first.
+ * @returns Frozen array of entries
+ */
+export const listEntries = async (): Promise<readonly ActionEntry[]> => {
+  const store = await txStore('readonly')
+  const all: readonly ActionEntry[] = await promisify(store.getAll())
+  return [...all].sort((a, b) => a.ts - b.ts)
+}
+
+/**
+ * Persist a new entry.
+ * @param entry - Stamped entry with id + ts
+ */
+export const putEntry = async (entry: ActionEntry): Promise<void> => {
+  const store = await txStore('readwrite')
+  await promisify(store.put(entry))
+}
+
+/**
+ * Drop a set of entry ids.
+ * @param ids - Identifiers to delete
+ */
+export const deleteEntries = async (
+  ids: readonly string[]
+): Promise<void> => {
+  await Promise.all(
+    ids.map(async id => {
+      const store = await txStore('readwrite')
+      await promisify(store.delete(id))
+    })
+  )
+}
+
+/**
+ * Wipe the entire object store.
+ */
+export const clearEntries = async (): Promise<void> => {
+  const store = await txStore('readwrite')
+  await promisify(store.clear())
+}

--- a/src/features/action-history/install-notifications.ts
+++ b/src/features/action-history/install-notifications.ts
@@ -1,0 +1,48 @@
+import { storeToRefs } from 'pinia'
+import { watch } from 'vue'
+import { useNotificationsStore } from '@/stores/notifications'
+import type { NotificationEntry } from '@/stores/notifications-types'
+import { recordAction } from './recorder'
+
+const SW_ERROR = 'sw-error' as const
+const NETWORK_ERROR = 'network-error' as const
+
+const reasonText = (n: NotificationEntry): string =>
+  n.message === undefined ? n.title : `${n.title}: ${n.message}`
+
+const RECORDERS: Partial<
+  Record<NotificationEntry['kind'], (n: NotificationEntry) => void>
+> = {
+  error: n => void recordAction({ kind: SW_ERROR, reason: reasonText(n) }),
+  network: n =>
+    void recordAction({
+      kind: NETWORK_ERROR,
+      url: '',
+      reason: reasonText(n),
+    }),
+}
+
+const toAction = (n: NotificationEntry): void => {
+  RECORDERS[n.kind]?.(n)
+}
+
+/**
+ * Mirror error / network entries from the notifications queue into
+ * the action-history ring buffer.
+ *
+ * Called once at app boot (sibling of `useNotificationsPersistence`).
+ * Lives outside the notifications module so the action-history
+ * feature stays self-contained.
+ */
+export const installNotificationsRecording = (): void => {
+  const queue = useNotificationsStore()
+  const { entries } = storeToRefs(queue)
+  watch(
+    entries,
+    (next, prev) => {
+      const seen = new Set((prev ?? []).map(e => e.id))
+      next.filter(e => !seen.has(e.id)).forEach(toAction)
+    },
+    { flush: 'post' }
+  )
+}

--- a/src/features/action-history/install-router.ts
+++ b/src/features/action-history/install-router.ts
@@ -1,0 +1,22 @@
+import type { Router } from 'vue-router'
+import { recordAction } from './recorder'
+
+/**
+ * Install an `afterEach` hook on the router that records every
+ * navigation as an action-history entry.
+ *
+ * Uses `afterEach` rather than `beforeEach` so we only record
+ * navigations that actually completed (a guard that returns
+ * `false` won't be recorded as a bogus event).
+ *
+ * @param router - Vue Router instance
+ */
+export const installRouterRecording = (router: Router): void => {
+  router.afterEach((to, from) => {
+    void recordAction({
+      kind: 'navigation',
+      from: from.fullPath,
+      to: to.fullPath,
+    })
+  })
+}

--- a/src/features/action-history/recorder.ts
+++ b/src/features/action-history/recorder.ts
@@ -1,0 +1,49 @@
+import { clearEntries, deleteEntries, listEntries, putEntry } from './db'
+import { stampEntry } from './redact'
+import { pruneEntries } from './ring-buffer'
+import type { ActionEntry, RecordableEntry } from './types'
+
+const newId = (): string => globalThis.crypto.randomUUID()
+
+const evict = async (): Promise<void> => {
+  const all = await listEntries()
+  const kept = pruneEntries({ entries: all, nowMs: Date.now() })
+  const keptIds = new Set(kept.map(e => e.id))
+  const removed = all.filter(e => !keptIds.has(e.id)).map(e => e.id)
+  await (removed.length > 0 ? deleteEntries(removed) : Promise.resolve())
+}
+
+/**
+ * Record a single action.
+ *
+ * Persists the entry and trims the buffer to the configured caps.
+ * Errors are swallowed — the recorder is a best-effort sidecar; we
+ * don't want a failed IDB write to blow up the user's main flow.
+ *
+ * @param entry - Recordable shape (id + ts will be assigned)
+ */
+export const recordAction = async (entry: RecordableEntry): Promise<void> => {
+  try {
+    const stamped = stampEntry(entry, Date.now(), newId)
+    await putEntry(stamped)
+    await evict()
+  } catch {
+    /* best-effort recorder; never throw out to caller */
+  }
+}
+
+/**
+ * Read the current ring buffer, post-prune.
+ * @returns Pruned array, oldest-first
+ */
+export const readHistory = async (): Promise<readonly ActionEntry[]> => {
+  const all = await listEntries()
+  return pruneEntries({ entries: all, nowMs: Date.now() })
+}
+
+/**
+ * Wipe the entire ring buffer (Settings → Clear my action history).
+ */
+export const clearHistory = async (): Promise<void> => {
+  await clearEntries()
+}

--- a/src/features/action-history/redact.test.ts
+++ b/src/features/action-history/redact.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { redactEntry, stampEntry } from './redact'
+import type { NavigationEntry, RecordableEntry, SaveEntry } from './types'
+
+describe('redactEntry', () => {
+  it('truncates long error message on save entries', () => {
+    const long = 'x'.repeat(700)
+    const entry: Omit<SaveEntry, 'id' | 'ts'> = {
+      kind: 'save',
+      action: 'save',
+      path: 'blog/foo.md',
+      status: 'failed',
+      errorMessage: long,
+    }
+    const out = redactEntry(entry) as Omit<SaveEntry, 'id' | 'ts'>
+    expect(out.errorMessage?.length).toBe(501)
+    expect(out.errorMessage?.endsWith('…')).toBe(true)
+  })
+
+  it('truncates sw-error reason at 500 chars', () => {
+    const entry: RecordableEntry = {
+      kind: 'sw-error',
+      reason: 'a'.repeat(800),
+    }
+    const out = redactEntry(entry) as { reason: string }
+    expect(out.reason.length).toBe(501)
+  })
+
+  it('does not include any "content" field on save entries', () => {
+    const entry: Omit<SaveEntry, 'id' | 'ts'> = {
+      kind: 'save',
+      action: 'commit',
+      path: 'pages/about.en.md',
+      status: 'ok',
+    }
+    const out = redactEntry(entry)
+    expect(JSON.stringify(out)).not.toMatch(/content/i)
+  })
+
+  it('passes navigation entries through unchanged', () => {
+    const entry: Omit<NavigationEntry, 'id' | 'ts'> = {
+      kind: 'navigation',
+      from: '/a',
+      to: '/b',
+    }
+    expect(redactEntry(entry)).toEqual(entry)
+  })
+})
+
+describe('stampEntry', () => {
+  it('attaches an id and ts to the redacted entry', () => {
+    const out = stampEntry(
+      { kind: 'auth', action: 'login' },
+      1_700_000_000_000,
+      () => 'fixed-id'
+    )
+    expect(out).toEqual({
+      kind: 'auth',
+      action: 'login',
+      id: 'fixed-id',
+      ts: 1_700_000_000_000,
+    })
+  })
+})

--- a/src/features/action-history/redact.ts
+++ b/src/features/action-history/redact.ts
@@ -1,0 +1,65 @@
+import { MAX_TEXT_LENGTH } from './config'
+import type {
+  ActionEntry,
+  NetworkErrorEntry,
+  RecordableEntry,
+  SaveEntry,
+  SwErrorEntry,
+} from './types'
+
+const truncate = (s: string, max = MAX_TEXT_LENGTH): string =>
+  s.length <= max ? s : `${s.slice(0, max)}…`
+
+const redactSave = (e: Omit<SaveEntry, 'id' | 'ts'>): typeof e => ({
+  ...e,
+  errorMessage:
+    e.errorMessage === undefined ? undefined : truncate(e.errorMessage),
+})
+
+const redactSw = (e: Omit<SwErrorEntry, 'id' | 'ts'>): typeof e => ({
+  ...e,
+  reason: truncate(e.reason),
+})
+
+const redactNet = (e: Omit<NetworkErrorEntry, 'id' | 'ts'>): typeof e => ({
+  ...e,
+  reason: truncate(e.reason),
+})
+
+/**
+ * Strip / truncate any field that could carry PII before persistence.
+ *
+ * The PII boundary lives here, not at every recorder call site. Any
+ * future entry kind that adds a free-text field MUST be handled
+ * explicitly — the discriminated union makes that omission a type
+ * error rather than a silent leak.
+ *
+ * @param entry - Recorded entry without id/ts
+ * @returns Entry with long strings truncated and contents stripped
+ */
+export const redactEntry = (entry: RecordableEntry): RecordableEntry => {
+  const dispatch = {
+    save: () => redactSave(entry as Omit<SaveEntry, 'id' | 'ts'>),
+    'sw-error': () => redactSw(entry as Omit<SwErrorEntry, 'id' | 'ts'>),
+    'network-error': () =>
+      redactNet(entry as Omit<NetworkErrorEntry, 'id' | 'ts'>),
+    navigation: () => entry,
+    stage: () => entry,
+    auth: () => entry,
+  } as const
+  return dispatch[entry.kind]()
+}
+
+/**
+ * Convenience: redact and stamp with a fresh id + ts.
+ * @param entry - Recordable entry
+ * @param now - Wall-clock timestamp to stamp
+ * @param idGen - Id factory (allow injection for tests)
+ * @returns Full ActionEntry ready to persist
+ */
+export const stampEntry = (
+  entry: RecordableEntry,
+  now: number,
+  idGen: () => string
+): ActionEntry =>
+  ({ ...redactEntry(entry), id: idGen(), ts: now }) as ActionEntry

--- a/src/features/action-history/ring-buffer.test.ts
+++ b/src/features/action-history/ring-buffer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { pruneEntries } from './ring-buffer'
+import type { NavigationEntry } from './types'
+
+const nav = (id: string, ts: number): NavigationEntry => ({
+  id,
+  ts,
+  kind: 'navigation',
+  from: '/a',
+  to: '/b',
+})
+
+describe('pruneEntries', () => {
+  const now = 1_000_000_000
+
+  it('returns input unchanged when below both caps', () => {
+    const xs = [nav('1', now - 1000), nav('2', now)]
+    expect(pruneEntries({ entries: xs, nowMs: now })).toEqual(xs)
+  })
+
+  it('drops entries older than maxAge', () => {
+    const xs = [nav('old', now - 70 * 60 * 1000), nav('fresh', now - 1000)]
+    const out = pruneEntries({ entries: xs, nowMs: now })
+    expect(out).toEqual([xs[1]])
+  })
+
+  it('drops oldest when count overflows maxEntries', () => {
+    const xs = Array.from({ length: 1010 }, (_, i) =>
+      nav(String(i), now - i)
+    ).reverse()
+    const out = pruneEntries({ entries: xs, nowMs: now })
+    expect(out).toHaveLength(1000)
+    expect(out[0]?.id).toBe('999')
+    expect(out[out.length - 1]?.id).toBe('0')
+  })
+
+  it('age cutoff and count cap compose — both applied', () => {
+    const xs = [
+      nav('ancient', now - 90 * 60 * 1000),
+      nav('mid', now - 30 * 60 * 1000),
+      nav('recent', now - 1000),
+    ]
+    const out = pruneEntries({
+      entries: xs,
+      nowMs: now,
+      maxEntries: 1,
+    })
+    expect(out).toEqual([xs[2]])
+  })
+
+  it('does not mutate the input array', () => {
+    const xs = [nav('1', now)]
+    const copy = [...xs]
+    pruneEntries({ entries: xs, nowMs: now })
+    expect(xs).toEqual(copy)
+  })
+})

--- a/src/features/action-history/ring-buffer.ts
+++ b/src/features/action-history/ring-buffer.ts
@@ -1,0 +1,29 @@
+import { MAX_AGE_MS, MAX_ENTRIES } from './config'
+import type { ActionEntry } from './types'
+
+interface PruneArgs {
+  readonly entries: readonly ActionEntry[]
+  readonly nowMs: number
+  readonly maxEntries?: number
+  readonly maxAgeMs?: number
+}
+
+/**
+ * Prune an action-history list to fit the bounded ring buffer.
+ *
+ * The buffer is bounded by **both** count and age (whichever is
+ * stricter). Entries are kept oldest-first; the head of the array
+ * is the oldest entry, the tail the newest. This shape is what the
+ * recorder's `append` writes back, and what the serialiser dumps.
+ *
+ * @param args - Current entries + clock + optional bounds override
+ * @returns Pruned array oldest-first (no mutation of the input)
+ */
+export const pruneEntries = (args: PruneArgs): readonly ActionEntry[] => {
+  const maxN = args.maxEntries ?? MAX_ENTRIES
+  const maxAge = args.maxAgeMs ?? MAX_AGE_MS
+  const cutoff = args.nowMs - maxAge
+  const fresh = args.entries.filter(e => e.ts >= cutoff)
+  const overflow = fresh.length - maxN
+  return overflow > 0 ? fresh.slice(overflow) : fresh
+}

--- a/src/features/action-history/serialize.test.ts
+++ b/src/features/action-history/serialize.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { renderHistoryJson, serializeHistory } from './serialize'
+import type { ActionEntry } from './types'
+
+const sample: ActionEntry[] = [
+  {
+    id: '1',
+    ts: 1_700_000_000_000,
+    kind: 'navigation',
+    from: '/',
+    to: '/content',
+  },
+  {
+    id: '2',
+    ts: 1_700_000_001_000,
+    kind: 'save',
+    action: 'commit',
+    path: 'blog/foo.md',
+    status: 'ok',
+  },
+]
+
+describe('serializeHistory', () => {
+  it('emits the v1 schema tag', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.schema).toBe('admin-action-history/v1')
+  })
+
+  it('records the wall-clock time as ISO 8601', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.capturedAt).toBe(new Date(1_700_000_002_000).toISOString())
+  })
+
+  it('reports the entry count', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.entryCount).toBe(2)
+  })
+
+  it('preserves the entries verbatim and in order', () => {
+    const s = serializeHistory(sample, 1_700_000_002_000)
+    expect(s.entries).toEqual(sample)
+  })
+})
+
+describe('renderHistoryJson', () => {
+  it('produces stable, indented JSON ending with a newline', () => {
+    const out = renderHistoryJson(sample, 1_700_000_002_000)
+    expect(out.endsWith('\n')).toBe(true)
+    expect(JSON.parse(out)).toMatchObject({
+      schema: 'admin-action-history/v1',
+      entryCount: 2,
+    })
+  })
+})

--- a/src/features/action-history/serialize.ts
+++ b/src/features/action-history/serialize.ts
@@ -1,0 +1,41 @@
+import type { ActionEntry } from './types'
+
+interface SerializedHistory {
+  readonly schema: 'admin-action-history/v1'
+  readonly capturedAt: string
+  readonly entryCount: number
+  readonly entries: readonly ActionEntry[]
+}
+
+/**
+ * Serialise the action history into the stable JSON shape that
+ * lands in the ticket as `actions-history.json`.
+ *
+ * The shape is versioned via `schema` so triage tooling can fail
+ * loudly if we ever change the layout.
+ *
+ * @param entries - Pruned history, oldest-first
+ * @param nowMs - Wall-clock timestamp of the snapshot
+ * @returns Serialised payload
+ */
+export const serializeHistory = (
+  entries: readonly ActionEntry[],
+  nowMs: number
+): SerializedHistory => ({
+  schema: 'admin-action-history/v1',
+  capturedAt: new Date(nowMs).toISOString(),
+  entryCount: entries.length,
+  entries,
+})
+
+/**
+ * Render the snapshot as a JSON string with stable indentation.
+ *
+ * @param entries - Pruned history, oldest-first
+ * @param nowMs - Wall-clock timestamp of the snapshot
+ * @returns Pretty-printed JSON string
+ */
+export const renderHistoryJson = (
+  entries: readonly ActionEntry[],
+  nowMs: number
+): string => `${JSON.stringify(serializeHistory(entries, nowMs), null, 2)}\n`

--- a/src/features/action-history/types.ts
+++ b/src/features/action-history/types.ts
@@ -1,0 +1,66 @@
+/** Discriminated union of every action we record. */
+export type ActionEntry =
+  | NavigationEntry
+  | SaveEntry
+  | StageEntry
+  | AuthEntry
+  | SwErrorEntry
+  | NetworkErrorEntry
+
+/** Common fields on every entry. */
+export interface BaseEntry {
+  readonly id: string
+  readonly ts: number
+}
+
+/** Route navigation. */
+export interface NavigationEntry extends BaseEntry {
+  readonly kind: 'navigation'
+  readonly from: string
+  readonly to: string
+}
+
+/** Save / commit / push outcome. */
+export interface SaveEntry extends BaseEntry {
+  readonly kind: 'save'
+  readonly action: 'save' | 'commit' | 'push'
+  readonly path: string
+  readonly status: 'ok' | 'failed'
+  readonly errorMessage?: string
+}
+
+/** Stage / unstage / discard event. */
+export interface StageEntry extends BaseEntry {
+  readonly kind: 'stage'
+  readonly action: 'stage' | 'unstage' | 'discard'
+  readonly path: string
+}
+
+/** Auth state change. */
+export interface AuthEntry extends BaseEntry {
+  readonly kind: 'auth'
+  readonly action: 'login' | 'logout' | 'token-refresh'
+}
+
+/** SW bridge error. */
+export interface SwErrorEntry extends BaseEntry {
+  readonly kind: 'sw-error'
+  readonly reason: string
+}
+
+/** User-visible network failure (toast / banner). */
+export interface NetworkErrorEntry extends BaseEntry {
+  readonly kind: 'network-error'
+  readonly url: string
+  readonly status?: number
+  readonly reason: string
+}
+
+/** Action entry without the auto-assigned id + ts. */
+export type RecordableEntry =
+  | Omit<NavigationEntry, 'id' | 'ts'>
+  | Omit<SaveEntry, 'id' | 'ts'>
+  | Omit<StageEntry, 'id' | 'ts'>
+  | Omit<AuthEntry, 'id' | 'ts'>
+  | Omit<SwErrorEntry, 'id' | 'ts'>
+  | Omit<NetworkErrorEntry, 'id' | 'ts'>

--- a/src/features/tickets/api/upload-history.ts
+++ b/src/features/tickets/api/upload-history.ts
@@ -1,0 +1,48 @@
+import type { TicketAttachment } from '../templates/attachment-types'
+import {
+  buildAttachmentPath,
+  randomAttachmentId,
+  TICKETS_BRANCH,
+  TICKETS_REPO_NAME,
+  TICKETS_REPO_OWNER,
+} from './attachment-paths'
+import { putContent } from './put-content'
+
+const RAW = `https://raw.githubusercontent.com/${TICKETS_REPO_OWNER}/${TICKETS_REPO_NAME}/${TICKETS_BRANCH}`
+
+const toBase64 = (text: string): string =>
+  globalThis.btoa(unescape(encodeURIComponent(text)))
+
+interface UploadDeps {
+  readonly token: string
+  readonly fileName: string
+  readonly text: string
+}
+
+/**
+ * Upload a text file (JSON, plain) to the tickets repo as an
+ * attachment so it can be linked from the issue body alongside
+ * the user's photos.
+ *
+ * @param deps - Token + name + raw text content
+ * @returns Resolved attachment with stable URL
+ */
+export const uploadTextAttachment = async (
+  deps: UploadDeps
+): Promise<TicketAttachment> => {
+  const id = randomAttachmentId()
+  const path = buildAttachmentPath(deps.fileName, id)
+  await putContent({
+    token: deps.token,
+    path,
+    content: toBase64(deps.text),
+    message: `Ticket attachment: ${deps.fileName}`,
+  })
+  return {
+    id,
+    name: deps.fileName,
+    url: `${RAW}/${path}`,
+    kind: 'file',
+    sizeBytes: deps.text.length,
+  }
+}

--- a/src/features/tickets/components/CreateTicketContainer.vue
+++ b/src/features/tickets/components/CreateTicketContainer.vue
@@ -3,8 +3,8 @@ import { ref } from 'vue'
 import { useAuthStore } from '@/stores/auth'
 import { uploadBatch } from './attachment-pipeline'
 import CreateTicketForm from './CreateTicketForm.vue'
-import { submitTicket } from './submit-ticket'
 import { useCreateForm } from './use-create-form'
+import { runTicketSubmit } from './use-ticket-submit'
 
 const emit = defineEmits<{ created: []; error: [msg: string] }>()
 const auth = useAuthStore()
@@ -23,32 +23,15 @@ const onUpload = async (files: readonly File[]): Promise<void> => {
   f.uploading.value = false
 }
 
-const setTitle = (v: string): void => {
-  f.title.value = v
-}
-const setTarget = (v: 'public-website' | 'admin'): void => {
-  f.target.value = v
-}
-const setTemplate = (v: typeof f.template.value): void => {
-  f.template.value = v
-}
-
 const onSubmit = async (): Promise<void> => {
   if (!auth.user || f.titleTrimmed.value.length === 0) return
-  const result = await submitTicket({
+  await runTicketSubmit({
     token: auth.user.accessToken,
-    title: f.titleTrimmed.value,
-    template: f.template.value,
-    labels: f.labels.value,
-    attachments: f.attachments.value,
+    form: f,
+    missing,
+    emitCreated: () => emit('created'),
+    emitError: msg => emit('error', msg),
   })
-  if (result.kind === 'invalid') missing.value = result.missing
-  else if (result.kind === 'error') emit('error', result.message)
-  else {
-    f.reset()
-    missing.value = []
-    emit('created')
-  }
 }
 </script>
 
@@ -60,9 +43,11 @@ const onSubmit = async (): Promise<void> => {
     :attachments="f.attachments.value"
     :uploading="f.uploading.value"
     :missing="missing"
-    @update:title="setTitle"
-    @update:target="setTarget"
-    @update:template="setTemplate"
+    @update:title="(v: string) => (f.title.value = v)"
+    @update:target="
+      (v: 'public-website' | 'admin') => (f.target.value = v)
+    "
+    @update:template="(v: typeof f.template.value) => (f.template.value = v)"
     @change-kind="f.setKind"
     @upload="onUpload"
     @remove-attachment="f.removeAttachment"

--- a/src/features/tickets/components/attach-history.ts
+++ b/src/features/tickets/components/attach-history.ts
@@ -1,0 +1,35 @@
+import { readHistory } from '@/features/action-history/recorder'
+import { renderHistoryJson } from '@/features/action-history/serialize'
+import { uploadTextAttachment } from '../api/upload-history'
+import type { TicketAttachment } from '../templates/attachment-types'
+
+const HISTORY_FILE = 'actions-history.json'
+
+/**
+ * Snapshot the current action-history ring buffer and upload it as
+ * a JSON attachment. Best-effort: if either step fails we log the
+ * cause via the supplied callback and return undefined, so the
+ * ticket can still go out without history.
+ *
+ * @param token - GitHub access token
+ * @param onError - Reporter for non-fatal failures
+ * @returns Attachment when upload succeeded
+ */
+export const attachActionHistory = async (
+  token: string,
+  onError: (msg: string) => void
+): Promise<TicketAttachment | undefined> => {
+  try {
+    const entries = await readHistory()
+    const text = renderHistoryJson(entries, Date.now())
+    return await uploadTextAttachment({
+      token,
+      fileName: HISTORY_FILE,
+      text,
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'history attach failed'
+    onError(msg)
+    return undefined
+  }
+}

--- a/src/features/tickets/components/use-ticket-submit.ts
+++ b/src/features/tickets/components/use-ticket-submit.ts
@@ -1,0 +1,53 @@
+import { Match } from 'effect'
+import type { Ref } from 'vue'
+import { attachActionHistory } from './attach-history'
+import { submitTicket } from './submit-ticket'
+import type { useCreateForm } from './use-create-form'
+
+interface SubmitDeps {
+  readonly token: string
+  readonly form: ReturnType<typeof useCreateForm>
+  readonly missing: Ref<readonly string[]>
+  readonly emitCreated: () => void
+  readonly emitError: (msg: string) => void
+}
+
+const dispatch = (
+  result: Awaited<ReturnType<typeof submitTicket>>,
+  deps: SubmitDeps
+): void =>
+  Match.value(result).pipe(
+    Match.discriminator('kind')('invalid', r => {
+      deps.missing.value = r.missing
+    }),
+    Match.discriminator('kind')('error', r => deps.emitError(r.message)),
+    Match.discriminator('kind')('ok', () => {
+      deps.form.reset()
+      deps.missing.value = []
+      deps.emitCreated()
+    }),
+    Match.exhaustive
+  )
+
+/**
+ * Run the full submit pipeline: attach the action-history JSON,
+ * compose the attachment list, post the ticket, and dispatch the
+ * outcome to the callbacks supplied by the host component.
+ *
+ * @param deps - Token, form state, missing-fields ref, callbacks
+ */
+export const runTicketSubmit = async (deps: SubmitDeps): Promise<void> => {
+  const history = await attachActionHistory(deps.token, deps.emitError)
+  const all =
+    history === undefined
+      ? deps.form.attachments.value
+      : [...deps.form.attachments.value, history]
+  const result = await submitTicket({
+    token: deps.token,
+    title: deps.form.titleTrimmed.value,
+    template: deps.form.template.value,
+    labels: deps.form.labels.value,
+    attachments: all,
+  })
+  dispatch(result, deps)
+}

--- a/src/stores/auth-actions.ts
+++ b/src/stores/auth-actions.ts
@@ -1,6 +1,7 @@
 import type { Ref } from 'vue'
 import { saveProfile } from '@/composables/useAuth/profile-cache'
 import { clearToken } from '@/composables/useAuth/token-storage'
+import { recordAction } from '@/features/action-history/recorder'
 import type { User } from '@/types/user'
 
 /**
@@ -11,12 +12,17 @@ import type { User } from '@/types/user'
 export const createSetUser =
   (user: Ref<User | null>) =>
   (u: User | null): void => {
+    const wasLoggedIn = user.value !== null
     user.value = u
     if (u) {
       saveProfile({
         username: u.username,
         name: u.name,
         avatar: u.avatar,
+      })
+      void recordAction({
+        kind: 'auth',
+        action: wasLoggedIn ? 'token-refresh' : 'login',
       })
     }
   }
@@ -33,4 +39,5 @@ export const createLogout =
     clearToken()
     user.value = null
     loading.value = false
+    void recordAction({ kind: 'auth', action: 'logout' })
   }

--- a/src/views/SettingsView/ActionHistorySection.vue
+++ b/src/views/SettingsView/ActionHistorySection.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { clearHistory } from '@/features/action-history/recorder'
+
+const status = ref<'idle' | 'cleared' | 'error'>('idle')
+
+const onClear = async (): Promise<void> => {
+  try {
+    await clearHistory()
+    status.value = 'cleared'
+  } catch {
+    status.value = 'error'
+  }
+}
+</script>
+
+<template>
+  <section class="ah-section">
+    <h2>Action History</h2>
+    <p class="lead">
+      A short rolling window of your recent actions (routes, saves,
+      auth changes, errors) is kept on this device so that ticket
+      reports include context. No file contents are recorded.
+    </p>
+    <button
+      type="button"
+      class="clear-btn"
+      data-testid="clear-action-history"
+      @click="onClear"
+    >
+      Clear my action history
+    </button>
+    <p
+      v-if="status === 'cleared'"
+      class="ok"
+      data-testid="clear-action-history-status"
+    >
+      History cleared.
+    </p>
+    <p v-else-if="status === 'error'" class="err">
+      Failed to clear history. Try again.
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.ah-section {
+  margin-bottom: 2rem;
+}
+
+h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.lead {
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+}
+
+.clear-btn {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background-soft);
+  color: var(--color-text);
+  cursor: pointer;
+  font-size: 0.875rem;
+}
+
+.ok {
+  color: var(--color-success, #1a7f37);
+  font-size: 0.8125rem;
+  margin-top: 0.5rem;
+}
+
+.err {
+  color: var(--color-danger, #d73a4a);
+  font-size: 0.8125rem;
+  margin-top: 0.5rem;
+}
+</style>

--- a/src/views/SettingsView/SettingsPage.vue
+++ b/src/views/SettingsView/SettingsPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { LabelEntry } from '@/stores/labels'
 import type { LanguageEntry } from '@/stores/settings'
+import ActionHistorySection from './ActionHistorySection.vue'
 import LabelsSection from './LabelsSection.vue'
 import LanguagesSection from './LanguagesSection.vue'
 import MembersSection from './MembersSection.vue'
@@ -38,6 +39,7 @@ defineEmits<{
       @save="$emit('save-labels', $event)"
     />
     <MembersSection />
+    <ActionHistorySection />
   </section>
 </template>
 


### PR DESCRIPTION
Closes #192. Stacked on top of #201 (which introduces the tickets-repo Contents API plumbing reused here).

## Summary
- IDB store `admin_action_history`, bounded by **1000 entries OR 60 minutes**, oldest evicted on overflow.
- Records: route navigations, auth state changes (login / logout / token-refresh), error and network notifications surfaced via the toast pipeline.
- PII boundary lives in `redact.ts`: file contents are never recorded; long error / reason fields are truncated at 500 chars; discriminated union forces explicit handling for any future entry kind.
- On ticket submit: `actions-history.json` attached next to user photos via the existing tickets-repo upload pipeline. Schema is versioned (`admin-action-history/v1`) so triage tooling can fail loudly on layout changes.
- Settings → **Action History → Clear my action history** wipes the store on demand.

## Acceptance
- [x] Relevant actions land in the IDB ring buffer (routes, auth, error / network notifications).
- [x] History bounded to ≤60 min AND ≤1000 entries (`pruneEntries` test).
- [x] On submit, `actions-history.json` is attached to the ticket.
- [x] No file *contents* leak — only path / size / status (`redact.test.ts`).
- [x] Settings exposes \"Clear my action history\" with success / error feedback.

## Tests
15 new unit tests:
- `ring-buffer.test.ts`: count overflow drops oldest, age cutoff drops stale, both caps compose, no input mutation.
- `redact.test.ts`: 700-char error truncated to 501; sw-error reason truncated; save entries never carry a \"content\" field; navigation pass-through.
- `serialize.test.ts`: schema tag, ISO 8601 `capturedAt`, entry order, JSON ends with newline.

Full validate green: vue-tsc, biome ci, oxlint, eslint (no \`if\` — submit-result branching uses `Match.discriminator`), vue-depth, stylelint. Full vitest 603 passing.

## Test plan
- [ ] Manual: navigate around, submit a ticket, open the issue on GitHub, fetch `actions-history.json` — verify the recent navigations / auth events show up.
- [ ] Manual: trigger a push failure (offline? bad token?) — verify it lands in the next attached history.
- [ ] Manual: Settings → Clear my action history → reopen Settings, confirm a fresh ticket attachment is empty.
- [ ] Verify bounded eviction empirically: hit 1100 nav events, confirm only the last 1000 are kept (covered by unit but worth a smoke).

## Out of scope
- SW-side instrumentation for save / commit / push outcomes — currently captured indirectly via the user-visible notifications. A direct hook on `pushAndTrack` is a follow-up if triage finds the indirect coverage thin.
- Stage / unstage events — same reasoning; current coverage prioritises the highest-signal events without invasive surgery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)