### PR TITLE
feat(newspaper): use issue slug as PDF/FB2 filename

### DIFF
--- a/src/components/MarkdownEditor/DocxUpload.vue
+++ b/src/components/MarkdownEditor/DocxUpload.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
+import { buildDocxMeta } from './docx-meta'
 import { docxFileToFb2 } from './docx-to-fb2'
 import { createDragHandlers } from './pdf-upload-handlers'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
+  readonly slug: string
   readonly issueTitle?: string
   readonly issueLang?: string
   readonly issueDescription?: string
@@ -37,13 +39,7 @@ const handleFile = async (file: File): Promise<void> => {
     emit('error', 'Only .docx files (Office Open XML) are accepted here')
     return
   }
-  const fb2 = await docxFileToFb2(file, {
-    ...(props.issueTitle === undefined ? {} : { issueTitle: props.issueTitle }),
-    ...(props.issueLang === undefined ? {} : { issueLang: props.issueLang }),
-    ...(props.issueDescription === undefined
-      ? {}
-      : { issueDescription: props.issueDescription }),
-  })
+  const fb2 = await docxFileToFb2(file, buildDocxMeta(props))
   emit('upload-fb2', fb2)
 }
 

--- a/src/components/MarkdownEditor/Fb2Upload.vue
+++ b/src/components/MarkdownEditor/Fb2Upload.vue
@@ -5,6 +5,7 @@ import { createDragHandlers } from './pdf-upload-handlers'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
+  readonly slug: string
 }>()
 
 const emit = defineEmits<{
@@ -36,7 +37,7 @@ const handleFile = (file: File): void => {
     emit('error', 'Only .fb2 files are accepted here')
     return
   }
-  const renamed = new File([file], 'gazette.fb2', {
+  const renamed = new File([file], `${props.slug}.fb2`, {
     type: file.type || 'application/x-fictionbook+xml',
   })
   emit('upload-fb2', renamed)

--- a/src/components/MarkdownEditor/NewspaperSourceUploads.vue
+++ b/src/components/MarkdownEditor/NewspaperSourceUploads.vue
@@ -10,6 +10,7 @@ defineProps<{
   readonly currentCover?: string
   readonly issueTitle?: string
   readonly issueLang?: string
+  readonly slug: string
 }>()
 
 defineEmits<{
@@ -36,6 +37,7 @@ const HINT =
     />
     <DocxUpload
       :assets="assets"
+      :slug="slug"
       :issue-title="issueTitle"
       :issue-lang="issueLang"
       @upload-fb2="$emit('upload-asset', $event)"
@@ -43,6 +45,7 @@ const HINT =
     />
     <Fb2Upload
       :assets="assets"
+      :slug="slug"
       @upload-fb2="$emit('upload-asset', $event)"
       @error="$emit('error', $event)"
     />

--- a/src/components/MarkdownEditor/docx-meta.ts
+++ b/src/components/MarkdownEditor/docx-meta.ts
@@ -1,0 +1,26 @@
+import type { IssueMeta } from './docx-to-fb2'
+
+interface DocxUploadProps {
+  readonly slug: string
+  readonly issueTitle?: string
+  readonly issueLang?: string
+  readonly issueDescription?: string
+}
+
+/**
+ * Build the IssueMeta payload passed to `docxFileToFb2`, omitting
+ * undefined fields so optional metadata stays absent in the FB2
+ * description rather than appearing as the literal string
+ * "undefined".
+ *
+ * @param props - DocxUpload component props
+ * @returns IssueMeta with only defined fields
+ */
+export const buildDocxMeta = (props: DocxUploadProps): IssueMeta => ({
+  slug: props.slug,
+  ...(props.issueTitle === undefined ? {} : { issueTitle: props.issueTitle }),
+  ...(props.issueLang === undefined ? {} : { issueLang: props.issueLang }),
+  ...(props.issueDescription === undefined
+    ? {}
+    : { issueDescription: props.issueDescription }),
+})

--- a/src/components/MarkdownEditor/docx-to-fb2.ts
+++ b/src/components/MarkdownEditor/docx-to-fb2.ts
@@ -3,6 +3,7 @@ import { htmlToFb2 } from '@/features/newspaper/html-to-fb2/html-to-fb2'
 
 /** Issue metadata baked into the FB2 description block. */
 export interface IssueMeta {
+  readonly slug: string
   readonly issueTitle?: string
   readonly issueLang?: string
   readonly issueDescription?: string
@@ -21,8 +22,8 @@ const buildFb2Meta = (meta: IssueMeta) => ({
  * itself is never persisted — we only emit the converted FB2.
  *
  * @param file Original `.docx` File from the upload widget.
- * @param meta Issue metadata to bake into the FB2 title-info block.
- * @returns A `gazette.fb2` File ready to feed the asset pipeline.
+ * @param meta Issue metadata + slug used as the output filename.
+ * @returns A `<slug>.fb2` File ready to feed the asset pipeline.
  */
 export const docxFileToFb2 = async (
   file: File,
@@ -32,5 +33,5 @@ export const docxFileToFb2 = async (
   const html = await convertDocxToHtml(buffer)
   const fb2 = htmlToFb2(html, buildFb2Meta(meta))
   const blob = new Blob([fb2], { type: 'application/x-fictionbook+xml' })
-  return new File([blob], 'gazette.fb2', { type: blob.type })
+  return new File([blob], `${meta.slug}.fb2`, { type: blob.type })
 }

--- a/src/views/ContentEditView/EditBodyArea.vue
+++ b/src/views/ContentEditView/EditBodyArea.vue
@@ -35,8 +35,9 @@ const fmString = (key: string): string | undefined => {
 <template>
   <section class="edit-body-area">
     <NewspaperSourceUploads
-      v-if="isNewspaper(contentType)"
+      v-if="isNewspaper(contentType) && slug"
       :assets="assets"
+      :slug="slug"
       :current-cover="fmString('image')"
       :issue-title="fmString('title')"
       :issue-lang="fmString('lang')"


### PR DESCRIPTION
## Summary
- Drops the hardcoded \`gazette.fb2\` filename in \`Fb2Upload.vue\` (line 39) and \`docx-to-fb2.ts\` (line 35) — both now use \`<slug>.fb2\`.
- Plumbs \`slug\` from \`EditBodyArea.vue\` → \`NewspaperSourceUploads.vue\` → \`DocxUpload.vue\` + \`Fb2Upload.vue\`.
- Extracts \`buildDocxMeta\` to keep DocxUpload's script under the 50-line budget.

## Companion PR
- \`public-website#TBD\` — drops the matching hardcoded \`gazette.{pdf,fb2}\` URL on the public site, switches to auto-discovery by extension so legacy issues with \`gazette.pdf\` keep working.

## Test plan
- [x] \`bun run validate\` — clean (vue-tsc + biome + oxlint + eslint + vue-template-depth + stylelint)
- [x] PdfUpload + cover-race + dedup-pending + transactional-save tests still green
- [ ] Re-upload a fresh fb2 on a new issue post-merge and confirm the asset is named after the slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)