### PR TITLE
feat(admin): theme switcher in header (system/light/dark)

### DIFF
--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -54,19 +54,37 @@
   color-scheme: dark;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    --color-background: hsl(0, 0%, 100%);
-    --color-surface: hsl(0, 0%, 98%);
-    --color-surface-elevated: hsl(0, 0%, 100%);
-    --color-text-primary: hsl(0, 0%, 13%);
-    --color-text-secondary: hsl(0, 0%, 40%);
-    --color-border: hsl(0, 0%, 90%);
-    --color-accent: #c25434;
-    --color-accent-hover: #a84428;
+/*
+ * Light tokens. Apply on:
+ *   1. OS preference when no explicit override is set, AND
+ *   2. when the user pinned `light` via the in-app switcher
+ *      (`<html data-theme="light">`).
+ *
+ * `<html data-theme="dark">` keeps the :root dark defaults above —
+ * no separate block needed. `<html data-theme="system">` removes the
+ * attribute, falling back to the media query.
+ */
+@mixin light-tokens {
+  --color-background: hsl(0, 0%, 100%);
+  --color-surface: hsl(0, 0%, 98%);
+  --color-surface-elevated: hsl(0, 0%, 100%);
+  --color-text-primary: hsl(0, 0%, 13%);
+  --color-text-secondary: hsl(0, 0%, 40%);
+  --color-border: hsl(0, 0%, 90%);
+  --color-accent: #c25434;
+  --color-accent-hover: #a84428;
 
-    color-scheme: light;
+  color-scheme: light;
+}
+
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme]) {
+    @include light-tokens;
   }
+}
+
+:root[data-theme='light'] {
+  @include light-tokens;
 }
 
 /* Backwards compatibility aliases */

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -10,6 +10,7 @@ import AppMain from './AppMain.vue'
 import AuthButton from './AuthButton.vue'
 import DeployStatusBar from './DeployStatus/DeployStatusBar.vue'
 import MobileMenu from './MobileMenu/MobileMenu.vue'
+import ThemeToggle from './ThemeToggle.vue'
 
 const slots = useSlots()
 const entries = inject(
@@ -36,6 +37,7 @@ const hash = __COMMIT_HASH__
   <AppHeader>
     <PushSyncBadge />
     <NotificationIndicator />
+    <ThemeToggle />
     <AuthButton />
   </AppHeader>
 

--- a/src/components/ThemeToggle.vue
+++ b/src/components/ThemeToggle.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { Match } from 'effect'
+import { computed } from 'vue'
+import { useTheme } from '@/composables/useTheme'
+import MoonIcon from './ThemeToggle/MoonIcon.vue'
+import SunIcon from './ThemeToggle/SunIcon.vue'
+import SystemIcon from './ThemeToggle/SystemIcon.vue'
+
+const { mode, next } = useTheme()
+
+const label = computed(() =>
+  Match.value(mode.value).pipe(
+    Match.when('system', () => 'Theme: system (click for light)'),
+    Match.when('light', () => 'Theme: light (click for dark)'),
+    Match.orElse(() => 'Theme: dark (click for system)')
+  )
+)
+
+const icon = computed(() =>
+  Match.value(mode.value).pipe(
+    Match.when('light', () => SunIcon),
+    Match.when('dark', () => MoonIcon),
+    Match.orElse(() => SystemIcon)
+  )
+)
+</script>
+
+<template>
+  <button
+    type="button"
+    class="theme-toggle"
+    :aria-label="label"
+    :title="label"
+    :data-mode="mode"
+    @click="next"
+  >
+    <component :is="icon" />
+  </button>
+</template>
+
+<style scoped>
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.theme-toggle:hover {
+  background: var(--color-surface-elevated);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/ThemeToggle/MoonIcon.vue
+++ b/src/components/ThemeToggle/MoonIcon.vue
@@ -1,0 +1,14 @@
+<template>
+  <svg
+    class="icon"
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    aria-hidden="true"
+  >
+    <path
+      d="M21 12.8A8.5 8.5 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"
+      fill="currentColor"
+    />
+  </svg>
+</template>

--- a/src/components/ThemeToggle/SunIcon.vue
+++ b/src/components/ThemeToggle/SunIcon.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import SunRays from './SunRays.vue'
+</script>
+
+<template>
+  <svg
+    class="icon"
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="4" fill="currentColor" />
+    <SunRays />
+  </svg>
+</template>

--- a/src/components/ThemeToggle/SunRays.vue
+++ b/src/components/ThemeToggle/SunRays.vue
@@ -1,0 +1,16 @@
+<template>
+  <g
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+  >
+    <line x1="12" y1="2" x2="12" y2="5" />
+    <line x1="12" y1="19" x2="12" y2="22" />
+    <line x1="2" y1="12" x2="5" y2="12" />
+    <line x1="19" y1="12" x2="22" y2="12" />
+    <line x1="4.5" y1="4.5" x2="6.6" y2="6.6" />
+    <line x1="17.4" y1="17.4" x2="19.5" y2="19.5" />
+    <line x1="4.5" y1="19.5" x2="6.6" y2="17.4" />
+    <line x1="17.4" y1="6.6" x2="19.5" y2="4.5" />
+  </g>
+</template>

--- a/src/components/ThemeToggle/SystemIcon.vue
+++ b/src/components/ThemeToggle/SystemIcon.vue
@@ -1,0 +1,19 @@
+<template>
+  <svg
+    class="icon"
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    aria-hidden="true"
+  >
+    <circle
+      cx="12"
+      cy="12"
+      r="9"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+    />
+    <path d="M12 3a9 9 0 0 1 0 18z" fill="currentColor" />
+  </svg>
+</template>

--- a/src/composables/useTheme/apply.test.ts
+++ b/src/composables/useTheme/apply.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { applyTheme } from './apply'
+
+describe('applyTheme', () => {
+  const root = globalThis.document.documentElement
+
+  beforeEach(() => {
+    root.removeAttribute('data-theme')
+  })
+
+  afterEach(() => {
+    root.removeAttribute('data-theme')
+  })
+
+  it('removes data-theme on "system"', () => {
+    root.setAttribute('data-theme', 'light')
+    applyTheme('system')
+    expect(root.hasAttribute('data-theme')).toBe(false)
+  })
+
+  it('sets data-theme="light" on "light"', () => {
+    applyTheme('light')
+    expect(root.getAttribute('data-theme')).toBe('light')
+  })
+
+  it('sets data-theme="dark" on "dark"', () => {
+    applyTheme('dark')
+    expect(root.getAttribute('data-theme')).toBe('dark')
+  })
+})

--- a/src/composables/useTheme/apply.ts
+++ b/src/composables/useTheme/apply.ts
@@ -1,0 +1,24 @@
+import { Match } from 'effect'
+import type { ThemeMode } from './types'
+
+const ATTR = 'data-theme'
+
+/**
+ * Reflect the current theme choice on the document root.
+ *
+ * - `system` removes the attribute so `prefers-color-scheme` rules
+ *   in `_variables.scss` take over.
+ * - `light` / `dark` sets `data-theme="light|dark"` to override.
+ *
+ * Safe to call before app mount — runs synchronously against
+ * `document.documentElement`. Becomes a no-op outside the browser.
+ *
+ * @param mode - The mode to apply
+ */
+export const applyTheme = (mode: ThemeMode): void => {
+  const root = globalThis.document?.documentElement
+  void Match.value(mode).pipe(
+    Match.when('system', () => root?.removeAttribute(ATTR)),
+    Match.orElse(m => root?.setAttribute(ATTR, m))
+  )
+}

--- a/src/composables/useTheme/index.ts
+++ b/src/composables/useTheme/index.ts
@@ -1,0 +1,4 @@
+export { applyTheme } from './apply'
+export { readStoredTheme } from './storage'
+export type { ThemeMode } from './types'
+export { useTheme } from './useTheme'

--- a/src/composables/useTheme/storage.test.ts
+++ b/src/composables/useTheme/storage.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { readStoredTheme, writeStoredTheme } from './storage'
+
+describe('useTheme storage', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear()
+  })
+
+  it('returns "system" when nothing stored', () => {
+    expect(readStoredTheme()).toBe('system')
+  })
+
+  it('round-trips a stored value', () => {
+    writeStoredTheme('dark')
+    expect(readStoredTheme()).toBe('dark')
+  })
+
+  it('falls back to "system" on a malformed value', () => {
+    globalThis.localStorage.setItem('admin_theme', 'neon-pink')
+    expect(readStoredTheme()).toBe('system')
+  })
+})

--- a/src/composables/useTheme/storage.ts
+++ b/src/composables/useTheme/storage.ts
@@ -1,0 +1,23 @@
+import type { ThemeMode } from './types'
+
+const KEY = 'admin_theme'
+
+const isMode = (v: string): v is ThemeMode =>
+  v === 'system' || v === 'light' || v === 'dark'
+
+/**
+ * Read the stored theme preference from localStorage.
+ * @returns The stored mode, or `system` if absent or malformed
+ */
+export const readStoredTheme = (): ThemeMode => {
+  const raw = globalThis.localStorage?.getItem(KEY) ?? undefined
+  return raw !== undefined && isMode(raw) ? raw : 'system'
+}
+
+/**
+ * Persist the theme preference to localStorage.
+ * @param mode - The mode to store
+ */
+export const writeStoredTheme = (mode: ThemeMode): void => {
+  globalThis.localStorage?.setItem(KEY, mode)
+}

--- a/src/composables/useTheme/types.ts
+++ b/src/composables/useTheme/types.ts
@@ -1,0 +1,5 @@
+/**
+ * Three-state theme preference. `system` follows
+ * `prefers-color-scheme`, the other two pin a value regardless of OS.
+ */
+export type ThemeMode = 'system' | 'light' | 'dark'

--- a/src/composables/useTheme/useTheme.ts
+++ b/src/composables/useTheme/useTheme.ts
@@ -1,0 +1,32 @@
+import { Match } from 'effect'
+import { ref } from 'vue'
+import { applyTheme } from './apply'
+import { readStoredTheme, writeStoredTheme } from './storage'
+import type { ThemeMode } from './types'
+
+const mode = ref<ThemeMode>(readStoredTheme())
+
+const cycle = (current: ThemeMode): ThemeMode =>
+  Match.value(current).pipe(
+    Match.when('system', () => 'light' as const),
+    Match.when('light', () => 'dark' as const),
+    Match.orElse(() => 'system' as const)
+  )
+
+const set = (next: ThemeMode): void => {
+  mode.value = next
+  writeStoredTheme(next)
+  applyTheme(next)
+}
+
+/**
+ * Read/write the admin's three-state theme preference. Backed by
+ * localStorage; reflected on the document root via `data-theme`.
+ *
+ * @returns The reactive mode plus setter and cycler
+ */
+export const useTheme = () => ({
+  mode,
+  set,
+  next: () => set(cycle(mode.value)),
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,10 @@
 import './assets/styles/index.scss'
 
 import { createApp } from './app'
+import { applyTheme, readStoredTheme } from './composables/useTheme'
 import { vChildren } from './directives/render'
+
+applyTheme(readStoredTheme())
 
 const { app } = createApp()
 


### PR DESCRIPTION
## Summary
Adds a 3-state theme toggle next to AuthButton — cycle: system → light → dark → system. Persisted in localStorage, applied via \`<html data-theme>\` before mount (no FOUC).

## How
- \`composables/useTheme/\` — storage / apply / hook split
- \`_variables.scss\` — light tokens in a mixin used by both \`prefers-color-scheme: light\` (no override) and \`:root[data-theme=\"light\"]\` (override)
- \`main.ts\` boots theme before \`createApp\`
- ThemeToggle.vue + sub-components (Sun/Moon/System icons + SunRays group) to keep template depth ≤ 2

## Test plan
- [x] vitest \`useTheme\` (6 cases) green
- [x] full \`bun run validate\` clean (vue-tsc + biome + oxlint + eslint + vue-template-depth + stylelint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)