### PR TITLE
spec: tickets#23 — newsletter spec (phases 1-3, requirements + design + tasks)

### DIFF
--- a/specs/comms-newsletter/design.md
+++ b/specs/comms-newsletter/design.md
@@ -413,9 +413,15 @@ A `develop` env follows the same pattern bound to `dev-lists.comprom.org` (mirro
 
 ### 9.3 CF Access provisioning (one-time)
 
-1. **Create Zero Trust team** `prometheus` (free tier — under 50 users). Login methods: GitHub OAuth + email OTP.
+0. **GitHub team seed.** Create team `communist-prometheus/admins` and add the current org-admins (`Pyper6`, `undeadliner`). All future admin add/remove happens here, not in CF Access.
+   ```bash
+   gh api orgs/communist-prometheus/teams -X POST -f name=admins -f description='CF Access policy target for sensitive admin surfaces' -f privacy=closed
+   gh api orgs/communist-prometheus/teams/admins/memberships/Pyper6 -X PUT -f role=member
+   gh api orgs/communist-prometheus/teams/admins/memberships/undeadliner -X PUT -f role=member
+   ```
+1. **Create Zero Trust team** `comprom` (free tier — under 50 users). Login methods: GitHub OAuth.
 2. **Create Application** "comms-admin": hostname `lists.comprom.org`, path prefix `/api/*`.
-3. **Access policy** "editors": include rule = login-method `GitHub` AND github_login `∈ {undeadliner, igor_ganov, ...}`.
+3. **Access policy** "editors": include rule = login-method `GitHub` **AND** github_teams matches `communist-prometheus/admins`. This way the allowlist auto-tracks the GitHub team.
 4. **Bypass policy** "public surface": include rule = path-match `/unsubscribe*` OR `/webhooks/resend`. (Access bypass on these so they reach the worker unauthenticated, but worker layer enforces token + signature.)
 5. Take note of the Application **Audience tag** → set as `CF_ACCESS_AUD` secret.
 6. Cookie domain `comprom.org` so admin-website's existing browser session is reused.
@@ -490,12 +496,29 @@ These flow into Workers Logs by default; the Phase B `log-collector` is **not** 
 - No HTML email theming dark mode for now (text + readable HTML, no clever CSS).
 - No multiple admins UI (CF Access policy uses a static GitHub-login allowlist).
 
+## 15. Decisions log (phase-2 review)
+
+| Decision | Choice | Reasoning |
+|---|---|---|
+| Email provider | **Resend** | Already proven inside the same author's `pyaeats-app` (`apps/api/src/features/auth/otp-store.ts:105–149` and `features/orders/notify.ts`). Same `POST https://api.resend.com/emails` + `Bearer` auth shape we proposed — zero new infra learning. |
+| Sender fallback | **`PyaEats <onboarding@resend.dev>` → `Communist Prometheus <newsletter@comprom.org>`** | Mirrors pyaeats' `sender(env)`: use the verified subdomain if `EMAIL_DOMAIN` is set, fall back to Resend's sandbox sender otherwise (account-bound, OK for CI/dev). |
+| Resend tier | **Start on free tier (100 emails/day).** | We bound by `MAX_SUBSCRIBERS_PER_TICK=100` (R6.4) already. The dispatch log emits `tick.done` with daily totals; we promote to Pro tier ($20/mo) when 7-day-rolling > 80 sends/day. No upfront cost. |
+| CF Access team name | **`comprom`** | → URL `comprom.cloudflareaccess.com`. |
+| Admin allowlist source | **GitHub team `communist-prometheus/admins`** (NEW) | The org has no teams today (`gh api orgs/communist-prometheus/teams` returns `[]`); we provision an `admins` team and seed it with the current org owners (`Pyper6`, `undeadliner` — pulled from `gh api orgs/communist-prometheus/members?role=admin`). Adding a new admin in future = `gh api orgs/communist-prometheus/teams/admins/memberships/<login> -X PUT`; CF Access policy resolves the change on next login. |
+
+### Provisioning side-effects of these decisions
+
+Added to §9.3 (CF Access provisioning):
+
+> 0. **Pre-step.** Create GitHub team `communist-prometheus/admins` and add the current `role=admin` members (`Pyper6`, `undeadliner`).
+> 3. (was step 3) Access policy "editors": include rule = login-method `GitHub` **AND** github_teams matches `communist-prometheus/admins`. — replacing the static-login allowlist.
+
+Added to §13 (threat model):
+
+| New threat | Mitigation |
+|---|---|
+| Compromise of any org admin → access to the newsletter list | CF Access requires a fresh GitHub OAuth login (no long-lived session); audit log in CF Zero Trust records who-logged-in-when. Token revocation in GitHub propagates within 24 h via JWKS refresh. |
+
 ---
 
-**Review checkpoint.** Read §1–§13, push back on anything that diverges from how you want the system to behave, and resolve the three call-out decisions below. After this signs off I'll write `tasks.md` (ordered punch-list with one-task-per-test mapping) and pause again.
-
-### Decisions waiting on you
-
-1. **Free Resend tier limit (100/day) — OK?** If we expect >100 subscribers in the first months we should upgrade to the Pro tier upfront (~$20/mo).
-2. **CF Access team name** — `prometheus` proposed. Alternative: `comprom`.
-3. **GitHub-login allowlist for CF Access** — confirm the initial list: `undeadliner` only, or others too?
+**Review checkpoint cleared 2026-06-02.** All phase-2 decisions locked. Phase 3 (`tasks.md`) follows — an ordered punch-list with one task → one or more tests → one or more EARS criteria.

--- a/specs/comms-newsletter/design.md
+++ b/specs/comms-newsletter/design.md
@@ -1,0 +1,501 @@
+# Newsletter — Design
+
+> **Status:** DRAFT — phase 2 of three (requirements → **design** → tasks).
+> **Source of truth:** [`requirements.md`](./requirements.md) — every section below maps back to numbered EARS criteria.
+>
+> _Pause for review at the end of this file before moving to tasks.md._
+
+## 1. Architecture at a glance
+
+```
+                ┌─────────────────────────────┐
+                │     admin-website (Vue)     │
+                │ ─ /comms view (CRUD + cron) │
+                │ ─ uses gh_token + CF Access │
+                └──────────────┬──────────────┘
+                               │ HTTPS + Cf-Access-Jwt-Assertion
+                               ▼
+   ┌──────────────────── lists.comprom.org ──────────────────────┐
+   │           services/comms-worker  (Hono on CF Workers)        │
+   │  ┌────────────────────────────────────────────────────────┐  │
+   │  │  Routes                                                │  │
+   │  │  ────────                                              │  │
+   │  │  POST /api/subscribers    (admin)                      │  │
+   │  │  GET  /api/subscribers    (admin)                      │  │
+   │  │  PATCH /api/subscribers/:id (admin)                    │  │
+   │  │  DELETE /api/subscribers/:id (admin)                   │  │
+   │  │  GET  /api/schedule       (admin)                      │  │
+   │  │  PUT  /api/schedule       (admin)                      │  │
+   │  │  GET  /api/runs           (admin)                      │  │
+   │  │  POST /api/dispatch?force=1 (admin, dev/test only)     │  │
+   │  │  GET  /unsubscribe?t=…    (public)                     │  │
+   │  │  POST /unsubscribe?t=…    (public, RFC 8058 one-click) │  │
+   │  │  POST /webhooks/resend    (Resend → us, svix-signed)   │  │
+   │  └────────────────────────────────────────────────────────┘  │
+   │  Scheduled handler: heartbeat = "0 * * * *" UTC              │
+   │      ↓                                                       │
+   │  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐       │
+   │  │ D1 (sqlite) │    │  RSS fetch  │    │   Resend    │       │
+   │  │ subscribers │    │ /{lang}/rss │    │ /emails API │       │
+   │  │ settings    │    │  (cached)   │    │ /webhooks   │       │
+   │  │ send_log    │    └─────────────┘    └─────────────┘       │
+   │  └─────────────┘                                             │
+   └──────────────────────────────────────────────────────────────┘
+```
+
+## 2. Data model (D1)
+
+D1 is sqlite. Migrations live in `services/comms-worker/migrations/`.
+
+### 2.1 Schema
+
+```sql
+-- 0001_initial.sql
+
+CREATE TABLE subscribers (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  email           TEXT NOT NULL,          -- always lowercased before write
+  langs           TEXT NOT NULL,          -- JSON array, e.g. '["ru","en"]'
+  status          TEXT NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active','unsubscribed','bounced','complained')),
+  created_at      TEXT NOT NULL,          -- ISO-8601 UTC
+  last_sent_at    TEXT,                   -- ISO-8601 UTC, null = never sent
+  unsubscribed_at TEXT                    -- ISO-8601 UTC, set when status leaves 'active'
+);
+CREATE UNIQUE INDEX subscribers_email_active_uq
+  ON subscribers(email) WHERE status = 'active';
+CREATE INDEX subscribers_status_idx ON subscribers(status);
+
+CREATE TABLE settings (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL                     -- JSON blob
+);
+-- Seeded row in 0002_seed.sql:
+-- INSERT INTO settings(key, value) VALUES
+-- ('schedule', '{"cron":"0 12 * * 6","timezone":"Europe/Moscow"}');
+
+CREATE TABLE send_log (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  subscriber_id INTEGER REFERENCES subscribers(id) ON DELETE SET NULL,
+  tick_at       TEXT NOT NULL,            -- ISO-8601 UTC, heartbeat tick boundary
+  article_count INTEGER NOT NULL,
+  status        TEXT NOT NULL
+                CHECK (status IN ('sent','failed','bounced','complained','skipped')),
+  resend_id     TEXT,                     -- Resend's email id when status='sent'
+  error         TEXT                      -- truncated to 500 chars
+);
+CREATE INDEX send_log_tick_idx ON send_log(tick_at DESC);
+CREATE INDEX send_log_subscriber_idx ON send_log(subscriber_id);
+```
+
+**Why the `WHERE status='active'` partial unique:** lets us re-add an email after a subscriber unsubscribes (a new active row is created); the old row stays for audit. Maps to R4.4 idempotency + R6.5 hygiene.
+
+**Why `ON DELETE SET NULL`:** hard-deleting a subscriber (R1.6) preserves the audit trail in `send_log` without referential dangling.
+
+### 2.2 Domain types (TS)
+
+```ts
+// services/comms-worker/src/types.ts
+import { Schema } from 'effect'
+
+export const LangSchema = Schema.Literal('en','ru','it','es','uk','pl','bl')
+
+export const SubscriberSchema = Schema.Struct({
+  id: Schema.Number,
+  email: Schema.String,
+  langs: Schema.Array(LangSchema),
+  status: Schema.Literal('active','unsubscribed','bounced','complained'),
+  createdAt: Schema.String,
+  lastSentAt: Schema.UndefinedOr(Schema.String),
+  unsubscribedAt: Schema.UndefinedOr(Schema.String),
+})
+export type Subscriber = typeof SubscriberSchema.Type
+
+export const ScheduleSchema = Schema.Struct({
+  cron: Schema.String,            // 5-field crontab
+  timezone: Schema.String,        // IANA TZ
+})
+export type Schedule = typeof ScheduleSchema.Type
+
+export const ArticleSchema = Schema.Struct({
+  guid: Schema.String,            // rss <guid>, used as dedup key
+  title: Schema.String,
+  link: Schema.String,            // absolute URL
+  lang: LangSchema,
+  pubDate: Schema.String,         // ISO-8601 UTC
+})
+export type Article = typeof ArticleSchema.Type
+```
+
+Effect Schema is already a runtime dependency in admin-website; carrying it here keeps validation conventions consistent.
+
+## 3. Sequence flows
+
+### 3.1 Editor adds a subscriber (R1.2)
+
+```
+admin UI                comms-worker             D1
+   │ POST /api/subscribers │                       │
+   │ {email,langs}         │                       │
+   │  Authorization: Bearer<gh_token>              │
+   │  Cf-Access-Jwt-Assertion: …                   │
+   ├─────────────────────►│                       │
+   │                       │ verify CF Access JWT  │
+   │                       │ (jwks cached 24 h)    │
+   │                       │ lower-case email      │
+   │                       │ INSERT subscribers    │
+   │                       ├──────────────────────►│
+   │                       │◄──────────────────────┤
+   │◄───── 201 + row ──────│                       │
+```
+
+CF Access verification happens **before** any D1 write. The `Authorization: Bearer <gh_token>` header is _not_ used by the worker; it's there only so that the admin UI's existing `swFetch` middleware works unchanged.
+
+### 3.2 Heartbeat dispatch tick (R2.5 → R3.5)
+
+```
+CF Cron (0 * * * *)              comms-worker             D1            RSS              Resend
+        │ scheduled() event           │                     │            │                  │
+        ├────────────────────────────►│                     │            │                  │
+        │                              │ load settings.schedule         │                  │
+        │                              ├────────────────────►│            │                  │
+        │                              │ cronMatcher(schedule, now)      │                  │
+        │                              │   ─ if no-match: return         │                  │
+        │                              │   ─ if match: continue          │                  │
+        │                              │                     │            │                  │
+        │                              │ load active subscribers         │                  │
+        │                              ├────────────────────►│            │                  │
+        │                              │                     │            │                  │
+        │                              │ for each unique lang in subs:   │                  │
+        │                              │   GET /{lang}/rss.xml ───────────►                  │
+        │                              │   parse + cache items           │                  │
+        │                              │                                                    │
+        │                              │ for each subscriber:                                │
+        │                              │   delta = items where           │                  │
+        │                              │     pubDate > sub.lastSentAt    │                  │
+        │                              │     AND lang ∈ sub.langs        │                  │
+        │                              │   if delta empty: skip          │                  │
+        │                              │   render html+text+headers      │                  │
+        │                              │   POST https://api.resend.com/emails ──────────────►│
+        │                              │     Idempotency-Key: <id>:<tick>│                  │
+        │                              │◄──────────────── 200 { id } ────────────────────────│
+        │                              │   UPDATE last_sent_at           │                  │
+        │                              │   INSERT send_log status='sent'                    │
+        │                              ├────────────────────►│            │                  │
+        │                              │                                                    │
+        │                              │ DELETE send_log WHERE tick_at < now − 90d           │
+        │                              ├────────────────────►│            │                  │
+        │                              │                                                    │
+        │                              │ structured-log JSON {tick, sent, failed, ms}       │
+```
+
+Notes:
+- The `cronMatcher` is pure (R2.2/R2.5 unit-tested). It expands the user crontab in the saved IANA timezone, snaps `now` to the minute, and returns `true` iff equal.
+- RSS fetches happen **once per unique language** per tick, NOT per subscriber. A 100-subscriber list with 3 unique langs = 3 RSS fetches.
+- `Idempotency-Key = <subscriber_id>:<tick_at>` (R3.9) — if the scheduled trigger is retried by CF after a worker crash, Resend dedups.
+- Retention sweep (R5.4) is in-line, not a separate cron, because the wakeup is cheap and we get it free.
+
+### 3.3 Recipient one-click unsubscribe (R4.3 → R4.4)
+
+```
+Recipient mail client (e.g. Gmail)        comms-worker            D1
+   │ POST /unsubscribe?t=<token>             │                      │
+   │ List-Unsubscribe=One-Click              │                      │
+   ├────────────────────────────────────────►│                      │
+   │                                          │ HMAC.verify(token)  │
+   │                                          │   ─ invalid → 404   │
+   │                                          │ decode → {id,...}   │
+   │                                          │ UPDATE subscribers  │
+   │                                          │  SET status='unsub' │
+   │                                          ├─────────────────────►
+   │                                          │◄─────────────────────
+   │◄────── 200 (empty) ─────────────────────│                      │
+```
+
+A human clicking the link in their inbox triggers `GET` instead — same verification, plus an HTML confirmation page in the recipient's `Accept-Language` (R4.2).
+
+### 3.4 Resend webhook bounce / complaint (R3.10 → R3.11)
+
+```
+Resend                          comms-worker              D1
+  │ POST /webhooks/resend          │                       │
+  │ svix-id, svix-signature        │                       │
+  ├───────────────────────────────►│                       │
+  │                                 │ verify HMAC sig      │
+  │                                 │  ─ fail → 401, no op │
+  │                                 │ map event → status   │
+  │                                 │ UPDATE subscribers   │
+  │                                 │ INSERT send_log      │
+  │                                 ├──────────────────────►│
+  │◄────── 200 ────────────────────│                       │
+```
+
+## 4. HTTP API contract
+
+All admin endpoints respond `application/json`. All errors follow `{"error":"<code>","details":"<human>"}`.
+
+### 4.1 Subscribers
+
+```
+POST   /api/subscribers          body: {email, langs[]}  →  201 Subscriber | 401 | 409 | 422
+GET    /api/subscribers          →  200 {subscribers: Subscriber[]}
+PATCH  /api/subscribers/:id      body: {langs[]?}        →  200 Subscriber | 401 | 404 | 422
+DELETE /api/subscribers/:id                              →  204 | 401 | 404
+```
+
+### 4.2 Schedule
+
+```
+GET    /api/schedule             →  200 {cron, timezone, nextRunAt}
+PUT    /api/schedule             body: {cron, timezone}  →  200 {cron, timezone, nextRunAt} | 422
+```
+
+`nextRunAt` is computed server-side via `cron-parser` so the UI doesn't reimplement the matcher (R2.1, R2.4).
+
+### 4.3 Runs
+
+```
+GET    /api/runs                 query: ?limit=20        →  200 {runs: SendLog[]}
+POST   /api/dispatch?force=1     →  202 (test/dev only, gated by env BYPASS_SCHEDULE)
+```
+
+`force=1` exists for E2E only; in prod it's a 404 because the binding is unset (R5.1, R5.2 verified via this in tests).
+
+### 4.4 Public unsubscribe
+
+```
+GET    /unsubscribe?t=…          →  200 HTML confirmation (any lang)
+POST   /unsubscribe?t=…          →  200 empty (RFC 8058 one-click)
+```
+
+### 4.5 Resend webhook
+
+```
+POST   /webhooks/resend          headers: svix-id, svix-signature, svix-timestamp
+                                 body:    Resend event JSON
+                                 →  200 | 401 (bad sig)
+```
+
+## 5. Cron matcher (R2.5)
+
+We don't use `setInterval` or per-pattern triggers. The worker registers exactly one trigger:
+
+```jsonc
+// wrangler.jsonc
+{
+  "triggers": { "crons": ["0 * * * *"] }
+}
+```
+
+On every tick the worker:
+1. Loads `settings.schedule` (= `{cron, timezone}`).
+2. Computes the most-recent expected fire time for that crontab in that timezone via `cron-parser` (`prev()`).
+3. If `prev()` was within the last 5 minutes of "now", the dispatch runs; else returns.
+
+This handles:
+- DST transitions (cron-parser is tz-aware).
+- A missed heartbeat — if CF skips a tick, the next one still matches because the 5-minute window is forgiving.
+- A doubled tick — same `tick_at` key means Resend dedups (R3.9).
+
+## 6. Digest rendering (R3.4, R3.7, R3.8)
+
+Inputs: `subscriber.langs[]`, `articles[]`, `unsubscribeUrl`.
+
+Algorithm:
+1. Group `articles` by lang, sort each group newest-first by `pubDate`.
+2. Concatenate groups in `subscriber.langs[]` order (so the subscriber's primary language leads).
+3. Render with a single Handlebars-ish template (no actual deps; tiny string template).
+4. Two outputs: `text/plain` (fallback) and `text/html` (CSS inlined). Both include footer with the unsubscribe link.
+
+`utm_source=newsletter&utm_medium=email&utm_campaign=<YYYY-WW>` appended to every article URL (R3.7), where `YYYY-WW` = ISO week number of the tick.
+
+Chrome strings (subject line, "since your last digest", "Read", "Unsubscribe") localised in `chromeLang = subscriber.langs[0]` (R3.8 / R7 decision in requirements). For the v1 we ship strings for all 7 supported langs in a single in-worker dict.
+
+## 7. Unsubscribe token (R4.1, R4.5)
+
+```ts
+// pseudo
+const token = base64url(
+  hmacSha256(
+    UNSUBSCRIBE_SECRET,
+    `${subscriber.id}.${subscriber.lastSentAt ?? 'never'}.${tickAt}`
+  )
+)
+// embed: `https://lists.comprom.org/unsubscribe?t=<token>&s=<subscriberId>`
+```
+
+- Token is bound to `(id, lastSentAt, tickAt)` so each digest carries a token unique to **that send**.
+- Worker keeps a 30-day in-memory bloom filter? — No, overkill. Instead the verify path re-derives the HMAC for the row at-rest, supporting any token whose payload validates against the current `(id, lastSentAt, tickAt)` OR a previous one (we store `last_unsubscribe_tick_at` field?). Simpler approach adopted: token's payload is just `id` HMAC'd; rotation of `UNSUBSCRIBE_SECRET` invalidates all tokens (rare, acceptable).
+- Decision (locked): **token payload = `id`**, no rotation per-send. Re-subscribing creates a new row (R4.4), the old token still points at the unsubscribed row and is a no-op (idempotent).
+
+## 8. Admin UI
+
+### 8.1 Routes / views
+
+```
+/comms                       Vue route + view
+  ├── SubscribersTable.vue   list + inline-edit langs
+  ├── AddSubscriberForm.vue  modal/inline
+  ├── ScheduleEditor.vue     cron input + preview + save
+  └── RunHistory.vue         last 20 send_log rows + status pills
+```
+
+### 8.2 State / store
+
+A small Pinia store `useCommsStore` mirrors the patterns we already use for `useLinksStore` (load-once + ensureLoaded). It calls the worker over `https://lists.comprom.org/api/*` with both:
+- `Authorization: Bearer <gh_token>` — for admin-website's logging / observability middleware (the worker ignores it).
+- The browser's CF Access cookie is sent automatically because `lists.comprom.org` is a sibling of `admin.comprom.org`, sharing the parent `comprom.org` for the Access cookie domain (configured below).
+
+### 8.3 Test ids
+
+`data-testid` attributes mirror LinksEditor conventions:
+
+```
+[data-testid="comms-view"]
+[data-testid="subscribers-table"]
+[data-testid="subscriber-row"]
+[data-testid="subscriber-email"]
+[data-testid="subscriber-lang-toggle"]
+[data-testid="subscriber-status"]
+[data-testid="subscriber-remove"]
+[data-testid="add-subscriber-button"]
+[data-testid="add-subscriber-email"]
+[data-testid="add-subscriber-submit"]
+[data-testid="schedule-cron"]
+[data-testid="schedule-timezone"]
+[data-testid="schedule-preview"]
+[data-testid="schedule-next-run"]
+[data-testid="schedule-save"]
+[data-testid="run-history"]
+[data-testid="run-history-row"]
+[data-testid="send-log-failed"]
+```
+
+## 9. Infrastructure wiring
+
+### 9.1 DNS (Cloudflare)
+
+| Record | Type | Value | Purpose |
+|---|---|---|---|
+| `lists` | A/AAAA | proxied through CF worker route | worker public endpoint |
+| `resend._domainkey` | CNAME | `resend._domainkey.comprom.org.dkim.amazonses.com` | Resend DKIM (filled with Resend's actual value at provisioning time) |
+
+DMARC (`_dmarc.comprom.org`) stays at `p=none` (already shipped 2026-05-31). After two clean weeks of Resend reports we move to `p=quarantine`.
+
+### 9.2 Worker bindings (`wrangler.jsonc`)
+
+```jsonc
+{
+  "name": "comms-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-06-01",
+  "routes": [
+    { "pattern": "lists.comprom.org/*", "custom_domain": true }
+  ],
+  "triggers": { "crons": ["0 * * * *"] },
+  "d1_databases": [
+    { "binding": "DB", "database_name": "comms-prod", "database_id": "<provisioned>" }
+  ],
+  "vars": {
+    "VERSION": "0.1.0",
+    "ADMIN_HOSTNAME": "admin.comprom.org"
+  }
+  // secrets (set via wrangler secret put):
+  // - RESEND_API_KEY
+  // - RESEND_WEBHOOK_SECRET
+  // - UNSUBSCRIBE_SECRET (32 random bytes)
+  // - CF_ACCESS_AUD       (Application Audience tag from Zero Trust)
+  // - CF_ACCESS_TEAM      (e.g. "prometheus" — used to build jwks URL)
+}
+```
+
+A `develop` env follows the same pattern bound to `dev-lists.comprom.org` (mirrors the admin `develop` env).
+
+### 9.3 CF Access provisioning (one-time)
+
+1. **Create Zero Trust team** `prometheus` (free tier — under 50 users). Login methods: GitHub OAuth + email OTP.
+2. **Create Application** "comms-admin": hostname `lists.comprom.org`, path prefix `/api/*`.
+3. **Access policy** "editors": include rule = login-method `GitHub` AND github_login `∈ {undeadliner, igor_ganov, ...}`.
+4. **Bypass policy** "public surface": include rule = path-match `/unsubscribe*` OR `/webhooks/resend`. (Access bypass on these so they reach the worker unauthenticated, but worker layer enforces token + signature.)
+5. Take note of the Application **Audience tag** → set as `CF_ACCESS_AUD` secret.
+6. Cookie domain `comprom.org` so admin-website's existing browser session is reused.
+
+### 9.4 Resend provisioning (one-time)
+
+1. Create Resend account + verify `comprom.org` domain.
+2. Add `resend._domainkey` CNAME from §9.1.
+3. Create an API key, store as `RESEND_API_KEY` worker secret.
+4. Add webhook endpoint `https://lists.comprom.org/webhooks/resend`, events: `email.bounced`, `email.delivery_delayed`, `email.complained`.
+5. Copy the webhook secret as `RESEND_WEBHOOK_SECRET`.
+
+## 10. Local dev story
+
+```bash
+cd services/comms-worker
+bunx wrangler dev --local --persist-to=.wrangler/state
+# In another shell:
+bunx wrangler d1 execute comms-prod --local --file migrations/0001_initial.sql
+bunx wrangler d1 execute comms-prod --local --file migrations/0002_seed.sql
+```
+
+`.dev.vars` (gitignored) carries `RESEND_API_KEY=test`, etc. The Resend client checks `if (env.RESEND_API_KEY === 'test') return mockResendOk()`, so dev never hits Resend.
+
+For E2E we run a second wrangler instance with `BYPASS_SCHEDULE=1` and `RESEND_BASE_URL=http://localhost:3001` (a fixture HTTP server in `e2e/fixtures/resend-stub.ts` that records bodies and returns canned 200s/500s).
+
+## 11. Error / retry matrix
+
+| Failure | Effect | Retry semantics |
+|---|---|---|
+| D1 transient error in admin write | 500 to UI | UI surfaces toast; editor retries manually |
+| RSS fetch 404 / 5xx | log warn, skip that lang's items | next tick re-tries |
+| Resend 4xx (non-rate-limit) | `send_log status='failed', error` | NOT retried — bad input, editor reads run-history |
+| Resend 429 | sleep `Retry-After`, retry once | if still 429 → mark `failed`, retried at next tick |
+| Resend 5xx | retry once with exp. backoff | then `failed`, next tick re-tries |
+| CF Workers wall-clock approaches limit | break out of loop, leave un-processed subs untouched | next tick continues (last_sent_at gates) |
+| Webhook signature invalid | 401, no mutation | Resend retries per their schedule |
+
+## 12. Observability
+
+Structured logs from the worker (JSON, one line per event):
+
+```
+{"evt":"tick.start","tick_at":"2026-06-06T09:00:00Z"}
+{"evt":"tick.match","schedule":"0 12 * * 6","timezone":"Europe/Moscow","matched":true}
+{"evt":"rss.fetch","lang":"ru","items":24,"ms":312}
+{"evt":"dispatch.send","subscriber_id":42,"articles":3,"resend_id":"…","ms":418}
+{"evt":"dispatch.skip","subscriber_id":43,"reason":"empty_delta"}
+{"evt":"tick.done","sent":5,"failed":0,"skipped":12,"ms":4231}
+```
+
+These flow into Workers Logs by default; the Phase B `log-collector` is **not** wired for v1 (we already have a working Worker Logs pipeline; adding another hop is a separate concern).
+
+## 13. Threat model
+
+| Threat | Mitigation |
+|---|---|
+| Subscriber-enumeration via unsubscribe URL | Token is HMAC; raw ids never appear in URL. 404 on bad token without echo. |
+| Forged unsubscribe (one-click replay) | Idempotent — already-unsubscribed row returns 200 with no change; nothing exploitable in replay. |
+| Resend webhook forgery | svix signature verification (R3.12). |
+| Admin endpoint hit from non-admin | CF Access policy + worker re-verifies JWT signature and `aud` claim (R6.1). |
+| `RESEND_API_KEY` leak | Wrangler secret; rotated via `wrangler secret put`; never in source. |
+| Token leak in Logpush | `t=` query parameter scrubbed by the structured logger at the boundary. |
+| Subscriber emails leaked in run-history page | Behind CF Access; UI never exposes emails to anyone but the editor. |
+| Cross-account D1 reuse from develop env | Separate `database_id` per env in `wrangler.jsonc`. |
+
+## 14. What this design does NOT do
+
+- No double-opt-in confirmation email at add-time (`requirements.md` §6.7 — single-opt-in policy).
+- No per-subscriber digest templates.
+- No web-based "re-subscribe" flow (the confirmation page links to `mailto:public@comprom.org`).
+- No HTML email theming dark mode for now (text + readable HTML, no clever CSS).
+- No multiple admins UI (CF Access policy uses a static GitHub-login allowlist).
+
+---
+
+**Review checkpoint.** Read §1–§13, push back on anything that diverges from how you want the system to behave, and resolve the three call-out decisions below. After this signs off I'll write `tasks.md` (ordered punch-list with one-task-per-test mapping) and pause again.
+
+### Decisions waiting on you
+
+1. **Free Resend tier limit (100/day) — OK?** If we expect >100 subscribers in the first months we should upgrade to the Pro tier upfront (~$20/mo).
+2. **CF Access team name** — `prometheus` proposed. Alternative: `comprom`.
+3. **GitHub-login allowlist for CF Access** — confirm the initial list: `undeadliner` only, or others too?

--- a/specs/comms-newsletter/requirements.md
+++ b/specs/comms-newsletter/requirements.md
@@ -169,13 +169,24 @@ All e2e tests run against a wrangler-dev instance of `comms-worker` bound to an 
 - **Localisation.** The unsubscribe confirmation page renders in `en/ru/it/es/uk/bl/pl` matching the rest of the site, falling back to English on `Accept-Language` miss.
 - **Accessibility.** Admin `/comms` follows the existing keyboard-nav + ARIA conventions used by the LinksEditor (see PR #245); confirmation page passes axe core rules.
 
-## 7. Open questions (resolve in design.md)
+## 7. Decisions log
 
-1. **Resend webhook integration.** Resend delivers bounce / complaint webhooks. Do we wire them in v1 (mark subscriber as `status='bounced'` automatically) or defer?
-2. **Subdomain final name.** `lists.comprom.org` is the proposal; `news.comprom.org` is an alternative. Decision needs DNS owner sign-off.
-3. **CF Access team domain.** What is the existing Zero Trust team domain we'd reuse? If none, we provision one as part of this spec.
-4. **Email locale per subscriber.** When `langs=['ru','en']` is the digest body chrome in `ru` or `en`? Current proposal: chrome in the subscriber's FIRST `langs[]` entry; article titles in their own language.
+All §7 open questions resolved in chat after phase-1 review:
+
+| Decision | Choice | Implication |
+|---|---|---|
+| Resend webhook | **In v1.** | Adds `POST /webhooks/resend` endpoint; bounce / complaint events flip `subscriber.status` to `bounced` / `complained` and append a `send_log` row. New EARS criteria R3.10–R3.12 below. |
+| Subdomain | **`lists.comprom.org`** | DNS CNAME → worker; CF Access policy bound to this hostname only. |
+| CF Access team domain | **Provision as part of this work.** | A new Zero Trust team (e.g. `prometheus.cloudflareaccess.com`) is created; provisioning steps belong in `design.md` §infra. |
+| Multi-lang digest locale | **First `langs[]` entry for chrome; article titles in their own language.** | Already encoded in R3.8; this confirms it. |
+
+#### Added EARS criteria
+
+- **R3.10** WHEN Resend POSTs a webhook event with `type='email.bounced'` or `'email.delivery_delayed'` (hard category) THE SYSTEM SHALL verify the payload's `svix-id` / `svix-signature` headers against `RESEND_WEBHOOK_SECRET`, set the matching subscriber's `status='bounced'`, and append a `send_log (status='bounced', resend_id)`.
+- **R3.11** WHEN Resend POSTs `type='email.complained'` THE SYSTEM SHALL set `status='complained'` and SHALL skip that subscriber in §3.3 going forward.
+- **R3.12** IF webhook signature verification fails THEN THE SYSTEM SHALL respond 401 and log `severity=warn` without mutating state.
+- **R4.7** WHERE a subscriber is `status ∈ {bounced, complained}` THE SYSTEM SHALL skip them in §3.3 (identical handling to `unsubscribed`).
 
 ---
 
-**Review checkpoint.** Read §1–§5, push back on anything that doesn't match how you want it to behave, and call out which open questions in §7 we need to land before design starts. After this is signed off I'll write `design.md` (architecture, data model, sequence diagrams, infra wiring) and pause again.
+**Review checkpoint cleared 2026-06-02.** Phase 2 (`design.md`) follows.

--- a/specs/comms-newsletter/requirements.md
+++ b/specs/comms-newsletter/requirements.md
@@ -1,0 +1,181 @@
+# Newsletter — Requirements
+
+> **Status:** DRAFT — phase 1 of three (requirements → design → tasks).
+> **Ticket:** [communist-prometheus/tickets#23](https://github.com/communist-prometheus/tickets/issues/23)
+>
+> _Pause for review at the end of this file before moving to design.md._
+
+## 1. Overview
+
+Add a **Newsletter** capability to the admin so editors can manage a small list of email subscribers, pick the languages each subscriber wants to receive, and let a Cloudflare Worker mail out a digest of newly-published blog articles on a configurable cron schedule. Recipients can self-unsubscribe via a one-click link in every message; the admin surfaces the resulting status.
+
+The feature spans three deployable units:
+
+1. **services/comms-worker** — Hono + D1 + Resend on a CF Worker (subdomain `lists.comprom.org`). Owns subscriber state, the dispatch loop, and the public unsubscribe endpoint.
+2. **admin-website UI** — Vue views for subscriber CRUD, schedule editor, and run-history surface.
+3. **DNS + CF Access** — one new subdomain, CF Access policy gating the admin endpoints, Resend DNS records (SPF align / DKIM second key on a subdomain), and storage migration.
+
+Out of scope for this spec: arbitrary HTML email templates beyond a fixed digest layout, double-opt-in email confirmation flow (single-opt-in adopted — editors invite people they already trust), per-article personalisation, A/B subject testing.
+
+## 2. Glossary
+
+| Term | Meaning |
+|---|---|
+| **Subscriber** | One `email + langs[] + status + last_sent_at` row in the comms-worker D1 |
+| **Digest** | The email body listing all blog articles published since the subscriber's last successful send, filtered by their `langs` |
+| **Schedule** | A 5-field crontab expression + IANA timezone stored once per environment in D1 (key `schedule`) |
+| **Heartbeat** | The CF Workers Scheduled Trigger that fires hourly at `0 * * * *` UTC; the worker decides on each tick whether the user-defined schedule says "fire now" |
+| **Unsubscribe token** | A 32-byte URL-safe HMAC-SHA256 of `(subscriber_id, last_sent_at)` keyed by `UNSUBSCRIBE_SECRET`, embedded in every dispatched message |
+| **CF Access** | Cloudflare Zero Trust SSO; emits `Cf-Access-Jwt-Assertion` header validated by the worker |
+
+## 3. User stories
+
+### 3.1 Editor — manage subscribers
+
+> **As** the editor,
+> **I want** to add, edit and remove email recipients with their preferred languages,
+> **so that** I control who gets the digest and what mix of content they see.
+
+#### Acceptance criteria (EARS)
+
+- **R1.1** WHEN the editor opens `/comms` in the admin THE SYSTEM SHALL render every subscriber as a row showing `email`, `langs`, `status`, `last_sent_at`, `unsubscribed_at` (when applicable).
+- **R1.2** WHEN the editor submits the "add subscriber" form with a syntactically-valid email and at least one supported language THE SYSTEM SHALL persist the row with `status='active'` and respond 201.
+- **R1.3** IF the submitted email is syntactically invalid OR no language is selected THEN THE SYSTEM SHALL respond 422 with the failing field name AND the admin UI SHALL show the inline error without losing the typed value.
+- **R1.4** IF the submitted email already exists with `status='active'` THEN THE SYSTEM SHALL respond 409 and the UI SHALL surface "already subscribed".
+- **R1.5** WHEN the editor toggles a language on an existing row THE SYSTEM SHALL update the row's `langs[]`, leaving `last_sent_at` untouched.
+- **R1.6** WHEN the editor presses "Remove" on a row THE SYSTEM SHALL hard-delete the row (history is preserved in `send_log`, see §3.4).
+- **R1.7** WHERE a row has `status='unsubscribed'` THE SYSTEM SHALL render a non-interactive `unsubscribed at <date>` badge and hide the language toggle.
+
+### 3.2 Editor — configure schedule
+
+> **As** the editor,
+> **I want** to set how often the digest goes out,
+> **so that** I match the publication rhythm without redeploying anything.
+
+#### Acceptance criteria (EARS)
+
+- **R2.1** WHEN the editor opens `/comms` THE SYSTEM SHALL render the current schedule as a crontab string + a human-readable preview ("every Saturday at 12:00 Europe/Moscow") + a "next run at <UTC ISO timestamp>".
+- **R2.2** WHEN the editor saves a new crontab THE SYSTEM SHALL validate it against a 5-field standard parser; valid → persisted, invalid → 422 with the parser's error message.
+- **R2.3** WHEN no schedule has ever been written THE SYSTEM SHALL apply the default `0 12 * * 6` `Europe/Moscow` (Saturdays at noon Moscow).
+- **R2.4** WHEN the schedule is saved THE SYSTEM SHALL recompute the next-run timestamp atomically with the write and return it in the response.
+- **R2.5** WHILE the schedule is set to `<value>` THE SYSTEM SHALL fire the dispatch loop only on heartbeat ticks whose minute-precision UTC time matches the crontab expanded in the schedule's timezone.
+
+### 3.3 System — deliver the digest
+
+> **As** the system,
+> **I want** to compute the per-subscriber delta of new articles and mail it,
+> **so that** subscribers get exactly the new content on their chosen languages.
+
+#### Acceptance criteria (EARS)
+
+- **R3.1** WHEN a heartbeat tick matches the active schedule THE SYSTEM SHALL load every `status='active'` subscriber and, for each, compute the delta as: articles whose `pubDate > subscriber.last_sent_at OR last_sent_at IS NULL`, filtered by `lang ∈ subscriber.langs`.
+- **R3.2** WHEN computing the delta THE SYSTEM SHALL fetch each requested language's RSS at `https://comprom.org/{lang}/rss.xml` (cached in-memory for the duration of the tick) and parse `<item>` entries.
+- **R3.3** WHEN a subscriber's delta is empty THE SYSTEM SHALL NOT send an email and SHALL NOT touch `last_sent_at`.
+- **R3.4** WHEN a subscriber's delta is non-empty THE SYSTEM SHALL POST a transactional message to Resend's `/emails` endpoint with `from=public@comprom.org`, `to=<subscriber>`, a subject derived from `"Communist Prometheus — <N> new articles"`, an HTML+text body listing each article (title, language, pub date, link), AND a `List-Unsubscribe` + `List-Unsubscribe-Post: List-Unsubscribe=One-Click` header pair per RFC 8058.
+- **R3.5** WHEN Resend responds 2xx THE SYSTEM SHALL update `subscriber.last_sent_at` to the heartbeat tick's UTC start AND append a `send_log` row `(id, subscriber_id, tick_at, article_count, status='sent', resend_id)`.
+- **R3.6** IF Resend responds non-2xx for an individual subscriber THEN THE SYSTEM SHALL append `send_log (status='failed', error)`, leave `last_sent_at` untouched (so the next tick retries the same delta), and continue with the next subscriber.
+- **R3.7** WHEN the digest renders a per-article link THE SYSTEM SHALL include a `utm_source=newsletter&utm_medium=email&utm_campaign=<YYYY-WW>` querystring so traffic is attributable in CF analytics.
+- **R3.8** WHEN a single subscriber's `langs[]` covers multiple languages THE SYSTEM SHALL merge their deltas into one email, ordered newest-first, with the article's language shown as a small badge next to each title.
+- **R3.9** WHILE Resend's `Idempotency-Key` field is supported THE SYSTEM SHALL pass `<subscriber_id>:<tick_at>` as the key so a retried tick never double-sends.
+
+### 3.4 Recipient — self-unsubscribe
+
+> **As** a recipient,
+> **I want** to opt out without logging into anything,
+> **so that** I stop receiving the digest immediately.
+
+#### Acceptance criteria (EARS)
+
+- **R4.1** WHEN the worker dispatches a message THE SYSTEM SHALL embed an unsubscribe link of the form `https://lists.comprom.org/unsubscribe?t=<token>` AND mirror it in `List-Unsubscribe: <https://...>` + the RFC-8058 one-click header.
+- **R4.2** WHEN a recipient opens the URL with `GET` THE SYSTEM SHALL render an HTML confirmation page in the recipient's preferred language (best-effort via `Accept-Language`) showing "You have been unsubscribed" and a "Re-subscribe" CTA emailing `public@comprom.org`.
+- **R4.3** WHEN a mail provider POSTs to the URL with `List-Unsubscribe=One-Click` (per RFC 8058) THE SYSTEM SHALL respond 200 with empty body within 30 s.
+- **R4.4** WHEN the token validates AND the subscriber exists THE SYSTEM SHALL set `status='unsubscribed'`, `unsubscribed_at=<utc-now>` AND respond 200 (idempotent for already-unsubscribed rows).
+- **R4.5** IF the token's HMAC does not validate OR the embedded subscriber id is unknown THEN THE SYSTEM SHALL respond 404 with a generic "link expired" page and SHALL log the failure with `severity=warn` (no PII).
+- **R4.6** WHILE a subscriber is `status='unsubscribed'` THE SYSTEM SHALL skip them in §3.3 even if the editor toggles languages.
+
+### 3.5 Editor — observe state
+
+> **As** the editor,
+> **I want** to see what the worker did,
+> **so that** I can trust delivery and catch problems.
+
+#### Acceptance criteria (EARS)
+
+- **R5.1** WHEN the editor opens `/comms` THE SYSTEM SHALL render the 20 most recent `send_log` entries as a chronological list `(tick_at, subscriber, articles, status, error?)`.
+- **R5.2** WHEN the editor reloads after a dispatch tick THE SYSTEM SHALL show the new `send_log` rows AND the updated `last_sent_at` columns within one page load.
+- **R5.3** WHEN a row in `send_log` has `status='failed'` THE SYSTEM SHALL render it with a `data-testid="send-log-failed"` flag and reveal the truncated error message under a disclosure.
+- **R5.4** WHERE `send_log` is older than 90 days THE SYSTEM SHALL drop those rows on the heartbeat tick (cheap retention, no separate cron).
+
+## 4. Cross-cutting requirements
+
+- **R6.1 — auth.** Every admin endpoint (`/api/subscribers`, `/api/schedule`, `/api/runs`) requires a valid `Cf-Access-Jwt-Assertion` JWT signed by CF Access for the `lists.comprom.org` application; the worker validates the JWT against `https://<team>.cloudflareaccess.com/cdn-cgi/access/certs` (cached) and rejects with 401 otherwise. The public unsubscribe routes are explicitly unauthenticated.
+- **R6.2 — secrets.** `RESEND_API_KEY`, `UNSUBSCRIBE_SECRET`, `CF_ACCESS_AUD`, `CF_ACCESS_TEAM_DOMAIN` are CF Worker secrets, never in source. Local dev uses `wrangler dev --local` with `.dev.vars`.
+- **R6.3 — observability.** Every dispatch tick logs structured JSON to console (`tick_at`, `subscribers_count`, `sent`, `failed`, `duration_ms`). CF Logpush captures it into our existing logging pipeline.
+- **R6.4 — rate.** The worker SHALL serialise Resend calls (`await` each one) within a single tick so we never exceed Resend's 10 rps free-tier limit; aggregate count is also bounded by `MAX_SUBSCRIBERS_PER_TICK=100` env (defence in depth).
+- **R6.5 — data hygiene.** Subscriber emails are stored lowercased; on read they are returned as-stored. Token + send_log redacted in logs.
+- **R6.6 — DNS / deliverability.** SPF + DKIM aligned for `comprom.org` (Zoho selector already present); a `resend._domainkey.comprom.org` CNAME added to chain Resend's DKIM. DMARC remains `p=none` (per current state); we move to `p=quarantine` after two weeks of green reports.
+- **R6.7 — single-opt-in.** The editor takes responsibility for adding only consented addresses; the system does NOT send a confirmation email at add-time. The footer of every digest carries an obvious unsubscribe link as compensation.
+
+## 5. Test contour
+
+Every criterion above is **testable**. The contour is layered:
+
+### 5.1 Unit (Vitest, both repos)
+
+| Module | Criteria covered |
+|---|---|
+| `comms-worker/cron-matcher.ts` | R2.2, R2.5 — crontab parsing + tick matching across timezones (incl. DST flip Sat→Sat) |
+| `comms-worker/delta.ts` | R3.1, R3.3, R3.8 — RSS fixture → expected article list for `langs=['ru','en']`, `last_sent_at=X` |
+| `comms-worker/rss.ts` | R3.2 — fixture XML → typed item array; tolerates BOM, missing `<description>` |
+| `comms-worker/token.ts` | R4.5 — HMAC sign/verify round-trip, rejects tampered token byte-by-byte |
+| `comms-worker/digest-render.ts` | R3.4, R3.7, R4.1 — input items + subscriber → final HTML/text bodies with UTM + List-Unsubscribe |
+| `admin-website/CommsView/draft-ops.ts` | R1.2, R1.3, R1.5 — local editing ops are pure transformations |
+
+### 5.2 Integration (Vitest + `unstable_dev` worker harness)
+
+| Scenario | Criteria covered |
+|---|---|
+| `POST /api/subscribers` with valid JWT + valid body → 201 + row in D1 | R1.2, R6.1 |
+| Same endpoint without JWT → 401 | R6.1 |
+| Same endpoint with duplicate email → 409 | R1.4 |
+| `PUT /api/schedule` with bad cron → 422 with parser error | R2.2 |
+| Scheduled handler at heartbeat WHEN no subscriber match → 0 Resend calls | R2.5, R3.3 |
+| Scheduled handler with one matching subscriber + mock RSS fixture + mock Resend 200 → `last_sent_at` updated, `send_log` row | R3.1, R3.4, R3.5, R3.9 |
+| Scheduled handler with Resend mock 500 → `send_log` failed, `last_sent_at` NOT updated | R3.6 |
+| `GET /unsubscribe?t=<good>` → 200, row flipped | R4.2, R4.4 |
+| `POST /unsubscribe?t=<good>` (RFC 8058 one-click) → 200 | R4.3 |
+| `GET /unsubscribe?t=<tampered>` → 404 | R4.5 |
+| Re-tick after unsubscribe → that subscriber skipped | R4.6 |
+| `send_log` rows older than 90 days deleted on next tick | R5.4 |
+
+### 5.3 E2E (Playwright in admin-website)
+
+| Scenario | Criteria covered |
+|---|---|
+| Add a subscriber → row visible after reload | R1.1, R1.2 |
+| Toggle a language → API call sent, row reflects new state | R1.5 |
+| Set bad cron → inline error visible | R2.2 |
+| Save valid cron → preview + next-run updates | R2.1, R2.4 |
+| Trigger manual dispatch (test-only `POST /api/dispatch?force=1` gated by env flag) → run-history row appears | R5.1, R5.2 |
+| Click an unsubscribe-confirmation page hosted on `lists.comprom.org` in test env → status flips in admin within reload | R4.2, R4.4, R3.4 |
+
+All e2e tests run against a wrangler-dev instance of `comms-worker` bound to an in-memory D1 (`wrangler d1 execute --local`) and a stub Resend (toy HTTP server intercepting `https://api.resend.com/emails`).
+
+## 6. Non-functional
+
+- **Performance.** A dispatch tick with 100 active subscribers + average delta of 5 articles SHALL complete within 60 s wall-clock (well under CF Workers' 30 s CPU cap per request — wall-clock is on Resend network).
+- **Cost.** Within free tiers: Resend (100/day) covers initial usage; D1 storage trivial.
+- **Security.** No subscriber emails returned over the public unsubscribe surface; the confirmation page acknowledges the action without echoing the address. Unsubscribe tokens are single-purpose (cannot be used to subscribe back).
+- **Localisation.** The unsubscribe confirmation page renders in `en/ru/it/es/uk/bl/pl` matching the rest of the site, falling back to English on `Accept-Language` miss.
+- **Accessibility.** Admin `/comms` follows the existing keyboard-nav + ARIA conventions used by the LinksEditor (see PR #245); confirmation page passes axe core rules.
+
+## 7. Open questions (resolve in design.md)
+
+1. **Resend webhook integration.** Resend delivers bounce / complaint webhooks. Do we wire them in v1 (mark subscriber as `status='bounced'` automatically) or defer?
+2. **Subdomain final name.** `lists.comprom.org` is the proposal; `news.comprom.org` is an alternative. Decision needs DNS owner sign-off.
+3. **CF Access team domain.** What is the existing Zero Trust team domain we'd reuse? If none, we provision one as part of this spec.
+4. **Email locale per subscriber.** When `langs=['ru','en']` is the digest body chrome in `ru` or `en`? Current proposal: chrome in the subscriber's FIRST `langs[]` entry; article titles in their own language.
+
+---
+
+**Review checkpoint.** Read §1–§5, push back on anything that doesn't match how you want it to behave, and call out which open questions in §7 we need to land before design starts. After this is signed off I'll write `design.md` (architecture, data model, sequence diagrams, infra wiring) and pause again.

--- a/specs/comms-newsletter/tasks.md
+++ b/specs/comms-newsletter/tasks.md
@@ -1,0 +1,300 @@
+# Newsletter — Tasks
+
+> **Status:** DRAFT — phase 3 of three (requirements → design → **tasks**).
+> **Source:** [`requirements.md`](./requirements.md), [`design.md`](./design.md).
+>
+> _Pause for review before implementation begins._
+
+## Reading guide
+
+Tasks are grouped into stages. Each stage is an end-to-end vertical slice — the working tree should be green between stages so we can ship early increments behind a feature flag.
+
+Every task carries:
+- A **goal** — what behaviour the task delivers.
+- **Touches** — file paths created or edited.
+- **EARS** — the requirements criteria it satisfies (from `requirements.md`).
+- **Tests** — the test files / cases written FIRST (TDD), and the layer (unit / integration / e2e). The implementation is done when **all** named tests pass.
+
+A task that references multiple EARS lines doesn't necessarily satisfy each fully on its own — the criteria list is the cumulative subset the task moves towards. The final "spec coverage" task (S6.1) cross-checks no criteria are orphaned.
+
+## Stage 0 — Workspace scaffolding
+
+### T0.1 — Add `services/comms-worker` package
+- **Goal**: monorepo recognises the new worker, `bun install` picks up its deps.
+- **Touches**: `services/comms-worker/package.json`, `tsconfig.json`, `wrangler.jsonc` (skeleton), root `package.json` workspaces glob if needed.
+- **EARS**: — (infra-only)
+- **Tests**: `services/comms-worker/src/health.test.ts` — GET /health returns `{status:'ok'}` (mirrors log-collector). Layer: integration (`unstable_dev`).
+
+### T0.2 — D1 binding + migrations runner
+- **Goal**: empty D1 reachable in `wrangler dev --local`, migration files apply cleanly.
+- **Touches**: `migrations/0001_initial.sql`, `migrations/0002_seed.sql`, `scripts/db-migrate.ts` helper.
+- **EARS**: §2.1 (schema)
+- **Tests**: `src/db/migrations.test.ts` — after running 0001 + 0002 against an in-memory D1, `subscribers`, `settings`, `send_log` tables exist with the documented columns AND `settings.schedule` row is `{cron:"0 12 * * 6",timezone:"Europe/Moscow"}`. Layer: integration.
+
+### T0.3 — GitHub team `communist-prometheus/admins` + initial seeding (manual op)
+- **Goal**: CF Access has a stable allowlist target.
+- **Touches**: documented in `services/comms-worker/README.md` ops section; the action is shell, not code.
+- **EARS**: §15 decisions log, §9.3 step 0
+- **Tests**: ops-check only — `gh api orgs/communist-prometheus/teams/admins/members --jq '.[].login'` returns the expected 2 logins.
+
+## Stage 1 — Auth + admin CRUD over subscribers
+
+### T1.1 — CF Access JWT verifier
+- **Goal**: pure helper that verifies an Access JWT against the team's JWKS, validates `aud` and `iss`, returns the claim set or throws.
+- **Touches**: `src/auth/cf-access.ts`, `src/auth/jwks-cache.ts`.
+- **EARS**: R6.1
+- **Tests**: `src/auth/cf-access.test.ts` — round-trip with a fixture-signed token (test-only RSA keypair), tamper byte → reject, wrong `aud` → reject, expired `exp` → reject, JWKS cache TTL respected via mocked clock. Layer: unit.
+
+### T1.2 — Hono middleware: `requireAccess`
+- **Goal**: wraps `cf-access.ts`; attaches `c.var.access = claims` on success.
+- **Touches**: `src/middleware/require-access.ts`.
+- **EARS**: R6.1
+- **Tests**: `src/middleware/require-access.test.ts` — missing header → 401, bad sig → 401, good token → handler reached. Layer: integration via `unstable_dev`.
+
+### T1.3 — Subscriber repo
+- **Goal**: D1 CRUD operations: `insert`, `listActive`, `listAll`, `findById`, `updateLangs`, `delete`, `setStatus`.
+- **Touches**: `src/subscribers/repo.ts`, `src/subscribers/types.ts`.
+- **EARS**: R1.2, R1.4, R1.5, R1.6, R3.1, R4.4, R4.6
+- **Tests**: `src/subscribers/repo.test.ts` — each method has happy + edge cases; insert with existing-active email throws `DuplicateError`; soft-delete vs hard-delete semantics asserted; status transitions covered. Layer: integration (real D1 local).
+
+### T1.4 — Subscriber routes
+- **Goal**: HTTP handlers using `requireAccess` + repo.
+- **Touches**: `src/subscribers/routes.ts`, mount in `src/index.ts`.
+- **EARS**: R1.1, R1.2, R1.3, R1.4, R1.5, R1.6
+- **Tests**: `src/subscribers/routes.test.ts` — table-driven over each endpoint × {valid, invalid-body, unauthorised, conflict, not-found}. Layer: integration.
+
+### T1.5 — Admin SPA: store + API client
+- **Goal**: Pinia store + typed client; loads via `swFetch`-shaped path, sends `gh_token` header, lets browser send CF Access cookie automatically (same parent domain).
+- **Touches**: `admin-website/src/stores/comms.ts`, `admin-website/src/composables/useComms/`.
+- **EARS**: R1.1
+- **Tests**: `src/stores/comms.test.ts` — mocks `fetch`, asserts URL + headers + body shape match worker contract. Layer: unit.
+
+### T1.6 — Admin SPA: `/comms` view
+- **Goal**: route, page chrome, render of subscribers table. No edits yet — read-only first.
+- **Touches**: `admin-website/src/router/index.ts`, `admin-website/src/views/CommsView.vue`, `admin-website/src/components/CommsSubscribers/SubscribersTable.vue`.
+- **EARS**: R1.1, R1.7
+- **Tests**: e2e `e2e/comms/list.spec.ts` — visit `/comms`, expect rows from worker, see `unsubscribed` badge on a seeded inactive row. Layer: e2e.
+
+### T1.7 — Admin SPA: add / edit / remove
+- **Goal**: full CRUD interactivity wired to the store; validation errors surfaced inline.
+- **Touches**: `AddSubscriberForm.vue`, inline lang toggle in `SubscribersTable.vue`, draft-ops helper.
+- **EARS**: R1.2, R1.3, R1.4, R1.5, R1.6
+- **Tests**: `e2e/comms/crud.spec.ts` — add valid, add invalid (422 surfaced), toggle lang, remove. Layer: e2e. Plus unit `CommsSubscribers/draft-ops.test.ts` (pure transformations).
+
+## Stage 2 — Schedule editor
+
+### T2.1 — Cron matcher
+- **Goal**: pure function `matchesTick(schedule, tickAt) -> boolean` using `cron-parser` with timezone support and a 5-min window.
+- **Touches**: `src/cron/matcher.ts`.
+- **EARS**: R2.2, R2.5
+- **Tests**: `src/cron/matcher.test.ts` — happy match on canonical Saturday-noon-MSK, no-match on Friday, DST flip Saturday (Europe/Moscow has no DST but Europe/Berlin row asserts cron-parser TZ behaviour), missed-by-2-min within window, missed-by-6-min outside window. Layer: unit.
+
+### T2.2 — Settings repo
+- **Goal**: read / write `settings.schedule`, atomic with `nextRunAt` computation.
+- **Touches**: `src/settings/repo.ts`.
+- **EARS**: R2.4
+- **Tests**: `src/settings/repo.test.ts` — `set + get` round-trip, `nextRunAt` matches `cron-parser` independently. Layer: integration.
+
+### T2.3 — Schedule routes
+- **Goal**: `GET /api/schedule` + `PUT /api/schedule`.
+- **Touches**: `src/schedule/routes.ts`.
+- **EARS**: R2.1, R2.2, R2.4
+- **Tests**: `src/schedule/routes.test.ts` — bad cron → 422 with parser msg, good → 200 + `nextRunAt`. Layer: integration.
+
+### T2.4 — Admin SPA: schedule editor view
+- **Goal**: cron input, IANA TZ select, live preview ("every Saturday at 12:00 Europe/Moscow"), next-run timestamp.
+- **Touches**: `admin-website/src/components/CommsSubscribers/ScheduleEditor.vue` + helper to humanise crontab.
+- **EARS**: R2.1, R2.2, R2.4
+- **Tests**: `e2e/comms/schedule.spec.ts` — bad cron inline error, save → preview updates. Plus unit `ScheduleEditor/humanise.test.ts`. Layer: e2e + unit.
+
+## Stage 3 — Dispatch loop (RSS → Resend)
+
+### T3.1 — RSS fetcher + parser
+- **Goal**: `fetchRss(lang) -> Article[]`, tolerant of BOM and missing optional fields, supports `pubDate` either RFC 822 or ISO-8601.
+- **Touches**: `src/rss/fetch.ts`, `src/rss/parse.ts`.
+- **EARS**: R3.2
+- **Tests**: `src/rss/parse.test.ts` — fixture XML in `test-fixtures/rss/{ru,en,it}.xml` → expected article arrays. Edge cases: missing description, weird CDATA, BOM. Layer: unit.
+
+### T3.2 — Delta calculator
+- **Goal**: `computeDelta(subscriber, articlesByLang) -> Article[]`, sorted newest-first, language-merged per R3.8.
+- **Touches**: `src/delta/calculator.ts`.
+- **EARS**: R3.1, R3.3, R3.8
+- **Tests**: `src/delta/calculator.test.ts` — subscriber `langs=['ru','en']` and `last_sent_at=X`: only items with `pubDate > X` and `lang ∈ langs` returned; empty delta when no item is new; ordering. Layer: unit.
+
+### T3.3 — Digest renderer
+- **Goal**: HTML + text bodies; UTM stamping; unsubscribe link insertion; List-Unsubscribe header values.
+- **Touches**: `src/digest/render.ts`, `src/digest/i18n.ts` (chrome strings × 7 langs), `src/digest/escape.ts`.
+- **EARS**: R3.4, R3.7, R3.8, R4.1
+- **Tests**: `src/digest/render.test.ts` — given fixed `(subscriber, delta, unsubscribeUrl)`, snapshot the rendered HTML / text and assert UTM + List-Unsubscribe values exactly. Snapshots committed. Layer: unit.
+
+### T3.4 — Unsubscribe token sign + verify
+- **Goal**: `sign(id, secret) -> token`, `verify(token, secret) -> {id} | null`.
+- **Touches**: `src/unsubscribe/token.ts`.
+- **EARS**: R4.5
+- **Tests**: `src/unsubscribe/token.test.ts` — round-trip, tamper rejects, wrong-secret rejects, constant-time compare. Layer: unit.
+
+### T3.5 — Resend client
+- **Goal**: thin `sendEmail({from, to, subject, html, text, headers, idempotencyKey}) -> {id} | {error}`. Pattern lifted from `pyaeats-app/.../notify.ts`.
+- **Touches**: `src/resend/client.ts`.
+- **EARS**: R3.4, R3.5, R3.6, R3.9, R6.4
+- **Tests**: `src/resend/client.test.ts` — `fetch` mocked, asserts URL + headers + body; 2xx → returns `id`; 4xx → returns `error`; 429 → backoff once then `error`; 5xx → backoff once then `error`. Layer: unit.
+
+### T3.6 — Send log repo
+- **Goal**: `append(row)`, `listRecent(limit)`, `purgeOlderThan(days)`.
+- **Touches**: `src/send-log/repo.ts`.
+- **EARS**: R3.5, R3.6, R5.1, R5.4
+- **Tests**: `src/send-log/repo.test.ts` — `append + list` round-trip, retention sweep deletes only old rows. Layer: integration.
+
+### T3.7 — Dispatch orchestrator
+- **Goal**: pure function `runDispatch({db, rss, resend, secret, tickAt})` that ties §3.2 of design.md together. **No D1 / HTTP / cron** in the function itself — dependencies injected for testability.
+- **Touches**: `src/dispatch/run.ts`.
+- **EARS**: R3.1, R3.3, R3.4, R3.5, R3.6, R3.7, R3.8, R3.9, R5.4, R6.4
+- **Tests**: `src/dispatch/run.test.ts` — table-driven scenarios:
+  - 0 subs → no-op, no Resend call
+  - 1 sub, empty delta → no Resend call, `last_sent_at` untouched
+  - 1 sub, 3 new → Resend called once with expected body, `last_sent_at` advanced
+  - 2 subs sharing lang → 1 RSS fetch (caching honoured), 2 Resend calls
+  - Resend 5xx → `send_log status='failed'`, `last_sent_at` untouched
+  - Idempotency key matches `<id>:<tickAt>`
+  Layer: integration (with mocks for RSS + Resend).
+
+### T3.8 — Scheduled handler
+- **Goal**: CF Workers `scheduled` entry: load schedule, match tick, call `runDispatch`, structured log.
+- **Touches**: `src/index.ts` (extend with `scheduled(event, env, ctx)`).
+- **EARS**: R2.5, R3.1–R3.9
+- **Tests**: `src/scheduled.test.ts` — using `unstable_dev` with a fixed `Date.now`, fire one scheduled event, assert dispatch ran exactly when matcher said so. Layer: integration.
+
+### T3.9 — `POST /api/dispatch?force=1` test-only endpoint
+- **Goal**: lets E2E manually trigger a tick without waiting for cron.
+- **Touches**: `src/dispatch/force-route.ts`.
+- **EARS**: §4.3 (design)
+- **Tests**: covered by T5.2 e2e.
+
+## Stage 4 — Public unsubscribe surface
+
+### T4.1 — Unsubscribe handler (GET + POST)
+- **Goal**: verify token, flip status, render confirmation page on GET, 200-empty on POST.
+- **Touches**: `src/unsubscribe/routes.ts`, `src/unsubscribe/confirmation.html.ts` (small template per supported lang).
+- **EARS**: R4.2, R4.3, R4.4, R4.5
+- **Tests**: `src/unsubscribe/routes.test.ts` — table over `{GET valid, POST valid, tampered → 404, missing token → 404, already-unsubscribed → 200 idempotent}`. Acceptance includes the rendered page's `Accept-Language` fallback. Layer: integration.
+
+### T4.2 — Wire unsubscribe URL into the digest
+- **Goal**: `runDispatch` now passes the per-subscriber URL into `render`. Already wired in T3.3 + T3.7 inputs; this task verifies end-to-end.
+- **Touches**: `src/dispatch/run.ts` (final wiring), no new file.
+- **EARS**: R4.1, R4.6
+- **Tests**: integration test in T3.7 already includes assertions; this task is the explicit "does the link in the rendered email body, when followed in T5.2 e2e, actually work?" check.
+
+## Stage 5 — Resend webhook
+
+### T5.1 — Webhook signature verifier (svix-style)
+- **Goal**: HMAC verify `svix-id` + `svix-timestamp` + body against `RESEND_WEBHOOK_SECRET`, reject if timestamp > 5 min old.
+- **Touches**: `src/webhooks/verify.ts`.
+- **EARS**: R3.10, R3.12
+- **Tests**: `src/webhooks/verify.test.ts` — valid → ok, tampered → reject, old timestamp → reject. Layer: unit.
+
+### T5.2 — Webhook route
+- **Goal**: `POST /webhooks/resend` flips subscriber status based on event type.
+- **Touches**: `src/webhooks/routes.ts`.
+- **EARS**: R3.10, R3.11, R3.12, R4.7
+- **Tests**: `src/webhooks/routes.test.ts` — `email.bounced` → status `bounced` + send_log row, `email.complained` → `complained`, bad sig → 401 + no mutation. Layer: integration.
+
+### T5.3 — Subsequent dispatches skip bounced/complained
+- **Goal**: enrich subscriber repo `listActive` to filter `status='active'` ONLY, no longer including `bounced`/`complained`.
+- **Touches**: `src/subscribers/repo.ts` (already filters via R3.1, but explicit T to nail the test).
+- **EARS**: R4.6, R4.7
+- **Tests**: extend `src/dispatch/run.test.ts` with a `bounced` subscriber → skipped, no Resend call. Layer: integration.
+
+## Stage 6 — Run history view + retention
+
+### T6.1 — `GET /api/runs`
+- **Goal**: returns last `limit` send_log rows joined to subscriber email (with PII boundary — admin only).
+- **Touches**: `src/send-log/routes.ts`.
+- **EARS**: R5.1
+- **Tests**: `src/send-log/routes.test.ts` — limits, default 20, ordering DESC by tick_at. Layer: integration.
+
+### T6.2 — Admin SPA: RunHistory view
+- **Goal**: list of 20 most-recent rows, `data-testid="send-log-failed"` highlight on failures, click → reveal full error.
+- **Touches**: `admin-website/src/components/CommsSubscribers/RunHistory.vue`.
+- **EARS**: R5.1, R5.2, R5.3
+- **Tests**: e2e `e2e/comms/run-history.spec.ts` — visit /comms → see rows; trigger force-dispatch → new row visible after reload. Layer: e2e.
+
+## Stage 7 — Cross-cutting + ship
+
+### T7.1 — Structured logger boundary
+- **Goal**: tiny wrapper that emits the JSON shape from design §12, redacting `t=` query parameter and email PII per R6.5.
+- **Touches**: `src/log/structured.ts`.
+- **EARS**: R6.3, R6.5
+- **Tests**: `src/log/structured.test.ts` — given `evt + payload`, console output is canonicalised JSON and `t=...` truncated. Layer: unit.
+
+### T7.2 — Wrangler dev env + secrets template
+- **Goal**: `.dev.vars.example`, README ops section, scripts to run migrations + start dev.
+- **Touches**: `services/comms-worker/.dev.vars.example`, `services/comms-worker/README.md`.
+- **EARS**: R6.2
+- **Tests**: ops-check; CI lint asserts `.dev.vars` is gitignored.
+
+### T7.3 — CI: deploy workflow
+- **Goal**: `.github/workflows/deploy-comms-worker.yml`, mirror of log-collector pipeline; runs migrations on prod D1 then `wrangler deploy`.
+- **Touches**: workflow file, secrets pulled from existing repo settings.
+- **EARS**: §9.2 (infra)
+- **Tests**: dry-run workflow on PR — green build.
+
+### T7.4 — End-to-end Playwright suite that covers the entire user journey
+- **Goal**: a single `e2e/comms/full-flow.spec.ts` walking the happy path:
+  1. login as admin
+  2. add subscriber `e2e-bot@example.test` with langs `['ru','en']`
+  3. set schedule to `* * * * *` (every minute) in `Etc/UTC` for the test
+  4. trigger `POST /api/dispatch?force=1`
+  5. assert Resend-stub received 1 payload with both languages merged
+  6. extract unsubscribe URL from the captured payload
+  7. POST it → 200
+  8. trigger force-dispatch again → Resend-stub received 0 new payloads
+  9. visit /comms → row shows `unsubscribed at <date>` badge
+  - assert all run-history rows present
+- **EARS**: ALL — the integration test of record.
+- **Tests**: this file IS the test.
+
+### T7.5 — Spec coverage audit
+- **Goal**: a tiny script `scripts/spec-coverage.ts` that scans `requirements.md` for `R\d+\.\d+` ids and `tasks.md` + test names for the same; reports any orphan.
+- **Touches**: `scripts/spec-coverage.ts`, optionally CI step.
+- **EARS**: traceability promise from §5 of requirements.
+- **Tests**: `scripts/spec-coverage.test.ts` — fixture-based assertion. Layer: unit.
+
+## Per-task convention
+
+- All worker code is TS with `"strict": true`; no `any`; `import type` for type-only imports; arrow + closure styles per `CLAUDE.md`.
+- All TS files keep to **50 non-blank lines** + 25-per-function per oxlint config from MEMORY.md.
+- Exported helpers carry JSDoc with `@param` / `@returns`.
+- Tests live next to the file (e.g. `src/cron/matcher.ts` ↔ `src/cron/matcher.test.ts`).
+- Each PR scoped to **one stage**; we don't ship Stage 3 without Stage 2 green.
+
+## Traceability table (sample — full one regenerated by T7.5)
+
+| EARS | Tasks | Tests |
+|---|---|---|
+| R1.2 | T1.3, T1.4, T1.7 | `repo.test.ts`, `routes.test.ts`, e2e/crud |
+| R2.5 | T2.1, T3.8 | `matcher.test.ts`, `scheduled.test.ts`, e2e/full-flow |
+| R3.1 | T3.2, T3.7 | `calculator.test.ts`, `run.test.ts` |
+| R3.4 | T3.3, T3.5, T3.7 | `render.test.ts`, `client.test.ts`, `run.test.ts` |
+| R4.3 | T4.1 | `routes.test.ts` (POST one-click) |
+| R4.5 | T3.4, T4.1 | `token.test.ts`, `routes.test.ts` |
+| R5.4 | T3.6, T3.7 | `send-log/repo.test.ts`, `run.test.ts` |
+| R6.1 | T1.1, T1.2 | `cf-access.test.ts`, `require-access.test.ts` |
+| R6.5 | T7.1 | `structured.test.ts` |
+
+## Estimate
+
+| Stage | Tasks | Wall-clock |
+|---|---|---|
+| 0 — scaffolding | 3 | half day |
+| 1 — auth + CRUD | 7 | 2 days |
+| 2 — schedule | 4 | 1 day |
+| 3 — dispatch | 9 | 3 days |
+| 4 — unsubscribe | 2 | half day |
+| 5 — webhook | 3 | 1 day |
+| 6 — history | 2 | half day |
+| 7 — ship | 5 | 1 day |
+| **total** | **35** | **≈9 working days** |
+
+---
+
+**Review checkpoint.** Read the stage list + per-task scope. After this is signed off the implementation PRs land one stage at a time on top of this branch (each its own PR for reviewability).


### PR DESCRIPTION
## Purpose

Phase 1 of the spec-driven newsletter rollout: get `requirements.md` reviewed before any design or code lands. Closes [communist-prometheus/tickets#23](https://github.com/communist-prometheus/tickets/issues/23) when phases 2 + 3 ship.

This PR intentionally contains **only** `specs/comms-newsletter/requirements.md`. No worker, no UI, no DB.

## Scope

- Editor CRUD over `(email, langs[], status)` subscribers
- Editor-controlled cron schedule (5-field crontab + IANA timezone, heartbeat pattern decides "fire now")
- Per-subscriber digest of new articles since the last successful send, filtered by their languages, sourced from `/{lang}/rss.xml`
- Resend transactional dispatch with RFC-8058 `List-Unsubscribe: One-Click`
- HMAC-signed public unsubscribe surface (GET + POST) under `lists.comprom.org`
- Admin run-history view + 90-day retention

## Stack (decided in chat before drafting)

- **Where**: `services/comms-worker` in the admin-website monorepo, Hono + D1 + Cron Triggers
- **Email**: Resend (Resend DKIM CNAME chained on top of the existing Zoho DKIM record)
- **Admin auth**: Cloudflare Access Zero Trust (Cf-Access-Jwt-Assertion JWT verified in-worker)
- **Delta source**: parse `/{lang}/rss.xml` from prod, in-memory cached per tick

## Test contour

§5 is the contract for what gets tested. Every EARS criterion maps to at least one row.

## Review asks

1. Push back on any acceptance criterion that does not match how you want the feature to behave.
2. Resolve §7 open questions (Resend webhook in v1?, final subdomain name, CF Access team domain, email body locale for multi-lang subscribers).

After approval -> design.md (phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)