### PR TITLE
fix(editor): rename of unsaved content (create→rename→save)

### DIFF
--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -6,6 +6,7 @@ import CoverImage from '@/components/AssetManager/CoverImage.vue'
 import ErrorMessage from '@/components/common/ErrorMessage.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue'
+import { buildRenameDeps } from './ContentEditView/build-rename-deps'
 import ContentEditMain from './ContentEditView/ContentEditMain.vue'
 import ContentPreview from './ContentEditView/ContentPreview.vue'
 import EditBreadcrumb from './ContentEditView/EditBreadcrumb.vue'
@@ -24,8 +25,9 @@ const props = defineProps<{ readonly type: string; readonly slug: string }>()
 const previewing = ref(false)
 const p = useEditPage(props.type, props.slug)
 const { handleSave, saving, saved, saveError } = initEditPage(p)
-const enterPreview = () => { previewing.value = true }
-const exitPreview = () => { previewing.value = false }
+const exitPreview = (): void => {
+  previewing.value = false
+}
 const flow = useSaveFlow({
   contentType: () => p.contentType.value,
   frontmatter: () => p.editor.frontmatterData.value,
@@ -33,24 +35,21 @@ const flow = useSaveFlow({
   saveError,
   exitPreview,
 })
-
 const { updateBody, updateFm } = makeUpdaters(
   p.editor.bodyContent,
   p.editor.frontmatterData
 )
-const handleSwitchLang = makeSwitchLang({
-  langs: p.langs,
-  switchLanguage: p.editor.switchLanguage,
-  buildPath: p.buildPath,
-})
-const handleRename = makeRename(props.type, props.slug)
-const title = computed(() => String(p.editor.frontmatterData.value.title ?? p.slug))
+const handleRename = makeRename(
+  props.type,
+  props.slug,
+  buildRenameDeps(p, props.slug)
+)
+const title = computed(() =>
+  String(p.editor.frontmatterData.value.title ?? p.slug)
+)
 const isRenameable = computed(
   () => p.contentType.value !== 'pages' && p.contentType.value !== 'common'
 )
-const setError = (msg: string): void => {
-  saveError.value = msg
-}
 </script>
 
 <template>
@@ -66,7 +65,13 @@ const setError = (msg: string): void => {
       v-if="!previewing"
       :model-value="p.editor.currentLang.value"
       :available-languages="p.langs.value"
-      @update:model-value="handleSwitchLang"
+      @update:model-value="
+        makeSwitchLang({
+          langs: p.langs,
+          switchLanguage: p.editor.switchLanguage,
+          buildPath: p.buildPath,
+        })
+      "
     />
     <CoverImage
       v-if="!previewing && p.hasCover.value && !p.editor.loadingFile.value"
@@ -86,11 +91,11 @@ const setError = (msg: string): void => {
       :lang="p.editor.currentLang.value"
       @update:body-content="updateBody"
       @update:frontmatter="updateFm"
-      @preview="enterPreview"
+      @preview="previewing = true"
       @paste:image="p.ah.onPasteImage"
       @upload-asset="p.ah.onUploadAsset"
       @set-cover="p.ah.onSetCover"
-      @error="setError"
+      @error="(m: string) => (saveError = m)"
     />
     <ContentPreview
       v-else

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -6,44 +6,33 @@ import CoverImage from '@/components/AssetManager/CoverImage.vue'
 import ErrorMessage from '@/components/common/ErrorMessage.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue'
-import { buildRenameDeps } from './ContentEditView/build-rename-deps'
 import ContentEditMain from './ContentEditView/ContentEditMain.vue'
 import ContentPreview from './ContentEditView/ContentPreview.vue'
 import EditBreadcrumb from './ContentEditView/EditBreadcrumb.vue'
 import { initEditPage } from './ContentEditView/init-edit-page'
 import PreviewFooter from './ContentEditView/PreviewFooter.vue'
 import PublishConfirmDialog from './ContentEditView/PublishConfirmDialog.vue'
+import { setupEditHandlers } from './ContentEditView/setup-handlers'
 import { useSaveFlow } from './ContentEditView/use-save-flow'
 import { useEditPage } from './ContentEditView/useEditPage'
-import {
-  makeRename,
-  makeSwitchLang,
-  makeUpdaters,
-} from './ContentEditView/wire-handlers'
 
 const props = defineProps<{ readonly type: string; readonly slug: string }>()
 const previewing = ref(false)
 const p = useEditPage(props.type, props.slug)
 const { handleSave, saving, saved, saveError } = initEditPage(p)
-const exitPreview = (): void => {
-  previewing.value = false
-}
+const h = setupEditHandlers(p, {
+  type: props.type,
+  slug: props.slug,
+  previewing,
+  saveError,
+})
 const flow = useSaveFlow({
   contentType: () => p.contentType.value,
   frontmatter: () => p.editor.frontmatterData.value,
   handleSave,
   saveError,
-  exitPreview,
+  exitPreview: h.exitPreview,
 })
-const { updateBody, updateFm } = makeUpdaters(
-  p.editor.bodyContent,
-  p.editor.frontmatterData
-)
-const handleRename = makeRename(
-  props.type,
-  props.slug,
-  buildRenameDeps(p, props.slug)
-)
 const title = computed(() =>
   String(p.editor.frontmatterData.value.title ?? p.slug)
 )
@@ -58,20 +47,14 @@ const isRenameable = computed(
       <EditBreadcrumb
         :content-type="p.contentType.value"
         :slug="slug" :renameable="isRenameable"
-        @rename="handleRename"
+        @rename="h.handleRename"
       />
     </nav>
     <LanguageSelector
       v-if="!previewing"
       :model-value="p.editor.currentLang.value"
       :available-languages="p.langs.value"
-      @update:model-value="
-        makeSwitchLang({
-          langs: p.langs,
-          switchLanguage: p.editor.switchLanguage,
-          buildPath: p.buildPath,
-        })
-      "
+      @update:model-value="h.handleSwitchLang"
     />
     <CoverImage
       v-if="!previewing && p.hasCover.value && !p.editor.loadingFile.value"
@@ -89,13 +72,13 @@ const isRenameable = computed(
       :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
       :assets="p.hasAssets.value ? p.assets.allAssets.value : undefined"
       :lang="p.editor.currentLang.value"
-      @update:body-content="updateBody"
-      @update:frontmatter="updateFm"
-      @preview="previewing = true"
+      @update:body-content="h.updateBody"
+      @update:frontmatter="h.updateFm"
+      @preview="h.enterPreview"
       @paste:image="p.ah.onPasteImage"
       @upload-asset="p.ah.onUploadAsset"
       @set-cover="p.ah.onSetCover"
-      @error="(m: string) => (saveError = m)"
+      @error="h.setError"
     />
     <ContentPreview
       v-else
@@ -109,7 +92,7 @@ const isRenameable = computed(
       :saving="saving"
       :saved="saved"
       @save="flow.onSave"
-      @back="exitPreview"
+      @back="h.exitPreview"
     />
     <AssetPanel
       v-if="!previewing && p.hasAssets.value && !p.editor.loadingFile.value"

--- a/src/views/ContentEditView/build-rename-deps.ts
+++ b/src/views/ContentEditView/build-rename-deps.ts
@@ -1,0 +1,38 @@
+import type { CreateContentData } from '@/components/CreateContentDialog/helpers'
+import type { useEditPage } from './useEditPage'
+
+type Page = ReturnType<typeof useEditPage>
+
+const stringField = (
+  fm: Record<string, unknown>,
+  key: string
+): string | undefined => {
+  const v = fm[key]
+  return typeof v === 'string' && v.length > 0 ? v : undefined
+}
+
+/**
+ * Build the dependency object passed to `makeRename`. Surfaces the
+ * "is this content already on disk?" probe (langs.size === 0 means
+ * the user hit `+ New` but never saved) and the in-flight draft
+ * builder so a local-only rename can re-stash the draft under the
+ * new slug.
+ * @param page - Edit page state from useEditPage
+ * @param currentSlug - Current slug being renamed
+ * @returns Rename dependencies for `makeRename`
+ */
+export const buildRenameDeps = (page: Page, currentSlug: string) => ({
+  isUnsaved: (): boolean => page.langs.value.size === 0,
+  currentDraft: (): CreateContentData => {
+    const fm = page.editor.frontmatterData.value
+    const description = stringField(fm, 'description')
+    const category = stringField(fm, 'category')
+    return {
+      slug: currentSlug,
+      lang: page.editor.currentLang.value,
+      title: stringField(fm, 'title') ?? '',
+      ...(description ? { description } : {}),
+      ...(category ? { category } : {}),
+    }
+  },
+})

--- a/src/views/ContentEditView/setup-handlers.ts
+++ b/src/views/ContentEditView/setup-handlers.ts
@@ -1,0 +1,50 @@
+import type { Ref } from 'vue'
+import { buildRenameDeps } from './build-rename-deps'
+import type { useEditPage } from './useEditPage'
+import { makeRename, makeSwitchLang, makeUpdaters } from './wire-handlers'
+
+type Page = ReturnType<typeof useEditPage>
+
+interface HandlerDeps {
+  readonly type: string
+  readonly slug: string
+  readonly previewing: Ref<boolean>
+  readonly saveError: Ref<string | null>
+}
+
+const buildPreviewToggles = (previewing: Ref<boolean>) => ({
+  enterPreview: (): void => {
+    previewing.value = true
+  },
+  exitPreview: (): void => {
+    previewing.value = false
+  },
+})
+
+/**
+ * Build the closures the SFC's template binds to. Extracted so the
+ * SFC stays under the per-file LOC budget — each handler is trivial
+ * but inlining all of them blows past sonar's `max-lines: 50` for
+ * the .vue file.
+ *
+ * @param page - Edit page state from `useEditPage`
+ * @param deps - Type/slug + the local `previewing` and `saveError` refs
+ * @returns Handler closures used by the template
+ */
+export const setupEditHandlers = (page: Page, deps: HandlerDeps) => ({
+  ...makeUpdaters(page.editor.bodyContent, page.editor.frontmatterData),
+  ...buildPreviewToggles(deps.previewing),
+  handleSwitchLang: makeSwitchLang({
+    langs: page.langs,
+    switchLanguage: page.editor.switchLanguage,
+    buildPath: page.buildPath,
+  }),
+  handleRename: makeRename(
+    deps.type,
+    deps.slug,
+    buildRenameDeps(page, deps.slug)
+  ),
+  setError: (msg: string): void => {
+    deps.saveError.value = msg
+  },
+})

--- a/src/views/ContentEditView/wire-handlers.test.ts
+++ b/src/views/ContentEditView/wire-handlers.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as draftStash from '@/composables/useContent/new-content-draft'
+import * as renameApi from '@/composables/useGitHubApi/rename-content'
+import { makeRename } from './wire-handlers'
+
+const mockNavigate = vi.fn<(url: string) => void>()
+
+afterEach(() => {
+  mockNavigate.mockReset()
+  vi.restoreAllMocks()
+})
+
+describe('makeRename — saved content path', () => {
+  it('calls renameContent and navigates to the new slug URL', async () => {
+    const apiSpy = vi
+      .spyOn(renameApi, 'renameContent')
+      .mockResolvedValue({ success: true, count: 1 })
+    const rename = makeRename('blog', 'old-slug', {
+      isUnsaved: () => false,
+      navigate: mockNavigate,
+    })
+    await rename('new-slug')
+    expect(apiSpy).toHaveBeenCalledWith('blog', 'old-slug', 'new-slug')
+    expect(mockNavigate).toHaveBeenCalledWith('/content/blog/edit/new-slug')
+  })
+})
+
+describe('makeRename — unsaved newspaper path (regression for create→rename→save flow)', () => {
+  /*
+   * The user-reported bug: creating a newspaper, renaming the slug
+   * BEFORE first save, then clicking Save fails with
+   * "No files found for newspaper/<old-slug>" because
+   * `renameContent` calls the SW BFF which expects the source
+   * directory to exist on disk.
+   *
+   * The fix is "local rename" when the content has never been
+   * persisted: re-stash the in-flight draft under the new slug so
+   * the next mount reads it, and navigate to the new URL — without
+   * hitting the SW.
+   */
+  it('skips renameContent and re-stashes the draft under the new slug', async () => {
+    const apiSpy = vi.spyOn(renameApi, 'renameContent')
+    const stashSpy = vi.spyOn(draftStash, 'setNewContentDraft')
+    const draft = {
+      slug: 'old-slug',
+      lang: 'ru' as const,
+      title: 'Test',
+      description: 'desc',
+    }
+    const rename = makeRename('newspaper', 'old-slug', {
+      isUnsaved: () => true,
+      currentDraft: () => draft,
+      navigate: mockNavigate,
+    })
+    await rename('renamed-slug')
+    expect(
+      apiSpy,
+      'SW rename must NOT fire on unsaved content'
+    ).not.toHaveBeenCalled()
+    expect(stashSpy).toHaveBeenCalledWith({ ...draft, slug: 'renamed-slug' })
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/content/newspaper/edit/renamed-slug'
+    )
+  })
+
+  it('still navigates to the new URL even when no draft is available', async () => {
+    const apiSpy = vi.spyOn(renameApi, 'renameContent')
+    const stashSpy = vi.spyOn(draftStash, 'setNewContentDraft')
+    const rename = makeRename('newspaper', 'old-slug', {
+      isUnsaved: () => true,
+      currentDraft: () => undefined,
+      navigate: mockNavigate,
+    })
+    await rename('renamed-slug')
+    expect(apiSpy).not.toHaveBeenCalled()
+    expect(stashSpy).not.toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/content/newspaper/edit/renamed-slug'
+    )
+  })
+})

--- a/src/views/ContentEditView/wire-handlers.ts
+++ b/src/views/ContentEditView/wire-handlers.ts
@@ -1,4 +1,6 @@
 import type { Ref } from 'vue'
+import type { CreateContentData } from '@/components/CreateContentDialog/helpers'
+import { setNewContentDraft } from '@/composables/useContent/new-content-draft'
 import { renameContent } from '@/composables/useGitHubApi/rename-content'
 import type { Language } from '@/types/content'
 
@@ -6,6 +8,16 @@ interface SwitchDeps {
   readonly langs: { readonly value: ReadonlySet<Language> }
   readonly switchLanguage: (lang: Language, path?: string) => void
   readonly buildPath: (lang: Language) => string
+}
+
+interface RenameDeps {
+  readonly isUnsaved: () => boolean
+  readonly currentDraft?: () => CreateContentData | undefined
+  readonly navigate?: (url: string) => void
+}
+
+const defaultNavigate = (url: string): void => {
+  globalThis.location.replace(url)
 }
 
 /**
@@ -24,18 +36,33 @@ export const makeSwitchLang =
   }
 
 /**
- * Persist a rename via the SW API and hard-reload to the new URL so
- * route state is clean.
+ * Persist a rename via the SW API (when the content already exists
+ * on disk) or do a local-only rename (re-stash the draft + navigate)
+ * when the user renames a freshly-created entity that hasn't been
+ * saved yet. The local-only branch fixes the create→rename→save
+ * regression where the SW would 404 on a slug that has no files
+ * committed in the working branch.
  *
- * @param type content type (e.g. 'blog')
+ * @param type content type (e.g. 'blog', 'newspaper')
  * @param oldSlug the slug being renamed
+ * @param deps `isUnsaved` (langs.value.size === 0 in the page),
+ *   optional `currentDraft` builder for the local-rename fallback,
+ *   optional `navigate` for testing
  * @returns a function that performs the rename
  */
 export const makeRename =
-  (type: string, oldSlug: string) =>
+  (type: string, oldSlug: string, deps: RenameDeps) =>
   async (newSlug: string): Promise<void> => {
+    const navigate = deps.navigate ?? defaultNavigate
+    const targetUrl = `/content/${type}/edit/${newSlug}`
+    if (deps.isUnsaved()) {
+      const draft = deps.currentDraft?.()
+      if (draft) setNewContentDraft({ ...draft, slug: newSlug })
+      navigate(targetUrl)
+      return
+    }
     await renameContent(type, oldSlug, newSlug)
-    globalThis.location.replace(`/content/${type}/edit/${newSlug}`)
+    navigate(targetUrl)
   }
 
 /**


### PR DESCRIPTION
## Summary
User flow that broke (newspaper-specific but the bug applies to any content type):

1. `+ New` → fill slug + title → `Create`
2. Editor opens (no file on disk yet, only a sessionStorage draft)
3. Click slug → type new slug → `Enter`
4. **Error: "No files found for newspaper/&lt;old-slug&gt;"** — `renameContent` SW call expected the source directory to exist, found nothing, threw.
5. Save never fired because the rename promise rejected.

## Fix
`makeRename` branches on whether the slug has any committed files (`page.langs.value.size === 0`). For unsaved content it skips the SW call, re-stashes the in-flight draft under the new slug, and navigates locally. The saved-content path is unchanged.

`buildRenameDeps` extracted into `ContentEditView/build-rename-deps.ts` to keep the SFC under the LOC budget.

## Test plan
- [x] 3 unit tests in `wire-handlers.test.ts` (saved path; unsaved+draft; unsaved+no-draft).
- [x] `bun run test:unit` — 667 pass.
- [x] `bun run type-check`, `lint:sonar`, `lint:jsdoc`, `check:ci`, `lint:vue-depth`, `lint:css` — all green.
- [ ] Realmode E2E for the full create→rename→save flow (follow-up — current PR ships the unit pinning + the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)