### PR TITLE
feat(links): drop the siteLang field from the LinksEditor

### DIFF
--- a/src/components/LinksEditor/LinkRow.vue
+++ b/src/components/LinksEditor/LinkRow.vue
@@ -42,11 +42,6 @@ const onField = (index: number, field: LinkField, e: Event): void => {
       :value="entry.category" :groups="groups"
       @change="emit('field', index, 'category', $event)"
     />
-    <input
-      type="text" class="f-text f-lang" :value="entry.siteLang"
-      placeholder="lang" data-testid="link-sitelang"
-      @input="onField(index, 'siteLang', $event)"
-    />
     <LinkRingToggle
       :checked="entry.inRing"
       @change="emit('ring', index, $event)"
@@ -68,7 +63,7 @@ const onField = (index: number, field: LinkField, e: Event): void => {
 .link-row {
   list-style: none;
   display: grid;
-  grid-template-columns: 2fr 2fr auto auto auto auto;
+  grid-template-columns: 2fr 2fr auto auto auto;
   gap: 0.4rem;
   align-items: center;
   padding: 0.75rem 0;
@@ -83,10 +78,6 @@ const onField = (index: number, field: LinkField, e: Event): void => {
   background: var(--color-background);
   color: var(--color-text);
   font-size: 0.8125rem;
-}
-
-.f-lang {
-  width: 3.5rem;
 }
 
 .f-remove {

--- a/src/components/LinksEditor/draft-ops.ts
+++ b/src/components/LinksEditor/draft-ops.ts
@@ -1,7 +1,7 @@
 import type { LinkEntry } from '@/stores/links'
 
 /** Editable string fields of a link entry. */
-export type LinkField = 'url' | 'name' | 'category' | 'siteLang'
+export type LinkField = 'url' | 'name' | 'category'
 
 /**
  * A blank entry for the "add" action.
@@ -11,7 +11,6 @@ export const emptyEntry = (): LinkEntry => ({
   url: '',
   name: '',
   category: 'organizations',
-  siteLang: 'en',
   inRing: true,
   descriptions: {},
 })

--- a/src/sw/mock/settings/links.ts
+++ b/src/sw/mock/settings/links.ts
@@ -6,7 +6,6 @@ export const linksJson = JSON.stringify({
       url: 'https://www.leftcom.org',
       name: 'Internationalist Communist Tendency',
       category: 'organizations',
-      siteLang: 'en',
       inRing: true,
       descriptions: {
         en: 'Internationalist communist organisation.',
@@ -17,7 +16,6 @@ export const linksJson = JSON.stringify({
       url: 'https://www.marxists.org',
       name: 'Marxists Internet Archive',
       category: 'resources',
-      siteLang: 'en',
       inRing: false,
       descriptions: {
         en: 'Archive of Marxist writers and documents.',
@@ -28,7 +26,6 @@ export const linksJson = JSON.stringify({
       url: 'https://www.anarchy.bg',
       name: 'Anarchy.bg',
       category: 'friendly',
-      siteLang: 'bg',
       inRing: false,
       descriptions: {
         en: 'Friendly anarchist resource.',

--- a/src/validation/schemas/links.ts
+++ b/src/validation/schemas/links.ts
@@ -9,7 +9,6 @@ export const LinkEntrySchema = Schema.Struct({
   url: Schema.String,
   name: Schema.String,
   category: Schema.String,
-  siteLang: Schema.String,
   inRing: Schema.Boolean,
   descriptions: Schema.Record({ key: Schema.String, value: Schema.String }),
 })


### PR DESCRIPTION
## Summary

The links editor on the admin had a `siteLang` text input — a 2-letter
code that the public links page rendered as a small badge after each
link name. In practice editors kept setting it inconsistently (it
labels the *site's* primary language, not the language of the
resource itself, and entries with multi-lingual sites needed an
arbitrary tag), so it confused readers more than it helped.

This drops the field from the editor, the draft-ops, the Effect
`LinkEntrySchema`, and the SW links mock used by the e2e tests. The
public-website page + content `links.json` lose the same field in a
companion PR on public-website + commit on the content repo, so the
two stay in sync.

- `LinkRow.vue`: removed the `siteLang` input and its grid column
- `draft-ops.ts`: removed `'siteLang'` from `LinkField` and the default on `emptyEntry()`
- `validation/schemas/links.ts`: dropped `siteLang: Schema.String`
- `sw/mock/settings/links.ts`: stripped `siteLang` from the mock document

## Test plan

- [x] `bun run build` (full client + SW build) — clean
- [x] `bun run test:unit` — 690/690 pass (no test referenced `siteLang`)
- [ ] visit `/settings` after deploy and confirm the row layout is intact + the language column is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)