### PR TITLE
fix(editor): visible feedback when clicking a dimmed language tab

### DIFF
--- a/e2e-realmode/lang-switch.spec.ts
+++ b/e2e-realmode/lang-switch.spec.ts
@@ -88,6 +88,36 @@ test('lang-switch newspaper: existing → dimmed preserves frontmatter', async (
   ).toBe('Sandbox issue 1')
 })
 
+/* The active language button must never carry the `dimmed` class
+ * even when the file does not yet exist. Otherwise the click
+ * produces ~50%-opacity heading-coloured feedback that reads as
+ * "nothing happened" on mobile (2026-05-10 user report:
+ * "кликаю кликаю и нихуя не открывается"). Pair the visual-state
+ * fix with an explicit "no XYZ version yet" hint below the tabs so
+ * the user sees a concrete affordance instead of guessing. */
+test('lang-switch newspaper: active button drops the dimmed modifier + missing-translation hint shows', async ({
+  page,
+}) => {
+  test.setTimeout(180_000)
+  wirePageLog(page, 'lang-switch-active-vis')
+  await bootRealmode(page, 'lang-switch-active-vis')
+  await visit(page, TARGET, SLOW)
+  await expectVisible(page, titleField(page), SLOW)
+
+  await langButton(page, 'Italiano').click()
+  await expectVisible(page, langButton(page, 'Italiano'), SLOW)
+  const klass =
+    (await langButton(page, 'Italiano').getAttribute('class')) ?? ''
+  expect(klass, `Italiano class is "${klass}"`).toContain('active')
+  expect(klass, 'active button must not carry dimmed').not.toContain('dimmed')
+
+  /* Hint is the unmistakable signal "yes you switched, but no file
+   * yet — type and Save". */
+  const hint = page.locator('[data-testid="missing-translation-hint"]')
+  await expectVisible(page, hint, SLOW)
+  await expect(hint).toContainText('Italiano')
+})
+
 /* Repro of the 2026-05-10 prod report: opening a single-lang issue
  * (only RU exists, EN dimmed), clicking English clears the title
  * field on prod even though seedFromCurrent's contract says

--- a/src/components/LanguageSelector/LanguageSelector.vue
+++ b/src/components/LanguageSelector/LanguageSelector.vue
@@ -15,13 +15,29 @@ const emit = defineEmits<{
 const settings = useSettingsStore()
 onMounted(() => settings.ensureLoaded())
 
-const langButtonClass = (code: Language) => ({
-  active: props.modelValue === code,
-  exists: props.availableLanguages?.has(code) ?? false,
-  dimmed:
-    props.availableLanguages !== undefined &&
-    !props.availableLanguages.has(code),
-})
+const langButtonClass = (code: Language) => {
+  const isActive = props.modelValue === code
+  const exists = props.availableLanguages?.has(code) ?? false
+  /* `dimmed` purely indicates "no file yet for this lang". Once
+   * the user clicks a dimmed tab, `isActive` overrides — otherwise
+   * .active.dimmed combine to ~50% opacity heading-coloured text,
+   * which on mobile reads as "click did nothing". The user kept
+   * tapping Italian and seeing no visible change (2026-05-10
+   * report). Active always wins on visibility. */
+  return {
+    active: isActive,
+    exists,
+    dimmed: !isActive && props.availableLanguages !== undefined && !exists,
+  }
+}
+
+const isMissingTranslation = (): boolean =>
+  props.availableLanguages !== undefined &&
+  !props.availableLanguages.has(props.modelValue)
+
+const activeLabel = (): string =>
+  settings.languages.find(l => l.code === props.modelValue)?.label ??
+  props.modelValue
 </script>
 
 <template>
@@ -37,6 +53,14 @@ const langButtonClass = (code: Language) => ({
     >
       {{ entry.label }}
     </button>
+    <p
+      v-if="isMissingTranslation()"
+      class="missing-hint"
+      data-testid="missing-translation-hint"
+    >
+      No {{ activeLabel() }} version yet — fill in the metadata and Save
+      to create one.
+    </p>
   </fieldset>
 </template>
 
@@ -84,5 +108,14 @@ const langButtonClass = (code: Language) => ({
   &.dimmed {
     opacity: 50%;
   }
+}
+
+.missing-hint {
+  flex-basis: 100%;
+  margin: 0.25rem 0 0;
+  padding: 0.25rem 0.5rem;
+  font-size: clamp(0.75rem, 1.5vw, 0.875rem);
+  color: var(--color-text-secondary);
+  font-style: italic;
 }
 </style>


### PR DESCRIPTION
## What

User report (2026-05-10): \"кликаю кликаю и нихуя не открывается\".
Opened a single-lang newspaper issue (only RU file), tapped Italian,
nothing visible happened — the user kept tapping the same button
expecting the click to do something.

## Why

The click *was* working (#228 made sure of it), but the UI gave no
usable feedback on mobile:

1. CSS combined \`.active\` (muted background + heading colour) with
   \`.dimmed\` (50 % opacity) — net result is the heading text at half
   opacity, which on a 390 px screen reads as \"nothing changed\".
2. No explicit \"you switched but no file yet\" cue. The user had no
   way to know the click did anything.

## Fix

- \`langButtonClass\` drops \`dimmed\` whenever the lang is active.
  Active tabs are always 100 % opacity; inactive tabs without a file
  stay dimmed as before.
- A \`<p data-testid=\"missing-translation-hint\">\` renders below
  the tab strip whenever the active lang has no file:
  \"No Italiano version yet — fill in the metadata and Save to
  create one.\" That's the affordance the user was looking for.

## Tests

\`lang-switch.spec.ts:lang-switch newspaper: active button drops
the dimmed modifier + missing-translation hint shows\` — asserts
both the active button's class and the hint visibility. Without the
fix the test goes red on the class assertion (Italian carries
\`active dimmed\`).

## After merge

prod-admin auto-deploys. Verify on mobile: open
\`/content/newspaper/edit/magazine-1-mai-2026\`, tap Italian → button
becomes solid, hint reads \"No Italiano version yet …\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)