### PR TITLE
fix(content): trust URL lang + hide Select on empty list

### DIFF
--- a/src/components/ContentList/ContentList.vue
+++ b/src/components/ContentList/ContentList.vue
@@ -43,6 +43,7 @@ const selectedCount = computed(() => props.selectedSlugs?.size ?? 0)
       v-if="!hideCreate"
       :select-mode="selectMode"
       :selected-count="selectedCount"
+      :has-items="filteredItems.length > 0"
       @create="emit('create')"
       @enter-select="emit('enterSelect')"
       @exit-select="emit('exitSelect')"

--- a/src/components/ContentList/ContentListHeader.vue
+++ b/src/components/ContentList/ContentListHeader.vue
@@ -4,6 +4,7 @@ import ListHeaderActions from './ListHeaderActions.vue'
 defineProps<{
   readonly selectMode?: boolean
   readonly selectedCount?: number
+  readonly hasItems?: boolean
 }>()
 
 defineEmits<{
@@ -20,6 +21,7 @@ defineEmits<{
     <ListHeaderActions
       :select-mode="selectMode"
       :selected-count="selectedCount"
+      :has-items="hasItems"
       @create="$emit('create')"
       @enter-select="$emit('enterSelect')"
       @exit-select="$emit('exitSelect')"

--- a/src/components/ContentList/ListHeaderActions.test.ts
+++ b/src/components/ContentList/ListHeaderActions.test.ts
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import ListHeaderActions from './ListHeaderActions.vue'
+
+describe('ListHeaderActions — out-of-select-mode', () => {
+  it('hides the Select button when there are no items to select', () => {
+    /*
+     * Reported regression on /content/newspaper?lang=ru — list was
+     * empty ("No content found for en"), but the Select button was
+     * still shown. Click did nothing visible (the list has no rows
+     * to gain checkboxes). The Select affordance only earns its
+     * spot when there is actually something to bulk-select.
+     */
+    const w = mount(ListHeaderActions, { props: { hasItems: false } })
+    expect(w.find('[data-testid="select-mode"]').exists()).toBe(false)
+    expect(w.find('[data-testid="create-button"]').exists()).toBe(true)
+  })
+
+  it('shows the Select button when items exist', () => {
+    const w = mount(ListHeaderActions, { props: { hasItems: true } })
+    expect(w.find('[data-testid="select-mode"]').exists()).toBe(true)
+  })
+
+  it('defaults to hidden when hasItems is omitted', () => {
+    const w = mount(ListHeaderActions, { props: {} })
+    expect(w.find('[data-testid="select-mode"]').exists()).toBe(false)
+  })
+})
+
+describe('ListHeaderActions — in-select-mode', () => {
+  it('shows count + Cancel + Delete-selected, ignores hasItems', () => {
+    const w = mount(ListHeaderActions, {
+      props: { selectMode: true, selectedCount: 2, hasItems: false },
+    })
+    expect(w.find('[data-testid="bulk-count"]').text()).toContain('2')
+    expect(w.find('[data-testid="bulk-cancel"]').exists()).toBe(true)
+    expect(w.find('[data-testid="bulk-delete"]').exists()).toBe(true)
+  })
+})

--- a/src/components/ContentList/ListHeaderActions.vue
+++ b/src/components/ContentList/ListHeaderActions.vue
@@ -2,6 +2,7 @@
 defineProps<{
   readonly selectMode?: boolean
   readonly selectedCount?: number
+  readonly hasItems?: boolean
 }>()
 
 defineEmits<{
@@ -37,6 +38,7 @@ defineEmits<{
   </template>
   <template v-else>
     <button
+      v-if="hasItems"
       type="button"
       class="btn btn-secondary"
       data-testid="select-mode"

--- a/src/views/ContentView/use-selected-lang.test.ts
+++ b/src/views/ContentView/use-selected-lang.test.ts
@@ -58,12 +58,20 @@ describe('useSelectedLang', () => {
     expect(lang.value).toBe('it')
   })
 
-  it('falls back when query.lang not in available list', async () => {
-    const { lang } = await mountWith('/content/blog?lang=zz', () => [
+  it('honours query.lang even when not in the loaded-content subset', async () => {
+    /*
+     * Earlier version validated `?lang=` against `available()` (the
+     * loaded-content subset) and silently demoted out-of-set values
+     * to `available[0]`. That broke the "select РУССКИЙ on a
+     * newspaper page that has no Russian issue yet" flow — the URL
+     * stayed at `ru` but the selector rendered `en` and the content
+     * area read "No content found for en". The contract now is:
+     * trust the URL. Available is the fallback default only.
+     */
+    const { lang } = await mountWith('/content/newspaper?lang=ru', () => [
       'en',
-      'ru',
     ])
-    expect(lang.value).toBe('en')
+    expect(lang.value).toBe('ru')
   })
 
   it('falls back to "en" when neither query nor available match', async () => {

--- a/src/views/ContentView/use-selected-lang.ts
+++ b/src/views/ContentView/use-selected-lang.ts
@@ -6,15 +6,6 @@ import { extractString } from '@/validation/extract-string'
 
 const DEFAULT_LANG: Language = 'en'
 
-const pickLang = (
-  raw: string | undefined,
-  available: readonly Language[],
-  fallback: Language
-): Language =>
-  raw !== undefined && available.includes(raw)
-    ? raw
-    : (available[0] ?? fallback)
-
 const writeLang = (
   router: Router,
   query: LocationQuery,
@@ -26,13 +17,20 @@ const writeLang = (
 /**
  * URL-bound selected-language ref.
  *
- * Reads `?lang=<code>` from the current route, validates it
- * against `available` (defaults to first available, then `en`),
- * and persists writes via `router.replace` so the value
- * survives back/forward navigation.
+ * Reads `?lang=<code>` from the current route as-is. The available-
+ * languages list is consulted only as a fallback default when the
+ * URL is missing the param — a code that the user has explicitly
+ * selected (even one with no content yet) MUST stay selected so they
+ * can land on an empty list and create the first entry.
+ *
+ * Earlier version validated `?lang=` against the loaded-content
+ * subset, which silently demoted `?lang=ru` to `en` when no Russian
+ * content existed — the URL stayed at `ru` but the selector rendered
+ * `en`, and the content area read "No content found for en".
+ *
  * @param available - Reactive set of language codes present in the
- *   current content list. The first entry is the fallback when the
- *   query param is missing or invalid.
+ *   current content list. Used only as the fallback default when
+ *   `?lang=` is absent.
  * @returns Computed get/set ref usable as a `v-model` target.
  */
 export const useSelectedLang = (available: () => readonly Language[]) => {
@@ -40,7 +38,7 @@ export const useSelectedLang = (available: () => readonly Language[]) => {
   const router = useRouter()
   return computed<Language>({
     get: () =>
-      pickLang(extractString(route.query.lang), available(), DEFAULT_LANG),
+      extractString(route.query.lang) ?? available()[0] ?? DEFAULT_LANG,
     set: lang => writeLang(router, route.query, lang),
   })
 }


### PR DESCRIPTION
## Symptom
Reporter on `/content/newspaper?lang=ru`:
- РУССКИЙ tab not highlighted (English shown selected instead)
- Content area says "No content found for **en**" while URL says `lang=ru`
- Select button visible on empty list, click does nothing

## Root causes

### Lang URL→UI desync
`useSelectedLang` validated the `?lang=` value against `available()` (the loaded-content subset). Newspaper has only English issues, so the validator demoted `?lang=ru` to `available[0]` = `en`. URL stayed at `ru`, UI rendered `en`. The fix is to trust the URL: the LanguageSelector renders all `settings.languages` tabs anyway, so a code with no content yet still selects cleanly and the editor can land on an empty list to create the first entry. `available()` is now the fallback default only.

### Select button on empty list
The Select toggle stayed visible regardless of list contents. With nothing to select, the click was a no-op. Plumbed a `hasItems` prop down `ContentList → ContentListHeader → ListHeaderActions`; Select only renders when there's actually something to bulk-select.

## Tests
- `use-selected-lang.test.ts`: pinned the URL-trust contract; replaced the now-incorrect "reject out-of-set" case with a regression test naming the original symptom
- `ListHeaderActions.test.ts` (new): `hasItems=false` hides Select, `hasItems=true` shows it, in-select-mode chrome ignores `hasItems`

`bun run validate` clean. Targeted vitest 22/22.

Closes #207 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)