### PR TITLE
fix(editor): auto-overwrite per-lang cover when previous was auto

### DIFF
--- a/src/components/MarkdownEditor/pdf-cover-policy.test.ts
+++ b/src/components/MarkdownEditor/pdf-cover-policy.test.ts
@@ -10,13 +10,20 @@ describe('shouldAutoSetCover', () => {
     expect(shouldAutoSetCover('')).toBe(true)
   })
 
-  it('preserves existing cover when one is set manually', () => {
+  it('preserves a manually picked cover', () => {
     expect(shouldAutoSetCover('manual.png')).toBe(false)
+    expect(shouldAutoSetCover('./assets/special-photo.jpg')).toBe(false)
+    expect(shouldAutoSetCover('./assets/hero.png')).toBe(false)
   })
 
-  it('preserves existing cover even when same as auto-default name', () => {
-    // If editor previously kept the auto cover.png, keep it — the
-    // policy is "user chose a cover" regardless of which file.
-    expect(shouldAutoSetCover('cover.png')).toBe(false)
+  it('overwrites a legacy auto cover.png — needed so re-uploading a PDF for a lang that inherited the legacy single-cover repoints to the new per-lang cover', () => {
+    expect(shouldAutoSetCover('cover.png')).toBe(true)
+    expect(shouldAutoSetCover('./assets/cover.png')).toBe(true)
+  })
+
+  it('overwrites a per-lang auto cover.<lang>.png', () => {
+    expect(shouldAutoSetCover('cover.en.png')).toBe(true)
+    expect(shouldAutoSetCover('./assets/cover.ru.png')).toBe(true)
+    expect(shouldAutoSetCover('./assets/cover.it.png')).toBe(true)
   })
 })

--- a/src/components/MarkdownEditor/pdf-cover-policy.ts
+++ b/src/components/MarkdownEditor/pdf-cover-policy.ts
@@ -1,12 +1,26 @@
+const AUTO_COVER_NAME = /^cover(\.[a-z]{2,3})?\.png$/i
+
+const isAutoCoverPath = (path: string): boolean => {
+  const filename = path.split('/').pop() ?? ''
+  return AUTO_COVER_NAME.test(filename)
+}
+
 /**
  * Decide whether a freshly extracted PDF cover should overwrite the
- * frontmatter image. We only auto-set when the entry has no cover
- * picked yet — once an editor has chosen a custom image we must not
- * silently replace it on the next PDF upload.
+ * frontmatter `image` field. We auto-set when there is no cover yet
+ * AND when the current cover is itself an auto-extracted name
+ * (`cover.png` or `cover.<lang>.png`) — re-uploading a PDF for a
+ * language that inherited the legacy `cover.png` from a previous lang
+ * must repoint to the new per-lang cover, otherwise the preview keeps
+ * showing the old image. Only paths that look manually picked
+ * (`hero.jpg`, `special-photo.png`, ...) are preserved.
  *
  * @param currentCover - frontmatter.image, or undefined when missing
- * @returns true when the new cover should also be wired into frontmatter
+ * @returns true when the new cover should be wired into frontmatter
  */
 export const shouldAutoSetCover = (
   currentCover: string | undefined
-): boolean => currentCover === undefined || currentCover === ''
+): boolean =>
+  currentCover === undefined ||
+  currentCover === '' ||
+  isAutoCoverPath(currentCover)


### PR DESCRIPTION
## Summary
- `shouldAutoSetCover` now treats any path whose basename matches `cover(.<lang>)?.png` as auto-extracted and lets a fresh PDF upload overwrite it.
- Re-uploading a PDF on a language that inherited the legacy `./assets/cover.png` correctly repoints frontmatter.image to the new `cover.<lang>.png`.
- Manually picked covers (e.g. `./assets/hero.jpg`) are still preserved.

The earlier policy returned `false` for any non-empty image, which masked the per-lang cover after re-upload — user reported "при загрузке файла пдф для другого языка, кавер берётся неправильно".

## Test plan
- [x] `bun run test:unit` (9 tests on pdf-cover-policy + PdfUpload pass).
- [x] `bun run type-check`, `lint:sonar`, `lint:jsdoc`, `check:ci` — green.
- [ ] Manual: open issue with `image: ./assets/cover.png`, switch to RU, re-upload PDF — preview shows new RU cover, save commits `cover.ru.png` referenced from RU frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)