### PR TITLE
fix(editor): cover preview follows the active language

### DIFF
--- a/src/views/ContentEditView/setup-lifecycle.ts
+++ b/src/views/ContentEditView/setup-lifecycle.ts
@@ -6,6 +6,10 @@ type Page = ReturnType<typeof useEditPage>
 
 /**
  * Wire up lifecycle hooks for the edit page.
+ * `assets.coverPath` follows `editor.frontmatterData.image` so that
+ * switching language re-points the cover preview at the active lang's
+ * image (per-lang covers, see `langScopedByType`). Without this watch,
+ * `coverPath` only got seeded once on initial load and stayed pinned.
  * @param page - Edit page state
  * @param initAll - Initialization function
  */
@@ -19,4 +23,10 @@ export const setupLifecycle = (page: Page, initAll: () => Promise<void>) => {
   watch(page.isAuth, auth => {
     if (auth) initAll()
   })
+  watch(
+    () => editor.frontmatterData.value.image,
+    img => {
+      assets.coverPath.value = typeof img === 'string' ? img : undefined
+    }
+  )
 }


### PR DESCRIPTION
## Summary
- Add `watch(() => editor.frontmatterData.image)` → `assets.coverPath` in `setup-lifecycle`.
- Without it, switching language re-pointed `frontmatterData` at the active lang's draft but `coverPath` was frozen at init-time, so the cover preview at the top of the editor (and newspaper PdfUpload state) kept showing the previous lang's cover.

Pairs with #231 — the per-lang upload code was already correct, but the visible cover state lagged behind.

## Test plan
- [x] `bun run type-check`, `lint:sonar`, `lint:jsdoc`, `check:ci` — green.
- [x] `bun run test:unit` — 663 pass.
- [ ] Manual: open a newspaper issue with EN cover, switch to RU (no IT yet) → cover preview clears. Re-upload IT PDF → IT cover renders. Switch back to EN → original EN cover renders.