### PR TITLE
feat(comms): tickets#23 stage 1 — CF Access JWT, subscribers CRUD, admin /comms

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,8 +21,10 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.2",
+        "@cloudflare/workers-types": "^4.20260603.1",
         "@playwright/test": "^1.58.2",
         "@tsconfig/node24": "^24.0.4",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/jsdom": "^27.0.0",
         "@types/node": "^24.10.13",
         "@typescript-eslint/eslint-plugin": "^8.56.0",
@@ -32,6 +34,7 @@
         "@vitest/ui": "^4.0.18",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.8.1",
+        "better-sqlite3": "^12.10.0",
         "cross-env": "^10.1.0",
         "dotenv": "^17.3.1",
         "effect": "^3.21.0",
@@ -188,6 +191,8 @@
     "@cacheable/memory": ["@cacheable/memory@2.0.8", "", { "dependencies": { "@cacheable/utils": "^2.4.0", "@keyv/bigmap": "^1.3.1", "hookified": "^1.15.1", "keyv": "^5.6.0" } }, "sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw=="],
 
     "@cacheable/utils": ["@cacheable/utils@2.4.1", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260603.1", "", {}, "sha512-TLeVHoBbcYv35S5TdRWUoj3IJ56BhHtrsuci+O7ithU8yz7ttNdCk6rAl1QUSGNVEWSIp54bWOuV/xmX1zu79g=="],
 
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
@@ -533,6 +538,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
@@ -745,9 +752,15 @@
 
     "basic-ftp": ["basic-ftp@5.2.2", "", {}, "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw=="],
 
+    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
+
     "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
+    "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
+
     "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
+
+    "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
     "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
@@ -792,6 +805,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "chrome-launcher": ["chrome-launcher@1.2.1", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-qmFR5PLMzHyuNJHwOloHPAHhbaNglkfeV/xDtt5b7xiFFyU1I+AZZX0PYseMuhenJSSirgxELYIbswcoc+5H4A=="],
 
@@ -866,6 +881,8 @@
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
+
+    "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -979,6 +996,8 @@
 
     "events-universal": ["events-universal@1.0.1", "", { "dependencies": { "bare-events": "^2.7.0" } }, "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw=="],
 
+    "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
     "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
@@ -1017,6 +1036,8 @@
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
+    "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
@@ -1030,6 +1051,8 @@
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
     "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
+
+    "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -1052,6 +1075,8 @@
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
 
     "get-uri": ["get-uri@6.0.5", "", { "dependencies": { "basic-ftp": "^5.0.2", "data-uri-to-buffer": "^6.0.2", "debug": "^4.3.4" } }, "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg=="],
+
+    "github-from-package": ["github-from-package@0.0.0", "", {}, "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
@@ -1411,6 +1436,8 @@
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
+    "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
@@ -1425,9 +1452,13 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
+
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "netmask": ["netmask@2.1.1", "", {}, "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA=="],
+
+    "node-abi": ["node-abi@3.92.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
@@ -1543,6 +1574,8 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
+    "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
@@ -1572,6 +1605,8 @@
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
     "read-package-json-fast": ["read-package-json-fast@4.0.0", "", { "dependencies": { "json-parse-even-better-errors": "^4.0.0", "npm-normalize-package-bin": "^4.0.0" } }, "sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg=="],
 
@@ -1745,6 +1780,8 @@
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
     "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
     "stubborn-fs": ["stubborn-fs@2.0.0", "", { "dependencies": { "stubborn-utils": "^1.0.1" } }, "sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA=="],
@@ -1779,9 +1816,9 @@
 
     "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
 
-    "tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
+    "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
-    "tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
+    "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "teex": ["teex@1.0.1", "", { "dependencies": { "streamx": "^2.12.5" } }, "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg=="],
 
@@ -1824,6 +1861,8 @@
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": "dist/cli.mjs" }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
+
+    "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
     "turndown": ["turndown@7.2.4", "", { "dependencies": { "@mixmark-io/domino": "^2.2.0" } }, "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ=="],
 
@@ -2005,6 +2044,8 @@
 
     "@opentelemetry/sdk-trace-base/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
+    "@puppeteer/browsers/tar-fs": ["tar-fs@3.1.2", "", { "dependencies": { "pump": "^3.0.0", "tar-stream": "^3.1.5" }, "optionalDependencies": { "bare-fs": "^4.0.1", "bare-path": "^3.0.0" } }, "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw=="],
+
     "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
@@ -2012,6 +2053,10 @@
     "@vue/compiler-vapor/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/devtools-api/@vue/devtools-kit": ["@vue/devtools-kit@7.7.9", "", { "dependencies": { "@vue/devtools-shared": "^7.7.9", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA=="],
+
+    "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
+    "bl/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "cacheable/keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
@@ -2103,6 +2148,8 @@
 
     "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "tar-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "unimport/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "vite-plugin-inspect/open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
@@ -2126,6 +2173,8 @@
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@puppeteer/browsers/tar-fs/tar-stream": ["tar-stream@3.1.8", "", { "dependencies": { "b4a": "^1.6.4", "bare-fs": "^4.5.5", "fast-fifo": "^1.2.0", "streamx": "^2.15.0" } }, "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ=="],
 
     "@vue/devtools-api/@vue/devtools-kit/@vue/devtools-shared": ["@vue/devtools-shared@7.7.9", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA=="],
 

--- a/package.json
+++ b/package.json
@@ -58,8 +58,10 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.2",
+    "@cloudflare/workers-types": "^4.20260603.1",
     "@playwright/test": "^1.58.2",
     "@tsconfig/node24": "^24.0.4",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/jsdom": "^27.0.0",
     "@types/node": "^24.10.13",
     "@typescript-eslint/eslint-plugin": "^8.56.0",
@@ -69,6 +71,7 @@
     "@vitest/ui": "^4.0.18",
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",
+    "better-sqlite3": "^12.10.0",
     "cross-env": "^10.1.0",
     "dotenv": "^17.3.1",
     "effect": "^3.21.0",

--- a/services/comms-worker/src/auth/base64url.ts
+++ b/services/comms-worker/src/auth/base64url.ts
@@ -1,0 +1,32 @@
+const fromBase64Std = (b64: string): string =>
+  b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+
+const toBase64Std = (b64url: string): string => {
+  const padded = b64url + '='.repeat((4 - (b64url.length % 4)) % 4)
+  return padded.replace(/-/g, '+').replace(/_/g, '/')
+}
+
+/**
+ * Encode bytes (or a string) to base64url.
+ * @param input Bytes or UTF-8 string to encode.
+ * @returns Base64url string without padding.
+ */
+export const base64urlEncode = (input: ArrayBuffer | string): string => {
+  const bytes =
+    typeof input === 'string'
+      ? new TextEncoder().encode(input)
+      : new Uint8Array(input)
+  const bin = Array.from(bytes, b => String.fromCharCode(b)).join('')
+  return fromBase64Std(globalThis.btoa(bin))
+}
+
+/**
+ * Decode a base64url string to a `Uint8Array`.
+ * @param raw Base64url-encoded string.
+ * @returns Decoded bytes.
+ */
+export const base64urlDecode = (raw: string): Uint8Array => {
+  const std = toBase64Std(raw)
+  const bin = globalThis.atob(std)
+  return Uint8Array.from(bin, c => c.charCodeAt(0))
+}

--- a/services/comms-worker/src/auth/cf-access-types.ts
+++ b/services/comms-worker/src/auth/cf-access-types.ts
@@ -1,0 +1,17 @@
+/** Subset of CF Access JWT claims this service relies on. */
+export type AccessClaims = {
+  readonly aud: string | ReadonlyArray<string>
+  readonly iss: string
+  readonly email: string
+  readonly sub: string
+  readonly exp: number
+  readonly iat: number
+}
+
+/** Config supplied per call to keep the verifier pure. */
+export type AccessVerifyConfig = {
+  readonly aud: string
+  readonly team: string
+  readonly fetchJwks?: (url: string) => Promise<Response>
+  readonly now?: () => number
+}

--- a/services/comms-worker/src/auth/cf-access.test.ts
+++ b/services/comms-worker/src/auth/cf-access.test.ts
@@ -1,0 +1,205 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { base64urlEncode } from './base64url'
+import { __clearAccessCache, verifyAccessJwt } from './cf-access'
+
+type KeyPair = {
+  readonly publicKey: CryptoKey
+  readonly privateKey: CryptoKey
+}
+
+const algorithm: RsaHashedKeyGenParams = {
+  name: 'RSASSA-PKCS1-v1_5',
+  modulusLength: 2048,
+  publicExponent: new Uint8Array([1, 0, 1]),
+  hash: 'SHA-256',
+}
+
+const generateRsaPair = async (): Promise<KeyPair> => {
+  const pair = await crypto.subtle.generateKey(algorithm, true, [
+    'sign',
+    'verify',
+  ])
+  return { publicKey: pair.publicKey, privateKey: pair.privateKey }
+}
+
+const exportJwks = async (
+  publicKey: CryptoKey,
+  kid: string
+): Promise<string> => {
+  const jwk = await crypto.subtle.exportKey('jwk', publicKey)
+  return JSON.stringify({ keys: [{ ...jwk, kid, alg: 'RS256', use: 'sig' }] })
+}
+
+type Claims = {
+  readonly aud: string | ReadonlyArray<string>
+  readonly iss: string
+  readonly email: string
+  readonly sub: string
+  readonly exp: number
+  readonly iat: number
+}
+
+const signJwt = async (
+  claims: Claims,
+  kid: string,
+  privateKey: CryptoKey
+): Promise<string> => {
+  const header = base64urlEncode(JSON.stringify({ alg: 'RS256', kid }))
+  const body = base64urlEncode(JSON.stringify(claims))
+  const data = `${header}.${body}`
+  const sig = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    new TextEncoder().encode(data)
+  )
+  return `${data}.${base64urlEncode(sig)}`
+}
+
+const TEAM = 'comprom'
+const ISS = `https://${TEAM}.cloudflareaccess.com`
+const AUD = 'aud-tag-abc'
+const NOW_MS = 1_750_000_000_000
+const NOW_SEC = Math.floor(NOW_MS / 1000)
+const claims = (overrides: Partial<Claims> = {}): Claims => ({
+  aud: AUD,
+  iss: ISS,
+  email: 'admin@comprom.org',
+  sub: 'github|undeadliner',
+  exp: NOW_SEC + 300,
+  iat: NOW_SEC - 10,
+  ...overrides,
+})
+
+let pair: KeyPair
+let jwks: string
+
+const config = (
+  overrides: Partial<Parameters<typeof verifyAccessJwt>[1]> = {}
+) => ({
+  aud: AUD,
+  team: TEAM,
+  now: () => NOW_MS,
+  fetchJwks: async () =>
+    new Response(jwks, { headers: { 'Content-Type': 'application/json' } }),
+  ...overrides,
+})
+
+beforeEach(async () => {
+  __clearAccessCache()
+  pair = await generateRsaPair()
+  jwks = await exportJwks(pair.publicKey, 'k1')
+})
+
+describe('verifyAccessJwt', () => {
+  it('returns claims for a valid token', async () => {
+    const tok = await signJwt(claims(), 'k1', pair.privateKey)
+    const res = await verifyAccessJwt(tok, config())
+    expect(res?.email).toBe('admin@comprom.org')
+    expect(res?.sub).toBe('github|undeadliner')
+  })
+
+  it('rejects when the audience does not match', async () => {
+    const tok = await signJwt(
+      claims({ aud: 'other-aud' }),
+      'k1',
+      pair.privateKey
+    )
+    const res = await verifyAccessJwt(tok, config())
+    expect(res).toBeUndefined()
+  })
+
+  it('accepts an aud claim provided as an array', async () => {
+    const tok = await signJwt(
+      claims({ aud: ['other', AUD] }),
+      'k1',
+      pair.privateKey
+    )
+    const res = await verifyAccessJwt(tok, config())
+    expect(res).toBeDefined()
+  })
+
+  it('rejects when the issuer does not match the team URL', async () => {
+    const tok = await signJwt(
+      claims({ iss: 'https://attacker.cloudflareaccess.com' }),
+      'k1',
+      pair.privateKey
+    )
+    const res = await verifyAccessJwt(tok, config())
+    expect(res).toBeUndefined()
+  })
+
+  it('rejects an expired token', async () => {
+    const tok = await signJwt(
+      claims({ exp: NOW_SEC - 10 }),
+      'k1',
+      pair.privateKey
+    )
+    const res = await verifyAccessJwt(tok, config())
+    expect(res).toBeUndefined()
+  })
+
+  it('rejects a token signed with the wrong key', async () => {
+    const other = await generateRsaPair()
+    const tok = await signJwt(claims(), 'k1', other.privateKey)
+    const res = await verifyAccessJwt(tok, config())
+    expect(res).toBeUndefined()
+  })
+
+  it('rejects a token whose body bytes are tampered', async () => {
+    const tok = await signJwt(claims(), 'k1', pair.privateKey)
+    const [h, b, s] = tok.split('.')
+    const tampered = `${h}.${b}xx.${s}`
+    const res = await verifyAccessJwt(tampered, config())
+    expect(res).toBeUndefined()
+  })
+
+  it('rejects when the kid is unknown to the JWKS', async () => {
+    const tok = await signJwt(claims(), 'unknown-kid', pair.privateKey)
+    const res = await verifyAccessJwt(tok, config())
+    expect(res).toBeUndefined()
+  })
+
+  it('caches JWKS within the TTL — second call does not refetch', async () => {
+    let fetches = 0
+    const cfg = config({
+      fetchJwks: async () => {
+        fetches += 1
+        return new Response(jwks, {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    })
+    const tok = await signJwt(claims(), 'k1', pair.privateKey)
+    await verifyAccessJwt(tok, cfg)
+    await verifyAccessJwt(tok, cfg)
+    expect(fetches).toBe(1)
+  })
+
+  it('refreshes JWKS once an entry exceeds the 24h TTL', async () => {
+    let fetches = 0
+    let nowMs = NOW_MS
+    const cfg = config({
+      now: () => nowMs,
+      fetchJwks: async () => {
+        fetches += 1
+        return new Response(jwks, {
+          headers: { 'Content-Type': 'application/json' },
+        })
+      },
+    })
+    const tok = await signJwt(
+      claims({ exp: NOW_SEC + 999_999 }),
+      'k1',
+      pair.privateKey
+    )
+    await verifyAccessJwt(tok, cfg)
+    nowMs = NOW_MS + 25 * 3600 * 1000
+    await verifyAccessJwt(tok, cfg)
+    expect(fetches).toBe(2)
+  })
+
+  it('rejects a structurally malformed token', async () => {
+    const res = await verifyAccessJwt('not.a.jwt', config())
+    expect(res).toBeUndefined()
+  })
+})

--- a/services/comms-worker/src/auth/cf-access.ts
+++ b/services/comms-worker/src/auth/cf-access.ts
@@ -1,0 +1,37 @@
+import type { AccessClaims, AccessVerifyConfig } from './cf-access-types'
+import { claimsOk } from './claims-check'
+import { __clearJwksCache, resolveJwks } from './jwks-cache'
+import { decodeJson, verifyRs256 } from './jwt-decode'
+
+export type { AccessClaims, AccessVerifyConfig } from './cf-access-types'
+
+/**
+ * Verify a CF Access JWT and return its claims when valid.
+ * @param token Compact-serialised JWT.
+ * @param cfg Audience, team, optional fetch + clock injectables.
+ * @returns Claims on success, undefined on any failure.
+ */
+export const verifyAccessJwt = async (
+  token: string,
+  cfg: AccessVerifyConfig
+): Promise<AccessClaims | undefined> => {
+  const [head, body, sig, ...rest] = token.split('.')
+  if (head === undefined || body === undefined || sig === undefined) {
+    return undefined
+  }
+  if (rest.length > 0) return undefined
+  const hdr = decodeJson<{ readonly kid?: string }>(head)
+  const claims = decodeJson<AccessClaims>(body)
+  if (hdr?.kid === undefined || claims === undefined) return undefined
+  const nowMs = cfg.now?.() ?? Date.now()
+  if (!claimsOk(claims, cfg, Math.floor(nowMs / 1000))) return undefined
+  const fetcher = cfg.fetchJwks ?? globalThis.fetch.bind(globalThis)
+  const key = (await resolveJwks(cfg.team, fetcher, nowMs)).get(hdr.kid)
+  if (key === undefined) return undefined
+  return (await verifyRs256(head, body, sig, key)) ? claims : undefined
+}
+
+/** Clear the JWKS cache. Intended for tests only. */
+export const __clearAccessCache = (): void => {
+  __clearJwksCache()
+}

--- a/services/comms-worker/src/auth/claims-check.ts
+++ b/services/comms-worker/src/auth/claims-check.ts
@@ -1,0 +1,21 @@
+import type { AccessClaims, AccessVerifyConfig } from './cf-access-types'
+
+const audOk = (aud: AccessClaims['aud'], expected: string): boolean =>
+  Array.isArray(aud) ? aud.includes(expected) : aud === expected
+
+/**
+ * Check the trio of claim constraints CF Access tokens must satisfy:
+ * unexpired, audience-aligned, and issued by the configured team.
+ * @param claims Decoded JWT claims.
+ * @param cfg Verifier config with audience + team.
+ * @param nowSec Current epoch seconds.
+ * @returns True iff all three checks pass.
+ */
+export const claimsOk = (
+  claims: AccessClaims,
+  cfg: AccessVerifyConfig,
+  nowSec: number
+): boolean =>
+  claims.exp > nowSec &&
+  audOk(claims.aud, cfg.aud) &&
+  claims.iss === `https://${cfg.team}.cloudflareaccess.com`

--- a/services/comms-worker/src/auth/jwks-cache.ts
+++ b/services/comms-worker/src/auth/jwks-cache.ts
@@ -1,0 +1,58 @@
+type JwksEntry = {
+  readonly keys: ReadonlyMap<string, CryptoKey>
+  readonly fetchedAt: number
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const cache = new Map<string, JwksEntry>()
+
+const importJwk = async (jwk: JsonWebKey): Promise<CryptoKey> =>
+  crypto.subtle.importKey(
+    'jwk',
+    jwk,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['verify']
+  )
+
+const parseJwks = async (
+  json: string
+): Promise<ReadonlyMap<string, CryptoKey>> => {
+  const doc = JSON.parse(json) as {
+    readonly keys?: ReadonlyArray<JsonWebKey & { kid?: string }>
+  }
+  const map = new Map<string, CryptoKey>()
+  for (const jwk of doc.keys ?? []) {
+    if (jwk.kid !== undefined) map.set(jwk.kid, await importJwk(jwk))
+  }
+  return map
+}
+
+/**
+ * Resolve the imported public keys for a CF Access team, caching
+ * for `CACHE_TTL_MS` ms keyed by team.
+ * @param team Team slug; the JWKS URL is derived from it.
+ * @param fetcher Injectable fetch (lets tests stub the network).
+ * @param nowMs Current epoch milliseconds (injectable for tests).
+ * @returns Map of `kid -> CryptoKey`.
+ */
+export const resolveJwks = async (
+  team: string,
+  fetcher: (url: string) => Promise<Response>,
+  nowMs: number
+): Promise<ReadonlyMap<string, CryptoKey>> => {
+  const cached = cache.get(team)
+  if (cached !== undefined && nowMs - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached.keys
+  }
+  const url = `https://${team}.cloudflareaccess.com/cdn-cgi/access/certs`
+  const res = await fetcher(url)
+  const keys = await parseJwks(await res.text())
+  cache.set(team, { keys, fetchedAt: nowMs })
+  return keys
+}
+
+/** Reset the in-memory JWKS cache. Intended for test isolation. */
+export const __clearJwksCache = (): void => {
+  cache.clear()
+}

--- a/services/comms-worker/src/auth/jwt-decode.ts
+++ b/services/comms-worker/src/auth/jwt-decode.ts
@@ -1,0 +1,37 @@
+import { base64urlDecode } from './base64url'
+
+/**
+ * Decode a base64url-encoded JSON segment. Returns undefined on any
+ * decode / parse failure so the caller can treat malformed tokens
+ * uniformly.
+ * @param b64u Base64url segment from a compact JWT.
+ * @returns Decoded value typed as `T`, or undefined.
+ */
+export const decodeJson = <T>(b64u: string): T | undefined => {
+  try {
+    return JSON.parse(new TextDecoder().decode(base64urlDecode(b64u))) as T
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Verify an RS256 signature over `<header>.<body>`.
+ * @param head Encoded header.
+ * @param body Encoded body.
+ * @param sig Base64url-encoded signature.
+ * @param key Imported RSA public key.
+ * @returns True iff the signature verifies.
+ */
+export const verifyRs256 = async (
+  head: string,
+  body: string,
+  sig: string,
+  key: CryptoKey
+): Promise<boolean> =>
+  crypto.subtle.verify(
+    'RSASSA-PKCS1-v1_5',
+    key,
+    base64urlDecode(sig),
+    new TextEncoder().encode(`${head}.${body}`)
+  )

--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -1,14 +1,33 @@
+import type { D1Database } from '@cloudflare/workers-types'
 import { Hono } from 'hono'
+import type { AccessClaims } from './auth/cf-access'
 import { registerHealthRoute } from './health'
+import {
+  type RequireAccessEnv,
+  requireAccess,
+} from './middleware/require-access'
+import { createRepo } from './subscribers/repo'
+import { mountSubscriberRoutes } from './subscribers/routes'
 
 /** Combined worker bindings across all registered routes. */
-export type Bindings = {
+export type Bindings = RequireAccessEnv & {
   readonly VERSION: string
   readonly ADMIN_HOSTNAME: string
+  readonly DB: D1Database
 }
 
-const app = new Hono<{ Bindings: Bindings }>()
+type Vars = { readonly access: AccessClaims }
+type WorkerCtx = { Bindings: Bindings; Variables: Vars }
+
+const nowIso = (): string => new Date().toISOString()
+
+const app = new Hono<WorkerCtx>()
+
 registerHealthRoute(app)
+app.use('/api/*', requireAccess())
+mountSubscriberRoutes(app, c =>
+  createRepo({ db: (c.env as Bindings).DB, now: nowIso })
+)
 
 /** Cloudflare Worker entry — delegates everything to Hono. */
 export default {

--- a/services/comms-worker/src/middleware/require-access.test.ts
+++ b/services/comms-worker/src/middleware/require-access.test.ts
@@ -1,0 +1,65 @@
+import { Hono } from 'hono'
+import { describe, expect, it, vi } from 'vitest'
+import type { AccessClaims } from '../auth/cf-access'
+import { type RequireAccessEnv, requireAccess } from './require-access'
+
+const claims: AccessClaims = {
+  aud: 'aud-tag',
+  iss: 'https://comprom.cloudflareaccess.com',
+  email: 'admin@comprom.org',
+  sub: 'github|undeadliner',
+  exp: 9_999_999_999,
+  iat: 1_700_000_000,
+}
+
+const env: RequireAccessEnv = {
+  CF_ACCESS_AUD: 'aud-tag',
+  CF_ACCESS_TEAM: 'comprom',
+}
+
+type Vars = { readonly access: AccessClaims }
+
+const build = (
+  verifier: (token: string) => Promise<AccessClaims | undefined>
+) => {
+  const app = new Hono<{ Bindings: RequireAccessEnv; Variables: Vars }>()
+  app.use('/api/*', requireAccess({ verifier }))
+  app.get('/api/echo', c => c.json({ email: c.var.access.email }))
+  return app
+}
+
+describe('requireAccess middleware', () => {
+  it('rejects when the header is missing', async () => {
+    const verifier = vi.fn()
+    const app = build(verifier)
+    const res = await app.fetch(new Request('http://x/api/echo'), env)
+    expect(res.status).toBe(401)
+    expect(verifier).not.toHaveBeenCalled()
+  })
+
+  it('rejects when the verifier returns undefined', async () => {
+    const verifier = vi.fn().mockResolvedValue(undefined)
+    const app = build(verifier)
+    const res = await app.fetch(
+      new Request('http://x/api/echo', {
+        headers: { 'Cf-Access-Jwt-Assertion': 'bad' },
+      }),
+      env
+    )
+    expect(res.status).toBe(401)
+    expect(verifier).toHaveBeenCalledWith('bad')
+  })
+
+  it('passes through and exposes claims on c.var.access', async () => {
+    const verifier = vi.fn().mockResolvedValue(claims)
+    const app = build(verifier)
+    const res = await app.fetch(
+      new Request('http://x/api/echo', {
+        headers: { 'Cf-Access-Jwt-Assertion': 'ok' },
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ email: 'admin@comprom.org' })
+  })
+})

--- a/services/comms-worker/src/middleware/require-access.ts
+++ b/services/comms-worker/src/middleware/require-access.ts
@@ -1,0 +1,52 @@
+import type { MiddlewareHandler } from 'hono'
+import type { AccessClaims } from '../auth/cf-access'
+import { verifyAccessJwt } from '../auth/cf-access'
+
+/** Bindings the middleware reads from the worker env. */
+export type RequireAccessEnv = {
+  readonly CF_ACCESS_AUD: string
+  readonly CF_ACCESS_TEAM: string
+}
+
+/** Variables the middleware writes onto the Hono context. */
+export type RequireAccessVariables = {
+  readonly access: AccessClaims
+}
+
+type Options = {
+  readonly verifier?: (token: string) => Promise<AccessClaims | undefined>
+}
+
+const ACCESS_HEADER = 'Cf-Access-Jwt-Assertion'
+
+/**
+ * Hono middleware enforcing a valid CF Access JWT on every wrapped
+ * route. On success attaches the decoded claims to `c.var.access`.
+ * @param opts Optional verifier override for tests.
+ * @returns Hono middleware handler.
+ */
+export const requireAccess =
+  (
+    opts: Options = {}
+  ): MiddlewareHandler<{
+    Bindings: RequireAccessEnv
+    Variables: RequireAccessVariables
+  }> =>
+  async (c, next) => {
+    const token = c.req.header(ACCESS_HEADER)
+    if (token === undefined || token === '') {
+      return c.json({ error: 'unauthorized' }, 401)
+    }
+    const claims = await (opts.verifier ?? defaultVerifier(c.env))(token)
+    if (claims === undefined) return c.json({ error: 'unauthorized' }, 401)
+    c.set('access', claims)
+    await next()
+  }
+
+const defaultVerifier =
+  (env: RequireAccessEnv) =>
+  (token: string): Promise<AccessClaims | undefined> =>
+    verifyAccessJwt(token, {
+      aud: env.CF_ACCESS_AUD,
+      team: env.CF_ACCESS_TEAM,
+    })

--- a/services/comms-worker/src/subscribers/repo-insert.ts
+++ b/services/comms-worker/src/subscribers/repo-insert.ts
@@ -1,0 +1,41 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { langsToJson, rowToSubscriber } from './serialize'
+import {
+  type NewSubscriber,
+  newDuplicateError,
+  type Subscriber,
+} from './types'
+
+const SQL_INSERT =
+  'INSERT INTO subscribers (email, langs, created_at) VALUES (?, ?, ?)'
+const SQL_LAST = 'SELECT * FROM subscribers WHERE rowid = last_insert_rowid()'
+const UNIQUE_MARKER = 'UNIQUE'
+
+/**
+ * Insert a new active subscriber row.
+ * @param db D1 database binding.
+ * @param now Clock returning ISO-8601 timestamps.
+ * @param input Email + langs to persist.
+ * @returns The persisted subscriber.
+ * @throws DuplicateError when an active row with that email exists.
+ */
+export const insertSubscriber = async (
+  db: D1Database,
+  now: () => string,
+  input: NewSubscriber
+): Promise<Subscriber> => {
+  const email = input.email.toLowerCase()
+  try {
+    await db
+      .prepare(SQL_INSERT)
+      .bind(email, langsToJson(input.langs), now())
+      .run()
+  } catch (e) {
+    if (e instanceof Error && e.message.includes(UNIQUE_MARKER)) {
+      throw newDuplicateError(email)
+    }
+    throw e
+  }
+  const row = await db.prepare(SQL_LAST).first()
+  return rowToSubscriber(row as Parameters<typeof rowToSubscriber>[0])
+}

--- a/services/comms-worker/src/subscribers/repo-read.ts
+++ b/services/comms-worker/src/subscribers/repo-read.ts
@@ -1,0 +1,35 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { rowToSubscriber } from './serialize'
+import type { Subscriber } from './types'
+
+type Row = Parameters<typeof rowToSubscriber>[0]
+
+const SQL_ACTIVE =
+  "SELECT * FROM subscribers WHERE status = 'active' ORDER BY id"
+const SQL_ALL = 'SELECT * FROM subscribers ORDER BY id'
+const SQL_BY_ID = 'SELECT * FROM subscribers WHERE id = ?'
+
+/** List all subscribers with `status='active'` ordered by id. */
+export const listActive = async (
+  db: D1Database
+): Promise<ReadonlyArray<Subscriber>> => {
+  const { results } = await db.prepare(SQL_ACTIVE).all<Row>()
+  return results.map(rowToSubscriber)
+}
+
+/** List every subscriber row regardless of status. */
+export const listAll = async (
+  db: D1Database
+): Promise<ReadonlyArray<Subscriber>> => {
+  const { results } = await db.prepare(SQL_ALL).all<Row>()
+  return results.map(rowToSubscriber)
+}
+
+/** Find one subscriber by id. */
+export const findById = async (
+  db: D1Database,
+  id: number
+): Promise<Subscriber | undefined> => {
+  const row = await db.prepare(SQL_BY_ID).bind(id).first<Row>()
+  return row === null ? undefined : rowToSubscriber(row)
+}

--- a/services/comms-worker/src/subscribers/repo-write.ts
+++ b/services/comms-worker/src/subscribers/repo-write.ts
@@ -1,0 +1,49 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { findById } from './repo-read'
+import { langsToJson } from './serialize'
+import type { Lang, Subscriber, SubscriberStatus } from './types'
+
+const SQL_UPDATE_LANGS = 'UPDATE subscribers SET langs = ? WHERE id = ?'
+const SQL_DELETE = 'DELETE FROM subscribers WHERE id = ?'
+const SQL_UPDATE_STATUS_INACTIVE =
+  'UPDATE subscribers SET status = ?, unsubscribed_at = ? WHERE id = ?'
+const SQL_UPDATE_STATUS_ACTIVE =
+  "UPDATE subscribers SET status = 'active', unsubscribed_at = NULL WHERE id = ?"
+
+/** Update only the `langs[]` column on an existing row. */
+export const updateLangs = async (
+  db: D1Database,
+  id: number,
+  langs: ReadonlyArray<Lang>
+): Promise<Subscriber | undefined> => {
+  await db.prepare(SQL_UPDATE_LANGS).bind(langsToJson(langs), id).run()
+  return findById(db, id)
+}
+
+/** Hard-delete one row by id, returning `true` iff something was deleted. */
+export const removeSubscriber = async (
+  db: D1Database,
+  id: number
+): Promise<boolean> => {
+  const res = await db.prepare(SQL_DELETE).bind(id).run()
+  return (res.meta.changes ?? 0) > 0
+}
+
+/** Transition a row's status; stamps `unsubscribed_at` on leave-active. */
+export const setStatus = async (
+  db: D1Database,
+  now: () => string,
+  id: number,
+  status: SubscriberStatus
+): Promise<Subscriber | undefined> => {
+  const sql =
+    status === 'active'
+      ? SQL_UPDATE_STATUS_ACTIVE
+      : SQL_UPDATE_STATUS_INACTIVE
+  const stmt =
+    status === 'active'
+      ? db.prepare(sql).bind(id)
+      : db.prepare(sql).bind(status, now(), id)
+  await stmt.run()
+  return findById(db, id)
+}

--- a/services/comms-worker/src/subscribers/repo.test.ts
+++ b/services/comms-worker/src/subscribers/repo.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createRepo, type SubscriberRepo } from './repo'
+import { makeTestD1 } from './test-d1'
+import { DUPLICATE_ERROR_NAME } from './types'
+
+let repo: SubscriberRepo
+const now = () => '2026-06-03T08:00:00.000Z'
+
+beforeEach(() => {
+  repo = createRepo({ db: makeTestD1(), now })
+})
+
+describe('SubscriberRepo.insert', () => {
+  it('persists a new active subscriber and lower-cases the email', async () => {
+    const s = await repo.insert({ email: 'Test@Comprom.ORG', langs: ['ru'] })
+    expect(s.email).toBe('test@comprom.org')
+    expect(s.langs).toEqual(['ru'])
+    expect(s.status).toBe('active')
+    expect(s.createdAt).toBe('2026-06-03T08:00:00.000Z')
+    expect(s.lastSentAt).toBeUndefined()
+  })
+
+  it('throws DuplicateError when an active row with that email exists', async () => {
+    await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    await expect(
+      repo.insert({ email: 'a@b.c', langs: ['en'] })
+    ).rejects.toMatchObject({ name: DUPLICATE_ERROR_NAME })
+  })
+
+  it('lets a previously-unsubscribed email be re-added as active', async () => {
+    const s1 = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    await repo.setStatus(s1.id, 'unsubscribed')
+    const s2 = await repo.insert({ email: 'a@b.c', langs: ['en'] })
+    expect(s2.id).not.toBe(s1.id)
+    expect(s2.status).toBe('active')
+  })
+})
+
+describe('SubscriberRepo.listActive / listAll', () => {
+  it('lists only active rows, excluding unsubscribed and bounced', async () => {
+    const a = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const b = await repo.insert({ email: 'b@b.c', langs: ['en'] })
+    await repo.insert({ email: 'c@b.c', langs: ['it'] })
+    await repo.setStatus(a.id, 'unsubscribed')
+    await repo.setStatus(b.id, 'bounced')
+    const active = await repo.listActive()
+    expect(active.map(s => s.email)).toEqual(['c@b.c'])
+    const all = await repo.listAll()
+    expect(all).toHaveLength(3)
+  })
+})
+
+describe('SubscriberRepo.findById / updateLangs', () => {
+  it('returns the row by id and reflects an updated langs[] array', async () => {
+    const s = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const updated = await repo.updateLangs(s.id, ['ru', 'en'])
+    expect(updated?.langs).toEqual(['ru', 'en'])
+    const found = await repo.findById(s.id)
+    expect(found?.langs).toEqual(['ru', 'en'])
+  })
+
+  it('returns undefined for unknown ids', async () => {
+    expect(await repo.findById(999)).toBeUndefined()
+    expect(await repo.updateLangs(999, ['ru'])).toBeUndefined()
+  })
+})
+
+describe('SubscriberRepo.remove', () => {
+  it('hard-deletes the row and reports it gone afterwards', async () => {
+    const s = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const ok = await repo.remove(s.id)
+    expect(ok).toBe(true)
+    expect(await repo.findById(s.id)).toBeUndefined()
+  })
+
+  it('returns false when the id does not match a row', async () => {
+    expect(await repo.remove(123)).toBe(false)
+  })
+})
+
+describe('SubscriberRepo.setStatus', () => {
+  it('flips status and stamps unsubscribed_at on transitions away from active', async () => {
+    const s = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const after = await repo.setStatus(s.id, 'unsubscribed')
+    expect(after?.status).toBe('unsubscribed')
+    expect(after?.unsubscribedAt).toBe('2026-06-03T08:00:00.000Z')
+  })
+
+  it('returns undefined for unknown ids', async () => {
+    expect(await repo.setStatus(999, 'bounced')).toBeUndefined()
+  })
+})

--- a/services/comms-worker/src/subscribers/repo.ts
+++ b/services/comms-worker/src/subscribers/repo.ts
@@ -1,0 +1,44 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { insertSubscriber } from './repo-insert'
+import { findById, listActive, listAll } from './repo-read'
+import { removeSubscriber, setStatus, updateLangs } from './repo-write'
+import type {
+  Lang,
+  NewSubscriber,
+  Subscriber,
+  SubscriberStatus,
+} from './types'
+
+/** Aggregated subscriber-repo surface used by Hono handlers. */
+export type SubscriberRepo = {
+  readonly insert: (input: NewSubscriber) => Promise<Subscriber>
+  readonly listActive: () => Promise<ReadonlyArray<Subscriber>>
+  readonly listAll: () => Promise<ReadonlyArray<Subscriber>>
+  readonly findById: (id: number) => Promise<Subscriber | undefined>
+  readonly updateLangs: (
+    id: number,
+    langs: ReadonlyArray<Lang>
+  ) => Promise<Subscriber | undefined>
+  readonly remove: (id: number) => Promise<boolean>
+  readonly setStatus: (
+    id: number,
+    status: SubscriberStatus
+  ) => Promise<Subscriber | undefined>
+}
+
+type Deps = { readonly db: D1Database; readonly now: () => string }
+
+/**
+ * Build a subscriber repo bound to a D1 database + clock.
+ * @param d Injected dependencies.
+ * @returns Repo facade.
+ */
+export const createRepo = (d: Deps): SubscriberRepo => ({
+  insert: input => insertSubscriber(d.db, d.now, input),
+  listActive: () => listActive(d.db),
+  listAll: () => listAll(d.db),
+  findById: id => findById(d.db, id),
+  updateLangs: (id, langs) => updateLangs(d.db, id, langs),
+  remove: id => removeSubscriber(d.db, id),
+  setStatus: (id, status) => setStatus(d.db, d.now, id, status),
+})

--- a/services/comms-worker/src/subscribers/route-handlers.ts
+++ b/services/comms-worker/src/subscribers/route-handlers.ts
@@ -1,0 +1,54 @@
+import type { Context } from 'hono'
+import type { SubscriberRepo } from './repo'
+import { isDuplicateError } from './types'
+import { validateLangsPatch, validateNewSubscriber } from './validate'
+
+/** Parse a positive integer from a path param. */
+export const parseId = (raw: string): number | undefined => {
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}
+
+/** POST /api/subscribers — create. */
+export const handleCreate = async (
+  c: Context,
+  repo: SubscriberRepo
+): Promise<Response> => {
+  const body = await c.req.json().catch(() => undefined)
+  const parsed = validateNewSubscriber(body)
+  if ('error' in parsed) return c.json({ error: parsed.error }, 422)
+  try {
+    return c.json(await repo.insert(parsed), 201)
+  } catch (e) {
+    if (isDuplicateError(e)) return c.json({ error: 'duplicate' }, 409)
+    throw e
+  }
+}
+
+/** PATCH /api/subscribers/:id — replace langs. */
+export const handlePatch = async (
+  c: Context,
+  repo: SubscriberRepo
+): Promise<Response> => {
+  const id = parseId(c.req.param('id'))
+  if (id === undefined) return c.json({ error: 'not_found' }, 404)
+  const body = await c.req.json().catch(() => undefined)
+  const parsed = validateLangsPatch(body)
+  if ('error' in parsed) return c.json({ error: parsed.error }, 422)
+  const updated = await repo.updateLangs(id, parsed.langs)
+  return updated === undefined
+    ? c.json({ error: 'not_found' }, 404)
+    : c.json(updated)
+}
+
+/** DELETE /api/subscribers/:id — hard delete. */
+export const handleDelete = async (
+  c: Context,
+  repo: SubscriberRepo
+): Promise<Response> => {
+  const id = parseId(c.req.param('id'))
+  if (id === undefined) return c.json({ error: 'not_found' }, 404)
+  return (await repo.remove(id))
+    ? c.body(null, 204)
+    : c.json({ error: 'not_found' }, 404)
+}

--- a/services/comms-worker/src/subscribers/routes.test.ts
+++ b/services/comms-worker/src/subscribers/routes.test.ts
@@ -1,0 +1,171 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { AccessClaims } from '../auth/cf-access'
+import { requireAccess } from '../middleware/require-access'
+import { createRepo } from './repo'
+import { mountSubscriberRoutes } from './routes'
+import { makeTestD1 } from './test-d1'
+import type { Subscriber } from './types'
+
+const claims: AccessClaims = {
+  aud: 'a',
+  iss: 'https://comprom.cloudflareaccess.com',
+  email: 'admin@comprom.org',
+  sub: 'github|undeadliner',
+  exp: 9_999_999_999,
+  iat: 1,
+}
+
+const env = { CF_ACCESS_AUD: 'a', CF_ACCESS_TEAM: 'comprom' }
+
+const build = () => {
+  const repo = createRepo({
+    db: makeTestD1(),
+    now: () => '2026-06-03T08:00:00.000Z',
+  })
+  const app = new Hono<{
+    Bindings: typeof env
+    Variables: { readonly access: AccessClaims }
+  }>()
+  app.use('/api/*', requireAccess({ verifier: async () => claims }))
+  mountSubscriberRoutes(app, () => repo)
+  return { app, repo }
+}
+
+const reqJson = (path: string, init: RequestInit = {}) =>
+  new Request(`http://x${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cf-Access-Jwt-Assertion': 'tok',
+      ...init.headers,
+    },
+  })
+
+let app: ReturnType<typeof build>['app']
+let repo: ReturnType<typeof build>['repo']
+
+beforeEach(() => {
+  const b = build()
+  app = b.app
+  repo = b.repo
+})
+
+describe('POST /api/subscribers', () => {
+  it('rejects when the access header is missing', async () => {
+    const res = await app.fetch(
+      new Request('http://x/api/subscribers', { method: 'POST' }),
+      env
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('creates a new active row and returns 201', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'a@b.c', langs: ['ru'] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as Subscriber
+    expect(body.email).toBe('a@b.c')
+    expect(body.langs).toEqual(['ru'])
+  })
+
+  it('returns 422 for invalid email syntax', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'not-an-email', langs: ['ru'] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+  })
+
+  it('returns 422 when langs is empty', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'a@b.c', langs: [] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+  })
+
+  it('returns 409 for duplicate active emails', async () => {
+    await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const res = await app.fetch(
+      reqJson('/api/subscribers', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'a@b.c', langs: ['en'] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(409)
+  })
+})
+
+describe('GET /api/subscribers', () => {
+  it('lists all rows including unsubscribed', async () => {
+    const a = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    await repo.insert({ email: 'b@b.c', langs: ['en'] })
+    await repo.setStatus(a.id, 'unsubscribed')
+    const res = await app.fetch(reqJson('/api/subscribers'), env)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      readonly subscribers: ReadonlyArray<Subscriber>
+    }
+    expect(body.subscribers).toHaveLength(2)
+  })
+})
+
+describe('PATCH /api/subscribers/:id', () => {
+  it('updates langs and returns the new row', async () => {
+    const s = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const res = await app.fetch(
+      reqJson(`/api/subscribers/${s.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ langs: ['en', 'it'] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Subscriber
+    expect(body.langs).toEqual(['en', 'it'])
+  })
+
+  it('returns 404 for unknown id', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers/999', {
+        method: 'PATCH',
+        body: JSON.stringify({ langs: ['ru'] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('DELETE /api/subscribers/:id', () => {
+  it('hard-deletes the row', async () => {
+    const s = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const res = await app.fetch(
+      reqJson(`/api/subscribers/${s.id}`, { method: 'DELETE' }),
+      env
+    )
+    expect(res.status).toBe(204)
+    expect(await repo.findById(s.id)).toBeUndefined()
+  })
+
+  it('returns 404 for unknown id', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers/999', { method: 'DELETE' }),
+      env
+    )
+    expect(res.status).toBe(404)
+  })
+})

--- a/services/comms-worker/src/subscribers/routes.ts
+++ b/services/comms-worker/src/subscribers/routes.ts
@@ -1,0 +1,22 @@
+import type { Context, Hono } from 'hono'
+import type { SubscriberRepo } from './repo'
+import { handleCreate, handleDelete, handlePatch } from './route-handlers'
+
+type App = Hono<{ Bindings: object; Variables: object }>
+type Resolve = (c: Context) => SubscriberRepo
+
+/**
+ * Mount the subscriber CRUD endpoints on the given Hono app.
+ * @param app Hono app, already wrapped with `requireAccess` for /api/*.
+ * @param resolve Builds the repo for the current request from its context.
+ * @returns The same app for chaining.
+ */
+export const mountSubscriberRoutes = (app: App, resolve: Resolve): App => {
+  app.get('/api/subscribers', async c =>
+    c.json({ subscribers: await resolve(c).listAll() })
+  )
+  app.post('/api/subscribers', c => handleCreate(c, resolve(c)))
+  app.patch('/api/subscribers/:id', c => handlePatch(c, resolve(c)))
+  app.delete('/api/subscribers/:id', c => handleDelete(c, resolve(c)))
+  return app
+}

--- a/services/comms-worker/src/subscribers/serialize.ts
+++ b/services/comms-worker/src/subscribers/serialize.ts
@@ -1,0 +1,39 @@
+import type { Lang, Subscriber, SubscriberStatus } from './types'
+import { LANGS } from './types'
+
+type Row = {
+  readonly id: number
+  readonly email: string
+  readonly langs: string
+  readonly status: string
+  readonly created_at: string
+  readonly last_sent_at: string | null
+  readonly unsubscribed_at: string | null
+}
+
+const isLang = (v: unknown): v is Lang =>
+  typeof v === 'string' && (LANGS as ReadonlyArray<string>).includes(v)
+
+const parseLangs = (json: string): ReadonlyArray<Lang> => {
+  const parsed = JSON.parse(json) as unknown
+  return Array.isArray(parsed) ? parsed.filter(isLang) : []
+}
+
+/**
+ * Translate a raw D1 row into the domain `Subscriber` shape.
+ * @param row Row returned by D1.
+ * @returns Typed subscriber.
+ */
+export const rowToSubscriber = (row: Row): Subscriber => ({
+  id: row.id,
+  email: row.email,
+  langs: parseLangs(row.langs),
+  status: row.status as SubscriberStatus,
+  createdAt: row.created_at,
+  lastSentAt: row.last_sent_at ?? undefined,
+  unsubscribedAt: row.unsubscribed_at ?? undefined,
+})
+
+/** JSON-stringify a `langs[]` array for the D1 `langs` column. */
+export const langsToJson = (langs: ReadonlyArray<Lang>): string =>
+  JSON.stringify(langs)

--- a/services/comms-worker/src/subscribers/test-d1.ts
+++ b/services/comms-worker/src/subscribers/test-d1.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { D1Database } from '@cloudflare/workers-types'
+import BetterSqlite3 from 'better-sqlite3'
+
+const MIG_DIR = resolve('services/comms-worker/migrations')
+
+type Stmt = ReturnType<BetterSqlite3.Database['prepare']>
+
+const meta = (rowid: number | bigint, changes: number) => ({
+  duration: 0,
+  size_after: 0,
+  rows_read: 0,
+  rows_written: 0,
+  last_row_id: Number(rowid),
+  changed_db: changes > 0,
+  changes,
+})
+
+const prepare = (db: BetterSqlite3.Database, sql: string) => {
+  const buildBound = (stmt: Stmt, params: ReadonlyArray<unknown>) => ({
+    first: async <T>() => (stmt.get(...params) ?? null) as T | null,
+    all: async <T>() => ({
+      results: stmt.all(...params) as T[],
+      success: true,
+      meta: meta(0, 0),
+    }),
+    run: async () => {
+      const r = stmt.run(...params)
+      return { success: true, meta: meta(r.lastInsertRowid, r.changes) }
+    },
+    raw: async () => stmt.raw().all(...params) as unknown[],
+  })
+  const stmt = db.prepare(sql)
+  return {
+    bind: (...params: unknown[]) => buildBound(stmt, params),
+    ...buildBound(stmt, []),
+  }
+}
+
+/**
+ * Build an in-memory better-sqlite3 database masquerading as a
+ * `D1Database` for repo unit tests. Applies the worker's real
+ * migrations so CHECK constraints + partial-unique indexes behave
+ * the same as in production D1.
+ * @returns A D1-compatible test database.
+ */
+export const makeTestD1 = (): D1Database => {
+  const db = new BetterSqlite3(':memory:')
+  for (const file of ['0001_initial.sql', '0002_seed.sql']) {
+    db.exec(readFileSync(resolve(MIG_DIR, file), 'utf8'))
+  }
+  return {
+    prepare: (sql: string) => prepare(db, sql),
+  } as unknown as D1Database
+}

--- a/services/comms-worker/src/subscribers/types.ts
+++ b/services/comms-worker/src/subscribers/types.ts
@@ -1,0 +1,50 @@
+/** Languages supported by the site (matches Astro SUPPORTED_LANGUAGES). */
+export const LANGS = ['en', 'ru', 'it', 'es', 'uk', 'pl', 'bl'] as const
+
+/** A single language code; narrow string type. */
+export type Lang = (typeof LANGS)[number]
+
+/** Lifecycle status carried by every subscriber row. */
+export type SubscriberStatus =
+  | 'active'
+  | 'unsubscribed'
+  | 'bounced'
+  | 'complained'
+
+/** Domain representation of a `subscribers` row. */
+export type Subscriber = {
+  readonly id: number
+  readonly email: string
+  readonly langs: ReadonlyArray<Lang>
+  readonly status: SubscriberStatus
+  readonly createdAt: string
+  readonly lastSentAt: string | undefined
+  readonly unsubscribedAt: string | undefined
+}
+
+/** Inputs accepted by the `insert` repo call. */
+export type NewSubscriber = {
+  readonly email: string
+  readonly langs: ReadonlyArray<Lang>
+}
+
+/** Sentinel name used by `DuplicateError` instances. */
+export const DUPLICATE_ERROR_NAME = 'DuplicateError'
+
+/** Error tag carried on the throw path for active-email dupes. */
+export type DuplicateError = Error & { readonly name: 'DuplicateError' }
+
+/**
+ * Construct a `DuplicateError` for the given email.
+ * @param email Email that collided with an existing active row.
+ * @returns Tagged error suitable for `throw`.
+ */
+export const newDuplicateError = (email: string): DuplicateError => {
+  const e = new Error(`subscriber already exists: ${email}`) as DuplicateError
+  Object.assign(e, { name: DUPLICATE_ERROR_NAME })
+  return e
+}
+
+/** Type guard for `DuplicateError`. */
+export const isDuplicateError = (e: unknown): e is DuplicateError =>
+  e instanceof Error && e.name === DUPLICATE_ERROR_NAME

--- a/services/comms-worker/src/subscribers/validate.ts
+++ b/services/comms-worker/src/subscribers/validate.ts
@@ -1,0 +1,46 @@
+import { LANGS, type Lang, type NewSubscriber } from './types'
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const allowedLangs = new Set<string>(LANGS)
+
+const isLang = (v: unknown): v is Lang =>
+  typeof v === 'string' && allowedLangs.has(v)
+
+/**
+ * Validate the body of `POST /api/subscribers`.
+ * @param body Raw parsed JSON body.
+ * @returns Normalised subscriber input on success, error code otherwise.
+ */
+export const validateNewSubscriber = (
+  body: unknown
+): NewSubscriber | { readonly error: 'email' | 'langs' } => {
+  if (typeof body !== 'object' || body === null) return { error: 'email' }
+  const { email, langs } = body as {
+    readonly email?: unknown
+    readonly langs?: unknown
+  }
+  if (typeof email !== 'string' || !EMAIL_RE.test(email)) {
+    return { error: 'email' }
+  }
+  if (!Array.isArray(langs) || langs.length === 0 || !langs.every(isLang)) {
+    return { error: 'langs' }
+  }
+  return { email, langs }
+}
+
+/**
+ * Validate the body of `PATCH /api/subscribers/:id`.
+ * @param body Raw parsed JSON body.
+ * @returns Langs array on success, error code otherwise.
+ */
+export const validateLangsPatch = (
+  body: unknown
+): { readonly langs: ReadonlyArray<Lang> } | { readonly error: 'langs' } => {
+  if (typeof body !== 'object' || body === null) return { error: 'langs' }
+  const { langs } = body as { readonly langs?: unknown }
+  if (!Array.isArray(langs) || langs.length === 0 || !langs.every(isLang)) {
+    return { error: 'langs' }
+  }
+  return { langs }
+}

--- a/src/config/comms.ts
+++ b/src/config/comms.ts
@@ -1,0 +1,16 @@
+const envBase = (): string => {
+  const v = import.meta.env.VITE_COMMS_BASE
+  return typeof v === 'string' && v.length > 0 ? v.replace(/\/$/, '') : ''
+}
+
+const defaultBase = (): string =>
+  import.meta.env.DEV ? 'http://localhost:8787' : 'https://lists.comprom.org'
+
+/**
+ * Read the comms-worker base URL from Vite env. Defaults to the
+ * production custom-domain route declared in
+ * `services/comms-worker/wrangler.jsonc`. Use VITE_COMMS_BASE in
+ * dev/e2e to point at a local `wrangler dev` instance.
+ * @returns Origin (no trailing slash) of the comms worker.
+ */
+export const getCommsBase = (): string => envBase() || defaultBase()

--- a/src/router/non-content-routes.ts
+++ b/src/router/non-content-routes.ts
@@ -21,6 +21,12 @@ export const nonContentRoutes: RouteRecordRaw[] = [
     component: () => import('../views/SettingsView/SettingsView.vue'),
   },
   {
+    path: '/comms',
+    name: 'comms',
+    meta: { requiresAuth: true },
+    component: () => import('../views/CommsView/CommsView.vue'),
+  },
+  {
     path: '/conflicts',
     name: 'conflicts',
     meta: { requiresAuth: true },

--- a/src/stores/comms-actions.ts
+++ b/src/stores/comms-actions.ts
@@ -1,0 +1,74 @@
+import type { Ref } from 'vue'
+import type { Lang, Subscriber } from '@/validation/schemas/subscriber'
+import {
+  apiAddSubscriber,
+  apiListSubscribers,
+  apiRemoveSubscriber,
+  apiUpdateLangs,
+} from './comms-api'
+
+/** Mutable refs the action factories read + write. */
+export type CommsRefs = {
+  readonly subscribers: Ref<readonly Subscriber[]>
+  readonly loading: Ref<boolean>
+  readonly loaded: Ref<boolean>
+  readonly saving: Ref<boolean>
+}
+
+/**
+ * Build the `load` action that refreshes `subscribers` from the worker.
+ * @param r Reactive refs the action mutates.
+ * @returns Async action returning void.
+ */
+export const createLoad = (r: CommsRefs) => async (): Promise<void> => {
+  r.loading.value = true
+  try {
+    const res = await apiListSubscribers()
+    r.subscribers.value = res.subscribers
+    r.loaded.value = true
+  } finally {
+    r.loading.value = false
+  }
+}
+
+/**
+ * Build the `add` action that POSTs a new subscriber + reloads.
+ * @param r Reactive refs the action mutates.
+ * @param load Loader used to refresh after the write.
+ * @returns Async action returning void.
+ */
+export const createAdd =
+  (r: CommsRefs, load: () => Promise<void>) =>
+  async (email: string, langs: readonly Lang[]): Promise<void> => {
+    r.saving.value = true
+    try {
+      await apiAddSubscriber(email, langs)
+      await load()
+    } finally {
+      r.saving.value = false
+    }
+  }
+
+/**
+ * Build the `updateLangs` action that PATCHes one row + reloads.
+ * @param load Loader used to refresh after the write.
+ * @returns Async action returning void.
+ */
+export const createUpdateLangs =
+  (load: () => Promise<void>) =>
+  async (id: number, langs: readonly Lang[]): Promise<void> => {
+    await apiUpdateLangs(id, langs)
+    await load()
+  }
+
+/**
+ * Build the `remove` action that DELETEs one row + reloads.
+ * @param load Loader used to refresh after the write.
+ * @returns Async action returning void.
+ */
+export const createRemove =
+  (load: () => Promise<void>) =>
+  async (id: number): Promise<void> => {
+    await apiRemoveSubscriber(id)
+    await load()
+  }

--- a/src/stores/comms-api.test.ts
+++ b/src/stores/comms-api.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Subscriber } from '@/validation/schemas/subscriber'
+import {
+  apiAddSubscriber,
+  apiListSubscribers,
+  apiRemoveSubscriber,
+  apiUpdateLangs,
+} from './comms-api'
+
+const okSubscriber: Subscriber = {
+  id: 7,
+  email: 'a@b.c',
+  langs: ['ru', 'en'],
+  status: 'active',
+  createdAt: '2026-06-03T00:00:00.000Z',
+  lastSentAt: undefined,
+  unsubscribedAt: undefined,
+}
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  mockFetch.mockReset()
+})
+
+const ok = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+describe('apiListSubscribers', () => {
+  it('GETs /api/subscribers with credentials and returns parsed list', async () => {
+    mockFetch.mockResolvedValue(ok({ subscribers: [okSubscriber] }))
+    const res = await apiListSubscribers()
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/subscribers$/)
+    expect(init.credentials).toBe('include')
+    expect(res.subscribers).toHaveLength(1)
+  })
+})
+
+describe('apiAddSubscriber', () => {
+  it('POSTs the email + langs and returns the created subscriber', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify(okSubscriber), { status: 201 })
+    )
+    const res = await apiAddSubscriber('a@b.c', ['ru'])
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/subscribers$/)
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe(JSON.stringify({ email: 'a@b.c', langs: ['ru'] }))
+    expect(res.email).toBe('a@b.c')
+  })
+
+  it('throws a readable error on 422', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'email' }), { status: 422 })
+    )
+    await expect(apiAddSubscriber('bad', ['ru'])).rejects.toThrow('email')
+  })
+})
+
+describe('apiUpdateLangs', () => {
+  it('PATCHes the langs at /api/subscribers/:id', async () => {
+    mockFetch.mockResolvedValue(ok(okSubscriber))
+    await apiUpdateLangs(7, ['en'])
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/subscribers\/7$/)
+    expect(init.method).toBe('PATCH')
+    expect(init.body).toBe(JSON.stringify({ langs: ['en'] }))
+  })
+})
+
+describe('apiRemoveSubscriber', () => {
+  it('DELETEs the row by id', async () => {
+    mockFetch.mockResolvedValue(new Response(null, { status: 204 }))
+    await apiRemoveSubscriber(7)
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/subscribers\/7$/)
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('throws on non-2xx', async () => {
+    mockFetch.mockResolvedValue(new Response(null, { status: 404 }))
+    await expect(apiRemoveSubscriber(7)).rejects.toThrow()
+  })
+})

--- a/src/stores/comms-api.ts
+++ b/src/stores/comms-api.ts
@@ -1,0 +1,75 @@
+import { decodeResponse } from '@/validation/decode-response'
+import type {
+  Lang,
+  Subscriber,
+  SubscribersList,
+} from '@/validation/schemas/subscriber'
+import {
+  SubscriberSchema,
+  SubscribersListSchema,
+} from '@/validation/schemas/subscriber'
+import { commsUrl, ensureOk, jsonHeaders } from './comms-http'
+
+/**
+ * GET /api/subscribers — list every subscriber row, regardless of status.
+ * @returns Parsed list payload.
+ */
+export const apiListSubscribers = async (): Promise<SubscribersList> => {
+  const res = await fetch(commsUrl('/api/subscribers'), {
+    credentials: 'include',
+  })
+  return decodeResponse(SubscribersListSchema)(res)
+}
+
+/**
+ * POST /api/subscribers — create one new active subscriber.
+ * @param email Lower-case canonical email address.
+ * @param langs Languages the subscriber wants in their digest.
+ * @returns The persisted subscriber row.
+ */
+export const apiAddSubscriber = async (
+  email: string,
+  langs: ReadonlyArray<Lang>
+): Promise<Subscriber> => {
+  const res = await fetch(commsUrl('/api/subscribers'), {
+    method: 'POST',
+    credentials: 'include',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ email, langs }),
+  })
+  return decodeResponse(SubscriberSchema)(res)
+}
+
+/**
+ * PATCH /api/subscribers/:id — replace the langs[] array.
+ * @param id Subscriber id.
+ * @param langs Replacement language list.
+ * @returns The updated subscriber row.
+ */
+export const apiUpdateLangs = async (
+  id: number,
+  langs: ReadonlyArray<Lang>
+): Promise<Subscriber> => {
+  const res = await fetch(commsUrl(`/api/subscribers/${id}`), {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ langs }),
+  })
+  return decodeResponse(SubscriberSchema)(res)
+}
+
+/**
+ * DELETE /api/subscribers/:id — hard delete.
+ * @param id Subscriber id.
+ * @returns Nothing; throws on non-2xx.
+ */
+export const apiRemoveSubscriber = async (id: number): Promise<void> => {
+  ensureOk(
+    await fetch(commsUrl(`/api/subscribers/${id}`), {
+      method: 'DELETE',
+      credentials: 'include',
+    }),
+    'Delete'
+  )
+}

--- a/src/stores/comms-http.ts
+++ b/src/stores/comms-http.ts
@@ -1,0 +1,29 @@
+import { getCommsBase } from '@/config/comms'
+
+/**
+ * Build an absolute URL pointing at the comms-worker.
+ * @param path Path beginning with `/`.
+ * @returns Fully-qualified URL.
+ */
+export const commsUrl = (path: string): string => `${getCommsBase()}${path}`
+
+/**
+ * Standard JSON content-type headers used by every comms POST/PATCH.
+ * @returns Headers object with `Content-Type: application/json`.
+ */
+export const jsonHeaders = (): HeadersInit => ({
+  'Content-Type': 'application/json',
+})
+
+/**
+ * Pass-through that throws when the response status is non-2xx.
+ * @param res The fetch response.
+ * @param step Human-readable label included in the error message.
+ * @returns The same response when ok.
+ */
+export const ensureOk = (res: Response, step: string): Response =>
+  res.ok
+    ? res
+    : (() => {
+        throw new Error(`${step} failed: ${res.status}`)
+      })()

--- a/src/stores/comms-state.ts
+++ b/src/stores/comms-state.ts
@@ -1,0 +1,32 @@
+import { ref } from 'vue'
+import type { Subscriber } from '@/validation/schemas/subscriber'
+import {
+  type CommsRefs,
+  createAdd,
+  createLoad,
+  createRemove,
+  createUpdateLangs,
+} from './comms-actions'
+
+/**
+ * Reactive state + actions for the comms (newsletter) admin store.
+ * Talks directly to lists.comprom.org; auth is the browser CF
+ * Access cookie set on `.comprom.org`.
+ * @returns Store state and actions.
+ */
+export const createCommsState = () => {
+  const r: CommsRefs = {
+    subscribers: ref<readonly Subscriber[]>([]),
+    loading: ref(false),
+    loaded: ref(false),
+    saving: ref(false),
+  }
+  const load = createLoad(r)
+  return {
+    ...r,
+    load,
+    add: createAdd(r, load),
+    updateLangs: createUpdateLangs(load),
+    remove: createRemove(load),
+  }
+}

--- a/src/stores/comms.ts
+++ b/src/stores/comms.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+import { createCommsState } from './comms-state'
+
+export type { Lang, Subscriber } from '@/validation/schemas/subscriber'
+
+/** Pinia store for the newsletter (comms) admin surface. */
+export const useCommsStore = defineStore('comms', () => {
+  const s = createCommsState()
+
+  /** Load subscribers once if not already loaded. */
+  const ensureLoaded = async (): Promise<void> => {
+    await (s.loaded.value ? Promise.resolve() : s.load())
+  }
+
+  return { ...s, ensureLoaded }
+})

--- a/src/validation/schemas/subscriber.ts
+++ b/src/validation/schemas/subscriber.ts
@@ -1,0 +1,28 @@
+import { Schema } from 'effect'
+
+const LangSchema = Schema.Literal('en', 'ru', 'it', 'es', 'uk', 'pl', 'bl')
+
+/** Newsletter subscriber, mirrors comms-worker D1 `subscribers` row. */
+export const SubscriberSchema = Schema.Struct({
+  id: Schema.Number,
+  email: Schema.String,
+  langs: Schema.Array(LangSchema),
+  status: Schema.Literal('active', 'unsubscribed', 'bounced', 'complained'),
+  createdAt: Schema.String,
+  lastSentAt: Schema.UndefinedOr(Schema.String),
+  unsubscribedAt: Schema.UndefinedOr(Schema.String),
+})
+
+/** Subscriber type derived from the schema. */
+export type Subscriber = typeof SubscriberSchema.Type
+
+/** Language type derived from the schema. */
+export type Lang = typeof LangSchema.Type
+
+/** Wrapper for the list endpoint. */
+export const SubscribersListSchema = Schema.Struct({
+  subscribers: Schema.Array(SubscriberSchema),
+})
+
+/** List response type. */
+export type SubscribersList = typeof SubscribersListSchema.Type

--- a/src/views/CommsView/AddSubscriberForm.vue
+++ b/src/views/CommsView/AddSubscriberForm.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { Lang } from '@/stores/comms'
+import { canSubmitNewSubscriber } from './draft-ops'
+import LangTogglePills from './LangTogglePills.vue'
+
+const props = defineProps<{ readonly saving?: boolean }>()
+const emit = defineEmits<{
+  add: [email: string, langs: readonly Lang[]]
+}>()
+
+const email = ref('')
+const langs = ref<readonly Lang[]>([])
+const error = ref<string | undefined>(undefined)
+
+const setLangs = (next: readonly Lang[]): void => {
+  langs.value = next
+}
+
+const submit = async (): Promise<void> => {
+  if (!canSubmitNewSubscriber(email.value, langs.value)) return
+  error.value = undefined
+  try {
+    emit('add', email.value.trim(), langs.value)
+    email.value = ''
+    langs.value = []
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Failed to add'
+  }
+}
+</script>
+
+<template>
+  <form class="add-form" data-testid="add-subscriber-form" @submit.prevent="submit">
+    <input
+      v-model="email"
+      type="email"
+      class="email"
+      placeholder="recipient@example.org"
+      data-testid="add-subscriber-email"
+      :disabled="saving"
+    />
+    <LangTogglePills :langs="langs" :disabled="saving" @change="setLangs" />
+    <button
+      type="submit"
+      class="submit"
+      data-testid="add-subscriber-submit"
+      :disabled="saving || !canSubmitNewSubscriber(email, langs)"
+    >
+      {{ saving ? 'Adding…' : 'Add subscriber' }}
+    </button>
+    <p v-if="error" class="error" data-testid="add-subscriber-error">{{ error }}</p>
+  </form>
+</template>
+
+<style scoped>
+.add-form {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.email {
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.submit {
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-background);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.error {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--color-danger, #c0392b);
+  font-size: 0.8125rem;
+}
+</style>

--- a/src/views/CommsView/CommsView.vue
+++ b/src/views/CommsView/CommsView.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import { onMounted } from 'vue'
+import type { Lang } from '@/stores/comms'
+import { useCommsStore } from '@/stores/comms'
+import AddSubscriberForm from './AddSubscriberForm.vue'
+import SubscribersTable from './SubscribersTable.vue'
+
+const store = useCommsStore()
+
+onMounted(() => {
+  void store.ensureLoaded()
+})
+
+const onAdd = (email: string, langs: readonly Lang[]): void => {
+  void store.add(email, langs)
+}
+
+const onLangs = (id: number, langs: readonly Lang[]): void => {
+  void store.updateLangs(id, langs)
+}
+
+const onRemove = (id: number): void => {
+  void store.remove(id)
+}
+</script>
+
+<template>
+  <section class="comms" data-testid="comms-view">
+    <header class="head">
+      <h1>Newsletter</h1>
+      <p class="lead">
+        Editor list — subscribers receive the weekly digest of new
+        articles on the languages they pick.
+      </p>
+    </header>
+    <AddSubscriberForm :saving="store.saving" @add="onAdd" />
+    <SubscribersTable
+      :subscribers="store.subscribers"
+      @langs="onLangs"
+      @remove="onRemove"
+    />
+    <p v-if="store.loading && store.subscribers.length === 0" data-testid="comms-loading">
+      Loading…
+    </p>
+  </section>
+</template>
+
+<style scoped>
+.comms {
+  max-width: 920px;
+  padding: 1.25rem;
+}
+
+.head {
+  margin-bottom: 1rem;
+}
+
+.lead {
+  color: var(--color-text-secondary);
+  margin: 0.25rem 0 0;
+}
+</style>

--- a/src/views/CommsView/LangTogglePills.vue
+++ b/src/views/CommsView/LangTogglePills.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import type { Lang } from '@/stores/comms'
+import { ALL_LANGS, toggleLang } from './draft-ops'
+
+const props = defineProps<{
+  readonly langs: readonly Lang[]
+  readonly disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  change: [langs: readonly Lang[]]
+}>()
+
+const onClick = (lang: Lang): void => {
+  emit('change', toggleLang(props.langs, lang))
+}
+</script>
+
+<template>
+  <span class="lang-toggle" data-testid="lang-toggle">
+    <button
+      v-for="lang in ALL_LANGS"
+      :key="lang"
+      type="button"
+      class="pill"
+      :class="{ 'pill--on': langs.includes(lang) }"
+      :disabled="disabled"
+      :data-testid="`lang-toggle-${lang}`"
+      :aria-pressed="langs.includes(lang)"
+      @click="onClick(lang)"
+    >
+      {{ lang }}
+    </button>
+  </span>
+</template>
+
+<style scoped>
+.lang-toggle {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.pill {
+  font-size: 0.6875rem;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+.pill--on {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.pill:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+</style>

--- a/src/views/CommsView/SubscriberRow.vue
+++ b/src/views/CommsView/SubscriberRow.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import type { Lang, Subscriber } from '@/stores/comms'
+import LangTogglePills from './LangTogglePills.vue'
+import SubscriberStatusBadge from './SubscriberStatusBadge.vue'
+
+defineProps<{ readonly entry: Subscriber }>()
+
+const emit = defineEmits<{
+  langs: [id: number, langs: readonly Lang[]]
+  remove: [id: number]
+}>()
+</script>
+
+<template>
+  <li class="subscriber-row" data-testid="subscriber-row">
+    <span class="email" data-testid="subscriber-email">{{ entry.email }}</span>
+    <LangTogglePills
+      :langs="entry.langs"
+      :disabled="entry.status !== 'active'"
+      @change="langs => emit('langs', entry.id, langs)"
+    />
+    <SubscriberStatusBadge :status="entry.status" />
+    <button
+      type="button"
+      class="remove"
+      data-testid="subscriber-remove"
+      @click="emit('remove', entry.id)"
+    >
+      ✕
+    </button>
+  </li>
+</template>
+
+<style scoped>
+.subscriber-row {
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  gap: 0.6rem;
+  align-items: center;
+  padding: 0.65rem 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.email {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.875rem;
+}
+
+.remove {
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+}
+</style>

--- a/src/views/CommsView/SubscriberStatusBadge.vue
+++ b/src/views/CommsView/SubscriberStatusBadge.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import type { Subscriber } from '@/stores/comms'
+
+const props = defineProps<{ readonly status: Subscriber['status'] }>()
+
+const label = (): string =>
+  props.status === 'active'
+    ? 'active'
+    : props.status === 'unsubscribed'
+      ? 'unsubscribed'
+      : props.status === 'bounced'
+        ? 'bounced'
+        : 'complained'
+</script>
+
+<template>
+  <span
+    class="status"
+    :class="`status--${status}`"
+    :data-testid="`subscriber-status-${status}`"
+  >
+    {{ label() }}
+  </span>
+</template>
+
+<style scoped>
+.status {
+  display: inline-block;
+  font-size: 0.6875rem;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+  padding: 0.1rem 0.45rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+}
+
+.status--active {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.status--bounced,
+.status--complained {
+  color: var(--color-danger, #c0392b);
+  border-color: var(--color-danger, #c0392b);
+}
+</style>

--- a/src/views/CommsView/SubscribersTable.vue
+++ b/src/views/CommsView/SubscribersTable.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { Lang, Subscriber } from '@/stores/comms'
+import SubscriberRow from './SubscriberRow.vue'
+
+defineProps<{ readonly subscribers: readonly Subscriber[] }>()
+
+const emit = defineEmits<{
+  langs: [id: number, langs: readonly Lang[]]
+  remove: [id: number]
+}>()
+</script>
+
+<template>
+  <ul class="subscribers" data-testid="subscribers-table">
+    <SubscriberRow
+      v-for="s in subscribers"
+      :key="s.id"
+      :entry="s"
+      @langs="(id, langs) => emit('langs', id, langs)"
+      @remove="id => emit('remove', id)"
+    />
+  </ul>
+</template>
+
+<style scoped>
+.subscribers {
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/views/CommsView/draft-ops.test.ts
+++ b/src/views/CommsView/draft-ops.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { canSubmitNewSubscriber, toggleLang } from './draft-ops'
+
+describe('canSubmitNewSubscriber', () => {
+  it('accepts a valid email with at least one lang', () => {
+    expect(canSubmitNewSubscriber('a@b.c', ['ru'])).toBe(true)
+  })
+
+  it('rejects a missing local-part', () => {
+    expect(canSubmitNewSubscriber('@b.c', ['ru'])).toBe(false)
+  })
+
+  it('rejects a missing tld', () => {
+    expect(canSubmitNewSubscriber('a@b', ['ru'])).toBe(false)
+  })
+
+  it('rejects when no langs are picked', () => {
+    expect(canSubmitNewSubscriber('a@b.c', [])).toBe(false)
+  })
+
+  it('trims surrounding whitespace before checking', () => {
+    expect(canSubmitNewSubscriber('  a@b.c  ', ['ru'])).toBe(true)
+  })
+})
+
+describe('toggleLang', () => {
+  it('adds a missing lang', () => {
+    expect(toggleLang(['ru'], 'en')).toEqual(['ru', 'en'])
+  })
+
+  it('removes a present lang', () => {
+    expect(toggleLang(['ru', 'en'], 'ru')).toEqual(['en'])
+  })
+
+  it('returns a new array (no mutation)', () => {
+    const current = ['ru'] as const
+    const next = toggleLang(current, 'en')
+    expect(next).not.toBe(current)
+  })
+})

--- a/src/views/CommsView/draft-ops.ts
+++ b/src/views/CommsView/draft-ops.ts
@@ -1,0 +1,40 @@
+import type { Lang } from '@/validation/schemas/subscriber'
+
+/** All languages supported by both the worker and the public site. */
+export const ALL_LANGS: ReadonlyArray<Lang> = [
+  'en',
+  'ru',
+  'it',
+  'es',
+  'uk',
+  'pl',
+  'bl',
+]
+
+/** Loose email-shape check used to gate the "Add" button. */
+export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * True iff the form has a valid-looking email and at least one lang.
+ * @param email Raw input value.
+ * @param langs Picked language list.
+ * @returns Whether the submit button should be enabled.
+ */
+export const canSubmitNewSubscriber = (
+  email: string,
+  langs: ReadonlyArray<Lang>
+): boolean => EMAIL_RE.test(email.trim()) && langs.length > 0
+
+/**
+ * Toggle a lang in the array immutably.
+ * @param current Existing langs.
+ * @param lang Lang to flip.
+ * @returns New langs list.
+ */
+export const toggleLang = (
+  current: ReadonlyArray<Lang>,
+  lang: Lang
+): ReadonlyArray<Lang> =>
+  current.includes(lang)
+    ? current.filter(l => l !== lang)
+    : [...current, lang]


### PR DESCRIPTION
Stage 1 of [specs/comms-newsletter/tasks.md](../tree/feat/23-comms-newsletter/specs/comms-newsletter/tasks.md). Stacks on Stage 0 PR #247.

## What this PR delivers

T1.1 — CF Access RS256 JWT verifier (R6.1)
T1.2 — `requireAccess` Hono middleware (R6.1)
T1.3 — Subscriber repo over D1 with a `better-sqlite3` in-memory adapter (R1.2–R1.6, R3.1, R4.6)
T1.4 — `/api/subscribers` GET/POST/PATCH/DELETE with email + lang validation (R1.1–R1.4)
T1.5 — Pinia store + typed API client speaking to `lists.comprom.org` (R1.1)
T1.6/T1.7 — `/comms` Vue view with table, add form, lang toggle pills, status badge (R1.1–R1.7)

## Tests

| Layer | Count | What |
|---|---|---|
| worker unit | 11 | CF Access verifier (JWKS cache, audience, issuer, tamper, expired, unknown kid) |
| worker integration (Hono+`app.fetch`) | 3 | requireAccess middleware (missing, bad, ok) |
| worker integration (D1 via better-sqlite3) | 10 | Subscriber repo (insert dedup, partial unique re-add, listActive/listAll, updateLangs, status, remove) |
| worker integration | 9 | /api/subscribers routes (401, 201, 422 × 2, 409, list, PATCH, DELETE, 404) |
| admin unit | 6 | comms-api (URL, method, body, credentials, error mapping) |
| admin unit | 8 | draft-ops (`EMAIL_RE`, `canSubmitNewSubscriber`, `toggleLang` immutability) |

57/57 green on stage tests. Repo suite 746/747 with one pre-existing flake in `PdfUpload.test.ts` unrelated to this PR.

## Explicitly deferred to Stage 7

- Playwright e2e for the `/comms` view (T1.6 / T1.7 in tasks.md). Requires a live `wrangler dev` worker behind a stub CF Access. Picked up in T7.4 (`full-flow.spec.ts`).

## Dev deps added

- `better-sqlite3` + `@types/better-sqlite3` — power the worker test D1 adapter so repo tests run real SQL (CHECK constraints + partial unique index honoured) in-process.
- `@cloudflare/workers-types` — brings `D1Database` typings into the worker.

## Out of scope (stage 2+)

- Schedule editor + cron matcher (stage 2)
- Dispatch loop, Resend client, digest renderer (stage 3)
- Unsubscribe + webhook (stages 4-5)
- Run history (stage 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)