### PR TITLE
feat(comms): tickets#23 stage 0 — scaffold comms-worker

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -106,7 +106,8 @@
         "eslint.config.js",
         "src/router/index.ts",
         "worker.ts",
-        "services/log-collector/src/index.ts"
+        "services/log-collector/src/index.ts",
+        "services/comms-worker/src/index.ts"
       ],
       "linter": {
         "rules": {

--- a/services/comms-worker/README.md
+++ b/services/comms-worker/README.md
@@ -1,0 +1,139 @@
+# comms-worker
+
+Newsletter dispatch service for `comprom.org`. Hono on Cloudflare
+Workers, backed by D1 for subscriber state and Resend for SMTP. See
+[`../../specs/comms-newsletter/`](../../specs/comms-newsletter/) for
+the full spec (requirements + design + tasks).
+
+Ticket: [tickets#23](https://github.com/communist-prometheus/tickets/issues/23).
+
+## Endpoints
+
+| Method | Path                  | Auth        | Purpose |
+|--------|-----------------------|-------------|---------|
+| GET    | `/health`             | none        | Liveness probe (Stage 0) |
+| GET    | `/api/subscribers`    | CF Access   | List (Stage 1) |
+| POST   | `/api/subscribers`    | CF Access   | Add (Stage 1) |
+| PATCH  | `/api/subscribers/:id`| CF Access   | Edit langs (Stage 1) |
+| DELETE | `/api/subscribers/:id`| CF Access   | Remove (Stage 1) |
+| GET    | `/api/schedule`       | CF Access   | Read cron pattern (Stage 2) |
+| PUT    | `/api/schedule`       | CF Access   | Save cron pattern (Stage 2) |
+| GET    | `/api/runs`           | CF Access   | Recent send_log rows (Stage 6) |
+| POST   | `/api/dispatch?force=1` | CF Access | Trigger a tick (dev/e2e only) |
+| GET    | `/unsubscribe?t=…`    | token       | Confirmation page (Stage 4) |
+| POST   | `/unsubscribe?t=…`    | token       | RFC 8058 one-click (Stage 4) |
+| POST   | `/webhooks/resend`    | svix sig    | Bounce / complaint events (Stage 5) |
+
+Scheduled trigger: `0 * * * *` (UTC heartbeat). The worker reads the
+saved `settings.schedule` and decides per-tick whether to dispatch
+(spec design §5).
+
+## One-time provisioning
+
+### GitHub team for CF Access
+
+CF Access matches against a GitHub team — adding / removing admins in
+future is a single `gh` call, not a CF policy edit.
+
+```bash
+# Create the team (private/closed visibility).
+gh api orgs/communist-prometheus/teams \
+  -X POST -f name=admins \
+  -f description='CF Access policy target for sensitive admin surfaces' \
+  -f privacy=closed
+
+# Seed with current org owners (gh api orgs/communist-prometheus/members?role=admin).
+gh api orgs/communist-prometheus/teams/admins/memberships/Pyper6 \
+  -X PUT -f role=member
+gh api orgs/communist-prometheus/teams/admins/memberships/undeadliner \
+  -X PUT -f role=member
+
+# Verify.
+gh api orgs/communist-prometheus/teams/admins/members --jq '.[].login'
+```
+
+### CF Access application
+
+1. Cloudflare Zero Trust → Settings → create team `comprom` (→ `comprom.cloudflareaccess.com`).
+2. Authentication → connect GitHub OAuth app, scope `read:org`.
+3. Access → Applications → Add a self-hosted application:
+   - Name: `comms-admin`
+   - Hostname: `lists.comprom.org`
+   - Path: `/api/*`
+4. Policy "editors":
+   - Action: Allow
+   - Include: Login method = GitHub **AND** GitHub team
+     `communist-prometheus/admins`
+5. Bypass policy "public surface":
+   - Action: Bypass
+   - Include: URL contains `/unsubscribe` OR `/webhooks/`
+6. Capture the application **Audience tag** → set as the
+   `CF_ACCESS_AUD` worker secret.
+7. Cookie domain: `comprom.org` (parent so admin.comprom.org's
+   existing browser session is reused).
+
+### Resend account
+
+1. Resend → add domain `comprom.org`, verify (DKIM CNAME + SPF check).
+2. Create an API key → store as `RESEND_API_KEY` worker secret.
+3. Webhook endpoint: `https://lists.comprom.org/webhooks/resend`.
+   Subscribe to events `email.bounced`, `email.delivery_delayed`,
+   `email.complained`. Copy the signing secret → store as
+   `RESEND_WEBHOOK_SECRET`.
+
+### D1 database
+
+```bash
+# Create the prod DB once.
+bunx wrangler d1 create comms-prod
+# Copy the printed `database_id` into wrangler.jsonc under
+# d1_databases[0].database_id. Then apply migrations:
+bunx wrangler d1 execute comms-prod \
+  --file services/comms-worker/migrations/0001_initial.sql
+bunx wrangler d1 execute comms-prod \
+  --file services/comms-worker/migrations/0002_seed.sql
+```
+
+For local dev, append `--local` to the same commands.
+
+## Secrets
+
+Set via `bunx wrangler secret put <name>` from this directory:
+
+| Secret                  | Purpose |
+|-------------------------|---------|
+| `RESEND_API_KEY`        | Resend transactional API auth |
+| `RESEND_WEBHOOK_SECRET` | Verify svix signatures on inbound Resend events |
+| `UNSUBSCRIBE_SECRET`    | HMAC secret for unsubscribe tokens (32 random bytes) |
+| `CF_ACCESS_AUD`         | CF Access Application Audience tag |
+| `CF_ACCESS_TEAM`        | CF Access team slug = `comprom` |
+
+## Local dev
+
+```bash
+cd services/comms-worker
+bunx wrangler dev --local --persist-to=.wrangler/state
+```
+
+Create `services/comms-worker/.dev.vars` (gitignored) with:
+
+```
+RESEND_API_KEY=test
+RESEND_WEBHOOK_SECRET=test
+UNSUBSCRIBE_SECRET=local-dev-secret-32-bytes-padding
+CF_ACCESS_AUD=local
+CF_ACCESS_TEAM=local
+```
+
+When `RESEND_API_KEY=test`, the Resend client short-circuits to a
+stub so dev never hits the real API (spec design §10).
+
+## Deploy
+
+```bash
+cd services/comms-worker
+bunx wrangler deploy                     # prod
+bunx wrangler deploy --env develop       # develop
+```
+
+CI workflow: `.github/workflows/deploy-comms-worker.yml` (Stage 7).

--- a/services/comms-worker/migrations/0001_initial.sql
+++ b/services/comms-worker/migrations/0001_initial.sql
@@ -1,0 +1,37 @@
+-- 0001_initial.sql
+-- Per specs/comms-newsletter/design.md §2.1.
+
+CREATE TABLE subscribers (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  email           TEXT NOT NULL,
+  langs           TEXT NOT NULL,
+  status          TEXT NOT NULL DEFAULT 'active'
+                  CHECK (status IN ('active','unsubscribed','bounced','complained')),
+  created_at      TEXT NOT NULL,
+  last_sent_at    TEXT,
+  unsubscribed_at TEXT
+);
+
+CREATE UNIQUE INDEX subscribers_email_active_uq
+  ON subscribers(email) WHERE status = 'active';
+
+CREATE INDEX subscribers_status_idx ON subscribers(status);
+
+CREATE TABLE settings (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE send_log (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  subscriber_id INTEGER REFERENCES subscribers(id) ON DELETE SET NULL,
+  tick_at       TEXT NOT NULL,
+  article_count INTEGER NOT NULL,
+  status        TEXT NOT NULL
+                CHECK (status IN ('sent','failed','bounced','complained','skipped')),
+  resend_id     TEXT,
+  error         TEXT
+);
+
+CREATE INDEX send_log_tick_idx ON send_log(tick_at DESC);
+CREATE INDEX send_log_subscriber_idx ON send_log(subscriber_id);

--- a/services/comms-worker/migrations/0002_seed.sql
+++ b/services/comms-worker/migrations/0002_seed.sql
@@ -1,0 +1,5 @@
+-- 0002_seed.sql
+-- Default schedule from requirements.md R2.3.
+
+INSERT INTO settings (key, value) VALUES
+  ('schedule', '{"cron":"0 12 * * 6","timezone":"Europe/Moscow"}');

--- a/services/comms-worker/migrations/migrations.test.ts
+++ b/services/comms-worker/migrations/migrations.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const dir = resolve('services/comms-worker/migrations')
+const read = (file: string): string =>
+  readFileSync(resolve(dir, file), 'utf8')
+
+const initial = read('0001_initial.sql')
+const seed = read('0002_seed.sql')
+
+describe('migration 0001_initial.sql', () => {
+  it('creates the subscribers table with required columns', () => {
+    expect(initial).toMatch(/CREATE TABLE subscribers/)
+    for (const col of [
+      'id              INTEGER PRIMARY KEY AUTOINCREMENT',
+      'email           TEXT NOT NULL',
+      'langs           TEXT NOT NULL',
+      'last_sent_at    TEXT',
+      'unsubscribed_at TEXT',
+    ]) {
+      expect(initial).toContain(col)
+    }
+  })
+
+  it('declares the status CHECK with all four allowed values', () => {
+    expect(initial).toMatch(
+      /CHECK\s*\(status\s+IN\s*\('active','unsubscribed','bounced','complained'\)\)/
+    )
+  })
+
+  it('creates the partial-unique index on active emails', () => {
+    expect(initial).toMatch(
+      /CREATE UNIQUE INDEX subscribers_email_active_uq[\s\S]*WHERE status = 'active'/
+    )
+  })
+
+  it('creates settings table keyed by `key`', () => {
+    expect(initial).toMatch(
+      /CREATE TABLE settings\s*\(\s*key\s+TEXT PRIMARY KEY/
+    )
+  })
+
+  it('creates send_log with ON DELETE SET NULL on subscriber_id', () => {
+    expect(initial).toMatch(
+      /subscriber_id\s+INTEGER\s+REFERENCES subscribers\(id\)\s+ON DELETE SET NULL/
+    )
+  })
+
+  it('creates the send_log tick + subscriber indexes', () => {
+    expect(initial).toContain(
+      'CREATE INDEX send_log_tick_idx ON send_log(tick_at DESC)'
+    )
+    expect(initial).toContain(
+      'CREATE INDEX send_log_subscriber_idx ON send_log(subscriber_id)'
+    )
+  })
+})
+
+describe('migration 0002_seed.sql', () => {
+  it('seeds the default schedule row', () => {
+    expect(seed).toMatch(/INSERT INTO settings.*VALUES/s)
+    expect(seed).toContain("'schedule'")
+    expect(seed).toContain('"cron":"0 12 * * 6"')
+    expect(seed).toContain('"timezone":"Europe/Moscow"')
+  })
+})

--- a/services/comms-worker/src/health.test.ts
+++ b/services/comms-worker/src/health.test.ts
@@ -1,0 +1,28 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { type HealthBody, registerHealthRoute } from './health'
+
+const buildApp = () =>
+  registerHealthRoute(new Hono<{ Bindings: { VERSION: string } }>())
+
+describe('GET /health (comms-worker)', () => {
+  it('returns status ok and the configured version', async () => {
+    const app = buildApp()
+    const res = await app.fetch(new Request('http://localhost/health'), {
+      VERSION: '0.1.0',
+    })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as HealthBody
+    expect(body.status).toBe('ok')
+    expect(body.version).toBe('0.1.0')
+    expect(body.at).toBeGreaterThan(0)
+  })
+
+  it('returns 404 for unknown routes', async () => {
+    const app = buildApp()
+    const res = await app.fetch(new Request('http://localhost/missing'), {
+      VERSION: '0',
+    })
+    expect(res.status).toBe(404)
+  })
+})

--- a/services/comms-worker/src/health.ts
+++ b/services/comms-worker/src/health.ts
@@ -1,0 +1,31 @@
+import type { Context, Hono } from 'hono'
+
+/** Healthcheck reply payload returned by the `/health` route. */
+export type HealthBody = {
+  readonly status: 'ok'
+  readonly version: string
+  readonly at: number
+}
+
+type Bindings = { readonly VERSION: string }
+
+/**
+ * Wire the `/health` route on the supplied Hono instance. Reads
+ * the build-time `VERSION` var so deploys can ship a known
+ * identifier without rebuilding the route.
+ * @param app Hono app to extend.
+ * @returns Same Hono app for chaining.
+ */
+export const registerHealthRoute = (
+  app: Hono<{ Bindings: Bindings }>
+): Hono<{ Bindings: Bindings }> => {
+  app.get('/health', (c: Context<{ Bindings: Bindings }>) => {
+    const body: HealthBody = {
+      status: 'ok',
+      version: c.env.VERSION,
+      at: Date.now(),
+    }
+    return c.json(body)
+  })
+  return app
+}

--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -1,0 +1,18 @@
+import { Hono } from 'hono'
+import { registerHealthRoute } from './health'
+
+/** Combined worker bindings across all registered routes. */
+export type Bindings = {
+  readonly VERSION: string
+  readonly ADMIN_HOSTNAME: string
+}
+
+const app = new Hono<{ Bindings: Bindings }>()
+registerHealthRoute(app)
+
+/** Cloudflare Worker entry — delegates everything to Hono. */
+export default {
+  fetch: app.fetch,
+}
+
+export { app }

--- a/services/comms-worker/wrangler.jsonc
+++ b/services/comms-worker/wrangler.jsonc
@@ -1,0 +1,33 @@
+{
+  "name": "comms-worker",
+  "compatibility_date": "2026-06-01",
+  "main": "src/index.ts",
+  // Routed to a custom domain so the admin SPA hits a stable URL and
+  // CF Access policies attach to the hostname.
+  "routes": [{ "pattern": "lists.comprom.org/*", "custom_domain": true }],
+  // Heartbeat fires hourly UTC; the worker decides per-tick whether
+  // the user-saved schedule says "fire now" via cron-parser (spec §5).
+  "triggers": { "crons": ["0 * * * *"] },
+  // Bindings declared but optional at deploy time so Stage 0 ships
+  // before the D1 binding lands in Stage 1+.
+  // Stage 1+:
+  // - DB                       — D1 database binding (subscribers, settings, send_log)
+  // Secrets (wrangler secret put):
+  // - RESEND_API_KEY           — Resend transactional API auth
+  // - RESEND_WEBHOOK_SECRET    — Svix-style webhook signature verification
+  // - UNSUBSCRIBE_SECRET       — HMAC secret for unsubscribe tokens
+  // - CF_ACCESS_AUD            — CF Access Application Audience tag
+  // - CF_ACCESS_TEAM           — CF Access team slug (= "comprom")
+  "vars": {
+    "VERSION": "0.1.0",
+    "ADMIN_HOSTNAME": "admin.comprom.org"
+  },
+  "env": {
+    "develop": {
+      "name": "comms-worker-develop",
+      "routes": [
+        { "pattern": "dev-lists.comprom.org", "custom_domain": true }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Stage 0 of [specs/comms-newsletter/tasks.md](../tree/feat/23-comms-newsletter/specs/comms-newsletter/tasks.md). Stacks on top of the spec PR #246.

## Scope

- **T0.1** `services/comms-worker` skeleton: wrangler.jsonc + Hono index.ts + /health route + test
- **T0.2** D1 migrations `0001_initial.sql` (schema) + `0002_seed.sql` (default schedule). Stage-0 test = structural regex assertions on the SQL; real-D1 round-trip lands in Stage 1 alongside the subscriber repo
- **T0.3** README documents one-time provisioning (GitHub team, CF Access app, Resend, D1, secrets). The GitHub team `communist-prometheus/admins` is already created and seeded with `undeadliner + Pyper6` (the two `role=admin` org members)

## Out of scope (stage 1+)

- D1 binding wired into the worker — no subscriber endpoints yet
- CF Access middleware — needs JWKS, audience, team config which arrive together
- Resend client / dispatch loop / unsubscribe

## Test plan

- [x] `bunx vitest run services/comms-worker/` — 9/9 pass
- [x] `bunx biome check services/comms-worker/` — clean
- [x] `gh api orgs/communist-prometheus/teams/admins/members --jq '.[].login'` returns the seeded members
- [ ] Manual: `cd services/comms-worker && bunx wrangler dev --local` boots, `curl localhost:8787/health` returns `{status:'ok'}` (no DB yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)