### PR TITLE
fix(newspaper): polyfill Map.getOrInsertComputed for pdfjs 5.6.205

### DIFF
--- a/src/features/newspaper/map-upsert-polyfill.test.ts
+++ b/src/features/newspaper/map-upsert-polyfill.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+/*
+ * Reproducer for the prod incident on 2026-05-07: pdfjs 5.6.205 calls
+ * `this[#fr].getOrInsertComputed(...)` on its private font registry
+ * Map. On engines that haven't shipped TC39 "Map upserts" yet the
+ * upload throws "this[#fr].getOrInsertComputed is not a function"
+ * and cover extraction silently fails for editors. The polyfill
+ * must install the method on both Map and WeakMap prototypes so any
+ * call site (private field or otherwise) works.
+ */
+
+interface Removable {
+  readonly mapHad: boolean
+  readonly weakHad: boolean
+}
+
+const stripPolyfill = (): Removable => {
+  const mapProto = Map.prototype
+  const weakProto = WeakMap.prototype
+  const mapHad = typeof mapProto.getOrInsertComputed === 'function'
+  const weakHad = typeof weakProto.getOrInsertComputed === 'function'
+  Reflect.deleteProperty(mapProto, 'getOrInsertComputed')
+  Reflect.deleteProperty(weakProto, 'getOrInsertComputed')
+  return { mapHad, weakHad }
+}
+
+const restoreNative = (had: Removable): void => {
+  if (!had.mapHad)
+    Reflect.deleteProperty(Map.prototype, 'getOrInsertComputed')
+  if (!had.weakHad)
+    Reflect.deleteProperty(WeakMap.prototype, 'getOrInsertComputed')
+}
+
+describe('map-upsert polyfill', () => {
+  let snapshot: Removable
+
+  beforeEach(() => {
+    vi.resetModules()
+    snapshot = stripPolyfill()
+  })
+
+  afterEach(() => {
+    restoreNative(snapshot)
+  })
+
+  it('without the polyfill, calling getOrInsertComputed throws', () => {
+    const m = new Map<string, number>()
+    expect(() => {
+      // Mirrors what pdfjs does on its private font-registry map.
+      // biome-ignore lint/suspicious/noExplicitAny: the whole point is to assert the method is missing
+      ;(m as any).getOrInsertComputed('k', () => 1)
+    }).toThrow()
+  })
+
+  it('after installing the polyfill, Map.getOrInsertComputed inserts on miss', async () => {
+    const { ensureMapUpsertPolyfill } = await import('./map-upsert-polyfill')
+    ensureMapUpsertPolyfill()
+    const m = new Map<string, number>()
+    let calls = 0
+    const v = m.getOrInsertComputed('answer', () => {
+      calls++
+      return 42
+    })
+    expect(v).toBe(42)
+    expect(m.get('answer')).toBe(42)
+    expect(calls).toBe(1)
+  })
+
+  it('after installing, getOrInsertComputed returns the existing value on hit and does NOT re-run the factory', async () => {
+    const { ensureMapUpsertPolyfill } = await import('./map-upsert-polyfill')
+    ensureMapUpsertPolyfill()
+    const m = new Map<string, number>([['k', 7]])
+    let calls = 0
+    const v = m.getOrInsertComputed('k', () => {
+      calls++
+      return 99
+    })
+    expect(v).toBe(7)
+    expect(calls).toBe(0)
+  })
+
+  it('also patches WeakMap', async () => {
+    const { ensureMapUpsertPolyfill } = await import('./map-upsert-polyfill')
+    ensureMapUpsertPolyfill()
+    const wm = new WeakMap<object, string>()
+    const k = {}
+    const v = wm.getOrInsertComputed(k, () => 'hello')
+    expect(v).toBe('hello')
+    expect(wm.get(k)).toBe('hello')
+  })
+
+  it('idempotent: subsequent calls are no-ops if the method exists', async () => {
+    const { ensureMapUpsertPolyfill } = await import('./map-upsert-polyfill')
+    ensureMapUpsertPolyfill()
+    const first = Map.prototype.getOrInsertComputed
+    ensureMapUpsertPolyfill()
+    expect(Map.prototype.getOrInsertComputed).toBe(first)
+  })
+})

--- a/src/features/newspaper/map-upsert-polyfill.ts
+++ b/src/features/newspaper/map-upsert-polyfill.ts
@@ -1,0 +1,75 @@
+/*
+ * Polyfill for the TC39 "Map upserts" proposal (Stage 4 in 2026).
+ * pdfjs 5.6.205 calls `this[#fr].getOrInsertComputed(...)` on its
+ * internal font registry; on engines that haven't shipped it yet
+ * (Chrome <138 / V8 <13.4 etc.) cover extraction crashes with
+ * "this[#fr].getOrInsertComputed is not a function" before the
+ * first page even renders. We install minimal implementations on
+ * Map and WeakMap prototypes.
+ *
+ * Note: pdfjs never stores `undefined` as a value, so we treat
+ * "get() === undefined" as "key absent" and skip the spec-exact
+ * `has()` branch — it would force a cast (project forbids `as`).
+ */
+
+declare global {
+  interface Map<K, V> {
+    /**
+     * Get the value at `key`, or insert and return `fn(key)` if absent.
+     * @param key - lookup key
+     * @param fn - factory invoked only when `key` is absent
+     * @returns existing or freshly inserted value
+     */
+    getOrInsertComputed(key: K, fn: (k: K) => V): V
+  }
+  interface WeakMap<K extends WeakKey, V> {
+    /**
+     * Get the value at `key`, or insert and return `fn(key)` if absent.
+     * @param key - lookup key
+     * @param fn - factory invoked only when `key` is absent
+     * @returns existing or freshly inserted value
+     */
+    getOrInsertComputed(key: K, fn: (k: K) => V): V
+  }
+}
+
+const upsertMap = function <K, V>(
+  this: Map<K, V>,
+  key: K,
+  fn: (k: K) => V
+): V {
+  const cached = this.get(key)
+  if (cached !== undefined) return cached
+  const fresh = fn(key)
+  this.set(key, fresh)
+  return fresh
+}
+
+const upsertWeakMap = function <K extends WeakKey, V>(
+  this: WeakMap<K, V>,
+  key: K,
+  fn: (k: K) => V
+): V {
+  const cached = this.get(key)
+  if (cached !== undefined) return cached
+  const fresh = fn(key)
+  this.set(key, fresh)
+  return fresh
+}
+
+let installed = false
+
+/**
+ * Install the polyfill on Map.prototype + WeakMap.prototype if the
+ * runtime is missing the methods. Idempotent and cheap to call.
+ */
+export const ensureMapUpsertPolyfill = (): void => {
+  if (installed) return
+  installed = true
+  if (typeof Map.prototype.getOrInsertComputed !== 'function') {
+    Map.prototype.getOrInsertComputed = upsertMap
+  }
+  if (typeof WeakMap.prototype.getOrInsertComputed !== 'function') {
+    WeakMap.prototype.getOrInsertComputed = upsertWeakMap
+  }
+}

--- a/src/features/newspaper/render-pdf-page.ts
+++ b/src/features/newspaper/render-pdf-page.ts
@@ -1,7 +1,10 @@
+import { ensureMapUpsertPolyfill } from './map-upsert-polyfill'
+
 const VENDOR = '/vendor/pdf.min.mjs'
 const WORKER = '/vendor/pdf.worker.min.mjs'
 
 const loadPdfJs = async () => {
+  ensureMapUpsertPolyfill()
   // @vite-ignore
   const mod = await import(VENDOR)
   mod.GlobalWorkerOptions.workerSrc = WORKER


### PR DESCRIPTION
## Summary
- pdfjs 5.6.205 calls \`this[#fr].getOrInsertComputed(...)\` on its private font-registry Map.
- On engines that haven't shipped the TC39 "Map upserts" proposal yet (Chrome <138 / V8 <13.4), the upload crashes with \`Error: PDF cover extraction failed: this[#fr].getOrInsertComputed is not a function\` — exactly what the user saw.
- \`renderFirstPage\` now calls \`ensureMapUpsertPolyfill()\` before the dynamic pdfjs import. Polyfill installs on Map.prototype + WeakMap.prototype, idempotent.

## Test plan
- [x] 5-case vitest suite for the polyfill: missing-method, miss-insert, hit-no-refire, WeakMap parity, idempotency
- [x] vue-tsc clean
- [x] biome check clean (1 pre-existing unrelated warning)
- [ ] Re-test PDF upload in production after deploy lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)