### PR TITLE
fix(content): list newest-first by publishDate

### DIFF
--- a/src/components/ContentList/ContentList.vue
+++ b/src/components/ContentList/ContentList.vue
@@ -4,6 +4,7 @@ import type { ContentItem, Language } from '@/types/content'
 import ContentListEmpty from './ContentListEmpty.vue'
 import ContentListHeader from './ContentListHeader.vue'
 import ContentListItem from './ContentListItem.vue'
+import { sortByDateNewestFirst } from './sort-by-date'
 
 const props = defineProps<{
   readonly items: readonly ContentItem[]
@@ -28,7 +29,9 @@ const emit = defineEmits<{
 }>()
 
 const filteredItems = computed(() =>
-  props.items.filter((item) => item.lang === props.selectedLang)
+  sortByDateNewestFirst(
+    props.items.filter(item => item.lang === props.selectedLang)
+  )
 )
 
 const selectedCount = computed(() => props.selectedSlugs?.size ?? 0)

--- a/src/components/ContentList/sort-by-date.test.ts
+++ b/src/components/ContentList/sort-by-date.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { ContentItem } from '@/types/content'
+import { sortByDateNewestFirst } from './sort-by-date'
+
+const item = (
+  slug: string,
+  frontmatter: Record<string, unknown>
+): ContentItem => ({
+  path: `content/blog/${slug}.md`,
+  slug,
+  lang: 'en',
+  frontmatter,
+})
+
+describe('sortByDateNewestFirst', () => {
+  it('orders newer publishDate first', () => {
+    const older = item('a', { publishDate: '2024-01-01' })
+    const newer = item('b', { publishDate: '2026-05-01' })
+    const result = sortByDateNewestFirst([older, newer])
+    expect(result.map(i => i.slug)).toEqual(['b', 'a'])
+  })
+
+  it('sinks items without a date to the bottom', () => {
+    const dated = item('a', { publishDate: '2024-01-01' })
+    const undated = item('b', { title: 'no date' })
+    const result = sortByDateNewestFirst([undated, dated])
+    expect(result.map(i => i.slug)).toEqual(['a', 'b'])
+  })
+
+  it('tie-breaks by slug when both items have no date', () => {
+    const x = item('zebra', {})
+    const y = item('apple', {})
+    const result = sortByDateNewestFirst([x, y])
+    expect(result.map(i => i.slug)).toEqual(['apple', 'zebra'])
+  })
+
+  it('accepts the legacy pubDate field as a fallback', () => {
+    const legacy = item('legacy', { pubDate: '2026-04-01' })
+    const modern = item('modern', { publishDate: '2026-01-01' })
+    const result = sortByDateNewestFirst([modern, legacy])
+    expect(result.map(i => i.slug)).toEqual(['legacy', 'modern'])
+  })
+
+  it('treats invalid date strings as missing', () => {
+    const bad = item('bad', { publishDate: 'not-a-date' })
+    const good = item('good', { publishDate: '2026-01-01' })
+    const result = sortByDateNewestFirst([bad, good])
+    expect(result.map(i => i.slug)).toEqual(['good', 'bad'])
+  })
+
+  it('accepts Date instances directly', () => {
+    const a = item('a', { publishDate: new Date('2024-06-01') })
+    const b = item('b', { publishDate: new Date('2026-06-01') })
+    const result = sortByDateNewestFirst([a, b])
+    expect(result.map(i => i.slug)).toEqual(['b', 'a'])
+  })
+
+  it('does not mutate its input', () => {
+    const input: readonly ContentItem[] = [
+      item('a', { publishDate: '2024-01-01' }),
+      item('b', { publishDate: '2026-01-01' }),
+    ]
+    const snapshot = input.map(i => i.slug)
+    sortByDateNewestFirst(input)
+    expect(input.map(i => i.slug)).toEqual(snapshot)
+  })
+})

--- a/src/components/ContentList/sort-by-date.ts
+++ b/src/components/ContentList/sort-by-date.ts
@@ -1,0 +1,54 @@
+import type { ContentItem } from '@/types/content'
+
+/**
+ * Coerce a frontmatter date-like value to an epoch ms.
+ * Strings (`YAML 1.2` keeps `YYYY-MM-DD` as strings) and `Date`
+ * instances are accepted; anything unparseable becomes `undefined`
+ * so callers can sink it to the bottom.
+ * @param value - Raw frontmatter field value
+ * @returns Epoch ms or `undefined` when invalid/missing
+ */
+const toEpoch = (value: unknown): number | undefined => {
+  const date =
+    value instanceof Date
+      ? value
+      : typeof value === 'string'
+        ? new Date(value)
+        : undefined
+  return date && !Number.isNaN(date.getTime()) ? date.getTime() : undefined
+}
+
+/**
+ * Read the publish date from a content item, accepting the legacy
+ * `pubDate` field as a fallback for older content.
+ * @param item - Content item
+ * @returns Epoch ms or `undefined`
+ */
+const itemEpoch = (item: ContentItem): number | undefined =>
+  toEpoch(item.frontmatter.publishDate) ?? toEpoch(item.frontmatter.pubDate)
+
+/**
+ * Comparator: newer publishDate first. Items missing/invalid date
+ * sink to the bottom; ties break alphabetically by slug.
+ * @param a - Left item
+ * @param b - Right item
+ * @returns Standard comparator result
+ */
+const compareNewestFirst = (a: ContentItem, b: ContentItem): number => {
+  const ea = itemEpoch(a)
+  const eb = itemEpoch(b)
+  const dateOrder =
+    ea === eb ? 0 : ea === undefined ? 1 : eb === undefined ? -1 : eb - ea
+  return dateOrder === 0 ? a.slug.localeCompare(b.slug) : dateOrder
+}
+
+/**
+ * Return a new array sorted newest-first by `publishDate` (with
+ * `pubDate` legacy fallback). Items without a valid date sink to
+ * the bottom and tie-break alphabetically by slug.
+ * @param items - Content items in any order
+ * @returns New array, newest-first
+ */
+export const sortByDateNewestFirst = (
+  items: readonly ContentItem[]
+): readonly ContentItem[] => [...items].sort(compareNewestFirst)


### PR DESCRIPTION
## Summary
- The content list (`/content/blog`, `/content/positions`, ...) used to render items in fetch order from GitHub, which surfaced as oldest-first. Now sorted newest-first by `publishDate`.
- Added a small `sort-by-date.ts` helper next to `ContentList` (component-level sort, store stays untouched so other consumers are unaffected).
- Items without a valid date sink to the bottom; ties break alphabetically by slug. Legacy `pubDate` field still accepted as a fallback.

Closes #208

## Test plan
- [x] Unit: `sort-by-date.test.ts` (7 cases — newer-first, missing-date sink, slug tie-break, legacy `pubDate`, invalid string, `Date` instance, immutability)
- [x] `bun run validate` — clean (type-check, biome, oxlint sonar, jsdoc, vue-depth, stylelint)
- [x] `bunx vitest run` — 574/574 passing
- [ ] Manual smoke: open `/content/blog` and confirm newest post is first

Generated with [Claude Code](https://claude.com/claude-code)