### PR TITLE
fix(admin): Select button + mobile edit-mode padding

### DIFF
--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -55,62 +55,64 @@ const setError = (msg: string): void => {
 
 <template>
   <AppLayout>
-    <nav class="edit-nav">
-      <EditBreadcrumb
-        :content-type="p.contentType.value"
-        :slug="slug" :renameable="isRenameable"
-        @rename="handleRename"
+    <section class="edit-frame">
+      <nav class="edit-nav">
+        <EditBreadcrumb
+          :content-type="p.contentType.value"
+          :slug="slug" :renameable="isRenameable"
+          @rename="handleRename"
+        />
+      </nav>
+      <LanguageSelector
+        v-if="!previewing"
+        :model-value="p.editor.currentLang.value"
+        :available-languages="p.langs.value"
+        @update:model-value="handleSwitchLang"
       />
-    </nav>
-    <LanguageSelector
-      v-if="!previewing"
-      :model-value="p.editor.currentLang.value"
-      :available-languages="p.langs.value"
-      @update:model-value="handleSwitchLang"
-    />
-    <CoverImage
-      v-if="!previewing && p.hasCover.value && !p.editor.loadingFile.value"
-      :cover-url="p.assets.coverUrl.value"
-      @delete-cover="p.ah.onRemoveCover"
-      @upload-cover="p.ah.onUploadCover"
-    />
-    <ContentEditMain
-      v-if="!previewing"
-      :body-content="p.editor.bodyContent.value"
-      :frontmatter-data="p.editor.frontmatterData.value"
-      :content-type="p.contentType.value"
-      :slug="p.slug"
-      :loading-file="p.editor.loadingFile.value"
-      :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
-      :assets="p.hasAssets.value ? p.assets.allAssets.value : undefined"
-      @update:body-content="updateBody"
-      @update:frontmatter="updateFm"
-      @preview="enterPreview"
-      @paste:image="p.ah.onPasteImage"
-      @upload-asset="p.ah.onUploadAsset"
-      @set-cover="p.ah.onSetCover"
-      @error="setError"
-    />
-    <ContentPreview
-      v-else
-      :body-content="p.editor.bodyContent.value"
-      :frontmatter-data="p.editor.frontmatterData.value"
-      :cover-url="p.assets.coverUrl.value"
-      :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
-    />
+      <CoverImage
+        v-if="!previewing && p.hasCover.value && !p.editor.loadingFile.value"
+        :cover-url="p.assets.coverUrl.value"
+        @delete-cover="p.ah.onRemoveCover"
+        @upload-cover="p.ah.onUploadCover"
+      />
+      <ContentEditMain
+        v-if="!previewing"
+        :body-content="p.editor.bodyContent.value"
+        :frontmatter-data="p.editor.frontmatterData.value"
+        :content-type="p.contentType.value"
+        :slug="p.slug"
+        :loading-file="p.editor.loadingFile.value"
+        :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
+        :assets="p.hasAssets.value ? p.assets.allAssets.value : undefined"
+        @update:body-content="updateBody"
+        @update:frontmatter="updateFm"
+        @preview="enterPreview"
+        @paste:image="p.ah.onPasteImage"
+        @upload-asset="p.ah.onUploadAsset"
+        @set-cover="p.ah.onSetCover"
+        @error="setError"
+      />
+      <ContentPreview
+        v-else
+        :body-content="p.editor.bodyContent.value"
+        :frontmatter-data="p.editor.frontmatterData.value"
+        :cover-url="p.assets.coverUrl.value"
+        :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
+      />
+      <AssetPanel
+        v-if="!previewing && p.hasAssets.value && !p.editor.loadingFile.value"
+        :assets="p.assets.allAssets.value"
+        @set-cover="p.ah.onSetCover"
+        @delete-asset="p.ah.onDeleteAsset"
+        @upload-asset="p.ah.onUploadAsset"
+      />
+    </section>
     <PreviewFooter
       v-if="previewing"
       :saving="saving"
       :saved="saved"
       @save="flow.onSave"
       @back="exitPreview"
-    />
-    <AssetPanel
-      v-if="!previewing && p.hasAssets.value && !p.editor.loadingFile.value"
-      :assets="p.assets.allAssets.value"
-      @set-cover="p.ah.onSetCover"
-      @delete-asset="p.ah.onDeleteAsset"
-      @upload-asset="p.ah.onUploadAsset"
     />
     <PublishConfirmDialog
       :show="flow.showDialog.value"
@@ -125,11 +127,29 @@ const setError = (msg: string): void => {
 </template>
 
 <style scoped>
+/*
+ * One frame for every edit-mode child: same max-width, same
+ * horizontal gutter, same vertical rhythm. Previously the breadcrumb
+ * sat flush at the viewport edge while the body had a 16-32px
+ * padding inset and the language fieldset had its own 8-16px inset —
+ * the result on mobile was a ragged left edge that the editor read
+ * as "more padding on the left than the right".
+ */
+.edit-frame {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.75rem, 2vw, 1.25rem);
+  padding: var(--content-frame-padding);
+  max-width: var(--content-narrow);
+  width: 100%;
+  margin-inline: auto;
+  box-sizing: border-box;
+}
+
 .edit-nav {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0;
   font-size: clamp(0.875rem, 2vw, 1rem);
 }
 </style>

--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -61,11 +61,8 @@ defineEmits<{
   flex-direction: column;
   flex: 1;
   gap: clamp(1rem, 2vw, 2rem);
-  padding: var(--content-frame-padding);
-  max-width: var(--content-narrow);
   width: 100%;
-  margin-inline: auto;
-  box-sizing: border-box;
+  min-width: 0;
 }
 
 .loading-state {

--- a/src/views/ContentView.vue
+++ b/src/views/ContentView.vue
@@ -14,6 +14,7 @@ import ContentViewHeader from './ContentView/ContentViewHeader.vue'
 import ContentViewMain from './ContentView/ContentViewMain.vue'
 import { createDeleteState } from './ContentView/delete-state'
 import { createSelectHandler } from './ContentView/select-handler'
+import { useBulkDelete } from './ContentView/use-bulk-delete'
 import { useContentView } from './ContentView/use-content-view'
 
 const props = defineProps<{ readonly contentType: ContentType }>()
@@ -31,6 +32,11 @@ const del = createDeleteState({
   contentType: typeRef,
   selectedLang,
   listItems: items,
+  reload: reloadContent,
+  pushAndTrack,
+})
+const bulk = useBulkDelete({
+  contentType: typeRef,
   reload: reloadContent,
   pushAndTrack,
 })
@@ -53,9 +59,15 @@ const handleCreate = (data: CreateContentData) => {
       :is-authenticated="isAuthenticated" :loading="loadingList"
       :hide-create="isFixedStructure" :hide-delete="isFixedStructure"
       :deleting-slugs="del.deletingSlugs.value"
+      :select-mode="bulk.selectMode.value"
+      :selected-slugs="bulk.selectedSlugs.value"
       @select="handleSelect"
       @create="() => { showCreateDialog = true }"
       @delete="item => { del.deleteTarget.value = item }"
+      @enter-select="bulk.enter"
+      @exit-select="bulk.exit"
+      @toggle-select="bulk.toggle"
+      @bulk-delete="bulk.runDelete"
     />
     <LoadingOverlay :show="loadingList" />
     <ErrorMessage :error="error" />

--- a/src/views/ContentView/use-bulk-delete.ts
+++ b/src/views/ContentView/use-bulk-delete.ts
@@ -1,0 +1,37 @@
+import type { Ref } from 'vue'
+import type { ContentType } from '@/types/content'
+import { runBulkDelete } from './bulk-delete-handler'
+import { createBulkDeleteState } from './bulk-delete-state'
+
+interface Deps {
+  readonly contentType: Ref<ContentType>
+  readonly reload: () => Promise<void>
+  readonly pushAndTrack: (message: string) => Promise<string>
+}
+
+/**
+ * Compose the bulk-delete state with a ready-to-fire delete handler.
+ *
+ * Pre-#201 the state existed but `ContentView.vue` never read or
+ * mutated it — the Select button emitted enter-select into the void.
+ * This helper bundles the state with a `runDelete` closure that
+ * picks up the current selection so the view can stay declarative.
+ *
+ * @param deps - Reactive content type + reload + push+track
+ * @returns State refs + a runDelete that exits select mode on success
+ */
+export const useBulkDelete = (deps: Deps) => {
+  const state = createBulkDeleteState()
+  const runDelete = async (): Promise<void> => {
+    await runBulkDelete(
+      {
+        contentType: deps.contentType.value,
+        pushAndTrack: deps.pushAndTrack,
+        reload: deps.reload,
+      },
+      state.selectedSlugs.value
+    )
+    state.exit()
+  }
+  return { ...state, runDelete }
+}


### PR DESCRIPTION
## Summary
Two reported issues, one PR — both touch the same UX pass on the content list / edit pages.

### 1. Select button does nothing
\`ContentView.vue\` never wired the bulk-delete state that #5 (commit \`6f6ade1\`) added. Clicking **Select** emitted \`enter-select\` from the list into the void. New \`useBulkDelete\` composable bundles state + handler so the view orchestrator stays declarative.

### 2. Mobile edit page padding looked ragged ("more on the left than the right")
On the edit page each direct child of \`AppMain\` had its own horizontal inset:
- \`.edit-nav\` — 0px
- \`LanguageSelector\` — ~8-16px
- \`ContentEditMain\` (\`.edit-main\`) — 16-32px
- \`AssetPanel\` — ~12-16px

On a phone viewport this read as a ragged left edge across siblings. Fix: wrap every editing sibling in one \`.edit-frame\` that owns the gutter (\`var(--content-frame-padding)\`) and the width cap (\`var(--content-narrow)\`), then drop the duplicate constraints from \`.edit-main\`.

## Test plan
- [ ] Manual: open \`/content/blog\`, click **Select** → checkboxes appear on each row, header swaps to \"N selected · Cancel · Delete selected\"
- [ ] Manual: select 2 rows → click Delete selected → both delete in one commit, list reloads
- [ ] Manual: open \`/content/blog/edit/<slug>\` on a 375px viewport → breadcrumb, language picker, frontmatter editor, body, asset panel all share the same left/right gutter
- [ ] Manual: same on a 768px tablet → same gutter, content cap kicks in once viewport > 56rem

## Validation
\`bun run validate\` green (vue-tsc + biome + oxlint + eslint + vue-depth + stylelint). \`bunx vitest run\` 567/567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)