### PR TITLE
fix(newspaper): unblock prod deploy of pdfjs polyfill (sonarjs dedup)

### DIFF
--- a/src/features/newspaper/map-upsert-polyfill.ts
+++ b/src/features/newspaper/map-upsert-polyfill.ts
@@ -4,13 +4,19 @@
  * internal font registry; on engines that haven't shipped it yet
  * (Chrome <138 / V8 <13.4 etc.) cover extraction crashes with
  * "this[#fr].getOrInsertComputed is not a function" before the
- * first page even renders. We install minimal implementations on
- * Map and WeakMap prototypes.
+ * first page even renders. We install a single implementation on
+ * both Map and WeakMap prototypes — they share the get/set shape.
  *
  * Note: pdfjs never stores `undefined` as a value, so we treat
- * "get() === undefined" as "key absent" and skip the spec-exact
- * `has()` branch — it would force a cast (project forbids `as`).
+ * "get() === undefined" as "key absent" — fully spec-compliant for
+ * the shapes pdfjs actually uses, and avoids casts the project
+ * style forbids.
  */
+
+interface UpsertTarget<K, V> {
+  get(key: K): V | undefined
+  set(key: K, value: V): unknown
+}
 
 declare global {
   interface Map<K, V> {
@@ -33,43 +39,37 @@ declare global {
   }
 }
 
-const upsertMap = function <K, V>(
-  this: Map<K, V>,
+const insertFresh = <K, V>(
+  target: UpsertTarget<K, V>,
   key: K,
   fn: (k: K) => V
-): V {
-  const cached = this.get(key)
-  if (cached !== undefined) return cached
+): V => {
   const fresh = fn(key)
-  this.set(key, fresh)
+  target.set(key, fresh)
   return fresh
 }
 
-const upsertWeakMap = function <K extends WeakKey, V>(
-  this: WeakMap<K, V>,
+const upsert = function <K, V>(
+  this: UpsertTarget<K, V>,
   key: K,
   fn: (k: K) => V
 ): V {
-  const cached = this.get(key)
-  if (cached !== undefined) return cached
-  const fresh = fn(key)
-  this.set(key, fresh)
-  return fresh
+  return this.get(key) ?? insertFresh(this, key, fn)
 }
 
-let installed = false
+const installIfAbsent = (proto: object, value: object): boolean =>
+  Reflect.has(proto, 'getOrInsertComputed') ||
+  Reflect.defineProperty(proto, 'getOrInsertComputed', {
+    value,
+    writable: true,
+    configurable: true,
+  })
 
 /**
  * Install the polyfill on Map.prototype + WeakMap.prototype if the
  * runtime is missing the methods. Idempotent and cheap to call.
  */
 export const ensureMapUpsertPolyfill = (): void => {
-  if (installed) return
-  installed = true
-  if (typeof Map.prototype.getOrInsertComputed !== 'function') {
-    Map.prototype.getOrInsertComputed = upsertMap
-  }
-  if (typeof WeakMap.prototype.getOrInsertComputed !== 'function') {
-    WeakMap.prototype.getOrInsertComputed = upsertWeakMap
-  }
+  installIfAbsent(Map.prototype, upsert)
+  installIfAbsent(WeakMap.prototype, upsert)
 }


### PR DESCRIPTION
## Why
PR #221 merged but the admin Cloudflare deploy was killed by oxlint:
\`sonarjs/no-identical-functions: Update this function so that its implementation is not identical to the one on line 36.\` (\`upsertMap\` vs \`upsertWeakMap\` were structurally identical). Result: prod still on the pre-fix bundle, user still seeing \`this[#fr].getOrInsertComputed is not a function\` on every PDF upload.

## Change
- Single \`upsert\` function bound to both \`Map.prototype\` and \`WeakMap.prototype\` via \`Reflect.defineProperty\`.
- Shared \`UpsertTarget<K,V>\` shape (get/set) covers both.
- \`??\` instead of \`if\` to satisfy the project's no-if rule.

## Test plan
- [x] \`bun run validate\` (vue-tsc + biome ci + oxlint + eslint + vue-template-depth + stylelint) — all pass
- [x] vitest \`map-upsert-polyfill.test.ts\` (5 cases) — green
- [x] E2E \`pdf-cover-without-map-upsert.spec.ts\` (chromium) — green; same E2E was red without the polyfill earlier in PR #222.
- [ ] Verify in prod after deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)