### PR TITLE
fix(deploy-status): pending build survives stale runs with identical message

### DIFF
--- a/e2e/content/deploy-bar-immediate.spec.ts
+++ b/e2e/content/deploy-bar-immediate.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForContentReady } from '../helpers/content-ready'
+import { openPreview, saveAndConfirm } from './preview-save'
+
+const openFirstArticle = async (
+  page: import('@playwright/test').Page
+): Promise<void> => {
+  await page.goto('/content/blog')
+  await waitForContentReady(page)
+  await page.locator('h3').first().click()
+  await page.waitForURL(/\/edit\//)
+  await waitForContentReady(page)
+}
+
+/**
+ * Reported flow: "I save the newspaper, the 'something is deploying'
+ * badge does not appear in the UI until I refresh the page". Existing
+ * suite (`save-deploy-flow.spec.ts > Deploy Bar After Save`) only
+ * asserts the bar shows up within 15 s — that timeout is wide enough
+ * to hide the actual bug, which is that the optimistic pending entry
+ * is being eaten by an older workflow_run that shares the commit
+ * message (`updated <title> in newspaper` is byte-identical on every
+ * re-edit of the same issue).
+ *
+ * This suite pins the *optimistic* contract:
+ *
+ * 1. The `.deploy-bar` appears IMMEDIATELY after Save (within 1.5 s,
+ *    well before any GitHub polling round-trip could complete) — the
+ *    `setPendingDeploy()` write must produce a visible bar in the
+ *    same animation frame.
+ *
+ * 2. The bar STAYS visible through the first polling tick: a stubbed
+ *    `workflow_runs` endpoint returns ONE historical run whose
+ *    `head_commit.message` matches the freshly-queued pending. Before
+ *    the fix (timestamp-floor in `isPendingMatched`) the merged list
+ *    drops the pending the instant the old run lands and the bar
+ *    disappears — visible to the user as a single flash.
+ */
+test.describe('Deploy bar — optimistic + survives stale runs', () => {
+  test('bar appears within 1.5 s of clicking Save', async ({ page }) => {
+    await openFirstArticle(page)
+    const btn = await openPreview(page)
+    await saveAndConfirm(page, btn)
+    /*
+     * 1500 ms is comfortably less than a real GitHub API
+     * round-trip — if the bar needs to wait for the poll, this
+     * fails. The bar must mount from `pendingDeploy.value` writing
+     * synchronously inside the save handler, before commit even
+     * resolves.
+     */
+    await expect(page.locator('.deploy-bar')).toBeVisible({ timeout: 1500 })
+  })
+
+  test('bar stays visible when an older run shares the commit message', async ({
+    page,
+  }) => {
+    /*
+     * Stub the workflow_runs poll BEFORE the navigation so the SW
+     * never sees the real GH API. One stale run, days old, with the
+     * exact commit message the editor would emit. Pre-fix this run
+     * matched the pending placeholder on the first merge tick and
+     * the bar flickered out.
+     */
+    const SAME_MESSAGE = 'updated Test Article 61 in blog'
+    await page.route(
+      '**/api.github.com/repos/communist-prometheus/public-website/actions/workflows/**',
+      async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            workflow_runs: [
+              {
+                id: 9_000_002,
+                name: 'Deploy to Cloudflare Workers',
+                status: 'completed',
+                conclusion: 'success',
+                head_branch: 'master',
+                head_sha: 'b'.repeat(40),
+                created_at: '2026-04-13T08:00:00Z',
+                updated_at: '2026-04-13T08:05:00Z',
+                head_commit: {
+                  message: `content: ${SAME_MESSAGE}`,
+                  author: { name: 'bot', email: 'bot@example.com' },
+                },
+              },
+            ],
+          }),
+        })
+      }
+    )
+    await page.route(
+      '**/api.github.com/repos/communist-prometheus/public-website/actions/runs/**',
+      async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ jobs: [] }),
+        })
+      }
+    )
+
+    await openFirstArticle(page)
+    const btn = await openPreview(page)
+    await saveAndConfirm(page, btn)
+    /* Optimistic appearance. */
+    await expect(page.locator('.deploy-bar')).toBeVisible({ timeout: 1500 })
+    /*
+     * Hold for 5 s — well past the first polling tick on a normal
+     * `POLL_INTERVAL_MS` cadence (~3 s). Pre-fix the bar
+     * disappeared inside this window; post-fix the timestamp floor
+     * keeps the pending alive until the *new* run lands.
+     */
+    await page.waitForTimeout(5000)
+    await expect(page.locator('.deploy-bar')).toBeVisible()
+  })
+})

--- a/e2e/content/regression-pending-deploy-stale-match.spec.ts
+++ b/e2e/content/regression-pending-deploy-stale-match.spec.ts
@@ -1,0 +1,108 @@
+import { expect, expectVisible, test, visit } from '@prometheus/e2e-toolkit'
+
+/**
+ * Regression — newspaper home build appears immediately after a save
+ * even when a historical run shares the commit message.
+ *
+ * Reported flow: "Upload a PDF for one language of a newspaper, click
+ * save, navigate to home — the new build does not appear until you
+ * refresh ~10 times."
+ *
+ * Root cause: `isPendingMatched` used pure substring matching on the
+ * commit message. The newspaper edit always emits
+ * `updated <title> in newspaper`, so an old completed run from a
+ * previous edit (same title) instantly matched the freshly-queued
+ * pending and dropped it. The user had no signal until GitHub's API
+ * eventually surfaced the real new run.
+ *
+ * Fix: also require the real run's `created_at` to be at-or-after the
+ * pending's `createdAt` (with a 60s clock-skew slack). This test
+ * pins the contract end-to-end: an old run with the same message
+ * must NOT eat the optimistic pending entry on /.
+ */
+test.describe('Pending deploy survives stale runs with the same message', () => {
+  test('home shows the optimistic pending entry even when an old run shares the commit message', async ({
+    page,
+  }) => {
+    const SAME_MESSAGE =
+      'updated Il giornale «Prometeo Comunista» #1 — Maggio 2026 in newspaper'
+
+    /* Intercept the GitHub workflow_runs poll and return a single
+     * historical run from a month ago whose commit message is
+     * identical to the pending we're about to set. Pre-fix this is
+     * exactly the wire shape that killed the optimistic entry. */
+    await page.route(
+      '**/api.github.com/repos/communist-prometheus/public-website/actions/workflows/**',
+      async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            workflow_runs: [
+              {
+                id: 9_000_001,
+                name: 'Deploy to Cloudflare Workers',
+                status: 'completed',
+                conclusion: 'success',
+                head_branch: 'master',
+                head_sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                created_at: '2026-04-13T08:00:00Z',
+                updated_at: '2026-04-13T08:05:00Z',
+                head_commit: {
+                  message: `content: ${SAME_MESSAGE}`,
+                  author: { name: 'bot', email: 'bot@example.com' },
+                },
+              },
+            ],
+          }),
+        })
+      }
+    )
+
+    /* The jobs endpoint is hit only when an entry expands; stub
+     * to an empty list so a transient call doesn't 404 noisily. */
+    await page.route(
+      '**/api.github.com/repos/communist-prometheus/public-website/actions/runs/**',
+      async route => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ jobs: [] }),
+        })
+      }
+    )
+
+    /* Seed the pending entry the way the save flow would, but with
+     * `createdAt = now` so it's clearly newer than the historical
+     * stub above. */
+    await visit(page, '/')
+    await page.evaluate(message => {
+      globalThis.sessionStorage.setItem(
+        'pending_deploy',
+        JSON.stringify({
+          id: `pending-${Date.now()}`,
+          message,
+          createdAt: new Date().toISOString(),
+        })
+      )
+    }, SAME_MESSAGE)
+    await page.reload({ waitUntil: 'domcontentloaded' })
+
+    /* Both entries must be visible on the deploy list — the
+     * historical run AND the new optimistic pending. Pre-fix only
+     * the historical one appeared because the pending was matched
+     * and dropped on the very first render of the merged list. */
+    await expectVisible(
+      page,
+      page.locator('section.deploy-list .deploy-item').first()
+    )
+    const items = page.locator('section.deploy-list .deploy-item')
+    await expect(items).toHaveCount(2)
+
+    /* Optimistic pending always renders at the top of the list
+     * (most recent first) and carries the synthetic `pending-`
+     * head_sha sentinel. */
+    const top = items.first()
+    await expect(top).toContainText(SAME_MESSAGE)
+  })
+})

--- a/e2e/throttled/critical-paths.spec.ts
+++ b/e2e/throttled/critical-paths.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForContentReady } from '../helpers/content-ready'
+import { openPreview, saveAndConfirm } from '../content/preview-save'
+import { applyThrottling } from './throttle'
+
+/**
+ * Critical-subset suite — these scenarios run under Slow 3G + 4× CPU
+ * throttling (see `./throttle.ts`). The point is to lock the
+ * end-to-end contract for users on bad cellular tethers and 4-year-old
+ * Android devices — where reactivity glitches that look fast on a dev
+ * laptop become 5-second dropouts and "is anything happening?" doubt.
+ *
+ * Pick rule for what belongs here: scenarios where the user makes a
+ * change and expects an *immediate* UI signal that the system received
+ * the change. Anything purely offline-local (typing, scrolling) is
+ * better tested at unit / interaction layer; anything that goes
+ * through service worker + GitHub + polling belongs here.
+ *
+ * Generous timeouts vs. unthrottled mirror tests: an animation frame
+ * that lands in <50 ms on a fast laptop can need 400-600 ms when the
+ * CPU is 4× slower AND the SW bridge is in flight AND a poll tick is
+ * scheduled. The contracts are still tight enough that a regression
+ * (e.g. the "old run eats new pending" bug) fails them.
+ */
+const openFirstArticle = async (
+  page: import('@playwright/test').Page
+): Promise<void> => {
+  await page.goto('/content/blog')
+  await waitForContentReady(page)
+  await page.locator('h3').first().click()
+  await page.waitForURL(/\/edit\//)
+  await waitForContentReady(page)
+}
+
+test.describe('Critical paths under Slow 3G + 4× CPU', () => {
+  test.beforeEach(async ({ page }) => {
+    await applyThrottling(page)
+  })
+
+  /*
+   * The headline regression: users on slow mobile didn't see the
+   * deploy bar after Save and concluded the save silently failed,
+   * then mashed F5 — which on the next mount re-ran polling and
+   * (eventually) showed the bar from a fresh run. With throttling on
+   * we *must* see the optimistic bar from the local pending write,
+   * not from a real workflow run.
+   */
+  test('deploy bar appears within 5 s of Save (no refresh needed)', async ({
+    page,
+  }) => {
+    await openFirstArticle(page)
+    const btn = await openPreview(page)
+    await saveAndConfirm(page, btn)
+    await expect(page.locator('.deploy-bar')).toBeVisible({ timeout: 5000 })
+  })
+
+  /*
+   * "Pick the first article, see it open in the editor" is the
+   * single most-walked path in this app. If it can't complete in
+   * 30 s on slow mobile, the rest of the admin is unreachable.
+   */
+  test('content list → editor opens within 30 s', async ({ page }) => {
+    await page.goto('/content/blog')
+    await waitForContentReady(page)
+    const firstCard = page.locator('h3').first()
+    await expect(firstCard).toBeVisible({ timeout: 30_000 })
+    await firstCard.click()
+    await page.waitForURL(/\/edit\//, { timeout: 30_000 })
+    await waitForContentReady(page)
+    await expect(page.locator('[data-testid="markdown-editor"]')).toBeVisible({
+      timeout: 30_000,
+    })
+  })
+})

--- a/e2e/throttled/throttle.ts
+++ b/e2e/throttled/throttle.ts
@@ -1,0 +1,39 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Network conditions roughly matching Lighthouse "Slow 3G" — what the
+ * admin would feel on a cellular tether in a basement or an underseat
+ * Wi-Fi on a long-haul flight. 50 kBps each way, 400 ms latency.
+ */
+const SLOW_3G = {
+  offline: false,
+  downloadThroughput: (400 * 1024) / 8,
+  uploadThroughput: (400 * 1024) / 8,
+  latency: 400,
+} as const
+
+/**
+ * CPU slowdown factor. 4× mirrors Lighthouse's mid-tier mobile profile:
+ * a 4-year-old Android phone on a bad day. Stronger than what most
+ * dev machines feel and stronger than CI runners, which is the
+ * point — the budget must survive there too.
+ */
+const CPU_SLOWDOWN = 4 as const
+
+/**
+ * Apply Slow 3G network + 4× CPU throttling to a Playwright page via
+ * Chrome DevTools Protocol. Idempotent per page (CDP sessions are
+ * cheap; later calls overwrite earlier conditions).
+ *
+ * Use in a `test.beforeEach` so the throttling is active for the
+ * page navigation itself, not just the post-load interactions —
+ * users on bad networks experience the boot, not just the click.
+ *
+ * @param page - The Playwright page to throttle.
+ */
+export const applyThrottling = async (page: Page): Promise<void> => {
+  const client = await page.context().newCDPSession(page)
+  await client.send('Network.enable')
+  await client.send('Network.emulateNetworkConditions', SLOW_3G)
+  await client.send('Emulation.setCPUThrottlingRate', { rate: CPU_SLOWDOWN })
+}

--- a/playwright.config.constants.ts
+++ b/playwright.config.constants.ts
@@ -3,3 +3,12 @@ export const LIGHTHOUSE_TEST_PATTERN = '**/lighthouse/**'
 
 /** Glob pattern to exclude mobile-specific tests. */
 export const MOBILE_TEST_PATTERN = '**/mobile/**'
+
+/**
+ * Glob pattern for the throttled critical-path suite. Tests under
+ * `e2e/throttled/` opt every page into Slow 3G + 4× CPU emulation via
+ * a `beforeEach` hook (see `e2e/throttled/throttle.ts`). The desktop
+ * + mobile projects exclude this pattern so the throttling never
+ * leaks into a fast-mode run.
+ */
+export const THROTTLED_TEST_PATTERN = '**/throttled/**'

--- a/playwright.config.projects.ts
+++ b/playwright.config.projects.ts
@@ -3,12 +3,18 @@ import { devices } from '@playwright/test'
 import {
   LIGHTHOUSE_TEST_PATTERN,
   MOBILE_TEST_PATTERN,
+  THROTTLED_TEST_PATTERN,
 } from './playwright.config.constants'
 import { lighthouseProjects } from './playwright.config.lighthouse'
+import { throttledCritical } from './playwright.config.throttled'
 
 const allBrowsers = process.env.BROWSERS === 'all'
 
-const desktopIgnore = [LIGHTHOUSE_TEST_PATTERN, MOBILE_TEST_PATTERN]
+const desktopIgnore = [
+  LIGHTHOUSE_TEST_PATTERN,
+  MOBILE_TEST_PATTERN,
+  THROTTLED_TEST_PATTERN,
+]
 
 /**
  * Build a desktop browser project config.
@@ -51,5 +57,6 @@ export const projects = [
   ...browserProjects,
   mobileGeneral,
   mobileSpecific,
+  throttledCritical,
   ...lighthouseProjects,
 ]

--- a/playwright.config.throttled.ts
+++ b/playwright.config.throttled.ts
@@ -1,0 +1,19 @@
+import { devices } from '@playwright/test'
+
+/**
+ * Throttled critical-path suite — mid-tier Android emulation
+ * (Pixel 7 viewport) with Slow 3G + 4× CPU applied per-test via the
+ * `applyThrottling` helper in `e2e/throttled/throttle.ts`. Kept as a
+ * separate project so the slow runs do not gate every PR; opt-in via
+ * `playwright test --project=throttled-critical` or schedule on CI
+ * nightly.
+ *
+ * Per-test timeout is bumped to 90 s — a 4× CPU + Slow 3G page boot
+ * can legitimately spend 20–30 s before the editor mounts.
+ */
+export const throttledCritical = {
+  name: 'throttled-critical',
+  use: { ...devices['Pixel 7'] },
+  testMatch: '**/throttled/**',
+  timeout: 90_000,
+}

--- a/src/composables/useDeployStatus/pending-deploy-projection.ts
+++ b/src/composables/useDeployStatus/pending-deploy-projection.ts
@@ -29,10 +29,25 @@ export const pendingToDeployBuild = (p: PendingDeploy): DeployBuild => {
   return { run, jobs: [] }
 }
 
+/*
+ * Clock-skew slack between client-side `pending.createdAt`
+ * (`new Date()` on the user's machine) and the server-side
+ * `workflow_runs[].created_at` returned by the GitHub API.
+ * A fresh run can legitimately be stamped a few seconds earlier
+ * than the pending — the slack absorbs that. Old runs (minutes /
+ * hours / days in the past) stay correctly out of the match.
+ */
+const PENDING_MATCH_SLACK_MS = 60_000
+
 /**
  * Decide whether the pending deploy has been superseded by a real
- * run. Match by commit message — the admin injects the same message
- * into the content-repo commit that triggers the workflow.
+ * run. Match by commit message + timestamp floor — the admin
+ * injects the same message into the content-repo commit that
+ * triggers the workflow, but the message is NOT unique across
+ * pushes (newspaper edit always emits `updated <title> in
+ * newspaper`), so message alone matches old runs that happen to
+ * share the text. The timestamp floor restricts the match to runs
+ * created at or after the pending was queued (modulo clock skew).
  * @param pending - Pending deploy candidate
  * @param runs - Real runs from the last poll tick
  * @returns True when any real run already represents this pending entry
@@ -40,9 +55,12 @@ export const pendingToDeployBuild = (p: PendingDeploy): DeployBuild => {
 export const isPendingMatched = (
   pending: PendingDeploy,
   runs: ReadonlyArray<DeployBuild>
-): boolean =>
-  runs.some(
+): boolean => {
+  const floor = Date.parse(pending.createdAt) - PENDING_MATCH_SLACK_MS
+  return runs.some(
     b =>
       b.run.head_sha !== PENDING_RUN_PREFIX &&
+      Date.parse(b.run.created_at) >= floor &&
       !!b.run.head_commit?.message?.includes(pending.message)
   )
+}

--- a/src/composables/useDeployStatus/pending-deploy.test.ts
+++ b/src/composables/useDeployStatus/pending-deploy.test.ts
@@ -9,7 +9,11 @@ import {
 } from './pending-deploy'
 import type { DeployBuild } from './workflow-types'
 
-const realBuild = (message: string, sha: string): DeployBuild => ({
+const realBuild = (
+  message: string,
+  sha: string,
+  createdAt = '2026-04-16T00:00:00Z'
+): DeployBuild => ({
   run: {
     id: 1,
     name: 'Deploy',
@@ -17,8 +21,8 @@ const realBuild = (message: string, sha: string): DeployBuild => ({
     conclusion: undefined,
     head_branch: 'master',
     head_sha: sha,
-    created_at: '2026-04-16T00:00:00Z',
-    updated_at: '2026-04-16T00:00:00Z',
+    created_at: createdAt,
+    updated_at: createdAt,
     head_commit: {
       message,
       author: { name: 'undeadliner', email: 'u@example.com' },
@@ -74,14 +78,24 @@ describe('pendingToDeployBuild', () => {
 describe('isPendingMatched', () => {
   it('returns true when a real run has the same commit message', () => {
     setPendingDeploy('same message')
-    const real = [realBuild('same message', 'deadbeef')]
-    expect(isPendingMatched(requirePending(), real)).toBe(true)
+    const pending = requirePending()
+    const real = [
+      realBuild('same message', 'deadbeef', new Date().toISOString()),
+    ]
+    expect(isPendingMatched(pending, real)).toBe(true)
   })
 
   it('matches when real commit has content: prefix', () => {
     setPendingDeploy('updated Hero in pages')
-    const real = [realBuild('content: updated Hero in pages', 'deadbeef')]
-    expect(isPendingMatched(requirePending(), real)).toBe(true)
+    const pending = requirePending()
+    const real = [
+      realBuild(
+        'content: updated Hero in pages',
+        'deadbeef',
+        new Date().toISOString()
+      ),
+    ]
+    expect(isPendingMatched(pending, real)).toBe(true)
   })
 
   it('returns false when no real run matches', () => {
@@ -94,5 +108,64 @@ describe('isPendingMatched', () => {
     setPendingDeploy('pending msg')
     const built = pendingToDeployBuild(requirePending())
     expect(isPendingMatched(requirePending(), [built])).toBe(false)
+  })
+
+  /*
+   * Regression: the newspaper edit view always emits the commit
+   * message `updated <title> in newspaper`. Re-editing the same
+   * issue (e.g. uploading a PDF for another language) produces the
+   * SAME message every time. The old run that completed a few
+   * minutes ago carried that exact message. Without a timestamp
+   * floor the optimistic pending entry was matched by the OLD run
+   * the instant the home list rendered — the new "queued" card
+   * vanished and nothing appeared again until GitHub's API caught
+   * up (10 manual refreshes for the user).
+   */
+  it('does NOT match a real run that already existed before the pending was created', () => {
+    const before = '2026-04-16T10:00:00Z'
+    const justNow = '2026-04-16T10:30:00Z'
+    setPendingDeploy('updated Magazine N 1 in newspaper')
+    const pending = requirePending()
+    const overrideCreatedAt = { ...pending, createdAt: justNow }
+    const oldRun = realBuild(
+      'updated Magazine N 1 in newspaper',
+      'deadbeef',
+      before
+    )
+    expect(isPendingMatched(overrideCreatedAt, [oldRun])).toBe(false)
+  })
+
+  it('matches a real run that started AFTER the pending was created', () => {
+    const justNow = '2026-04-16T10:30:00Z'
+    const afterPending = '2026-04-16T10:30:08Z'
+    setPendingDeploy('updated Magazine N 1 in newspaper')
+    const pending = requirePending()
+    const overrideCreatedAt = { ...pending, createdAt: justNow }
+    const newRun = realBuild(
+      'updated Magazine N 1 in newspaper',
+      'cafef00d',
+      afterPending
+    )
+    expect(isPendingMatched(overrideCreatedAt, [newRun])).toBe(true)
+  })
+
+  /*
+   * GitHub stamps `workflow_runs[].created_at` server-side; the
+   * pending's `createdAt` is client-side `new Date()`. Clock skew
+   * of a few seconds is normal — a fresh run can be stamped
+   * slightly before the pending. The match must absorb that.
+   */
+  it('matches a fresh run stamped within the clock-skew slack window', () => {
+    const justNow = '2026-04-16T10:30:00Z'
+    const slightlyEarlier = '2026-04-16T10:29:55Z'
+    setPendingDeploy('updated Magazine N 1 in newspaper')
+    const pending = requirePending()
+    const overrideCreatedAt = { ...pending, createdAt: justNow }
+    const skewedRun = realBuild(
+      'updated Magazine N 1 in newspaper',
+      'cafef00d',
+      slightlyEarlier
+    )
+    expect(isPendingMatched(overrideCreatedAt, [skewedRun])).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- **Root cause**: `isPendingMatched` matched real runs by substring of the commit message alone. The newspaper edit view always emits `updated <title> in newspaper`, so the previous successful run from a prior edit instantly matched the freshly-queued optimistic pending the moment the home list rendered. The new build silently vanished until GitHub's API surfaced the new workflow_run (≈10 manual refreshes for the user).
- **Fix**: gate the match by a `created_at` floor. A real run only supersedes the pending when its server-side timestamp is at-or-after the pending's client-side `createdAt` (with 60 s of clock-skew slack absorbing the gap between `new Date()` in the browser and GitHub's run timestamp).
- **Behavior after fix**: optimistic pending appears on /home the moment Save commits and stays there until the *new* workflow_run with that message lands, regardless of how many old runs share the text.

## Tests
- **Unit** — `pending-deploy.test.ts`: failing-then-passing regression test (`does NOT match a real run that already existed before the pending was created`) + a forward case (`matches a real run that started AFTER the pending was created`) + clock-skew slack edge.
- **E2E** — `e2e/content/regression-pending-deploy-stale-match.spec.ts`: routes the `workflow_runs` poll to a stubbed historical run that shares the commit message; asserts /home renders BOTH entries instead of collapsing to one.

## Test plan
- [x] `npx vitest run src/composables/useDeployStatus` — 25/25 pass locally
- [ ] CI e2e for the new regression spec
- [ ] Manual: re-edit an existing newspaper, save, navigate to /home — new build card is visible immediately (no refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)