### PR TITLE
fix(assets): same-name re-upload no longer wipes the asset

### DIFF
--- a/src/composables/useAssets/transactional-save.test.ts
+++ b/src/composables/useAssets/transactional-save.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const writeAssetMock = vi.fn(async (_path: string, _b64: string) => {})
+const deleteAssetMock = vi.fn(async (_path: string) => {})
+const stageFileMock = vi.fn(async (_path: string, _content: string) => {})
+const commitStagedMock = vi.fn(async (_msg: string) => ({ sha: 'deadbeef' }))
+
+vi.mock('../useGitHubApi/write-asset', () => ({
+  writeAsset: (p: string, b: string) => writeAssetMock(p, b),
+}))
+vi.mock('../useGitHubApi/delete-asset', () => ({
+  deleteAsset: (p: string) => deleteAssetMock(p),
+}))
+vi.mock('../useGitHubApi/stage-file', () => ({
+  stageFile: (p: string, c: string) => stageFileMock(p, c),
+}))
+vi.mock('../useGitHubApi/commit-staged', () => ({
+  commitStaged: (m: string) => commitStagedMock(m),
+}))
+vi.mock('@/config/github', () => ({
+  getGitHubConfig: () => ({
+    contentPath: '',
+    owner: 'o',
+    repo: 'r',
+    branch: 'main',
+  }),
+}))
+
+const { transactionalSave } = await import('./transactional-save')
+
+const pendingAsset = (name: string) => ({
+  name,
+  blobUrl: `blob:${name}`,
+  base64: 'AA==',
+  mimeType: name.endsWith('.pdf') ? 'application/pdf' : 'image/png',
+  size: 1,
+})
+
+beforeEach(() => {
+  writeAssetMock.mockClear()
+  deleteAssetMock.mockClear()
+  stageFileMock.mockClear()
+  commitStagedMock.mockClear()
+})
+
+describe('transactionalSave — replace-collision regression', () => {
+  it('does NOT delete a path that the same save is also writing', async () => {
+    /*
+     * Reproducer for the prod incident on 2026-05-07 where re-saving
+     * `magazine-1-mai-2026` wiped its PDF + cover.png.
+     *
+     * `addAsset` schedules the existing committed path for deletion
+     * via scheduleReplace AND queues new bytes in pendingAdds. With
+     * same filename the target path collides — flushAdds writes,
+     * then flushDeletes runs `git rm` on the same path → file gone.
+     */
+    const path = 'newspaper/magazine-1-mai-2026/assets/cover.png'
+    await transactionalSave({
+      type: 'newspaper',
+      slug: 'magazine-1-mai-2026',
+      articlePath: 'newspaper/magazine-1-mai-2026/index.ru.md',
+      articleContent: '---\ntitle: x\n---\n',
+      message: 'updated',
+      pendingAdds: [pendingAsset('cover.png')],
+      pendingDeletes: new Set([path]),
+    })
+    expect(writeAssetMock).toHaveBeenCalledWith(path, 'AA==')
+    expect(deleteAssetMock).not.toHaveBeenCalledWith(path)
+  })
+
+  it('still deletes paths that are NOT being re-added', async () => {
+    const orphan = 'newspaper/magazine-1-mai-2026/assets/old-illustration.jpg'
+    await transactionalSave({
+      type: 'newspaper',
+      slug: 'magazine-1-mai-2026',
+      articlePath: 'newspaper/magazine-1-mai-2026/index.ru.md',
+      articleContent: '---\ntitle: x\n---\n',
+      message: 'updated',
+      pendingAdds: [pendingAsset('cover.png')],
+      pendingDeletes: new Set([orphan]),
+    })
+    expect(deleteAssetMock).toHaveBeenCalledWith(orphan)
+  })
+
+  it('handles many pending adds + a colliding delete cleanly', async () => {
+    const collide = 'newspaper/magazine-1-mai-2026/assets/Magazine1 (3).pdf'
+    const orphan = 'newspaper/magazine-1-mai-2026/assets/notes.txt'
+    await transactionalSave({
+      type: 'newspaper',
+      slug: 'magazine-1-mai-2026',
+      articlePath: 'newspaper/magazine-1-mai-2026/index.ru.md',
+      articleContent: '---\ntitle: x\n---\n',
+      message: 'updated',
+      pendingAdds: [
+        pendingAsset('Magazine1 (3).pdf'),
+        pendingAsset('cover.png'),
+      ],
+      pendingDeletes: new Set([collide, orphan]),
+    })
+    const deleted = deleteAssetMock.mock.calls.map(c => c[0])
+    expect(deleted).toContain(orphan)
+    expect(deleted).not.toContain(collide)
+  })
+})

--- a/src/composables/useAssets/transactional-save.ts
+++ b/src/composables/useAssets/transactional-save.ts
@@ -1,5 +1,6 @@
 import { commitStaged } from '../useGitHubApi/commit-staged'
 import { stageFile } from '../useGitHubApi/stage-file'
+import { buildAssetPath } from './build-asset-path'
 import { flushAdds } from './flush-adds'
 import { flushDeletes } from './flush-deletes'
 import type { PendingAsset } from './types'
@@ -17,6 +18,33 @@ export interface SaveParams {
   readonly pendingDeletes: ReadonlySet<string>
 }
 
+/*
+ * Drop deletes that target a path also present in pendingAdds.
+ *
+ * Replacing an asset with the SAME filename produces a collision:
+ * `addAsset` schedules the existing committed path for deletion via
+ * `scheduleReplace` (so the old bytes are removed) AND queues the
+ * new bytes in pendingAdds. With same name + same slug + same type
+ * → same target path. Without this filter, transactionalSave first
+ * stages the new bytes via flushAdds, then runs `git rm` on the
+ * same path via flushDeletes — net effect: file gone. The user
+ * uploads a new PDF, the save commits, and the asset disappears.
+ *
+ * Deletes are still applied to truly orphan paths (e.g. the editor
+ * deleted an asset and didn't replace it).
+ */
+const dropOverlap = (
+  type: string,
+  slug: string,
+  adds: readonly PendingAsset[],
+  deletes: ReadonlySet<string>
+): ReadonlySet<string> => {
+  const addedPaths = new Set(
+    adds.map(a => buildAssetPath(type, slug, a.name))
+  )
+  return new Set([...deletes].filter(p => !addedPaths.has(p)))
+}
+
 /**
  * Perform a transactional save: stage all changes, then commit.
  * @param params - Save parameters
@@ -25,8 +53,14 @@ export interface SaveParams {
 export const transactionalSave = async (
   params: SaveParams
 ): Promise<string> => {
+  const safeDeletes = dropOverlap(
+    params.type,
+    params.slug,
+    params.pendingAdds,
+    params.pendingDeletes
+  )
   await flushAdds(params.type, params.slug, params.pendingAdds)
-  await flushDeletes(params.pendingDeletes)
+  await flushDeletes(safeDeletes)
   await stageFile(params.articlePath, params.articleContent)
   const result = await commitStaged(params.message)
   return result.sha


### PR DESCRIPTION
## Summary
- Replacing an asset with a new file of the same name (e.g. re-upload `cover.png` or the PDF) was wiping the file from git: `flushAdds` wrote new bytes, then `flushDeletes` ran `git rm` on the SAME path because `scheduleReplace` had queued the old (== new) path for deletion.
- `transactionalSave` now filters `pendingDeletes` to exclude any path that's also present in `pendingAdds`. Orphan deletes still apply.

## Reproduced in prod on 2026-05-07
- Re-saving `newspaper/magazine-1-mai-2026` via the create-then-edit flow committed deletions of both `Magazine1 (3).pdf` and `cover.png` (commit `ac30705da9` on `public-website-content`), even though the user had just uploaded them.

## Test plan
- [x] `bunx vitest run src/composables/useAssets/transactional-save.test.ts` — 3 new tests, all green.
- [x] Verified the new tests **fail** against the previous code (stashed the fix, ran the suite, observed the collision-path being deleted).
- [x] Full `useAssets` suite green (122 tests).
- [ ] Re-upload `Magazine1 (3).pdf` to `magazine-1-mai-2026` after merge to restore the deleted assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)