### PR TITLE
feat(newspaper): per-language PDF/FB2/cover assets

### DIFF
--- a/e2e-realmode/README.md
+++ b/e2e-realmode/README.md
@@ -55,7 +55,7 @@ not enough.
 | `delete-all-langs.spec.ts` | Card → Delete → "Delete all languages" removes the whole slug directory |
 | `rename-blog.spec.ts` | Inline slug rename rewrites the directory in a single commit |
 | `asset-upload.spec.ts` | Asset picker stages a binary, Save commits to `blog/<slug>/assets/<file>.png` |
-| `newspaper-fb2.spec.ts` | FB2 dropzone commits `newspaper/<slug>/assets/<slug>.fb2`, and the issue index passes astro's newspaper schema |
+| `newspaper-fb2.spec.ts` | FB2 dropzone commits `newspaper/<slug>/assets/<slug>.<lang>.fb2`, and the issue index passes astro's newspaper schema |
 | `schema-gate.spec.ts` | SW rejects writes whose filename lang is outside `supportedLangs`, and writes whose frontmatter `lang` disagrees with the filename |
 | `astro-schema-drift.spec.ts` | Vendored astro mirror has the same collection + field set as upstream `public-website/src/content.config.ts` |
 

--- a/e2e-realmode/newspaper-fb2.spec.ts
+++ b/e2e-realmode/newspaper-fb2.spec.ts
@@ -13,7 +13,7 @@ test.beforeEach(async () => {
   await resetSandboxBaseline()
 })
 
-test('newspaper FB2 upload commits sources to assets/<slug>.fb2', async ({
+test('newspaper FB2 upload commits sources to assets/<slug>.<lang>.fb2', async ({
   page,
 }) => {
   test.setTimeout(180_000)
@@ -28,9 +28,12 @@ test('newspaper FB2 upload commits sources to assets/<slug>.fb2', async ({
     SLOW
   )
 
-  /* Fb2Upload renames any uploaded file to `<slug>.fb2` regardless
-   * of the source filename — committing that exact name is the
-   * regression contract (#225 broke this once already). */
+  /* Fb2Upload renames any uploaded file to `<slug>.<lang>.fb2`
+   * regardless of the source filename — committing that exact name
+   * is the regression contract (#225 broke this once already, and
+   * #231 made it per-lang so EN and IT can coexist). The default
+   * lang on `/content/newspaper/edit/...` is EN, so the expected
+   * path is `<slug>.en.fb2`. */
   await page
     .locator('[data-testid="fb2-dropzone"] + input[type="file"]')
     .setInputFiles({
@@ -45,7 +48,7 @@ test('newspaper FB2 upload commits sources to assets/<slug>.fb2', async ({
   const shaAfter = await waitForHeadAdvance(shaBefore)
   expect(shaAfter).not.toBe(shaBefore)
 
-  const path = `newspaper/${SLUG}/assets/${SLUG}.fb2`
+  const path = `newspaper/${SLUG}/assets/${SLUG}.en.fb2`
   const remote = await readFile(path)
   expect(remote, `${path} must exist on sandbox`).toBeTruthy()
   expect(remote).toContain('FictionBook')

--- a/src/components/MarkdownEditor/DocxUpload.vue
+++ b/src/components/MarkdownEditor/DocxUpload.vue
@@ -4,10 +4,12 @@ import type { AssetDisplay } from '@/composables/useAssets/types'
 import { buildDocxMeta } from './docx-meta'
 import { docxFileToFb2 } from './docx-to-fb2'
 import { createDragHandlers } from './pdf-upload-handlers'
+import { matchesSource, sourceName } from './source-asset-naming'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
   readonly slug: string
+  readonly lang: string
   readonly issueTitle?: string
   readonly issueLang?: string
   readonly issueDescription?: string
@@ -25,9 +27,7 @@ const DOCX_MIME =
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
 
 const fb2Asset = computed(() =>
-  props.assets?.find(
-    a => a.name.toLowerCase().endsWith('.fb2') && a.status !== 'pending-delete'
-  )
+  props.assets?.find(a => matchesSource(a, props.slug, props.lang, 'fb2'))
 )
 
 const triggerUpload = () => {
@@ -40,7 +40,9 @@ const handleFile = async (file: File): Promise<void> => {
     return
   }
   const fb2 = await docxFileToFb2(file, buildDocxMeta(props))
-  emit('upload-fb2', fb2)
+  emit('upload-fb2', new File([fb2], sourceName(props.slug, props.lang, 'fb2'), {
+    type: fb2.type || 'application/x-fictionbook+xml',
+  }))
 }
 
 const handleChange = (event: Event): void => {

--- a/src/components/MarkdownEditor/Fb2Upload.vue
+++ b/src/components/MarkdownEditor/Fb2Upload.vue
@@ -2,10 +2,12 @@
 import { computed, ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import { createDragHandlers } from './pdf-upload-handlers'
+import { matchesSource, sourceName } from './source-asset-naming'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
   readonly slug: string
+  readonly lang: string
 }>()
 
 const emit = defineEmits<{
@@ -17,27 +19,19 @@ const inputRef = ref<HTMLInputElement>()
 const dragging = ref(false)
 
 const fb2Asset = computed(() =>
-  props.assets?.find(
-    a => a.name.toLowerCase().endsWith('.fb2') && a.status !== 'pending-delete'
-  )
+  props.assets?.find(a => matchesSource(a, props.slug, props.lang, 'fb2'))
 )
 
 const triggerUpload = () => {
   inputRef.value?.click()
 }
 
-/*
- * Direct FB2 upload — the editor already has the FB2 produced
- * elsewhere (Calibre, scribus → fb2, hand-written, etc.) and just
- * wants it shipped. Validates by extension since browsers don't
- * agree on a MIME for application/x-fictionbook+xml.
- */
 const handleFile = (file: File): void => {
   if (!file.name.toLowerCase().endsWith('.fb2')) {
     emit('error', 'Only .fb2 files are accepted here')
     return
   }
-  const renamed = new File([file], `${props.slug}.fb2`, {
+  const renamed = new File([file], sourceName(props.slug, props.lang, 'fb2'), {
     type: file.type || 'application/x-fictionbook+xml',
   })
   emit('upload-fb2', renamed)

--- a/src/components/MarkdownEditor/NewspaperSourceUploads.vue
+++ b/src/components/MarkdownEditor/NewspaperSourceUploads.vue
@@ -30,6 +30,8 @@ const HINT =
     <PdfUpload
       :assets="assets"
       :current-cover="currentCover"
+      :slug="slug"
+      :lang="issueLang ?? 'en'"
       @upload-pdf="$emit('upload-asset', $event)"
       @upload-cover="$emit('upload-asset', $event)"
       @set-cover="$emit('set-cover', $event)"
@@ -38,6 +40,7 @@ const HINT =
     <DocxUpload
       :assets="assets"
       :slug="slug"
+      :lang="issueLang ?? 'en'"
       :issue-title="issueTitle"
       :issue-lang="issueLang"
       @upload-fb2="$emit('upload-asset', $event)"
@@ -46,6 +49,7 @@ const HINT =
     <Fb2Upload
       :assets="assets"
       :slug="slug"
+      :lang="issueLang ?? 'en'"
       @upload-fb2="$emit('upload-asset', $event)"
       @error="$emit('error', $event)"
     />

--- a/src/components/MarkdownEditor/PdfUpload.test.ts
+++ b/src/components/MarkdownEditor/PdfUpload.test.ts
@@ -3,7 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import PdfUpload from './PdfUpload.vue'
 
-const COVER_NAME = 'cover.png'
+const PICKED_COVER = 'cover.png'
+const EMITTED_COVER = 'cover.en.png'
+const EMITTED_PDF = 'sample.en.pdf'
 
 const fakePdf = (): File =>
   new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], 'issue.pdf', {
@@ -11,7 +13,7 @@ const fakePdf = (): File =>
   })
 
 const fakeCover = (): File =>
-  new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], COVER_NAME, {
+  new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], PICKED_COVER, {
     type: 'image/png',
   })
 
@@ -50,14 +52,16 @@ describe('PdfUpload — happy path', () => {
     vi.doMock('@/features/newspaper/extract-pdf-cover', () => ({
       extractPdfCover: async () => fakeCover(),
     }))
-    const w = mount(PdfUpload, { props: {} })
+    const w = mount(PdfUpload, { props: { slug: 'sample', lang: 'en' } })
     await driveFileInput(w, fakePdf())
 
-    expect(w.emitted('upload-pdf')?.[0]?.[0]).toBeInstanceOf(File)
+    const pdfFile = w.emitted('upload-pdf')?.[0]?.[0] as File | undefined
+    expect(pdfFile).toBeInstanceOf(File)
+    expect(pdfFile?.name).toBe(EMITTED_PDF)
     const coverFile = w.emitted('upload-cover')?.[0]?.[0] as File | undefined
     expect(coverFile).toBeInstanceOf(File)
-    expect(coverFile?.name).toBe(COVER_NAME)
-    expect(w.emitted('set-cover')?.[0]?.[0]).toBe(COVER_NAME)
+    expect(coverFile?.name).toBe(EMITTED_COVER)
+    expect(w.emitted('set-cover')?.[0]?.[0]).toBe(EMITTED_COVER)
     expect(w.emitted('error')).toBeUndefined()
   })
 
@@ -66,7 +70,11 @@ describe('PdfUpload — happy path', () => {
       extractPdfCover: async () => fakeCover(),
     }))
     const w = mount(PdfUpload, {
-      props: { currentCover: './assets/custom.jpg' },
+      props: {
+        currentCover: './assets/custom.jpg',
+        slug: 'sample',
+        lang: 'en',
+      },
     })
     await driveFileInput(w, fakePdf())
 
@@ -90,7 +98,7 @@ describe('PdfUpload — error path', () => {
         throw new Error('worker fetch failed: 404')
       },
     }))
-    const w = mount(PdfUpload, { props: {} })
+    const w = mount(PdfUpload, { props: { slug: 'sample', lang: 'en' } })
     await driveFileInput(w, fakePdf())
 
     expect(w.emitted('upload-pdf')).toBeDefined()
@@ -105,7 +113,7 @@ describe('PdfUpload — error path', () => {
     vi.doMock('@/features/newspaper/extract-pdf-cover', () => ({
       extractPdfCover: async () => fakeCover(),
     }))
-    const w = mount(PdfUpload, { props: {} })
+    const w = mount(PdfUpload, { props: { slug: 'sample', lang: 'en' } })
     const fakeImage = new File(['x'], 'photo.png', { type: 'image/png' })
     await driveFileInput(w, fakeImage)
 

--- a/src/components/MarkdownEditor/PdfUpload.vue
+++ b/src/components/MarkdownEditor/PdfUpload.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
-import { shouldAutoSetCover } from './pdf-cover-policy'
+import { runPdfUpload } from './pdf-upload-flow'
 import { createDragHandlers } from './pdf-upload-handlers'
+import { matchesSource } from './source-asset-naming'
 
 const props = defineProps<{
   readonly assets?: readonly AssetDisplay[]
   readonly currentCover?: string
+  readonly slug: string
+  readonly lang: string
 }>()
 
 const emit = defineEmits<{
@@ -21,37 +24,25 @@ const dragging = ref(false)
 
 const pdfAsset = computed(() =>
   props.assets?.find(
-    (a) => a.mimeType === 'application/pdf' && a.status !== 'pending-delete'
+    a =>
+      a.mimeType === 'application/pdf' &&
+      matchesSource(a, props.slug, props.lang, 'pdf')
   )
 )
 
-const triggerUpload = () => { inputRef.value?.click() }
-
-/*
- * On every PDF upload we extract the first page and add it to assets
- * (so editors can swap to it later). We only auto-set frontmatter.image
- * when there is no cover yet — if the user has chosen a custom cover
- * we must not silently overwrite it.
- */
-const extractCover = async (file: File): Promise<File | undefined> => {
-  try {
-    const m = await import('@/features/newspaper/extract-pdf-cover')
-    return await m.extractPdfCover(file)
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err)
-    emit('error', `PDF cover extraction failed: ${reason}`)
-    return undefined
-  }
+const triggerUpload = () => {
+  inputRef.value?.click()
 }
 
-const handleFile = async (file: File) => {
-  if (file.type !== 'application/pdf') return
-  emit('upload-pdf', file)
-  const cover = await extractCover(file)
-  if (cover === undefined) return
-  emit('upload-cover', cover)
-  if (shouldAutoSetCover(props.currentCover)) emit('set-cover', 'cover.png')
+const flowEmits = {
+  uploadPdf: (f: File) => emit('upload-pdf', f),
+  uploadCover: (f: File) => emit('upload-cover', f),
+  setCover: (n: string) => emit('set-cover', n),
+  error: (m: string) => emit('error', m),
 }
+
+const handleFile = (file: File) =>
+  runPdfUpload(file, { ...props, emits: flowEmits })
 
 const handleChange = (event: Event) => {
   if (!(event.target instanceof HTMLInputElement)) return
@@ -60,7 +51,10 @@ const handleChange = (event: Event) => {
   event.target.value = ''
 }
 
-const { onDrop, onDragOver, onDragLeave } = createDragHandlers(dragging, handleFile)
+const { onDrop, onDragOver, onDragLeave } = createDragHandlers(
+  dragging,
+  handleFile
+)
 </script>
 
 <template>

--- a/src/components/MarkdownEditor/pdf-upload-flow.ts
+++ b/src/components/MarkdownEditor/pdf-upload-flow.ts
@@ -1,0 +1,64 @@
+import { shouldAutoSetCover } from './pdf-cover-policy'
+import { coverName, sourceName } from './source-asset-naming'
+
+interface FlowEmits {
+  readonly uploadPdf: (file: File) => void
+  readonly uploadCover: (file: File) => void
+  readonly setCover: (name: string) => void
+  readonly error: (message: string) => void
+}
+
+interface FlowDeps {
+  readonly slug: string
+  readonly lang: string
+  readonly currentCover: string | undefined
+  readonly emits: FlowEmits
+}
+
+const extractCover = async (
+  file: File,
+  lang: string
+): Promise<File | undefined> => {
+  const m = await import('@/features/newspaper/extract-pdf-cover')
+  const raw = await m.extractPdfCover(file)
+  return new File([raw], coverName(lang), { type: raw.type || 'image/png' })
+}
+
+const fanOutCover = (cover: File, deps: FlowDeps): void => {
+  deps.emits.uploadCover(cover)
+  void (shouldAutoSetCover(deps.currentCover)
+    ? deps.emits.setCover(coverName(deps.lang))
+    : undefined)
+}
+
+const continuePdfUpload = async (
+  file: File,
+  deps: FlowDeps
+): Promise<void> => {
+  const renamed = new File([file], sourceName(deps.slug, deps.lang, 'pdf'), {
+    type: file.type,
+  })
+  deps.emits.uploadPdf(renamed)
+  const cover = await extractCover(file, deps.lang).catch((err: unknown) => {
+    const reason = err instanceof Error ? err.message : String(err)
+    deps.emits.error(`PDF cover extraction failed: ${reason}`)
+    return undefined
+  })
+  void (cover === undefined ? undefined : fanOutCover(cover, deps))
+}
+
+/**
+ * Run the PDF upload pipeline: rename to `<slug>.<lang>.pdf`, emit
+ * upload-pdf, extract a per-lang cover image, emit upload-cover and
+ * set-cover when no custom cover is in place. Errors during cover
+ * extraction surface via the `error` emit so the editor can show
+ * them — silent fallback to a missing cover is exactly what hid the
+ * earlier extraction regression.
+ * @param file - User-picked PDF
+ * @param deps - Slug / lang / current cover / emit hooks
+ * @returns Promise resolving once the chain settles
+ */
+export const runPdfUpload = (file: File, deps: FlowDeps): Promise<void> =>
+  file.type === 'application/pdf'
+    ? continuePdfUpload(file, deps)
+    : Promise.resolve()

--- a/src/components/MarkdownEditor/source-asset-naming.ts
+++ b/src/components/MarkdownEditor/source-asset-naming.ts
@@ -1,0 +1,47 @@
+import type { AssetDisplay } from '@/composables/useAssets/types'
+
+/**
+ * Per-lang filename for a newspaper source. Mirrors the convention
+ * used by `findIssueAsset` in public-website.
+ * @param slug - Issue slug
+ * @param lang - Language code
+ * @param ext - File extension WITHOUT the leading dot
+ * @returns Per-lang filename like `magazine-1.ru.pdf`
+ */
+export const sourceName = (slug: string, lang: string, ext: string): string =>
+  `${slug}.${lang}.${ext}`
+
+/**
+ * Per-lang cover filename matching the convention above.
+ * @param lang - Language code
+ * @returns Cover filename like `cover.ru.png`
+ */
+export const coverName = (lang: string): string => `cover.${lang}.png`
+
+const isLive = (a: AssetDisplay): boolean => a.status !== 'pending-delete'
+
+/**
+ * Match a source asset against the current `<slug>.<lang>.<ext>`
+ * naming. Falls back to the pre-multilang `<slug>.<ext>` so
+ * existing single-language issues keep rendering until someone
+ * re-uploads under the new convention.
+ * @param a - Asset under inspection
+ * @param slug - Issue slug
+ * @param lang - Active language
+ * @param ext - File extension without the leading dot
+ * @returns Whether the asset is the source for this lang
+ */
+export const matchesSource = (
+  a: AssetDisplay,
+  slug: string,
+  lang: string,
+  ext: string
+): boolean => {
+  const name = a.name.toLowerCase()
+  return (
+    isLive(a) &&
+    name.endsWith(`.${ext}`) &&
+    (name === sourceName(slug, lang, ext).toLowerCase() ||
+      name === `${slug}.${ext}`.toLowerCase())
+  )
+}

--- a/src/composables/useContent/useMultiLangEditor.ts
+++ b/src/composables/useContent/useMultiLangEditor.ts
@@ -2,13 +2,26 @@ import { useGitHubApi } from '../useGitHubApi'
 import { createEditorState } from './useMultiLangEditor/state'
 import { wireEditor } from './useMultiLangEditor/wire-editor'
 
+/** Options affecting per-language seeding behaviour. */
+export interface MultiLangEditorOptions {
+  /**
+   * Frontmatter keys that are scoped to a single language and
+   * MUST NOT be carried over when seeding a fresh draft after the
+   * user clicks a dimmed lang tab. For newspaper, `image` is
+   * per-lang (each translation has its own cover); for blog or
+   * positions the cover is entity-level and stays shared.
+   */
+  readonly langScopedFields?: readonly string[]
+}
+
 /**
  * Multi-language editor composable with per-language
  * draft cache
+ * @param options - Optional per-type tweaks (see MultiLangEditorOptions)
  * @returns Multi-language editor interface
  */
-export const useMultiLangEditor = () => {
+export const useMultiLangEditor = (options: MultiLangEditorOptions = {}) => {
   const { getFile, update } = useGitHubApi()
   const ctx = createEditorState()
-  return wireEditor(ctx, getFile, update)
+  return wireEditor(ctx, getFile, update, options.langScopedFields ?? [])
 }

--- a/src/composables/useContent/useMultiLangEditor/build-actions.ts
+++ b/src/composables/useContent/useMultiLangEditor/build-actions.ts
@@ -36,18 +36,22 @@ export const buildSaveActions = (ctx: EditorContext, update: UpdateFn) => ({
  * Build navigation editor actions from context.
  * @param ctx - Editor context
  * @param loadLang - Language loader function
+ * @param langScopedFields - Frontmatter keys to drop when seeding
+ *   a fresh-language draft
  * @returns Switch and reset functions
  */
 export const buildNavActions = (
   ctx: EditorContext,
-  loadLang: LoadLangFn
+  loadLang: LoadLangFn,
+  langScopedFields: readonly string[] = []
 ) => ({
   switchLanguage: createSwitchLanguage(
     ctx.cache,
     ctx.originalCache,
     ctx.state,
     ctx.fileSha,
-    loadLang
+    loadLang,
+    langScopedFields
   ),
   reset: createReset(ctx.cache, ctx.originalCache, ctx.state, ctx.fileSha),
 })

--- a/src/composables/useContent/useMultiLangEditor/build-return.ts
+++ b/src/composables/useContent/useMultiLangEditor/build-return.ts
@@ -12,17 +12,20 @@ type UpdateFn = ReturnType<typeof useGitHubApi>['update']
  * @param loadLang - Language loader function
  * @param isDirty - Dirty state computed
  * @param update - GitHub update function
+ * @param langScopedFields - Frontmatter keys excluded from seeding
+ *   when switching to a brand-new lang
  * @returns Wired editor return object
  */
 export const buildEditorReturn = (
   ctx: EditorContext,
   loadLang: LoadLangFn,
   isDirty: ComputedRef<boolean>,
-  update: UpdateFn
+  update: UpdateFn,
+  langScopedFields: readonly string[] = []
 ) => ({
   ...ctx.state,
   isDirty,
   loadLanguageVersion: loadLang,
   ...buildSaveActions(ctx, update),
-  ...buildNavActions(ctx, loadLang),
+  ...buildNavActions(ctx, loadLang, langScopedFields),
 })

--- a/src/composables/useContent/useMultiLangEditor/seed-from-current.ts
+++ b/src/composables/useContent/useMultiLangEditor/seed-from-current.ts
@@ -1,0 +1,56 @@
+import type { Ref } from 'vue'
+import type { Language } from '@/types/content'
+import type { EditorDraft, MultiLangEditorState } from './types'
+
+const dropFields = (
+  src: Record<string, unknown>,
+  fields: readonly string[]
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = { ...src }
+  for (const k of fields) delete out[k]
+  return out
+}
+
+/**
+ * Seed a fresh draft for a brand-new lang. Frontmatter is mostly
+ * entity-level (every translation shares title/category/etc.); the
+ * exceptions live in `langScopedFields`. Newspaper passes
+ * `['image']` so each lang gets its own cover; blog and positions
+ * pass nothing (cover stays shared).
+ *
+ * Wiping frontmatter wholesale would make the next Save fail with
+ * "title is missing" / "category is missing", so we copy then drop
+ * the per-lang keys. The same snapshot is mirrored into
+ * `originalCache` so isDirty reports the freshly-switched draft as
+ * clean and the unsaved-changes guard does not fire.
+ *
+ * @param cache - Per-lang draft cache
+ * @param originalCache - Per-lang baseline for diffing
+ * @param state - Editor state refs
+ * @param lang - Target language we are switching INTO
+ * @param fileSha - File SHA ref (cleared since the new file does not exist yet)
+ * @param langScopedFields - Frontmatter keys that must NOT carry over
+ */
+export const seedFromCurrent = (
+  cache: Map<Language, EditorDraft>,
+  originalCache: Map<Language, EditorDraft>,
+  state: MultiLangEditorState,
+  lang: Language,
+  fileSha: Ref<string>,
+  langScopedFields: readonly string[]
+): void => {
+  const previous = state.frontmatterData.value
+  const carried = dropFields(previous, langScopedFields)
+  const seeded = { ...carried, lang }
+  state.frontmatterData.value = seeded
+  state.bodyContent.value = ''
+  fileSha.value = ''
+  const draft: EditorDraft = {
+    frontmatter: { ...seeded },
+    body: '',
+    sha: '',
+    loaded: true,
+  }
+  cache.set(lang, draft)
+  originalCache.set(lang, { ...draft, frontmatter: { ...seeded } })
+}

--- a/src/composables/useContent/useMultiLangEditor/switch-language.ts
+++ b/src/composables/useContent/useMultiLangEditor/switch-language.ts
@@ -1,50 +1,18 @@
 import type { Ref } from 'vue'
 import type { Language } from '@/types/content'
+import { seedFromCurrent } from './seed-from-current'
 import { snapshotAndSwitch, tryRestoreCached } from './switch-helpers'
 import type { EditorDraft, MultiLangEditorState } from './types'
 
-/*
- * Frontmatter is an entity-level property — every language version of
- * the same content shares title/description/category/etc. Only `lang`
- * differs per file, and the body is independent. When the user
- * switches to a language that has no file yet (and no prior draft in
- * cache), seed the new draft with the previous frontmatter (with lang
- * updated) and an empty body. Wiping frontmatter to {} here would make
- * the next Save fail with "category is missing" / "title is missing".
- *
- * Seeding ALSO writes the same snapshot into originalCache so isDirty
- * reports the freshly-switched draft as clean — the user has not
- * edited anything yet, so the unsaved-changes guard must not fire.
- */
-const seedFromCurrent = (
-  cache: Map<Language, EditorDraft>,
-  originalCache: Map<Language, EditorDraft>,
-  state: MultiLangEditorState,
-  lang: Language,
-  fileSha: Ref<string>
-): void => {
-  const previous = state.frontmatterData.value
-  const seeded = { ...previous, lang }
-  state.frontmatterData.value = seeded
-  state.bodyContent.value = ''
-  fileSha.value = ''
-  const draft: EditorDraft = {
-    frontmatter: { ...seeded },
-    body: '',
-    sha: '',
-    loaded: true,
-  }
-  cache.set(lang, draft)
-  originalCache.set(lang, { ...draft, frontmatter: { ...seeded } })
-}
-
 /**
- * Creates a function that switches language with cache
+ * Creates a function that switches language with cache.
  * @param cache - Draft cache map
  * @param originalCache - Original cache map for clean-state comparison
  * @param state - Editor state
  * @param fileSha - File SHA ref
  * @param loadFn - Function to load a file by path
+ * @param langScopedFields - Frontmatter keys to drop when seeding
+ *   a draft for a brand-new lang (default empty)
  * @returns Async function to switch language
  */
 export const createSwitchLanguage =
@@ -53,7 +21,8 @@ export const createSwitchLanguage =
     originalCache: Map<Language, EditorDraft>,
     state: MultiLangEditorState,
     fileSha: Ref<string>,
-    loadFn: (path: string) => Promise<void>
+    loadFn: (path: string) => Promise<void>,
+    langScopedFields: readonly string[] = []
   ) =>
   async (lang: Language, path?: string): Promise<void> => {
     snapshotAndSwitch(cache, state, fileSha, lang)
@@ -62,5 +31,12 @@ export const createSwitchLanguage =
       await loadFn(path)
       return
     }
-    seedFromCurrent(cache, originalCache, state, lang, fileSha)
+    seedFromCurrent(
+      cache,
+      originalCache,
+      state,
+      lang,
+      fileSha,
+      langScopedFields
+    )
   }

--- a/src/composables/useContent/useMultiLangEditor/wire-editor.ts
+++ b/src/composables/useContent/useMultiLangEditor/wire-editor.ts
@@ -11,12 +11,16 @@ type Api = ReturnType<typeof useGitHubApi>
  * @param ctx - Editor context with state and caches
  * @param getFile - GitHub API getFile function
  * @param update - GitHub API update function
+ * @param langScopedFields - Frontmatter keys to drop when seeding a
+ *   new-language draft (newspaper passes `['image']` so each lang
+ *   gets its own cover instead of inheriting the previous lang's).
  * @returns Fully wired editor interface
  */
 export const wireEditor = (
   ctx: EditorContext,
   getFile: Api['getFile'],
-  update: Api['update']
+  update: Api['update'],
+  langScopedFields: readonly string[] = []
 ) => {
   const { cache, originalCache, fileSha, saveVersion, state } = ctx
   const loadLang = createLoadLanguageVersion(
@@ -34,5 +38,5 @@ export const wireEditor = (
     saveVersion
   )
   state.isDirty = isDirty
-  return buildEditorReturn(ctx, loadLang, isDirty, update)
+  return buildEditorReturn(ctx, loadLang, isDirty, update, langScopedFields)
 }

--- a/src/views/ContentEditView/page-state.ts
+++ b/src/views/ContentEditView/page-state.ts
@@ -1,9 +1,18 @@
 import { useAssets } from '@/composables/useAssets/useAssets'
 import { useContentList } from '@/composables/useContent/useContentList'
 import { useMultiLangEditor } from '@/composables/useContent/useMultiLangEditor'
+import type { ContentType } from '@/types/content'
 import { createAssetHandlers } from './asset-handlers'
 import { createPageComputeds } from './page-computeds'
 import { validateContentType } from './validate-type'
+
+/* Frontmatter keys that should NOT carry over when the user
+ * switches to a brand-new language file. Newspaper issues store the
+ * cover per-lang (each translation publishes a different printed
+ * issue with its own cover image), so `image` resets on switch. */
+const langScopedByType: Partial<Record<ContentType, readonly string[]>> = {
+  newspaper: ['image'],
+}
 
 /**
  * Create core reactive state for content edit page.
@@ -14,7 +23,9 @@ import { validateContentType } from './validate-type'
 export const createPageState = (type: string, slug: string) => {
   const validType = validateContentType(type)
   const list = useContentList(validType)
-  const editor = useMultiLangEditor()
+  const editor = useMultiLangEditor({
+    langScopedFields: langScopedByType[validType] ?? [],
+  })
   const assets = useAssets(type, slug, undefined)
 
   return {


### PR DESCRIPTION
## Summary
- Newspaper editor renames uploads to `<slug>.<lang>.{pdf,fb2}` and `cover.<lang>.png`, so each translation owns its own bundle (covers AND files).
- `useMultiLangEditor` gets `langScopedFields` — for `newspaper` only, `image` is treated as lang-scoped, so switching languages preserves entity-level metadata while letting the cover differ per lang.
- `pdf-upload-flow.ts`, `source-asset-naming.ts`, and `seed-from-current.ts` extracted to keep files under the 50-LOC sonarjs limit.

Why: editor used to write a single `<slug>.pdf`/`cover.png` regardless of active language, so uploading IT files overwrote the EN bundle in the same `assets/` dir. This is the admin half — public-website#94 teaches `findIssueAsset` to pick the per-lang variant.

## Test plan
- [x] `bun run test:unit` — 663 passed.
- [x] `bun run lint:sonar`, `lint:jsdoc`, `check:ci`, `lint:css`, `lint:vue-depth`, `type-check` — all green.
- [ ] Realmode: open RU-only newspaper issue, switch to IT, upload IT PDF, verify both `<slug>.ru.pdf` and `<slug>.it.pdf` exist after save.
- [ ] Manual: cover for RU != cover for IT after re-upload under each lang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)