### PR TITLE
fix(newspaper): strip converter metadata from uploaded FB2

### DIFF
--- a/e2e-realmode/newspaper-fb2.spec.ts
+++ b/e2e-realmode/newspaper-fb2.spec.ts
@@ -9,6 +9,30 @@ import { saveAndConfirm } from './helpers/save-flow'
 const SLUG = 'issue-1'
 const FB2_BODY = '<?xml version="1.0" encoding="UTF-8"?>\n<FictionBook/>\n'
 
+/* A Calibre-style FB2: <document-info> carries the converter's OS /
+ * library account name + tool fingerprint, and <custom-info> stashes a
+ * local library path. The body cites the same surname in a footnote —
+ * sanitisation must scrub the *metadata* and leave the *content*. */
+const CALIBRE_LEAK_FB2 = `<?xml version="1.0" encoding="UTF-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+<description>
+  <title-info>
+    <book-title>Prometeo Comunista N 1</book-title>
+    <author><nickname>Prometeo Comunista</nickname></author>
+    <lang>it</lang>
+  </title-info>
+  <document-info>
+    <author><first-name>Jane</first-name><last-name>Roe</last-name></author>
+    <program-used>calibre 4.99.5</program-used>
+    <id>ec5f6add-ca4a-45c6-9e60-33be0385347e</id>
+    <version>1.0</version>
+  </document-info>
+  <custom-info info-type="calibre_library_path">/home/jane.roe/Calibre Library</custom-info>
+</description>
+<body><section><p>Roe, J. "Una visita alla fabbrica" // 2000.</p></section></body>
+</FictionBook>
+`
+
 test.beforeEach(async () => {
   await resetSandboxBaseline()
 })
@@ -59,4 +83,43 @@ test('newspaper FB2 upload commits sources to assets/<slug>.<lang>.fb2', async (
    * deploy. */
   const issueIndex = await readFile(`newspaper/${SLUG}/index.en.md`)
   await assertAstroAccepts('newspaper', issueIndex ?? '')
+})
+
+test('uploaded FB2 is stripped of converter metadata before commit', async ({
+  page,
+}) => {
+  test.setTimeout(180_000)
+  await bootRealmode(page, 'newspaper-fb2-sanitize')
+  await visit(page, `/content/newspaper/edit/${SLUG}`, SLOW)
+  await expectVisible(
+    page,
+    page.locator('[data-testid="newspaper-source-uploads"]'),
+    SLOW
+  )
+
+  await page
+    .locator('[data-testid="fb2-dropzone"] + input[type="file"]')
+    .setInputFiles({
+      name: 'magazine.fb2',
+      mimeType: 'application/x-fictionbook+xml',
+      buffer: Buffer.from(CALIBRE_LEAK_FB2, 'utf8'),
+    })
+  await expectVisible(page, page.locator('[data-testid="fb2-current"]'), SLOW)
+
+  const shaBefore = await headSha()
+  await saveAndConfirm(page)
+  await waitForHeadAdvance(shaBefore)
+
+  const remote =
+    (await readFile(`newspaper/${SLUG}/assets/${SLUG}.en.fb2`)) ?? ''
+  expect(remote, 'committed FB2 must exist').toBeTruthy()
+  /* Metadata scrubbed … */
+  expect(remote).not.toContain('Jane')
+  expect(remote).not.toContain('calibre')
+  expect(remote).not.toContain('custom-info')
+  expect(remote).not.toContain('ec5f6add-ca4a-45c6-9e60-33be0385347e')
+  expect(remote).toContain('<nickname>Communist Prometheus</nickname>')
+  /* … content preserved (the footnote citation is editor-authored). */
+  expect(remote).toContain('Roe, J. "Una visita alla fabbrica"')
+  expect(remote).toContain('<book-title>Prometeo Comunista N 1</book-title>')
 })

--- a/src/components/MarkdownEditor/Fb2Upload.vue
+++ b/src/components/MarkdownEditor/Fb2Upload.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import type { AssetDisplay } from '@/composables/useAssets/types'
+import { sanitizeFb2 } from '@/features/newspaper/sanitize-fb2'
 import { createDragHandlers } from './pdf-upload-handlers'
+import { readFb2Text } from './read-fb2-text'
 import { matchesSource, sourceName } from './source-asset-naming'
 
 const props = defineProps<{
@@ -26,15 +28,18 @@ const triggerUpload = () => {
   inputRef.value?.click()
 }
 
-const handleFile = (file: File): void => {
+const handleFile = async (file: File): Promise<void> => {
   if (!file.name.toLowerCase().endsWith('.fb2')) {
     emit('error', 'Only .fb2 files are accepted here')
     return
   }
-  const renamed = new File([file], sourceName(props.slug, props.lang, 'fb2'), {
-    type: file.type || 'application/x-fictionbook+xml',
-  })
-  emit('upload-fb2', renamed)
+  const cleaned = sanitizeFb2(await readFb2Text(file))
+  emit(
+    'upload-fb2',
+    new File([cleaned], sourceName(props.slug, props.lang, 'fb2'), {
+      type: 'application/x-fictionbook+xml',
+    })
+  )
 }
 
 const handleChange = (event: Event): void => {

--- a/src/components/MarkdownEditor/read-fb2-text.ts
+++ b/src/components/MarkdownEditor/read-fb2-text.ts
@@ -1,0 +1,28 @@
+const PROLOG_BYTES = 200
+
+const declaredEncoding = (head: string): string =>
+  head.match(/encoding=["']([^"']+)["']/i)?.[1] ?? 'utf-8'
+
+const decode = (buf: ArrayBuffer, encoding: string): string => {
+  try {
+    return new TextDecoder(encoding).decode(buf)
+  } catch {
+    return new TextDecoder('utf-8').decode(buf)
+  }
+}
+
+/**
+ * Read an FB2 File as text, honouring the encoding declared in its XML
+ * prolog (older Russian FB2s are often windows-1251) instead of blindly
+ * assuming UTF-8 — a wrong guess mojibakes Cyrillic on commit.
+ *
+ * @param file - The uploaded `.fb2` File.
+ * @returns The file decoded with its declared (or UTF-8) encoding.
+ */
+export const readFb2Text = async (file: File): Promise<string> => {
+  const buf = await file.arrayBuffer()
+  const head = new TextDecoder('ascii').decode(
+    new Uint8Array(buf, 0, Math.min(PROLOG_BYTES, buf.byteLength))
+  )
+  return decode(buf, declaredEncoding(head))
+}

--- a/src/features/newspaper/sanitize-fb2.test.ts
+++ b/src/features/newspaper/sanitize-fb2.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeFb2 } from './sanitize-fb2'
+
+/*
+ * Calibre (and other ebook converters) stamp the uploader's OS / library
+ * account name into the FB2 <document-info><author> block. That FB2 is
+ * served verbatim from the public site, so the name leaks. sanitizeFb2
+ * neutralises <document-info> (and drops <custom-info>) while leaving the
+ * book's <title-info> and the article body byte-for-byte intact —
+ * including bibliographic citations that legitimately mention the same
+ * surname. (Placeholder name "Jane Roe" stands in for the real one.)
+ */
+const LEAKING_FB2 = `<?xml version="1.0" encoding="UTF-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0" xmlns:l="http://www.w3.org/1999/xlink">
+<description>
+    <title-info>
+        <book-title>primo numero della rivista</book-title>
+        <author><first-name>prometeo</first-name><last-name>comunista</last-name></author>
+        <genre>rivista</genre>
+        <lang>ru</lang>
+        </title-info>
+    <document-info>
+        <author><first-name>Jane</first-name><last-name>Roe</last-name></author>
+        <program-used>calibre 4.99.5</program-used>
+        <date>8.5.2026</date>
+        <id>ec5f6add-ca4a-45c6-9e60-33be0385347e</id>
+        <version>1.0</version>
+    </document-info>
+    <custom-info info-type="calibre_library_path">/home/jane.roe/Calibre Library</custom-info>
+    <publish-info>
+    <year>2026</year></publish-info>
+</description>
+<body>
+<section>
+<p><strong>PROMETEO COMUNISTA N 1, Maggio 2026</strong></p>
+<p> - Roe, J. "Una visita alla fabbrica" // Bollettino n. 1(49). 2000. Febbraio.</p>
+<p>Текст на русском языке: пролетарии всех стран, соединяйтесь.</p>
+</section>
+</body>
+</FictionBook>
+`
+
+describe('sanitizeFb2', () => {
+  it('strips the uploader name and tool metadata from <document-info>', () => {
+    const out = sanitizeFb2(LEAKING_FB2)
+    expect(out).not.toContain('Jane')
+    expect(out).not.toContain('<first-name>Jane</first-name>')
+    expect(out).not.toContain('calibre')
+    expect(out).not.toContain('ec5f6add-ca4a-45c6-9e60-33be0385347e')
+    expect(out).toContain('<document-info>')
+    expect(out).toContain('<nickname>Communist Prometheus</nickname>')
+  })
+
+  it('drops <custom-info> blocks entirely', () => {
+    const out = sanitizeFb2(LEAKING_FB2)
+    expect(out).not.toContain('custom-info')
+    expect(out).not.toContain('jane.roe')
+  })
+
+  it('keeps <title-info>, the body, and bibliographic citations intact', () => {
+    const out = sanitizeFb2(LEAKING_FB2)
+    expect(out).toContain(
+      '<book-title>primo numero della rivista</book-title>'
+    )
+    expect(out).toContain('PROMETEO COMUNISTA N 1, Maggio 2026')
+    expect(out).toContain('Roe, J. "Una visita alla fabbrica"')
+    expect(out).toContain('пролетарии всех стран, соединяйтесь')
+  })
+
+  it('is a no-op for an FB2 that has no <document-info>', () => {
+    const minimal =
+      '<?xml version="1.0" encoding="UTF-8"?>\n' +
+      '<FictionBook><description><title-info>' +
+      '<book-title>x</book-title></title-info></description>' +
+      '<body><section><p>hi</p></section></body></FictionBook>'
+    expect(sanitizeFb2(minimal)).toBe(minimal)
+  })
+})

--- a/src/features/newspaper/sanitize-fb2.ts
+++ b/src/features/newspaper/sanitize-fb2.ts
@@ -1,0 +1,33 @@
+/*
+ * FB2 carries two metadata blocks: <title-info> (the book — author,
+ * title, language; editor-controlled and user-facing) and
+ * <document-info> (the *file* — who/what produced it). Ebook
+ * converters such as Calibre auto-fill <document-info><author> with the
+ * uploader's OS / library account name, and the FB2 is served verbatim
+ * from the public site — so that name leaks. This replaces
+ * <document-info> with a neutral block and removes any <custom-info>
+ * (Calibre also stashes local library paths there), leaving <title-info>
+ * and the article body byte-for-byte unchanged.
+ */
+const NEUTRAL_DOCUMENT_INFO =
+  '<document-info><author><nickname>Communist Prometheus</nickname>' +
+  '</author><date>2026</date>' +
+  '<id>00000000-0000-0000-0000-000000000000</id>' +
+  '<version>1.0</version></document-info>'
+
+const replaceBlock = (xml: string, tag: string, to: string): string =>
+  xml.replace(new RegExp(`<${tag}\\b[^>]*>[\\s\\S]*?</${tag}>`, 'gi'), to)
+
+/**
+ * Neutralise file-level FB2 metadata that could expose the uploader.
+ * No-op when the input carries no <document-info> / <custom-info>.
+ *
+ * @param xml - Raw FB2 XML as a UTF-8 string.
+ * @returns FB2 XML with a neutral <document-info> and no <custom-info>.
+ */
+export const sanitizeFb2 = (xml: string): string =>
+  replaceBlock(
+    replaceBlock(xml, 'custom-info', ''),
+    'document-info',
+    NEUTRAL_DOCUMENT_INFO
+  )


### PR DESCRIPTION
## Problem
The newspaper FB2 files committed via the admin (Calibre-converted, uploaded through the "Drop a .fb2 file directly" widget) carried the uploader's real name in `<document-info><author><first-name>…</first-name><last-name>…</last-name></author>` plus `<program-used>calibre …</program-used>`, `<id>` UUID, and Calibre's `<custom-info>` library path. Since the FB2 is served verbatim from the public site, that name leaked on the live download. No test covered this.

(The leaked blobs were also purged from `public-website-content` history via `git filter-repo` + force-push — done separately, out of scope of this PR.)

## Change
- `src/features/newspaper/sanitize-fb2.ts` — `sanitizeFb2(xml)`: replace `<document-info>` with a neutral block (`<nickname>Communist Prometheus</nickname>`), drop every `<custom-info>`. Leaves `<title-info>` and the article body byte-for-byte intact — including bibliographic citations that legitimately mention the same surname (those are editor-authored content, not metadata).
- `src/components/MarkdownEditor/read-fb2-text.ts` — read the upload honouring the encoding declared in its XML prolog (older Russian FB2s are often windows-1251) instead of blindly assuming UTF-8.
- `Fb2Upload.vue` — sanitize on upload before emitting the asset; always re-stamp `application/x-fictionbook+xml`.

## Tests
- `sanitize-fb2.test.ts` — 4 cases: strips name + tool metadata, drops `<custom-info>`, keeps title-info/body/citations, no-op when `<document-info>` absent.
- `e2e-realmode/newspaper-fb2.spec.ts` — new spec: upload a Calibre-style leaking FB2, save, assert the committed `assets/<slug>.<lang>.fb2` has no `Sergey`/`calibre`/`custom-info`/UUID and has the neutral author, while the body footnote citation is preserved.
- `bun run type-check`, `lint:sonar`, `lint:jsdoc`, biome check, and the unit suite (`src/components/MarkdownEditor`, `src/features/newspaper`, `src/composables/useAssets`) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)