### PR TITLE
fix(editor): newspaper edit mobile overflow (ArticlesPicker)

### DIFF
--- a/e2e-realmode/fixtures/baseline/blog/programme-outline-introduction/index.en.md
+++ b/e2e-realmode/fixtures/baseline/blog/programme-outline-introduction/index.en.md
@@ -1,0 +1,12 @@
+---
+title: Programme outline introduction
+description: Long-slug fixture for the mobile-overflow regression test.
+category: general
+lang: en
+published: true
+publishDate: 2026-01-01
+---
+
+# Programme outline introduction
+
+Long-slug fixture used to surface ArticlesPicker overflow on narrow viewports.

--- a/e2e-realmode/fixtures/baseline/newspaper/issue-1/index.en.md
+++ b/e2e-realmode/fixtures/baseline/newspaper/issue-1/index.en.md
@@ -4,8 +4,14 @@ description: Baseline newspaper issue used by real-mode E2E.
 lang: en
 published: true
 publishDate: 2026-01-01
+articles:
+  - welcome
+  - programme-outline-introduction
 ---
 
 # Sandbox issue 1
 
-Baseline content. Restored before every real-mode test run.
+Baseline content. Restored before every real-mode test run. The
+`articles` list intentionally references a long-slug entry so the
+mobile-overflow regression test can surface ArticlesPicker layout
+breakage.

--- a/e2e-realmode/mobile-overflow.spec.ts
+++ b/e2e-realmode/mobile-overflow.spec.ts
@@ -1,0 +1,52 @@
+import { devices } from '@playwright/test'
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit'
+import { bootRealmode, SLOW } from './helpers/realmode-page'
+import { resetSandboxBaseline } from './helpers/reset-baseline'
+
+const TARGET = '/content/newspaper/edit/issue-1'
+
+test.use(devices['iPhone 12 Pro'])
+
+test.beforeEach(async () => {
+  await resetSandboxBaseline()
+})
+
+/* User report (2026-05-10): newspaper edit page on mobile renders
+ * ~840 px wide (more than 2× the 390 px viewport). Root cause was a
+ * missing `min-width: 0` on `.frontmatter-editor` paired with a
+ * `.slug` flex item that refused to shrink in `LinkedArticleRow`.
+ * Long Russian article slugs in the issue's `articles` list pushed
+ * the row past the viewport and the whole frontmatter section
+ * inherited the bloat.
+ *
+ * This test pins the layout: at iPhone 12 Pro width the document
+ * must not scroll horizontally. The baseline `issue-1` deliberately
+ * lists `programme-outline-introduction` (a 30-char slug) so the
+ * overflow surface is real, not synthetic. */
+test('mobile: newspaper edit fits the viewport horizontally', async ({
+  page,
+}) => {
+  test.setTimeout(180_000)
+  await bootRealmode(page, 'mobile-newspaper')
+  await visit(page, TARGET, SLOW)
+  await expectVisible(page, page.locator('input#fm-title'), SLOW)
+  /* The articles picker must have rendered before we measure —
+   * its rows are the widest content on this page. */
+  await expectVisible(
+    page,
+    page.locator('[data-testid^="linked-"]').first(),
+    SLOW
+  )
+
+  const widths = await page.evaluate(() => ({
+    inner: window.innerWidth,
+    doc: document.documentElement.scrollWidth,
+    body: document.body.scrollWidth,
+  }))
+
+  expect(
+    widths.doc,
+    `document scroll width (${widths.doc}) must not exceed viewport (${widths.inner}) on mobile`
+  ).toBeLessThanOrEqual(widths.inner + 1)
+  expect(widths.body).toBeLessThanOrEqual(widths.inner + 1)
+})

--- a/src/components/MarkdownEditor/ArticlesPicker/LinkedArticleRow.vue
+++ b/src/components/MarkdownEditor/ArticlesPicker/LinkedArticleRow.vue
@@ -17,8 +17,8 @@ defineEmits<{
 <template>
   <li class="linked-row" :data-testid="`linked-${slug}`">
     <span class="position">{{ position }}.</span>
-    <span class="title">{{ title }}</span>
-    <code class="slug">{{ slug }}</code>
+    <span class="title" :title="title">{{ title }}</span>
+    <code class="slug" :title="slug">{{ slug }}</code>
     <button
       type="button"
       class="row-btn"
@@ -59,6 +59,12 @@ defineEmits<{
   border-radius: var(--radius-sm);
   background: var(--color-background-soft);
   font-size: 0.875rem;
+
+  /* Long slugs / titles must not push the row past the viewport.
+   * Without `min-width: 0` flex children compute their hypothetical
+   * size from their content, the row hugs the widest piece, and the
+   * whole frontmatter editor overflows on mobile. */
+  min-width: 0;
 }
 
 .position {
@@ -77,10 +83,28 @@ defineEmits<{
 }
 
 .slug {
-  flex-shrink: 0;
+  /* Was `flex-shrink: 0` — kept the full slug visible at any cost,
+   * which broke 390-wide layouts whenever slugs were long
+   * (`programme-outline-intro` etc.). Allow shrinking + ellipsis so
+   * the row stays inside the viewport; full slug surfaces via the
+   * native title tooltip on hover. */
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--color-text-secondary);
   font-family: var(--font-mono, monospace);
   font-size: 0.75rem;
+}
+
+/* Drop the slug entirely on the smallest viewports — title carries
+ * enough information for the editor and the slug is still on the
+ * detail page. */
+@media (width <= 480px) {
+  .slug {
+    display: none;
+  }
 }
 
 .row-btn {

--- a/src/components/MarkdownEditor/FrontmatterEditor.vue
+++ b/src/components/MarkdownEditor/FrontmatterEditor.vue
@@ -50,6 +50,16 @@ const handleFieldUpdate = (key: string, value: unknown) => {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   padding: clamp(0.75rem, 2vw, 1rem);
+
+  /* Without `min-width: 0`, a flex item's hypothetical size is at
+   * least its `min-content` — which for newspaper issues with long
+   * Russian article slugs in ArticlesPicker pushes the fieldset
+   * past the viewport. The parent `.edit-main` is constrained but
+   * can't force this child to shrink without it. Same trick on the
+   * inner LinkedArticleRow scope. */
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 legend {


### PR DESCRIPTION
## What

User reported: newspaper edit page on mobile renders ~840 px wide on
a 390 px viewport. Frontmatter fieldset, inputs, articles picker —
everything overflows. Workflow unusable on a phone.

## Root cause

Two flex-layout traps stacked. \`.frontmatter-editor\` (FIELDSET
inside \`.edit-main\`'s flex column) defaulted to \`min-width: auto\`,
so for newspaper issues with long unbreakable article slugs the
min-content was wider than the parent and the fieldset escaped its
constraint. Inside, \`.linked-row .slug\` was \`flex-shrink: 0\` —
long Russian slugs (\`programme-outline-introduction\`, etc.) pushed
each row past the viewport, cascading up the layout tree.

## Fix

- \`.frontmatter-editor { min-width: 0; width: 100%; box-sizing:
  border-box }\` — fieldset stays within parent now.
- \`.linked-row .slug { flex-shrink: 1; min-width: 0; overflow:
  hidden; text-overflow: ellipsis }\` + \`@media (max-width: 480px)\`
  hides slug entirely on small viewports. Title is enough; full slug
  surfaces via the tooltip on hover.

## Tests

- New \`e2e-realmode/mobile-overflow.spec.ts\` runs at iPhone 12 Pro
  and asserts \`documentElement.scrollWidth <= innerWidth\` on the
  newspaper edit page. Without the CSS fix the test goes red
  (doc=835, viewport=390); with the fix, green.
- Baseline \`newspaper/issue-1\` now lists \`articles:
  - welcome
  - programme-outline-introduction\` so the picker has rows to
  measure. Added the matching baseline blog entry.

## Verify after merge

Open dev/prod-admin in a phone-sized window, navigate to
\`/content/newspaper/edit/<any issue with articles>\`. Page must fit
the viewport with no horizontal scroll. Tooltips on truncated titles
still surface the full slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)