### PR TITLE
fix(newspaper-edit): unbreak mobile layout — sticky-footer overlap + FAB collision

### DIFF
--- a/e2e/mobile/newspaper-edit-layout.spec.ts
+++ b/e2e/mobile/newspaper-edit-layout.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { MOBILE_FAB } from '../helpers/mobile-constants'
+
+/**
+ * Regression for the broken mobile layout on /content/newspaper/edit
+ * at iPhone-class viewports.
+ *
+ * Two visible bugs that this test pins:
+ *
+ * 1. The `EditorFooter` had `position: sticky; bottom: 0`. Its sticky
+ *    containing block was `.edit-body-area`, which on a newspaper edit
+ *    page sits entirely below the viewport at scroll=0 (frontmatter +
+ *    articles picker push it past 812px on iPhone 12 Pro). Sticky
+ *    clamps to the parent's TOP when its target (`bottom: 0` against
+ *    viewport-bottom) falls outside the parent — so the Preview
+ *    footer rendered on TOP of the "SOURCE FILES" header instead of
+ *    after the dropzones.
+ *
+ * 2. The `AddArticleRow` "Add" button sat in the bottom-right area
+ *    where the global MobileMenu FAB lives (fixed, ~56px,
+ *    bottom-right). At certain scroll positions the FAB rendered on
+ *    top of the Add button.
+ *
+ * Asserts:
+ *   - The Preview button is positioned AFTER the SOURCE FILES section
+ *     (natural flow, no sticky overlap).
+ *   - The Preview button does not intersect the floating FAB.
+ *   - The "Add" button on the articles-picker does not intersect the
+ *     floating FAB.
+ */
+test.describe('Newspaper edit — mobile layout', () => {
+  test('Preview button sits after source uploads (no sticky overlap)', async ({
+    page,
+  }) => {
+    await page.goto('/content/newspaper/edit/issue-1')
+    const sources = page.getByTestId('newspaper-source-uploads')
+    const preview = page.getByTestId('preview-button')
+    await expect(sources).toBeVisible()
+    await expect(preview).toBeVisible()
+    const sourcesBox = await sources.boundingBox()
+    const previewBox = await preview.boundingBox()
+    expect(sourcesBox).not.toBeNull()
+    expect(previewBox).not.toBeNull()
+    if (!sourcesBox || !previewBox) return
+    /*
+     * Preview must start AT OR BELOW the bottom of source uploads.
+     * Pre-fix the sticky footer clamped to the top of the section
+     * and rendered ON TOP of the "SOURCE FILES" header.
+     */
+    expect(previewBox.y).toBeGreaterThanOrEqual(
+      sourcesBox.y + sourcesBox.height - 1
+    )
+  })
+
+  test('Preview and Add buttons do not collide with the FAB', async ({
+    page,
+  }) => {
+    await page.goto('/content/newspaper/edit/issue-1')
+    const fab = page.getByTestId(MOBILE_FAB)
+    const preview = page.getByTestId('preview-button')
+    const add = page.getByTestId('article-add')
+    await expect(fab).toBeVisible()
+    await expect(preview).toBeVisible()
+    await expect(add).toBeVisible()
+    const fabBox = await fab.boundingBox()
+    const previewBox = await preview.boundingBox()
+    const addBox = await add.boundingBox()
+    expect(fabBox && previewBox && addBox).toBeTruthy()
+    if (!fabBox || !previewBox || !addBox) return
+    const intersects = (
+      a: { x: number; y: number; width: number; height: number },
+      b: { x: number; y: number; width: number; height: number }
+    ): boolean =>
+      !(
+        a.x + a.width <= b.x ||
+        b.x + b.width <= a.x ||
+        a.y + a.height <= b.y ||
+        b.y + b.height <= a.y
+      )
+    expect(intersects(previewBox, fabBox)).toBe(false)
+    expect(intersects(addBox, fabBox)).toBe(false)
+  })
+})

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -51,7 +51,24 @@
   --z-modal: 1000;
   --z-debug: 9999;
 
+  /*
+   * Width occupied by the bottom-right MobileMenu FAB
+   * (`MobileMenuFab.vue`: 56px + 16px edge margin). 0 on desktop —
+   * the FAB hides at ≥768px viewport. Mobile bumps it so any
+   * sticky / right-anchored interactive control reserves a gutter
+   * that the floating nav button can sit in without obscuring
+   * content. Use as `padding-inline-end: var(--fab-safe-inline-end)`
+   * on bottom-pinned bars and tight rows like AddArticleRow.
+   */
+  --fab-safe-inline-end: 0px;
+
   color-scheme: dark;
+}
+
+@media (width < 768px) {
+  :root {
+    --fab-safe-inline-end: calc(56px + 16px + 0.5rem);
+  }
 }
 
 /*

--- a/src/components/MarkdownEditor/ArticlesPicker/AddArticleRow.vue
+++ b/src/components/MarkdownEditor/ArticlesPicker/AddArticleRow.vue
@@ -46,12 +46,23 @@ const onClick = (): void => {
 
 <style scoped>
 .add-row {
+  /*
+   * On mobile the MobileMenu FAB (fixed, bottom-right, ~56px) would
+   * otherwise sit on top of the Add button when the picker happens
+   * to align with the viewport bottom — observed regression on
+   * /content/newspaper/edit at 375px. `--fab-safe-inline-end`
+   * resolves to 0 on desktop (FAB hidden) and the FAB gutter on
+   * narrow screens.
+   */
   display: flex;
   gap: 0.5rem;
+  flex-wrap: wrap;
+  padding-inline-end: var(--fab-safe-inline-end);
 }
 
 .select {
-  flex: 1;
+  flex: 1 1 12rem;
+  min-width: 0;
   padding: 0.375rem 0.5rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -61,6 +72,7 @@ const onClick = (): void => {
 }
 
 .add-btn {
+  flex: 0 0 auto;
   padding: 0.375rem 0.75rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);

--- a/src/components/MarkdownEditor/EditorFooter.vue
+++ b/src/components/MarkdownEditor/EditorFooter.vue
@@ -23,12 +23,27 @@ const emit = defineEmits<{ preview: [] }>()
 </template>
 
 <style scoped>
+/*
+ * `position: sticky; bottom: 0` was the original intent (keep
+ * Preview reachable on long pages), but the sticky containing
+ * block here is `.edit-body-area`, which on /content/newspaper/edit
+ * sits entirely below the viewport at scrollY=0 (frontmatter +
+ * articles picker push it down past 812px on a 375x812 mobile).
+ * Sticky then clamps to `.edit-body-area`'s TOP instead of the
+ * viewport bottom — the Preview footer was rendering on TOP of the
+ * "Source files" section header. Natural flow places the footer
+ * after content, which scroll-reaches without the overlap.
+ *
+ * Mobile-FAB safe gutter still applies so the Preview button
+ * doesn't slide under the floating navigation button.
+ */
 .editor-footer {
-  position: sticky;
-  bottom: 0;
-  z-index: 5;
   display: flex;
   padding: clamp(0.75rem, 2vw, 1rem);
+  padding-inline-end: max(
+    clamp(0.75rem, 2vw, 1rem),
+    var(--fab-safe-inline-end)
+  );
   border-top: 1px solid var(--color-border);
   justify-content: flex-end;
   background: var(--color-background);


### PR DESCRIPTION
## Summary
Two visible regressions on `/content/newspaper/edit/*` at iPhone-class viewports (375 × 812):

1. **Preview footer overlapped the SOURCE FILES section.** `EditorFooter` had `position: sticky; bottom: 0` with `.edit-body-area` as its sticky containing block. On a newspaper edit page that container sits entirely below the viewport at scroll = 0 (frontmatter editor + articles picker push it past 812 px). Sticky then clamps to the parent's TOP instead of the viewport bottom — and the Preview footer rendered on top of the "SOURCE FILES" header. Switched to natural flow; the Preview button now sits after the dropzones, reachable by scroll.

2. **MobileMenu FAB hid the "Add" button on the articles picker.** AddArticleRow's "Add" sat in the bottom-right area where the global FAB lives (fixed, ~56 px, bottom-right). At scroll positions where the picker row aligned with the viewport bottom, the FAB rendered on top of "Add". Added a global `--fab-safe-inline-end` token (0 on desktop, 72 px on `<768px`) and applied it to AddArticleRow + EditorFooter padding-inline-end, plus `flex-wrap` on AddArticleRow so "Add" stacks below the select on narrow viewports.

Before → after at 375 × 812 (mock-auth dev build):
- The Preview button now lives where it belongs, after the source-file dropzones.
- The Articles picker "Add" button is visible, in its own row below the select, far from the FAB.
- Desktop unchanged (FAB hidden at `≥768px`; `--fab-safe-inline-end: 0`).

## Tests
- `e2e/mobile/newspaper-edit-layout.spec.ts` — two regression assertions:
  - Preview button geometry comes AFTER `[data-testid="newspaper-source-uploads"]` (no sticky overlap).
  - Preview + Add bounding boxes do not intersect the FAB.

## Manual verification
- `bun run dev` + `VITE_MOCK_AUTH=true MOCK_OAUTH=true`, Chrome DevTools at 375 × 812:
  - Source files header + hint visible, dropzones below it, Preview at the end, Add wraps below the select. No element hidden by FAB.
- Same flow at 1400 × 900 — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)