### PR TITLE
fix(content): article-picker by lang + Category select + Description editable

### DIFF
--- a/src/components/MarkdownEditor/ArticlesPicker/ArticlesPicker.vue
+++ b/src/components/MarkdownEditor/ArticlesPicker/ArticlesPicker.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useContentStore } from '@/stores/content'
+import type { ContentItem } from '@/types/content'
+import type { Language } from '@/types/language'
 import AddArticleRow from './AddArticleRow.vue'
 import { articleOptions } from './article-options'
 import LinkedArticleRow from './LinkedArticleRow.vue'
@@ -8,6 +10,7 @@ import { moveDown, moveUp, removeAt } from './reorder'
 
 const props = defineProps<{
   readonly value: readonly string[] | undefined
+  readonly lang: Language
 }>()
 
 const emit = defineEmits<{
@@ -19,19 +22,32 @@ const blog = store.itemsByType('blog')
 
 const linked = computed<readonly string[]>(() => props.value ?? [])
 
+type Entry = readonly [slug: string, title: string]
+
+const toEntry = (item: ContentItem): Entry => {
+  const t = item.frontmatter['title']
+  const title = typeof t === 'string' && t.trim() !== '' ? t : ''
+  return [item.slug, title]
+}
+
 const titleBySlug = computed(() => {
-  const map = new Map<string, string>()
-  for (const item of blog.value) {
-    const t = item.frontmatter['title']
-    if (typeof t === 'string' && t.trim() !== '') map.set(item.slug, t)
-  }
-  return map
+  const entries: readonly Entry[] = blog.value
+    .filter(item => item.lang === props.lang)
+    .map(toEntry)
+    .filter(([, title]) => title !== '')
+  return new Map<string, string>(entries)
 })
 
 const labelFor = (slug: string): string =>
   titleBySlug.value.get(slug) ?? slug
 
-const options = computed(() => articleOptions(blog.value, linked.value))
+const options = computed(() =>
+  articleOptions({
+    items: blog.value,
+    lang: props.lang,
+    exclude: linked.value,
+  })
+)
 </script>
 
 <template>

--- a/src/components/MarkdownEditor/ArticlesPicker/article-options.ts
+++ b/src/components/MarkdownEditor/ArticlesPicker/article-options.ts
@@ -1,59 +1,59 @@
 import type { ContentItem } from '@/types/content'
+import type { Language } from '@/types/language'
 
 /** A blog article available to be linked into a newspaper issue. */
 export interface ArticleOption {
   readonly slug: string
   readonly title: string
+  readonly publishedAt: number
 }
 
-const titleFromFrontmatter = (fm: ContentItem['frontmatter']): string => {
-  const t = fm['title']
-  return typeof t === 'string' && t.trim() !== '' ? t : ''
+/** Arguments for {@link articleOptions}. */
+export interface ArticleOptionsInput {
+  readonly items: readonly ContentItem[]
+  readonly lang: Language
+  readonly exclude: readonly string[]
 }
 
-const shouldOverwrite = (
-  existing: ArticleOption | undefined,
-  candidate: ArticleOption
-): boolean =>
-  existing === undefined ||
-  (existing.title === existing.slug && candidate.title !== candidate.slug)
+const stringFm = (fm: ContentItem['frontmatter'], key: string): string => {
+  const v = fm[key]
+  return typeof v === 'string' ? v : ''
+}
 
-const candidateFor = (item: ContentItem): ArticleOption => ({
+const titleOf = (item: ContentItem): string =>
+  stringFm(item.frontmatter, 'title').trim() || item.slug
+
+const dateOf = (item: ContentItem): number => {
+  const raw =
+    stringFm(item.frontmatter, 'publishDate') ||
+    stringFm(item.frontmatter, 'pubDate')
+  const ms = raw ? Date.parse(raw) : Number.NaN
+  return Number.isNaN(ms) ? Number.NEGATIVE_INFINITY : ms
+}
+
+const toOption = (item: ContentItem): ArticleOption => ({
   slug: item.slug,
-  title: titleFromFrontmatter(item.frontmatter) || item.slug,
+  title: titleOf(item),
+  publishedAt: dateOf(item),
 })
 
-const accumulate = (
-  acc: Map<string, ArticleOption>,
-  item: ContentItem,
-  taken: ReadonlySet<string>
-): Map<string, ArticleOption> => {
-  const candidate = candidateFor(item)
-  return taken.has(item.slug)
-    ? acc
-    : shouldOverwrite(acc.get(item.slug), candidate)
-      ? acc.set(item.slug, candidate)
-      : acc
-}
+const compare = (a: ArticleOption, b: ArticleOption): number =>
+  b.publishedAt - a.publishedAt || a.title.localeCompare(b.title)
 
 /**
- * Reduce the blog content store to a deduped, alphabetised list of
- * article slugs with the best human-readable title we can pull from
- * any of the language-specific frontmatters. Already-linked slugs
- * are filtered out so the picker offers only fresh choices.
- *
- * @param items All blog ContentItems from the store.
- * @param exclude Slugs already linked from the current newspaper.
- * @returns Alphabetised available articles.
+ * Build the available-articles list for the newspaper picker, scoped
+ * to a single language and sorted newest-first with an alphabetical
+ * title tie-break. Already-linked slugs and items in other languages
+ * are dropped.
+ * @param input Items, current language, and slugs to exclude.
+ * @returns Picker options for the current language.
  */
 export const articleOptions = (
-  items: readonly ContentItem[],
-  exclude: readonly string[]
+  input: ArticleOptionsInput
 ): readonly ArticleOption[] => {
-  const taken = new Set(exclude)
-  const bySlug = items.reduce<Map<string, ArticleOption>>(
-    (acc, item) => accumulate(acc, item, taken),
-    new Map()
-  )
-  return [...bySlug.values()].sort((a, b) => a.title.localeCompare(b.title))
+  const taken = new Set(input.exclude)
+  return input.items
+    .filter(it => it.lang === input.lang && !taken.has(it.slug))
+    .map(toOption)
+    .sort(compare)
 }

--- a/src/components/MarkdownEditor/FrontmatterEditor.test.ts
+++ b/src/components/MarkdownEditor/FrontmatterEditor.test.ts
@@ -15,7 +15,7 @@ const TODAY = '2026-04-23'
 
 const mountEditor = (frontmatter: Record<string, unknown>) =>
   mount(FrontmatterEditor, {
-    props: { frontmatter, contentType: 'blog' as const },
+    props: { frontmatter, contentType: 'blog' as const, lang: 'en' as const },
     global: { plugins: [createPinia()] },
   })
 

--- a/src/components/MarkdownEditor/FrontmatterEditor.vue
+++ b/src/components/MarkdownEditor/FrontmatterEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ContentType } from '@/types/content'
+import type { Language } from '@/types/language'
 import FrontmatterField from './FrontmatterField.vue'
 import { getFields } from './frontmatter-fields'
 
@@ -7,6 +8,7 @@ const props = defineProps<{
   readonly frontmatter: Record<string, unknown>
   readonly contentType: ContentType
   readonly slug?: string
+  readonly lang: Language
 }>()
 
 const emit = defineEmits<{
@@ -34,6 +36,7 @@ const handleFieldUpdate = (key: string, value: unknown) => {
       :key="field.key"
       :field="field"
       :value="frontmatter[field.key]"
+      :lang="lang"
       @update="handleFieldUpdate(field.key, $event)"
     />
   </fieldset>

--- a/src/components/MarkdownEditor/FrontmatterField.vue
+++ b/src/components/MarkdownEditor/FrontmatterField.vue
@@ -1,22 +1,25 @@
 <script setup lang="ts">
+import type { Language } from '@/types/language'
 import ArticlesPicker from './ArticlesPicker/ArticlesPicker.vue'
-import type { FieldDefinition } from './frontmatter-fields'
+import FrontmatterSelect from './FrontmatterSelect.vue'
+import type { FieldDefinition } from './field-types'
 import { formatDateValue, parseFieldValue } from './frontmatter-values'
 import IssuePicker from './IssuePicker/IssuePicker.vue'
 
 const props = defineProps<{
   readonly field: FieldDefinition
   readonly value: unknown
+  readonly lang: Language
 }>()
 
-const emit = defineEmits<{
-  update: [value: unknown]
-}>()
+const emit = defineEmits<{ update: [value: unknown] }>()
 
-const displayValue = (): string => {
-  if (props.field.type === 'date') return formatDateValue(props.value)
-  return String(props.value ?? '')
-}
+const stringValue = (): string => String(props.value ?? '')
+
+const displayValue = (): string =>
+  props.field.type === 'date'
+    ? formatDateValue(props.value)
+    : stringValue()
 
 const isChecked = (): boolean =>
   props.value === true || props.value === 'true'
@@ -32,17 +35,17 @@ const issueValue = (): string | undefined =>
     : undefined
 
 const handleInput = (event: Event) => {
-  const target = event.target
-  if (
-    !(target instanceof HTMLInputElement) &&
-    !(target instanceof HTMLTextAreaElement)
-  )
-    return
-  if (props.field.type === 'checkbox') {
-    emit('update', (target as HTMLInputElement).checked)
+  const t = event.target
+  if (t instanceof HTMLInputElement && props.field.type === 'checkbox') {
+    emit('update', t.checked)
     return
   }
-  emit('update', parseFieldValue(props.field.type, target.value))
+  if (t instanceof HTMLInputElement || t instanceof HTMLTextAreaElement)
+    emit('update', parseFieldValue(props.field.type, t.value))
+}
+
+const onSelect = (v: string): void => {
+  emit('update', parseFieldValue('select', v))
 }
 </script>
 
@@ -73,12 +76,20 @@ const handleInput = (event: Event) => {
   <ArticlesPicker
     v-else-if="field.type === 'articles'"
     :value="articlesValue()"
+    :lang="lang"
     @update="emit('update', $event)"
   />
   <IssuePicker
     v-else-if="field.type === 'issue'"
     :value="issueValue()"
     @update="emit('update', $event)"
+  />
+  <FrontmatterSelect
+    v-else-if="field.type === 'select'"
+    :field="field"
+    :value="stringValue()"
+    :lang="lang"
+    @change="onSelect"
   />
   <input
     v-else

--- a/src/components/MarkdownEditor/FrontmatterSelect.vue
+++ b/src/components/MarkdownEditor/FrontmatterSelect.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useLabelsStore } from '@/stores/labels'
+import type { Language } from '@/types/language'
+import type { FieldDefinition } from './field-types'
+import { buildLabelOptions } from './select-options'
+
+const props = defineProps<{
+  readonly field: FieldDefinition
+  readonly value: string
+  readonly lang: Language
+}>()
+
+const emit = defineEmits<{ change: [v: string] }>()
+
+const labelsStore = useLabelsStore()
+void labelsStore.ensureLoaded()
+
+const options = computed(() =>
+  props.field.type === 'select' && props.field.optionsSource === 'labels'
+    ? buildLabelOptions(labelsStore.labels, props.lang, props.value)
+    : []
+)
+
+const onChange = (e: Event): void => {
+  emit('change', (e.target as HTMLSelectElement).value)
+}
+</script>
+
+<template>
+  <select
+    :id="`fm-${field.key}`"
+    :value="value"
+    :required="field.required"
+    class="field-input"
+    @change="onChange"
+  >
+    <option value="" disabled>
+      Select {{ field.label.toLowerCase() }}
+    </option>
+    <option
+      v-for="opt in options"
+      :key="opt.value"
+      :value="opt.value"
+      :disabled="opt.disabled"
+    >
+      {{ opt.label }}
+    </option>
+  </select>
+</template>
+
+<style scoped>
+.field-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: clamp(0.375rem, 1vw, 0.5rem);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  font-family: inherit;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: var(--color-heading);
+}
+</style>

--- a/src/components/MarkdownEditor/MarkdownEditor.vue
+++ b/src/components/MarkdownEditor/MarkdownEditor.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ContentType } from '@/types/content'
+import type { Language } from '@/types/language'
 import EditorFooter from './EditorFooter.vue'
 import EditorHeader from './EditorHeader.vue'
 import FrontmatterEditor from './FrontmatterEditor.vue'
@@ -11,6 +12,7 @@ defineProps<{
   readonly loading?: boolean
   readonly frontmatter?: Record<string, unknown>
   readonly contentType?: ContentType
+  readonly lang?: Language
 }>()
 
 const emit = defineEmits<{
@@ -26,9 +28,10 @@ const emit = defineEmits<{
     <output v-else-if="loading" class="loading-state">Loading file...</output>
     <EditorHeader v-else :file-path="filePath" />
     <FrontmatterEditor
-      v-if="filePath && !loading && frontmatter && contentType"
+      v-if="filePath && !loading && frontmatter && contentType && lang"
       :frontmatter="frontmatter"
       :content-type="contentType"
+      :lang="lang"
       @update:frontmatter="emit('update:frontmatter', $event)"
     />
     <MarkdownEditorBody

--- a/src/components/MarkdownEditor/field-types.ts
+++ b/src/components/MarkdownEditor/field-types.ts
@@ -1,0 +1,31 @@
+/** Discriminator for select-typed fields, naming the data source. */
+export type SelectOptionsSource = 'labels'
+
+interface BaseField {
+  readonly key: string
+  readonly label: string
+  readonly required?: boolean
+}
+
+interface PrimitiveField extends BaseField {
+  readonly type:
+    | 'text'
+    | 'textarea'
+    | 'number'
+    | 'date'
+    | 'checkbox'
+    | 'articles'
+    | 'issue'
+}
+
+interface SelectField extends BaseField {
+  readonly type: 'select'
+  readonly optionsSource: SelectOptionsSource
+}
+
+/**
+ * Schema for a frontmatter form field. Most types map 1:1 to a
+ * native input. `select` is sourced from a named data set so the
+ * renderer can pull localised options from a store.
+ */
+export type FieldDefinition = PrimitiveField | SelectField

--- a/src/components/MarkdownEditor/fields-blog.ts
+++ b/src/components/MarkdownEditor/fields-blog.ts
@@ -1,11 +1,11 @@
 import type { FieldDefinition } from './frontmatter-fields'
 
 /**
- * Frontmatter fields shown on the blog edit page. `description`
- * was retired (#3): the public site still renders an existing
- * description as a preface block, but new entries don't ask for
- * one — listings derive their preview from the body's first
- * paragraph instead.
+ * Frontmatter fields shown on the blog edit page. Description is
+ * optional — listings derive a preview from the body's first
+ * paragraph when blank — but editors can still author one for the
+ * preface block on the public site. Category is sourced from the
+ * shared labels store so taxonomy stays consistent.
  */
 export const blogFields: readonly FieldDefinition[] = [
   {
@@ -15,9 +15,15 @@ export const blogFields: readonly FieldDefinition[] = [
     required: true,
   },
   {
+    key: 'description',
+    label: 'Description',
+    type: 'textarea',
+  },
+  {
     key: 'category',
     label: 'Category',
-    type: 'text',
+    type: 'select',
+    optionsSource: 'labels',
     required: true,
   },
   { key: 'published', label: 'Published', type: 'checkbox' },

--- a/src/components/MarkdownEditor/fields-newspaper.ts
+++ b/src/components/MarkdownEditor/fields-newspaper.ts
@@ -2,7 +2,8 @@ import type { FieldDefinition } from './frontmatter-fields'
 
 /**
  * Frontmatter fields shown on the newspaper-issue edit page.
- * `description` retired — see fields-blog.ts.
+ * Description is optional — kept for parity with the create
+ * dialog so editors can fill in a preface when wanted.
  */
 export const newspaperFields: readonly FieldDefinition[] = [
   {
@@ -10,6 +11,11 @@ export const newspaperFields: readonly FieldDefinition[] = [
     label: 'Title',
     type: 'text',
     required: true,
+  },
+  {
+    key: 'description',
+    label: 'Description',
+    type: 'textarea',
   },
   { key: 'published', label: 'Published', type: 'checkbox' },
   { key: 'publishDate', label: 'Publish Date', type: 'date' },

--- a/src/components/MarkdownEditor/frontmatter-fields.test.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.test.ts
@@ -3,16 +3,43 @@ import { getFields } from './frontmatter-fields'
 
 describe('getFields', () => {
   describe('blog', () => {
-    it('returns blog fields', () => {
+    it('returns blog fields including description and category select', () => {
       const fields = getFields('blog')
       const keys = fields.map(f => f.key)
       expect(keys).toEqual([
         'title',
+        'description',
         'category',
         'published',
         'publishDate',
         'newspaper',
       ])
+    })
+
+    it('exposes description as an optional textarea', () => {
+      const fields = getFields('blog')
+      const description = fields.find(f => f.key === 'description')
+      expect(description?.type).toBe('textarea')
+      expect(description?.required).toBeUndefined()
+    })
+
+    it('exposes category as a required labels-sourced select', () => {
+      const fields = getFields('blog')
+      const category = fields.find(f => f.key === 'category')
+      expect(category?.type).toBe('select')
+      expect(category?.required).toBe(true)
+      expect(
+        category?.type === 'select' ? category.optionsSource : undefined
+      ).toBe('labels')
+    })
+  })
+
+  describe('newspaper', () => {
+    it('includes optional description', () => {
+      const fields = getFields('newspaper')
+      const description = fields.find(f => f.key === 'description')
+      expect(description?.type).toBe('textarea')
+      expect(description?.required).toBeUndefined()
     })
   })
 

--- a/src/components/MarkdownEditor/frontmatter-fields.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.ts
@@ -1,3 +1,4 @@
+import { Match, pipe } from 'effect'
 import type { ContentType } from '@/types/content'
 import {
   basePageFields,
@@ -8,23 +9,9 @@ import {
   pageFieldsBySlug,
   positionsFields,
 } from './field-definitions'
+import type { FieldDefinition } from './field-types'
 
-/**
- * Schema for a frontmatter form field
- */
-export interface FieldDefinition {
-  readonly key: string
-  readonly label: string
-  readonly type:
-    | 'text'
-    | 'textarea'
-    | 'number'
-    | 'date'
-    | 'checkbox'
-    | 'articles'
-    | 'issue'
-  readonly required?: boolean
-}
+export type { FieldDefinition, SelectOptionsSource } from './field-types'
 
 const fieldsByContentType: Readonly<
   Record<ContentType, readonly FieldDefinition[]>
@@ -36,6 +23,20 @@ const fieldsByContentType: Readonly<
   newspaper: newspaperFields,
 }
 
+const fieldsForType = (type: ContentType): readonly FieldDefinition[] =>
+  fieldsByContentType[type] ?? []
+
+const resolveBySlug = (
+  type: ContentType,
+  slug: string
+): readonly FieldDefinition[] =>
+  pipe(
+    Match.value(type),
+    Match.when('pages', () => pageFieldsBySlug[slug] ?? basePageFields),
+    Match.when('common', () => commonFieldsBySlug[slug] ?? labelsFields),
+    Match.orElse(() => fieldsForType(type))
+  )
+
 /**
  * Get field definitions for a content type.
  * @param type - The content type
@@ -45,10 +46,5 @@ const fieldsByContentType: Readonly<
 export const getFields = (
   type: ContentType,
   slug?: string
-): readonly FieldDefinition[] => {
-  if (slug && type === 'pages')
-    return pageFieldsBySlug[slug] ?? basePageFields
-  if (slug && type === 'common')
-    return commonFieldsBySlug[slug] ?? labelsFields
-  return fieldsByContentType[type] ?? []
-}
+): readonly FieldDefinition[] =>
+  slug === undefined ? fieldsForType(type) : resolveBySlug(type, slug)

--- a/src/components/MarkdownEditor/select-options.test.ts
+++ b/src/components/MarkdownEditor/select-options.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { LabelEntry } from '@/stores/labels'
+import { buildLabelOptions } from './select-options'
+
+const labels: readonly LabelEntry[] = [
+  { key: 'news', translations: { en: 'News', uk: 'Новини' } },
+  { key: 'op-ed', translations: { en: 'Op-ed' } },
+]
+
+describe('buildLabelOptions', () => {
+  it('returns one option per label, localised by lang', () => {
+    const options = buildLabelOptions(labels, 'en', '')
+    expect(options).toEqual([
+      { value: 'news', label: 'News' },
+      { value: 'op-ed', label: 'Op-ed' },
+    ])
+  })
+
+  it('falls back to key when lang has no translation', () => {
+    const options = buildLabelOptions(labels, 'uk', '')
+    expect(options[1]).toEqual({ value: 'op-ed', label: 'op-ed' })
+  })
+
+  it('keeps the current value as a known option without duplication', () => {
+    const options = buildLabelOptions(labels, 'en', 'news')
+    expect(options.map(o => o.value)).toEqual(['news', 'op-ed'])
+    expect(options.every(o => o.disabled !== true)).toBe(true)
+  })
+
+  it('prepends a disabled fallback when current is unknown', () => {
+    const options = buildLabelOptions(labels, 'en', 'legacy-cat')
+    expect(options[0]).toEqual({
+      value: 'legacy-cat',
+      label: '(unknown: legacy-cat)',
+      disabled: true,
+    })
+    expect(options.slice(1).map(o => o.value)).toEqual(['news', 'op-ed'])
+  })
+
+  it('treats empty current as known (no fallback prepended)', () => {
+    const options = buildLabelOptions(labels, 'en', '')
+    expect(options[0]?.disabled).toBeUndefined()
+  })
+})

--- a/src/components/MarkdownEditor/select-options.ts
+++ b/src/components/MarkdownEditor/select-options.ts
@@ -1,0 +1,47 @@
+import type { LabelEntry } from '@/stores/labels'
+
+/** A single option for a `<select>` control. */
+export interface SelectOption {
+  readonly value: string
+  readonly label: string
+  readonly disabled?: boolean
+}
+
+const localise = (entry: LabelEntry, lang: string): string =>
+  entry.translations[lang] ?? entry.key
+
+const toOption =
+  (lang: string) =>
+  (entry: LabelEntry): SelectOption => ({
+    value: entry.key,
+    label: localise(entry, lang),
+  })
+
+const unknownOption = (key: string): SelectOption => ({
+  value: key,
+  label: `(unknown: ${key})`,
+  disabled: true,
+})
+
+const includesKey =
+  (key: string) =>
+  (opt: SelectOption): boolean =>
+    opt.value === key
+
+/**
+ * Build select options from labels, keeping the current value
+ * accessible even when it is not part of the labels store.
+ * @param labels - Available label entries
+ * @param lang - Current language for option text
+ * @param current - Current selected value (may be unknown)
+ * @returns Ordered options ready to render in a `<select>`
+ */
+export const buildLabelOptions = (
+  labels: readonly LabelEntry[],
+  lang: string,
+  current: string
+): readonly SelectOption[] => {
+  const base = labels.map(toOption(lang))
+  const isKnown = current === '' || base.some(includesKey(current))
+  return isKnown ? base : [unknownOption(current), ...base]
+}

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -83,6 +83,7 @@ const setError = (msg: string): void => {
       :loading-file="p.editor.loadingFile.value"
       :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
       :assets="p.hasAssets.value ? p.assets.allAssets.value : undefined"
+      :lang="p.editor.currentLang.value"
       @update:body-content="updateBody"
       @update:frontmatter="updateFm"
       @preview="enterPreview"

--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import type { ContentType } from '@/types/content'
+import type { Language } from '@/types/language'
 import ContentEditMainBody from './ContentEditMainBody.vue'
 
 defineProps<{
@@ -11,6 +12,7 @@ defineProps<{
   readonly loadingFile: boolean
   readonly assetUrlMap?: ReadonlyMap<string, string>
   readonly assets?: readonly AssetDisplay[]
+  readonly lang: Language
 }>()
 
 defineEmits<{
@@ -37,6 +39,7 @@ defineEmits<{
       :slug="slug"
       :asset-url-map="assetUrlMap"
       :assets="assets"
+      :lang="lang"
       @update:body-content="$emit('update:bodyContent', $event)"
       @update:frontmatter="$emit('update:frontmatter', $event)"
       @preview="$emit('preview')"

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -2,6 +2,7 @@
 import FrontmatterEditor from '@/components/MarkdownEditor/FrontmatterEditor.vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import type { ContentType } from '@/types/content'
+import type { Language } from '@/types/language'
 import EditBodyArea from './EditBodyArea.vue'
 
 defineProps<{
@@ -9,6 +10,7 @@ defineProps<{
   readonly frontmatterData: Record<string, unknown>
   readonly contentType: ContentType
   readonly slug?: string
+  readonly lang: Language
   readonly assetUrlMap?: ReadonlyMap<string, string>
   readonly assets?: readonly AssetDisplay[]
 }>()
@@ -31,6 +33,7 @@ defineEmits<{
     :frontmatter="frontmatterData"
     :content-type="contentType"
     :slug="slug"
+    :lang="lang"
     @update:frontmatter="$emit('update:frontmatter', $event)"
   />
   <EditBodyArea


### PR DESCRIPTION
## Summary
Three related fixes bundled because they all touch the FrontmatterField pipeline and the lang-threading is shared.

### #205 — Article picker filters by language + sorts newest-first
`articleOptions` now takes `{ items, lang, exclude }`, filters items by lang, sorts by `publishDate` (legacy `pubDate` fallback) descending with alphabetical title tie-break. Lang prop threaded ContentEditView → ContentEditMain → ContentEditMainBody → FrontmatterEditor → FrontmatterField → ArticlesPicker.

### #209 — Category as labels-driven select on edit
Blog Category is now a `<select>` populated from the labels store, same shape as CreateContentDialog. Localised option text via the article's currentLang. Legacy categories outside the labels store render as disabled `(unknown: <key>)` so existing data isn't silently lost.

### #206 — Description editable on edit
Optional textarea brought back to blogFields + newspaperFields. Editors entered description on creation but had no way to fix typos after.

## Architectural changes
- `FieldDefinition` now a discriminated union with a `'select'` branch carrying `optionsSource: 'labels'`. Extracted to `field-types.ts` so `frontmatter-fields.ts` stays under the 50-line file cap.
- New `FrontmatterSelect.vue` renders the labels-driven select; keeps `FrontmatterField.vue` slim.
- New `select-options.ts` + tests build option lists from labels with legacy unknown-key handling.

## Validation
`bun run validate` exit 0 (vue-tsc, biome ci, oxlint sonar, eslint jsdoc, vue-depth, stylelint). `bunx vitest run` 575/575.

Closes #205, #206, #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)