### PR TITLE
fix(frontmatter): disable block scalars to keep round-trip lossless

### DIFF
--- a/src/sw/handlers/shared/frontmatter.ts
+++ b/src/sw/handlers/shared/frontmatter.ts
@@ -58,8 +58,15 @@ export const parseFrontmatterStrict = (
  * Serialize frontmatter and body to markdown. `yaml.stringify`
  * auto-quotes any value that would otherwise break the parser
  * (colon-in-text, leading reserved chars, embedded newlines, …).
- * Keep `lineWidth: 0` so long prose values stay on one line —
- * makes the diffs in the content repo readable.
+ *
+ * `blockQuote: false` disables block scalar (`|+`/`>`) output —
+ * fast-check found that block scalars silently lose a leading
+ * space when the value is `" \n"` (and similar whitespace-only
+ * shapes), so the round-trip fails. Forcing flow-style strings
+ * keeps the round-trip lossless while plain values still serialize
+ * unquoted, so the content-repo diffs stay readable.
+ *
+ * `lineWidth: 0` keeps long prose values on one line.
  * @param fm - Frontmatter key-value pairs
  * @param body - Markdown body
  * @returns Complete markdown string with YAML frontmatter
@@ -72,7 +79,7 @@ export const serializeFrontmatter = (
   for (const [k, v] of Object.entries(fm)) {
     if (v !== undefined) filtered[k] = v
   }
-  const yaml = yamlStringify(filtered, { lineWidth: 0 })
+  const yaml = yamlStringify(filtered, { lineWidth: 0, blockQuote: false })
   const trimmed = yaml.endsWith('\n') ? yaml.slice(0, -1) : yaml
   return `---\n${trimmed}\n---\n\n${body}`
 }

--- a/src/utils/frontmatter/stringify.test.ts
+++ b/src/utils/frontmatter/stringify.test.ts
@@ -83,6 +83,16 @@ Content here`)
         'real-world-from-manchester',
         "Capital has not changed its predatory nature: it has simply scaled the infernal conditions of the 19th-century Manchester factory to the dimensions of the entire planet. Faced with the inexorable fall of the rate of profit in the '70s, capitalism launched the mechanisms of global revenge: it relocated physical production to the countries of the 'new' capitalism.",
       ],
+      /*
+       * The fuzz contract found this counterexample: a value
+       * shaped " \n" (leading space then newline) was emitted as a
+       * YAML block scalar (`|+`) which silently dropped the
+       * leading space on parse. `blockQuote: false` keeps strings
+       * in flow style so they round-trip losslessly.
+       */
+      ['leading-space-then-newline', ' \n'],
+      ['tabs-then-newline', '\t\t'],
+      ['only-whitespace-and-newlines', '   \n   '],
     ]
     for (const [name, value] of cases) {
       it(`round-trips ${name}`, () => {

--- a/src/utils/frontmatter/stringify.ts
+++ b/src/utils/frontmatter/stringify.ts
@@ -32,6 +32,13 @@ const normaliseDates = (
  * `lineWidth: 0` disables auto-wrapping so prose paragraphs in
  * description / pageDescription stay on one line — easier diffs.
  *
+ * `blockQuote: false` disables block scalar (`|+`/`>`) output —
+ * fast-check (`frontmatter.fuzz.test`) caught that block scalars
+ * silently drop a leading space when a value is shaped like `" \n"`,
+ * which broke the serialize→parse round-trip. Flow-style strings
+ * round-trip losslessly while plain unquoted values still print
+ * cleanly for normal text.
+ *
  * @param frontmatter - Frontmatter object
  * @param content - Markdown content
  * @returns Formatted markdown with frontmatter
@@ -40,7 +47,10 @@ export const stringifyFrontmatter = (
   frontmatter: Record<string, unknown>,
   content: string
 ): string => {
-  const yaml = yamlStringify(normaliseDates(frontmatter), { lineWidth: 0 })
+  const yaml = yamlStringify(normaliseDates(frontmatter), {
+    lineWidth: 0,
+    blockQuote: false,
+  })
   /*
    * `yaml.stringify` already terminates with `\n`. Strip it so we
    * don't get a blank line before the closing `---` fence.


### PR DESCRIPTION
## Summary
- Pass \`blockQuote: false\` to \`yaml.stringify\` in both serializers (\`src/sw/handlers/shared/frontmatter.ts\`, \`src/utils/frontmatter/stringify.ts\`).
- The fuzz contract caught a real bug: \`title: \" \n\"\` was emitted as a block scalar (\`|+\`) and parsed back as just \`\"\n\"\` — leading space was silently dropped.
- Pin three deterministic counterexamples in \`stringify.test.ts\` so a future fuzz seed isn't required to detect a regression.

This fixes the master-deploy block from #233 (fuzz failure during deploy unit tests).

## Test plan
- [x] \`bun run test:unit src/utils/frontmatter/stringify.test.ts src/sw/handlers/shared/frontmatter.fuzz.test.ts\` — 22/22 pass.
- [x] \`bun run type-check\`, \`lint:sonar\`, \`lint:jsdoc\`, \`check:ci\` — green.
- [ ] Real-mode E2E in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)