### PR TITLE
test(settings): mock seed fan-out to unblock master deploy

### DIFF
--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -83,6 +83,17 @@ describe('useSettingsStore', () => {
       json: async () => ({ content: { sha: 'sha2' } }),
     })
 
+    /* `updateLanguages` fans out to `seedNewLanguages` via
+     * `fireAndForward` — that path now surfaces rejections to the
+     * unhandled-rejection event, so the GET /api/github/content/...
+     * calls it makes need a default mock. Empty `items` short-
+     * circuits the seed; the test still asserts the SHA path on the
+     * Save call (mock.calls[1]). */
+    mockSwFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    })
+
     const newLangs = [
       { code: 'en', label: 'English' },
       { code: 'de', label: 'Deutsch' },


### PR DESCRIPTION
Hot-fix: master deploy after #226 went red on a post-tests unhandled
rejection.

\`fireAndForward(seedNewLanguages(...))\` in updateLanguages now
forwards rejections to \`unhandledrejection\` (intentionally — it's
how the silent-catch antipattern dies). The test mocked only the
load + save \`swFetch\` calls; the seed fan-out's GET
\`/api/github/content/...\` returned undefined and threw
\`Cannot read properties of undefined (reading 'ok')\` in vitest's
post-tests phase even though all 663 tests passed.

Mock \`swFetch\` default to return \`{ items: [] }\` — seed short-
circuits cleanly. SHA assertion still hits mock.calls[1].

🤖 Generated with [Claude Code](https://claude.com/claude-code)