### PR TITLE
feat(content): preserve language in URL (lang= query param)

### DIFF
--- a/src/views/ContentView/use-content-view.ts
+++ b/src/views/ContentView/use-content-view.ts
@@ -5,7 +5,11 @@ import { useContentCreator } from '@/composables/useContent/useContentCreator'
 import { useContentList } from '@/composables/useContent/useContentList'
 import { usePermissions } from '@/composables/usePermissions'
 import { useAuthStore } from '@/stores/auth'
-import type { ContentType, Language } from '@/types/content'
+import type { ContentType } from '@/types/content'
+import { useSelectedLang } from './use-selected-lang'
+
+const langsOf = (items: ReturnType<typeof useContentList>['items']) =>
+  computed(() => [...new Set(items.value.map(i => i.lang))])
 
 const FIXED: ReadonlySet<ContentType> = new Set(['pages', 'common'])
 
@@ -30,7 +34,8 @@ export const useContentView = (contentType: Ref<ContentType>) => {
   const list = useContentList(contentType)
   const { createContent } = useContentCreator(() => contentType.value)
   const error = ref<string | null>(null)
-  const selectedLang = ref<Language>('en')
+  const availableLangs = langsOf(list.items)
+  const selectedLang = useSelectedLang(() => availableLangs.value)
   const showCreateDialog = ref(false)
 
   return {

--- a/src/views/ContentView/use-selected-lang.test.ts
+++ b/src/views/ContentView/use-selected-lang.test.ts
@@ -1,0 +1,97 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import { useSelectedLang } from './use-selected-lang'
+
+const Stub = defineComponent({
+  setup: () => ({}),
+  render: () => h('div'),
+})
+
+const setupRouter = (initialPath: string) => {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/content/:type', component: Stub },
+      { path: '/content/:type/edit/:slug', component: Stub },
+    ],
+  })
+  router.push(initialPath)
+  return router
+}
+
+const captureLang = (available: () => readonly string[]) => {
+  const slot: { ref?: ReturnType<typeof useSelectedLang> } = {}
+  const Host = defineComponent({
+    setup: () => {
+      slot.ref = useSelectedLang(available)
+      return () => h('div')
+    },
+  })
+  return { slot, Host }
+}
+
+const mountWith = async (
+  initialPath: string,
+  available: () => readonly string[]
+) => {
+  const router = setupRouter(initialPath)
+  await router.isReady()
+  const { slot, Host } = captureLang(available)
+  mount(Host, { global: { plugins: [router] } })
+  if (!slot.ref) throw new Error('useSelectedLang not captured')
+  return { router, lang: slot.ref }
+}
+
+describe('useSelectedLang', () => {
+  it('reads from query.lang when valid', async () => {
+    const { lang } = await mountWith('/content/blog?lang=ru', () => [
+      'en',
+      'ru',
+    ])
+    expect(lang.value).toBe('ru')
+  })
+
+  it('falls back to first available when query.lang missing', async () => {
+    const { lang } = await mountWith('/content/blog', () => ['it', 'en'])
+    expect(lang.value).toBe('it')
+  })
+
+  it('falls back when query.lang not in available list', async () => {
+    const { lang } = await mountWith('/content/blog?lang=zz', () => [
+      'en',
+      'ru',
+    ])
+    expect(lang.value).toBe('en')
+  })
+
+  it('falls back to "en" when neither query nor available match', async () => {
+    const { lang } = await mountWith('/content/blog', () => [])
+    expect(lang.value).toBe('en')
+  })
+
+  it('writes via router.replace, merging the existing query', async () => {
+    const { router, lang } = await mountWith(
+      '/content/blog?foo=bar&lang=en',
+      () => ['en', 'ru']
+    )
+    const spy = vi.spyOn(router, 'replace')
+    lang.value = 'ru'
+    await nextTick()
+    expect(spy).toHaveBeenCalledWith({
+      query: { foo: 'bar', lang: 'ru' },
+    })
+  })
+
+  it('round-trips: after setter, getter reflects new value', async () => {
+    const { lang } = await mountWith('/content/blog?lang=en', () => [
+      'en',
+      'ru',
+    ])
+    lang.value = 'ru'
+    await new Promise(r => setTimeout(r, 0))
+    await nextTick()
+    expect(lang.value).toBe('ru')
+  })
+})

--- a/src/views/ContentView/use-selected-lang.ts
+++ b/src/views/ContentView/use-selected-lang.ts
@@ -1,0 +1,46 @@
+import { computed } from 'vue'
+import type { LocationQuery, Router } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import type { Language } from '@/types/content'
+import { extractString } from '@/validation/extract-string'
+
+const DEFAULT_LANG: Language = 'en'
+
+const pickLang = (
+  raw: string | undefined,
+  available: readonly Language[],
+  fallback: Language
+): Language =>
+  raw !== undefined && available.includes(raw)
+    ? raw
+    : (available[0] ?? fallback)
+
+const writeLang = (
+  router: Router,
+  query: LocationQuery,
+  lang: Language
+): void => {
+  void router.replace({ query: { ...query, lang } })
+}
+
+/**
+ * URL-bound selected-language ref.
+ *
+ * Reads `?lang=<code>` from the current route, validates it
+ * against `available` (defaults to first available, then `en`),
+ * and persists writes via `router.replace` so the value
+ * survives back/forward navigation.
+ * @param available - Reactive set of language codes present in the
+ *   current content list. The first entry is the fallback when the
+ *   query param is missing or invalid.
+ * @returns Computed get/set ref usable as a `v-model` target.
+ */
+export const useSelectedLang = (available: () => readonly Language[]) => {
+  const route = useRoute()
+  const router = useRouter()
+  return computed<Language>({
+    get: () =>
+      pickLang(extractString(route.query.lang), available(), DEFAULT_LANG),
+    set: lang => writeLang(router, route.query, lang),
+  })
+}


### PR DESCRIPTION
## Summary
Selected language now lives in the route as `?lang=<code>`. Editor selects RU on `/content/blog`, opens an article, hits Back — list restores RU instead of dropping back to EN.

The list view's `selectedLang` ref is replaced with a computed getter/setter backed by `route.query.lang` and `router.replace`. Invalid query values fall back to the first available language.

## Files
- `src/views/ContentView/use-selected-lang.ts` (new) — URL-bound lang accessor
- `src/views/ContentView/use-selected-lang.test.ts` (new) — 6 unit tests
- `src/views/ContentView/use-content-view.ts` — wires the new helper

## Test plan
- [ ] Manual: visit `/content/blog?lang=ru` → list pre-filtered to RU
- [ ] Manual: select RU → click an article → click Back → RU still highlighted
- [ ] Manual: paste invalid `?lang=zz` → falls back gracefully

Closes #207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)