### PR TITLE
fix(newspaper): surface PDF cover extraction errors instead of swallowing

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,6 +76,7 @@
   "ignorePatterns": [
     "eslint.config.js",
     "eslint.legacy-if.js",
+    ".claude/**",
     "src/auto-imports.d.ts",
     "src/components.d.ts",
     "cors-proxy/**",

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
       "!!cors-proxy",
       "!!.wrangler",
       "!!public/vendor",
-      "!!e2e-toolkit"
+      "!!e2e-toolkit",
+      "!!.claude"
     ],
     "ignoreUnknown": false
   },

--- a/src/components/MarkdownEditor/NewspaperSourceUploads.vue
+++ b/src/components/MarkdownEditor/NewspaperSourceUploads.vue
@@ -32,6 +32,7 @@ const HINT =
       @upload-pdf="$emit('upload-asset', $event)"
       @upload-cover="$emit('upload-asset', $event)"
       @set-cover="$emit('set-cover', $event)"
+      @error="$emit('error', $event)"
     />
     <DocxUpload
       :assets="assets"

--- a/src/components/MarkdownEditor/PdfUpload.vue
+++ b/src/components/MarkdownEditor/PdfUpload.vue
@@ -13,6 +13,7 @@ const emit = defineEmits<{
   'upload-pdf': [file: File]
   'upload-cover': [file: File]
   'set-cover': [name: string]
+  error: [message: string]
 }>()
 
 const inputRef = ref<HTMLInputElement>()
@@ -32,12 +33,22 @@ const triggerUpload = () => { inputRef.value?.click() }
  * when there is no cover yet — if the user has chosen a custom cover
  * we must not silently overwrite it.
  */
+const extractCover = async (file: File): Promise<File | undefined> => {
+  try {
+    const m = await import('@/features/newspaper/extract-pdf-cover')
+    return await m.extractPdfCover(file)
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err)
+    emit('error', `PDF cover extraction failed: ${reason}`)
+    return undefined
+  }
+}
+
 const handleFile = async (file: File) => {
   if (file.type !== 'application/pdf') return
   emit('upload-pdf', file)
-  const m = await import('@/features/newspaper/extract-pdf-cover')
-  const cover = await m.extractPdfCover(file)
-  if (!cover) return
+  const cover = await extractCover(file)
+  if (cover === undefined) return
   emit('upload-cover', cover)
   if (shouldAutoSetCover(props.currentCover)) emit('set-cover', 'cover.png')
 }

--- a/src/features/newspaper/extract-pdf-cover.test.ts
+++ b/src/features/newspaper/extract-pdf-cover.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { extractPdfCover } from './extract-pdf-cover'
+import * as renderModule from './render-pdf-page'
+
+const fakePdf = (): File =>
+  new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], 'issue.pdf', {
+    type: 'application/pdf',
+  })
+
+const fakeBlob = (): Blob => new Blob(['png-bytes'], { type: 'image/png' })
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('extractPdfCover', () => {
+  it('returns a PNG File named cover.png when render succeeds', async () => {
+    vi.spyOn(renderModule, 'renderFirstPage').mockResolvedValue(fakeBlob())
+    const out = await extractPdfCover(fakePdf())
+    expect(out.name).toBe('cover.png')
+    expect(out.type).toBe('image/png')
+    expect(out).toBeInstanceOf(File)
+  })
+
+  it('propagates errors from the renderer instead of swallowing them', async () => {
+    /*
+     * Pre-fix: extractPdfCover wrapped the renderer in a `try {} catch
+     * { return undefined }`. That made the "no cover appeared" symptom
+     * indistinguishable from a successful no-op in the UI. The fix is
+     * to let exceptions bubble so the upload pipeline can surface them
+     * via the editor's error toast — which is exactly what this test
+     * pins.
+     */
+    vi.spyOn(renderModule, 'renderFirstPage').mockRejectedValue(
+      new Error('worker fetch failed: 404')
+    )
+    await expect(extractPdfCover(fakePdf())).rejects.toThrow(
+      /worker fetch failed: 404/
+    )
+  })
+})

--- a/src/features/newspaper/extract-pdf-cover.ts
+++ b/src/features/newspaper/extract-pdf-cover.ts
@@ -1,18 +1,23 @@
 import { renderFirstPage } from './render-pdf-page'
 
+const COVER_FILENAME = 'cover.png'
+
 /**
  * Extract first page of a PDF as a PNG File.
+ *
+ * Errors propagate to the caller. The previous version silently
+ * returned `undefined` on any failure, which made the broken
+ * "PDF cover doesn't auto-extract" flow indistinguishable in the
+ * UI from a happy-path no-op — editors had no signal that anything
+ * had failed. Now exceptions reach the upload pipeline, which
+ * surfaces them via the editor's error toast.
+ *
  * @param pdfFile - PDF file to extract cover from
- * @returns PNG File of the first page, or undefined on error
+ * @returns PNG File of the first page
+ * @throws when pdfjs / canvas / worker fails (network, OOM,
+ *   incompatible PDF, missing worker script, etc.)
  */
-export const extractPdfCover = async (
-  pdfFile: File
-): Promise<File | undefined> => {
-  try {
-    const blob = await renderFirstPage(pdfFile)
-    if (!blob) return undefined
-    return new File([blob], 'cover.png', { type: 'image/png' })
-  } catch {
-    return undefined
-  }
+export const extractPdfCover = async (pdfFile: File): Promise<File> => {
+  const blob = await renderFirstPage(pdfFile)
+  return new File([blob], COVER_FILENAME, { type: 'image/png' })
 }

--- a/src/features/newspaper/render-pdf-page.ts
+++ b/src/features/newspaper/render-pdf-page.ts
@@ -8,14 +8,29 @@ const loadPdfJs = async () => {
   return mod
 }
 
+const toBlob = (canvas: HTMLCanvasElement): Promise<Blob> =>
+  new Promise<Blob>((resolve, reject) =>
+    canvas.toBlob(
+      b =>
+        b ? resolve(b) : reject(new Error('canvas.toBlob returned null')),
+      'image/png'
+    )
+  )
+
 /**
  * Render the first page of a PDF to a PNG Blob.
- * @param pdfFile - PDF file
- * @returns PNG blob or undefined
+ *
+ * Throws on any failure rather than returning undefined — the
+ * editor's upload pipeline catches and surfaces these via the error
+ * toast, so the "no cover appeared" symptom now carries a real
+ * message (worker fetch failed, canvas 2d context unavailable,
+ * pdfjs OOM, etc.) instead of being a silent no-op.
+ *
+ * @param pdfFile - PDF file to render
+ * @returns PNG blob of the first page
+ * @throws when pdfjs / canvas / worker fails
  */
-export const renderFirstPage = async (
-  pdfFile: File
-): Promise<Blob | undefined> => {
+export const renderFirstPage = async (pdfFile: File): Promise<Blob> => {
   const pdfjsLib = await loadPdfJs()
   const data = new Uint8Array(await pdfFile.arrayBuffer())
   const doc = await pdfjsLib.getDocument({ data }).promise
@@ -25,9 +40,9 @@ export const renderFirstPage = async (
   canvas.width = viewport.width
   canvas.height = viewport.height
   const ctx = canvas.getContext('2d')
-  if (!ctx) return undefined
+  if (ctx === null) {
+    throw new Error('canvas 2d context unavailable')
+  }
   await page.render({ canvasContext: ctx, viewport, canvas }).promise
-  return new Promise<Blob | undefined>(resolve =>
-    canvas.toBlob(b => resolve(b ?? undefined), 'image/png')
-  )
+  return toBlob(canvas)
 }


### PR DESCRIPTION
## Summary
Editor reports PDF cover no longer auto-extracts on newspaper upload. The previous `extractPdfCover` wrapped the entire renderer in `try {} catch { return undefined }` — any pdfjs / canvas / worker failure was indistinguishable from a successful no-op. Editor sees an empty cover slot with zero signal of what went wrong.

Fix: errors propagate. `extractPdfCover` and `renderFirstPage` now throw on failure. `PdfUpload.vue` catches at the upload boundary and emits via the existing `error` event chain that lights up the editor's error toast. Wired through `NewspaperSourceUploads`.

The actual root cause of the user's symptom will now surface in the toast (worker fetch 404, canvas 2d unavailable, OOM, incompatible PDF, …) — they can act on it instead of staring at a blank.

`renderFirstPage`'s `canvas.toBlob` null branch and `getContext('2d')` null branch are now explicit errors too.

## Tests
- `extract-pdf-cover.test.ts` — happy path returns `cover.png` PNG; renderer errors propagate (not swallowed)
- 2 cases, both green

## Tooling
- Added `.claude/**` to biome and oxlint ignore lists so worktree clones don't poison the lint pass

Closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)