### PR TITLE
feat(comms): tickets#23 stage 2 — schedule editor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.8.1",
         "better-sqlite3": "^12.10.0",
+        "cron-parser": "^5.5.0",
         "cross-env": "^10.1.0",
         "dotenv": "^17.3.1",
         "effect": "^3.21.0",
@@ -854,6 +855,8 @@
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
+    "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
+
     "cross-env": ["cross-env@10.1.0", "", { "dependencies": { "@epic-web/invariant": "^1.0.0", "cross-spawn": "^7.0.6" }, "bin": { "cross-env": "dist/bin/cross-env.js", "cross-env-shell": "dist/bin/cross-env-shell.js" } }, "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -1313,6 +1316,8 @@
     "lop": ["lop@0.4.2", "", { "dependencies": { "duck": "^0.1.12", "option": "~0.2.1", "underscore": "^1.13.1" } }, "sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw=="],
 
     "lru-cache": ["lru-cache@11.3.3", "", {}, "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.8.1",
     "better-sqlite3": "^12.10.0",
+    "cron-parser": "^5.5.0",
     "cross-env": "^10.1.0",
     "dotenv": "^17.3.1",
     "effect": "^3.21.0",

--- a/services/comms-worker/src/cron/matcher.test.ts
+++ b/services/comms-worker/src/cron/matcher.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { matchesTick, type Schedule, TICK_WINDOW_MS } from './matcher'
+
+const MSK: Schedule = { cron: '0 12 * * 6', timezone: 'Europe/Moscow' }
+const BERLIN: Schedule = { cron: '0 12 * * *', timezone: 'Europe/Berlin' }
+
+describe('TICK_WINDOW_MS', () => {
+  it('is five minutes', () => {
+    expect(TICK_WINDOW_MS).toBe(5 * 60 * 1000)
+  })
+})
+
+describe('matchesTick — canonical Saturday-noon Europe/Moscow', () => {
+  it('matches an on-time heartbeat at 09:00Z on Saturday 2026-06-06', () => {
+    expect(matchesTick(MSK, new Date('2026-06-06T09:00:00.000Z'))).toBe(true)
+  })
+
+  it('does not match the same hour on Friday 2026-06-05', () => {
+    expect(matchesTick(MSK, new Date('2026-06-05T09:00:00.000Z'))).toBe(false)
+  })
+
+  it('matches a heartbeat 2 minutes late (inside window)', () => {
+    expect(matchesTick(MSK, new Date('2026-06-06T09:02:00.000Z'))).toBe(true)
+  })
+
+  it('does not match a heartbeat 6 minutes late (outside window)', () => {
+    expect(matchesTick(MSK, new Date('2026-06-06T09:06:00.000Z'))).toBe(false)
+  })
+})
+
+describe('matchesTick — DST behaviour in Europe/Berlin', () => {
+  it('matches CEST summer noon (10:00Z = 12:00 Berlin DST)', () => {
+    expect(matchesTick(BERLIN, new Date('2026-06-06T10:00:00.000Z'))).toBe(
+      true
+    )
+    expect(matchesTick(BERLIN, new Date('2026-06-06T11:00:00.000Z'))).toBe(
+      false
+    )
+  })
+
+  it('matches CET winter noon (11:00Z = 12:00 Berlin standard)', () => {
+    expect(matchesTick(BERLIN, new Date('2026-12-06T11:00:00.000Z'))).toBe(
+      true
+    )
+    expect(matchesTick(BERLIN, new Date('2026-12-06T10:00:00.000Z'))).toBe(
+      false
+    )
+  })
+})

--- a/services/comms-worker/src/cron/matcher.ts
+++ b/services/comms-worker/src/cron/matcher.ts
@@ -1,0 +1,29 @@
+import { CronExpressionParser } from 'cron-parser'
+
+/** Persisted schedule shape: 5-field crontab + IANA timezone. */
+export type Schedule = {
+  readonly cron: string
+  readonly timezone: string
+}
+
+/** Forgiveness window between expected fire and the actual heartbeat. */
+export const TICK_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * True iff a heartbeat at `tickAt` lands within `TICK_WINDOW_MS` after the
+ * most-recent expected fire time of the schedule's crontab, computed in its
+ * saved IANA timezone (DST-aware via cron-parser).
+ * @param schedule Saved cron + timezone.
+ * @param tickAt Heartbeat moment under test (UTC).
+ * @returns Whether dispatch should run for this tick.
+ */
+export const matchesTick = (schedule: Schedule, tickAt: Date): boolean => {
+  const tickMs = tickAt.getTime()
+  const lookbackStart = new Date(tickMs - TICK_WINDOW_MS - 1)
+  const iter = CronExpressionParser.parse(schedule.cron, {
+    currentDate: lookbackStart,
+    tz: schedule.timezone,
+  })
+  const nextMs = iter.next().toDate().getTime()
+  return nextMs <= tickMs
+}

--- a/services/comms-worker/src/cron/parse.test.ts
+++ b/services/comms-worker/src/cron/parse.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import type { Schedule } from './matcher'
+import { nextRunAt, validateCron } from './parse'
+
+const MSK: Schedule = { cron: '0 12 * * 6', timezone: 'Europe/Moscow' }
+
+describe('validateCron', () => {
+  it('accepts a valid 5-field expression', () => {
+    expect(validateCron('0 12 * * 6')).toEqual({ ok: true })
+  })
+
+  it('rejects an unparseable expression with a non-empty parser message', () => {
+    const r = validateCron('not a cron')
+    expect(r.ok).toBe(false)
+    const error = 'error' in r ? r.error : ''
+    expect(error.length).toBeGreaterThan(0)
+  })
+
+  it('rejects an out-of-range minute', () => {
+    expect(validateCron('99 * * * *').ok).toBe(false)
+  })
+})
+
+describe('nextRunAt', () => {
+  it('returns the next ISO timestamp in UTC for the given schedule', () => {
+    const r = nextRunAt(MSK, new Date('2026-06-01T00:00:00.000Z'))
+    expect(r).toBe('2026-06-06T09:00:00.000Z')
+  })
+
+  it('returns the strictly-next fire even when called on a fire moment', () => {
+    const r = nextRunAt(MSK, new Date('2026-06-06T09:00:00.000Z'))
+    expect(r).toBe('2026-06-13T09:00:00.000Z')
+  })
+
+  it('honours IANA timezone (Etc/UTC daily at 00:00)', () => {
+    const utc: Schedule = { cron: '0 0 * * *', timezone: 'Etc/UTC' }
+    const r = nextRunAt(utc, new Date('2026-06-06T12:00:00.000Z'))
+    expect(r).toBe('2026-06-07T00:00:00.000Z')
+  })
+})

--- a/services/comms-worker/src/cron/parse.ts
+++ b/services/comms-worker/src/cron/parse.ts
@@ -1,0 +1,37 @@
+import { CronExpressionParser } from 'cron-parser'
+import type { Schedule } from './matcher'
+
+/** Discriminated result returned by {@link validateCron}. */
+export type CronValidation =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly error: string }
+
+/**
+ * Parse a 5-field cron expression and report whether it is well-formed.
+ * @param cron Crontab string to validate.
+ * @returns `{ok:true}` on success, `{ok:false,error}` with the parser's message.
+ */
+export const validateCron = (cron: string): CronValidation => {
+  try {
+    CronExpressionParser.parse(cron)
+    return { ok: true }
+  } catch (e) {
+    const error = e instanceof Error ? e.message : 'invalid cron'
+    return { ok: false, error }
+  }
+}
+
+/**
+ * Compute the next ISO-8601 UTC timestamp at which the schedule will fire.
+ * @param schedule Saved cron + timezone.
+ * @param from Reference point; the returned moment is strictly after this.
+ * @returns ISO-8601 UTC string of the next expected fire time.
+ */
+export const nextRunAt = (schedule: Schedule, from: Date): string =>
+  CronExpressionParser.parse(schedule.cron, {
+    currentDate: from,
+    tz: schedule.timezone,
+  })
+    .next()
+    .toDate()
+    .toISOString()

--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -6,6 +6,8 @@ import {
   type RequireAccessEnv,
   requireAccess,
 } from './middleware/require-access'
+import { mountScheduleRoutes } from './schedule/routes'
+import { createSettingsRepo } from './settings/repo'
 import { createRepo } from './subscribers/repo'
 import { mountSubscriberRoutes } from './subscribers/routes'
 
@@ -20,6 +22,7 @@ type Vars = { readonly access: AccessClaims }
 type WorkerCtx = { Bindings: Bindings; Variables: Vars }
 
 const nowIso = (): string => new Date().toISOString()
+const nowDate = (): Date => new Date()
 
 const app = new Hono<WorkerCtx>()
 
@@ -27,6 +30,11 @@ registerHealthRoute(app)
 app.use('/api/*', requireAccess())
 mountSubscriberRoutes(app, c =>
   createRepo({ db: (c.env as Bindings).DB, now: nowIso })
+)
+mountScheduleRoutes(
+  app,
+  c => createSettingsRepo({ db: (c.env as Bindings).DB }),
+  nowDate
 )
 
 /** Cloudflare Worker entry — delegates everything to Hono. */

--- a/services/comms-worker/src/schedule/handlers.ts
+++ b/services/comms-worker/src/schedule/handlers.ts
@@ -1,0 +1,30 @@
+import type { Context } from 'hono'
+import type { SettingsRepo } from '../settings/repo'
+import { validateScheduleBody } from './validate'
+
+/** Type of the request-bound clock used by the handlers. */
+export type NowFn = () => Date
+
+/** GET /api/schedule — return current saved schedule or the seed default. */
+export const handleGetSchedule = async (
+  c: Context,
+  repo: SettingsRepo,
+  now: NowFn
+): Promise<Response> => {
+  const sched = await repo.getSchedule(now())
+  if (sched === undefined) return c.json({ error: 'not_found' }, 404)
+  return c.json(sched)
+}
+
+/** PUT /api/schedule — validate body then persist. */
+export const handlePutSchedule = async (
+  c: Context,
+  repo: SettingsRepo,
+  now: NowFn
+): Promise<Response> => {
+  const body = await c.req.json().catch(() => undefined)
+  const parsed = validateScheduleBody(body)
+  if (!parsed.ok) return c.json({ error: parsed.error }, 422)
+  const saved = await repo.setSchedule(parsed.value, now())
+  return c.json(saved)
+}

--- a/services/comms-worker/src/schedule/routes.test.ts
+++ b/services/comms-worker/src/schedule/routes.test.ts
@@ -1,0 +1,145 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { AccessClaims } from '../auth/cf-access'
+import { requireAccess } from '../middleware/require-access'
+import { createSettingsRepo } from '../settings/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { mountScheduleRoutes } from './routes'
+
+const claims: AccessClaims = {
+  aud: 'a',
+  iss: 'https://comprom.cloudflareaccess.com',
+  email: 'admin@comprom.org',
+  sub: 'github|undeadliner',
+  exp: 9_999_999_999,
+  iat: 1,
+}
+
+const env = { CF_ACCESS_AUD: 'a', CF_ACCESS_TEAM: 'comprom' }
+const FROZEN = new Date('2026-06-01T00:00:00.000Z')
+
+const build = () => {
+  const repo = createSettingsRepo({ db: makeTestD1() })
+  const app = new Hono<{
+    Bindings: typeof env
+    Variables: { readonly access: AccessClaims }
+  }>()
+  app.use('/api/*', requireAccess({ verifier: async () => claims }))
+  mountScheduleRoutes(
+    app,
+    () => repo,
+    () => FROZEN
+  )
+  return { app, repo }
+}
+
+const reqJson = (path: string, init: RequestInit = {}) =>
+  new Request(`http://x${path}`, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cf-Access-Jwt-Assertion': 'tok',
+      ...init.headers,
+    },
+  })
+
+let app: ReturnType<typeof build>['app']
+
+beforeEach(() => {
+  app = build().app
+})
+
+describe('GET /api/schedule', () => {
+  it('rejects when the access header is missing', async () => {
+    const res = await app.fetch(new Request('http://x/api/schedule'), env)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the seeded default schedule with nextRunAt', async () => {
+    const res = await app.fetch(reqJson('/api/schedule'), env)
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      cron: string
+      timezone: string
+      nextRunAt: string
+    }
+    expect(body.cron).toBe('0 12 * * 6')
+    expect(body.timezone).toBe('Europe/Moscow')
+    expect(body.nextRunAt).toBe('2026-06-06T09:00:00.000Z')
+  })
+})
+
+describe('PUT /api/schedule', () => {
+  it('rejects when the access header is missing', async () => {
+    const res = await app.fetch(
+      new Request('http://x/api/schedule', { method: 'PUT' }),
+      env
+    )
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 422 with parser message on bad cron', async () => {
+    const res = await app.fetch(
+      reqJson('/api/schedule', {
+        method: 'PUT',
+        body: JSON.stringify({
+          cron: 'not a cron',
+          timezone: 'Etc/UTC',
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+    const body = (await res.json()) as { error: string }
+    expect(body.error.length).toBeGreaterThan(0)
+  })
+
+  it('returns 422 when timezone is unknown', async () => {
+    const res = await app.fetch(
+      reqJson('/api/schedule', {
+        method: 'PUT',
+        body: JSON.stringify({
+          cron: '0 12 * * *',
+          timezone: 'Mars/Olympus',
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+  })
+
+  it('returns 422 when the body shape is malformed', async () => {
+    const res = await app.fetch(
+      reqJson('/api/schedule', {
+        method: 'PUT',
+        body: JSON.stringify({ cron: '0 12 * * *' }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+  })
+
+  it('persists a valid value and returns the new nextRunAt', async () => {
+    const res = await app.fetch(
+      reqJson('/api/schedule', {
+        method: 'PUT',
+        body: JSON.stringify({
+          cron: '*/15 * * * *',
+          timezone: 'Etc/UTC',
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      cron: string
+      timezone: string
+      nextRunAt: string
+    }
+    expect(body.cron).toBe('*/15 * * * *')
+    expect(body.nextRunAt).toBe('2026-06-01T00:15:00.000Z')
+    const after = await app.fetch(reqJson('/api/schedule'), env)
+    const afterBody = (await after.json()) as { cron: string }
+    expect(afterBody.cron).toBe('*/15 * * * *')
+  })
+})

--- a/services/comms-worker/src/schedule/routes.ts
+++ b/services/comms-worker/src/schedule/routes.ts
@@ -1,0 +1,23 @@
+import type { Context, Hono } from 'hono'
+import type { SettingsRepo } from '../settings/repo'
+import { handleGetSchedule, handlePutSchedule, type NowFn } from './handlers'
+
+type App = Hono<{ Bindings: object; Variables: object }>
+type Resolve = (c: Context) => SettingsRepo
+
+/**
+ * Mount the schedule endpoints on the given Hono app.
+ * @param app Hono app, already wrapped with `requireAccess` for /api/*.
+ * @param resolve Builds the settings repo for the current request.
+ * @param now Clock used to compute the `nextRunAt` field on the response.
+ * @returns The same app for chaining.
+ */
+export const mountScheduleRoutes = (
+  app: App,
+  resolve: Resolve,
+  now: NowFn
+): App => {
+  app.get('/api/schedule', c => handleGetSchedule(c, resolve(c), now))
+  app.put('/api/schedule', c => handlePutSchedule(c, resolve(c), now))
+  return app
+}

--- a/services/comms-worker/src/schedule/validate.ts
+++ b/services/comms-worker/src/schedule/validate.ts
@@ -1,0 +1,49 @@
+import type { Schedule } from '../cron/matcher'
+import { validateCron } from '../cron/parse'
+
+/** Result of validating a `PUT /api/schedule` body. */
+export type ScheduleValidation =
+  | { readonly ok: true; readonly value: Schedule }
+  | { readonly ok: false; readonly error: string }
+
+const isValidTz = (tz: string): boolean => {
+  try {
+    new Intl.DateTimeFormat('en', { timeZone: tz })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const readShape = (
+  body: unknown
+): { readonly cron: string; readonly timezone: string } | undefined => {
+  if (typeof body !== 'object' || body === null) return undefined
+  const { cron, timezone } = body as {
+    readonly cron?: unknown
+    readonly timezone?: unknown
+  }
+  if (typeof cron !== 'string' || typeof timezone !== 'string') {
+    return undefined
+  }
+  return { cron, timezone }
+}
+
+/**
+ * Validate the body of `PUT /api/schedule`.
+ * @param body Raw parsed JSON body.
+ * @returns Discriminated union; carries either the parsed Schedule
+ *   or the error message returned to the client as 422.
+ */
+export const validateScheduleBody = (body: unknown): ScheduleValidation => {
+  const shape = readShape(body)
+  if (shape === undefined) {
+    return { ok: false, error: 'body must be {cron, timezone}' }
+  }
+  const cronCheck = validateCron(shape.cron)
+  if (!cronCheck.ok) return { ok: false, error: cronCheck.error }
+  if (!isValidTz(shape.timezone)) {
+    return { ok: false, error: `unknown timezone: ${shape.timezone}` }
+  }
+  return { ok: true, value: shape }
+}

--- a/services/comms-worker/src/settings/repo.test.ts
+++ b/services/comms-worker/src/settings/repo.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { createSettingsRepo, type SettingsRepo } from './repo'
+
+let repo: SettingsRepo
+
+beforeEach(() => {
+  repo = createSettingsRepo({ db: makeTestD1() })
+})
+
+describe('SettingsRepo.getSchedule', () => {
+  it('returns the seeded default schedule with nextRunAt', async () => {
+    const r = await repo.getSchedule(new Date('2026-06-01T00:00:00.000Z'))
+    expect(r?.cron).toBe('0 12 * * 6')
+    expect(r?.timezone).toBe('Europe/Moscow')
+    expect(r?.nextRunAt).toBe('2026-06-06T09:00:00.000Z')
+  })
+})
+
+describe('SettingsRepo.setSchedule', () => {
+  it('upserts a new value and returns the updated row with nextRunAt', async () => {
+    const fresh = { cron: '*/15 * * * *', timezone: 'Etc/UTC' }
+    const saved = await repo.setSchedule(
+      fresh,
+      new Date('2026-06-01T00:00:00.000Z')
+    )
+    expect(saved.cron).toBe('*/15 * * * *')
+    expect(saved.timezone).toBe('Etc/UTC')
+    expect(saved.nextRunAt).toBe('2026-06-01T00:15:00.000Z')
+  })
+
+  it('persists across reads', async () => {
+    const fresh = { cron: '0 8 * * 1', timezone: 'Europe/Moscow' }
+    await repo.setSchedule(fresh, new Date('2026-06-01T00:00:00.000Z'))
+    const got = await repo.getSchedule(new Date('2026-06-01T00:00:00.000Z'))
+    expect(got?.cron).toBe('0 8 * * 1')
+    expect(got?.timezone).toBe('Europe/Moscow')
+    expect(got?.nextRunAt).toBe('2026-06-01T05:00:00.000Z')
+  })
+})

--- a/services/comms-worker/src/settings/repo.ts
+++ b/services/comms-worker/src/settings/repo.ts
@@ -1,0 +1,61 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import type { Schedule } from '../cron/matcher'
+import { nextRunAt } from '../cron/parse'
+
+/** Schedule plus its next computed fire time, as returned by the repo. */
+export type ScheduleWithNext = Schedule & { readonly nextRunAt: string }
+
+/** Repo facade for the `settings.schedule` row. */
+export type SettingsRepo = {
+  readonly getSchedule: (now: Date) => Promise<ScheduleWithNext | undefined>
+  readonly setSchedule: (
+    schedule: Schedule,
+    now: Date
+  ) => Promise<ScheduleWithNext>
+}
+
+type Deps = { readonly db: D1Database }
+type Row = { readonly value: string }
+
+const KEY = 'schedule'
+const SQL_GET = 'SELECT value FROM settings WHERE key = ?'
+const SQL_UPSERT =
+  'INSERT INTO settings (key, value) VALUES (?, ?) ' +
+  'ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+
+const parseRow = (raw: string): Schedule => {
+  const json = JSON.parse(raw) as Schedule
+  return { cron: json.cron, timezone: json.timezone }
+}
+
+const withNext = (s: Schedule, now: Date): ScheduleWithNext => ({
+  ...s,
+  nextRunAt: nextRunAt(s, now),
+})
+
+const fetchSchedule = async (
+  db: D1Database,
+  now: Date
+): Promise<ScheduleWithNext | undefined> => {
+  const row = (await db.prepare(SQL_GET).bind(KEY).first()) as Row | null
+  return row === null ? undefined : withNext(parseRow(row.value), now)
+}
+
+const persistSchedule = async (
+  db: D1Database,
+  s: Schedule,
+  now: Date
+): Promise<ScheduleWithNext> => {
+  await db.prepare(SQL_UPSERT).bind(KEY, JSON.stringify(s)).run()
+  return withNext(s, now)
+}
+
+/**
+ * Build a settings repo bound to the given D1 database.
+ * @param d Injected dependencies.
+ * @returns Repo facade.
+ */
+export const createSettingsRepo = (d: Deps): SettingsRepo => ({
+  getSchedule: now => fetchSchedule(d.db, now),
+  setSchedule: (s, now) => persistSchedule(d.db, s, now),
+})

--- a/src/stores/schedule-actions.ts
+++ b/src/stores/schedule-actions.ts
@@ -1,0 +1,56 @@
+import type { Ref } from 'vue'
+import type {
+  Schedule,
+  ScheduleWithNext,
+} from '@/validation/schemas/schedule'
+import { apiGetSchedule, apiPutSchedule } from './schedule-api'
+
+/** Mutable refs the schedule action factories read + write. */
+export type ScheduleRefs = {
+  readonly schedule: Ref<ScheduleWithNext | undefined>
+  readonly loading: Ref<boolean>
+  readonly loaded: Ref<boolean>
+  readonly saving: Ref<boolean>
+  readonly error: Ref<string | undefined>
+}
+
+/**
+ * Build the `load` action that pulls the schedule from the worker.
+ * @param r Reactive refs the action mutates.
+ * @returns Async action returning void.
+ */
+export const createLoadSchedule =
+  (r: ScheduleRefs) => async (): Promise<void> => {
+    r.loading.value = true
+    r.error.value = undefined
+    try {
+      r.schedule.value = await apiGetSchedule()
+      r.loaded.value = true
+    } catch (e) {
+      r.error.value =
+        e instanceof Error ? e.message : 'Failed to load schedule'
+    } finally {
+      r.loading.value = false
+    }
+  }
+
+/**
+ * Build the `save` action that PUTs a new schedule and refreshes state.
+ * @param r Reactive refs the action mutates.
+ * @returns Async action returning void.
+ */
+export const createSaveSchedule =
+  (r: ScheduleRefs) =>
+  async (next: Schedule): Promise<void> => {
+    r.saving.value = true
+    r.error.value = undefined
+    try {
+      r.schedule.value = await apiPutSchedule(next)
+    } catch (e) {
+      r.error.value =
+        e instanceof Error ? e.message : 'Failed to save schedule'
+      throw e
+    } finally {
+      r.saving.value = false
+    }
+  }

--- a/src/stores/schedule-api.test.ts
+++ b/src/stores/schedule-api.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ScheduleWithNext } from '@/validation/schemas/schedule'
+import { apiGetSchedule, apiPutSchedule } from './schedule-api'
+
+const okSchedule: ScheduleWithNext = {
+  cron: '0 12 * * 6',
+  timezone: 'Europe/Moscow',
+  nextRunAt: '2026-06-06T09:00:00.000Z',
+}
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  mockFetch.mockReset()
+})
+
+const okJson = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+describe('apiGetSchedule', () => {
+  it('GETs /api/schedule with credentials and parses the payload', async () => {
+    mockFetch.mockResolvedValue(okJson(okSchedule))
+    const res = await apiGetSchedule()
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/schedule$/)
+    expect(init.credentials).toBe('include')
+    expect(res.cron).toBe('0 12 * * 6')
+    expect(res.nextRunAt).toBe('2026-06-06T09:00:00.000Z')
+  })
+})
+
+describe('apiPutSchedule', () => {
+  it('PUTs the cron + timezone and returns the new ScheduleWithNext', async () => {
+    mockFetch.mockResolvedValue(okJson(okSchedule))
+    const res = await apiPutSchedule({
+      cron: '0 12 * * 6',
+      timezone: 'Europe/Moscow',
+    })
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/schedule$/)
+    expect(init.method).toBe('PUT')
+    expect(init.body).toBe(
+      JSON.stringify({ cron: '0 12 * * 6', timezone: 'Europe/Moscow' })
+    )
+    expect(res.timezone).toBe('Europe/Moscow')
+  })
+
+  it('throws with the worker error message on 422', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'invalid cron' }), {
+        status: 422,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    await expect(
+      apiPutSchedule({ cron: 'bad', timezone: 'Etc/UTC' })
+    ).rejects.toThrow(/invalid cron/)
+  })
+})

--- a/src/stores/schedule-api.ts
+++ b/src/stores/schedule-api.ts
@@ -1,0 +1,36 @@
+import { decodeResponse } from '@/validation/decode-response'
+import type {
+  Schedule,
+  ScheduleWithNext,
+} from '@/validation/schemas/schedule'
+import { ScheduleWithNextSchema } from '@/validation/schemas/schedule'
+import { commsUrl, jsonHeaders } from './comms-http'
+
+/**
+ * GET /api/schedule — return the saved schedule with computed `nextRunAt`.
+ * @returns Parsed schedule payload.
+ */
+export const apiGetSchedule = async (): Promise<ScheduleWithNext> => {
+  const res = await fetch(commsUrl('/api/schedule'), {
+    credentials: 'include',
+  })
+  return decodeResponse(ScheduleWithNextSchema)(res)
+}
+
+/**
+ * PUT /api/schedule — persist `{cron, timezone}` and receive the
+ * recomputed `nextRunAt` in the response.
+ * @param schedule New `{cron, timezone}` pair.
+ * @returns Persisted schedule with `nextRunAt`.
+ */
+export const apiPutSchedule = async (
+  schedule: Schedule
+): Promise<ScheduleWithNext> => {
+  const res = await fetch(commsUrl('/api/schedule'), {
+    method: 'PUT',
+    credentials: 'include',
+    headers: jsonHeaders(),
+    body: JSON.stringify(schedule),
+  })
+  return decodeResponse(ScheduleWithNextSchema)(res)
+}

--- a/src/stores/schedule-state.ts
+++ b/src/stores/schedule-state.ts
@@ -1,0 +1,27 @@
+import { ref } from 'vue'
+import type { ScheduleWithNext } from '@/validation/schemas/schedule'
+import {
+  createLoadSchedule,
+  createSaveSchedule,
+  type ScheduleRefs,
+} from './schedule-actions'
+
+/**
+ * Reactive state + actions for the newsletter dispatch schedule.
+ * Mirrors the comms-state factory shape.
+ * @returns Refs plus `load` and `save` actions.
+ */
+export const createScheduleState = () => {
+  const r: ScheduleRefs = {
+    schedule: ref<ScheduleWithNext | undefined>(undefined),
+    loading: ref(false),
+    loaded: ref(false),
+    saving: ref(false),
+    error: ref<string | undefined>(undefined),
+  }
+  return {
+    ...r,
+    load: createLoadSchedule(r),
+    save: createSaveSchedule(r),
+  }
+}

--- a/src/stores/schedule.ts
+++ b/src/stores/schedule.ts
@@ -1,0 +1,19 @@
+import { defineStore } from 'pinia'
+import { createScheduleState } from './schedule-state'
+
+export type {
+  Schedule,
+  ScheduleWithNext,
+} from '@/validation/schemas/schedule'
+
+/** Pinia store for the newsletter dispatch schedule. */
+export const useScheduleStore = defineStore('comms-schedule', () => {
+  const s = createScheduleState()
+
+  /** Load the schedule once if not already loaded. */
+  const ensureLoaded = async (): Promise<void> => {
+    await (s.loaded.value ? Promise.resolve() : s.load())
+  }
+
+  return { ...s, ensureLoaded }
+})

--- a/src/validation/schemas/schedule.ts
+++ b/src/validation/schemas/schedule.ts
@@ -1,0 +1,20 @@
+import { Schema } from 'effect'
+
+/** Saved newsletter schedule: 5-field cron + IANA timezone. */
+export const ScheduleSchema = Schema.Struct({
+  cron: Schema.String,
+  timezone: Schema.String,
+})
+
+/** Plain `{cron, timezone}` type used on PUT bodies. */
+export type Schedule = typeof ScheduleSchema.Type
+
+/** Server response shape — adds the next computed UTC fire time. */
+export const ScheduleWithNextSchema = Schema.Struct({
+  cron: Schema.String,
+  timezone: Schema.String,
+  nextRunAt: Schema.String,
+})
+
+/** Response type derived from {@link ScheduleWithNextSchema}. */
+export type ScheduleWithNext = typeof ScheduleWithNextSchema.Type

--- a/src/views/CommsView/AddSubscriberForm.vue
+++ b/src/views/CommsView/AddSubscriberForm.vue
@@ -83,7 +83,7 @@ const submit = async (): Promise<void> => {
 }
 
 .submit:disabled {
-  opacity: 0.5;
+  opacity: 50%;
   cursor: not-allowed;
 }
 

--- a/src/views/CommsView/CommsView.vue
+++ b/src/views/CommsView/CommsView.vue
@@ -2,13 +2,18 @@
 import { onMounted } from 'vue'
 import type { Lang } from '@/stores/comms'
 import { useCommsStore } from '@/stores/comms'
+import type { Schedule } from '@/stores/schedule'
+import { useScheduleStore } from '@/stores/schedule'
 import AddSubscriberForm from './AddSubscriberForm.vue'
+import ScheduleEditor from './ScheduleEditor.vue'
 import SubscribersTable from './SubscribersTable.vue'
 
 const store = useCommsStore()
+const schedule = useScheduleStore()
 
 onMounted(() => {
   void store.ensureLoaded()
+  void schedule.ensureLoaded()
 })
 
 const onAdd = (email: string, langs: readonly Lang[]): void => {
@@ -22,17 +27,25 @@ const onLangs = (id: number, langs: readonly Lang[]): void => {
 const onRemove = (id: number): void => {
   void store.remove(id)
 }
+
+const onScheduleSave = (next: Schedule): void => {
+  void schedule.save(next)
+}
 </script>
 
 <template>
   <section class="comms" data-testid="comms-view">
-    <header class="head">
-      <h1>Newsletter</h1>
-      <p class="lead">
-        Editor list — subscribers receive the weekly digest of new
-        articles on the languages they pick.
-      </p>
-    </header>
+    <h1 class="title">Newsletter</h1>
+    <p class="lead">
+      Editor list — subscribers receive the weekly digest of new
+      articles on the languages they pick.
+    </p>
+    <ScheduleEditor
+      :schedule="schedule.schedule"
+      :saving="schedule.saving"
+      :error="schedule.error"
+      @save="onScheduleSave"
+    />
     <AddSubscriberForm :saving="store.saving" @add="onAdd" />
     <SubscribersTable
       :subscribers="store.subscribers"
@@ -51,8 +64,8 @@ const onRemove = (id: number): void => {
   padding: 1.25rem;
 }
 
-.head {
-  margin-bottom: 1rem;
+.title {
+  margin: 0 0 0.25rem;
 }
 
 .lead {

--- a/src/views/CommsView/LangTogglePills.vue
+++ b/src/views/CommsView/LangTogglePills.vue
@@ -23,7 +23,7 @@ const onClick = (lang: Lang): void => {
       :key="lang"
       type="button"
       class="pill"
-      :class="{ 'pill--on': langs.includes(lang) }"
+      :class="{ 'pill-on': langs.includes(lang) }"
       :disabled="disabled"
       :data-testid="`lang-toggle-${lang}`"
       :aria-pressed="langs.includes(lang)"
@@ -54,13 +54,13 @@ const onClick = (lang: Lang): void => {
   text-transform: uppercase;
 }
 
-.pill--on {
+.pill-on {
   color: var(--color-accent);
   border-color: var(--color-accent);
 }
 
 .pill:disabled {
   cursor: not-allowed;
-  opacity: 0.5;
+  opacity: 50%;
 }
 </style>

--- a/src/views/CommsView/ScheduleEditor.vue
+++ b/src/views/CommsView/ScheduleEditor.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import type {
+  Schedule,
+  ScheduleWithNext,
+} from '@/validation/schemas/schedule'
+import { humaniseCron } from './humanise-cron'
+import {
+  canSubmitSchedule,
+  hasChanged,
+  initialDraft,
+} from './schedule-draft-ops'
+import TimezoneSelect from './TimezoneSelect.vue'
+
+const props = defineProps<{
+  readonly schedule: ScheduleWithNext | undefined
+  readonly saving: boolean
+  readonly error: string | undefined
+}>()
+
+const emit = defineEmits<{
+  save: [next: Schedule]
+}>()
+
+const draft = ref<Schedule>(initialDraft(props.schedule))
+
+watch(
+  () => props.schedule,
+  next => {
+    draft.value = initialDraft(next)
+  }
+)
+
+const preview = computed(
+  () => `${humaniseCron(draft.value.cron)} (${draft.value.timezone})`
+)
+
+const canSave = computed(
+  () =>
+    canSubmitSchedule(draft.value) &&
+    hasChanged(draft.value, props.schedule) &&
+    !props.saving
+)
+
+const submit = (): void => emit('save', { ...draft.value })
+</script>
+
+<template>
+  <form class="editor" data-testid="schedule-editor" @submit.prevent="submit">
+    <input
+      v-model="draft.cron"
+      type="text"
+      class="cron"
+      data-testid="schedule-cron"
+      aria-label="Crontab expression"
+      placeholder="0 12 * * 6"
+      autocomplete="off"
+      spellcheck="false"
+      :disabled="saving"
+    />
+    <TimezoneSelect v-model="draft.timezone" :disabled="saving" />
+    <p class="preview" data-testid="schedule-preview">{{ preview }}</p>
+    <p class="next" data-testid="schedule-next-run">
+      Next run: {{ props.schedule?.nextRunAt ?? '—' }}
+    </p>
+    <button
+      type="submit"
+      class="save"
+      data-testid="schedule-save"
+      :disabled="!canSave"
+    >
+      {{ saving ? 'Saving…' : 'Save schedule' }}
+    </button>
+    <p v-if="error" class="error" data-testid="schedule-error">{{ error }}</p>
+  </form>
+</template>
+
+<style scoped>
+.editor {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.55rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.cron {
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: var(--font-mono, monospace);
+}
+
+.preview {
+  margin: 0.3rem 0 0;
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+}
+
+.next {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  font-family: var(--font-mono, monospace);
+}
+
+.save {
+  justify-self: start;
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-background);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.save:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
+.error {
+  margin: 0;
+  color: var(--color-danger, #c0392b);
+  font-size: 0.8125rem;
+}
+</style>

--- a/src/views/CommsView/SubscriberStatusBadge.vue
+++ b/src/views/CommsView/SubscriberStatusBadge.vue
@@ -16,7 +16,7 @@ const label = (): string =>
 <template>
   <span
     class="status"
-    :class="`status--${status}`"
+    :class="`status-${status}`"
     :data-testid="`subscriber-status-${status}`"
   >
     {{ label() }}
@@ -36,13 +36,13 @@ const label = (): string =>
   text-transform: uppercase;
 }
 
-.status--active {
+.status-active {
   color: var(--color-accent);
   border-color: var(--color-accent);
 }
 
-.status--bounced,
-.status--complained {
+.status-bounced,
+.status-complained {
   color: var(--color-danger, #c0392b);
   border-color: var(--color-danger, #c0392b);
 }

--- a/src/views/CommsView/TimezoneSelect.vue
+++ b/src/views/CommsView/TimezoneSelect.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { COMMON_TIMEZONES } from './tz-list'
+
+const props = defineProps<{
+  readonly modelValue: string
+  readonly disabled?: boolean
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const onChange = (e: Event): void => {
+  emit('update:modelValue', (e.target as HTMLSelectElement).value)
+}
+</script>
+
+<template>
+  <select
+    :value="props.modelValue"
+    class="tz"
+    data-testid="schedule-timezone"
+    aria-label="Timezone"
+    :disabled="props.disabled"
+    @change="onChange"
+  >
+    <option v-for="tz in COMMON_TIMEZONES" :key="tz" :value="tz">
+      {{ tz }}
+    </option>
+  </select>
+</template>
+
+<style scoped>
+.tz {
+  padding: 0.4rem 0.55rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  color: var(--color-text);
+  font-size: 0.875rem;
+  font-family: var(--font-mono, monospace);
+}
+</style>

--- a/src/views/CommsView/humanise-cron.test.ts
+++ b/src/views/CommsView/humanise-cron.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { humaniseCron } from './humanise-cron'
+
+describe('humaniseCron', () => {
+  it('handles every-minute', () => {
+    expect(humaniseCron('* * * * *')).toBe('every minute')
+  })
+
+  it('handles every-N-minutes', () => {
+    expect(humaniseCron('*/15 * * * *')).toBe('every 15 minutes')
+  })
+
+  it('handles hourly at a fixed minute', () => {
+    expect(humaniseCron('30 * * * *')).toBe('every hour at minute 30')
+  })
+
+  it('handles daily at HH:MM', () => {
+    expect(humaniseCron('5 8 * * *')).toBe('every day at 08:05')
+  })
+
+  it('handles weekly on a named day at HH:MM', () => {
+    expect(humaniseCron('0 12 * * 6')).toBe('every Saturday at 12:00')
+  })
+
+  it('handles weekly on Sunday with cron index 0', () => {
+    expect(humaniseCron('30 9 * * 0')).toBe('every Sunday at 09:30')
+  })
+
+  it('handles weekly on Sunday with cron index 7 (alias)', () => {
+    expect(humaniseCron('30 9 * * 7')).toBe('every Sunday at 09:30')
+  })
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(humaniseCron('   0 12 * * 6   ')).toBe('every Saturday at 12:00')
+  })
+
+  it('falls through to the raw expression for unmatched patterns', () => {
+    expect(humaniseCron('0 12 1 * *')).toBe('0 12 1 * *')
+  })
+})

--- a/src/views/CommsView/humanise-cron.ts
+++ b/src/views/CommsView/humanise-cron.ts
@@ -1,0 +1,45 @@
+const DAYS = [
+  'Sunday',
+  'Monday',
+  'Tuesday',
+  'Wednesday',
+  'Thursday',
+  'Friday',
+  'Saturday',
+] as const
+
+const fmt2 = (n: number): string => String(n).padStart(2, '0')
+
+type Rule = readonly [RegExp, (m: RegExpExecArray) => string]
+
+const RULES: ReadonlyArray<Rule> = [
+  [/^\*\s+\*\s+\*\s+\*\s+\*$/, () => 'every minute'],
+  [/^\*\/(\d+)\s+\*\s+\*\s+\*\s+\*$/, m => `every ${m[1]} minutes`],
+  [/^(\d+)\s+\*\s+\*\s+\*\s+\*$/, m => `every hour at minute ${m[1]}`],
+  [
+    /^(\d+)\s+(\d+)\s+\*\s+\*\s+\*$/,
+    m => `every day at ${fmt2(Number(m[2]))}:${fmt2(Number(m[1]))}`,
+  ],
+  [
+    /^(\d+)\s+(\d+)\s+\*\s+\*\s+(\d+)$/,
+    m => {
+      const day = DAYS[Number(m[3]) % 7] ?? 'day'
+      return `every ${day} at ${fmt2(Number(m[2]))}:${fmt2(Number(m[1]))}`
+    },
+  ],
+]
+
+/**
+ * Render a small set of canonical crontab patterns into plain English.
+ * Falls through to the raw trimmed expression for shapes outside the set.
+ * @param cron Raw crontab string.
+ * @returns Human-readable label for the schedule input.
+ */
+export const humaniseCron = (cron: string): string => {
+  const trimmed = cron.trim()
+  const matched = RULES.map(([re, fn]) => ({
+    fn,
+    match: re.exec(trimmed),
+  })).find(r => r.match !== null)
+  return matched?.match ? matched.fn(matched.match) : trimmed
+}

--- a/src/views/CommsView/schedule-draft-ops.test.ts
+++ b/src/views/CommsView/schedule-draft-ops.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canSubmitSchedule,
+  hasChanged,
+  initialDraft,
+} from './schedule-draft-ops'
+
+const REMOTE = {
+  cron: '0 12 * * 6',
+  timezone: 'Europe/Moscow',
+  nextRunAt: '2026-06-06T09:00:00.000Z',
+}
+
+describe('initialDraft', () => {
+  it('returns the persisted cron + timezone when one is loaded', () => {
+    expect(initialDraft(REMOTE)).toEqual({
+      cron: '0 12 * * 6',
+      timezone: 'Europe/Moscow',
+    })
+  })
+
+  it('falls back to the spec default when nothing is loaded yet', () => {
+    expect(initialDraft(undefined)).toEqual({
+      cron: '0 12 * * 6',
+      timezone: 'Europe/Moscow',
+    })
+  })
+})
+
+describe('hasChanged', () => {
+  it('is false when the draft matches the loaded schedule', () => {
+    expect(hasChanged(REMOTE, REMOTE)).toBe(false)
+  })
+
+  it('is true when the cron differs', () => {
+    expect(
+      hasChanged({ cron: '*/30 * * * *', timezone: 'Europe/Moscow' }, REMOTE)
+    ).toBe(true)
+  })
+
+  it('is true when the tz differs', () => {
+    expect(
+      hasChanged({ cron: '0 12 * * 6', timezone: 'Etc/UTC' }, REMOTE)
+    ).toBe(true)
+  })
+
+  it('is true when no remote schedule is loaded yet', () => {
+    expect(hasChanged(REMOTE, undefined)).toBe(true)
+  })
+})
+
+describe('canSubmitSchedule', () => {
+  it('rejects an empty cron', () => {
+    expect(canSubmitSchedule({ cron: '', timezone: 'Etc/UTC' })).toBe(false)
+  })
+
+  it('rejects an empty timezone', () => {
+    expect(canSubmitSchedule({ cron: '0 12 * * 6', timezone: '' })).toBe(
+      false
+    )
+  })
+
+  it('rejects shapes that are not five whitespace-separated fields', () => {
+    expect(canSubmitSchedule({ cron: '0 12 * *', timezone: 'Etc/UTC' })).toBe(
+      false
+    )
+  })
+
+  it('accepts a well-shaped 5-field expression with a non-empty tz', () => {
+    expect(
+      canSubmitSchedule({ cron: '0 12 * * 6', timezone: 'Europe/Moscow' })
+    ).toBe(true)
+  })
+})

--- a/src/views/CommsView/schedule-draft-ops.ts
+++ b/src/views/CommsView/schedule-draft-ops.ts
@@ -1,0 +1,49 @@
+import type {
+  Schedule,
+  ScheduleWithNext,
+} from '@/validation/schemas/schedule'
+
+/** Default schedule applied when nothing has ever been persisted (R2.3). */
+export const DEFAULT_SCHEDULE: Schedule = {
+  cron: '0 12 * * 6',
+  timezone: 'Europe/Moscow',
+}
+
+/**
+ * Build the editor draft seed from the loaded schedule, falling back
+ * to the spec default when the worker has nothing persisted yet.
+ * @param loaded Schedule pulled from the worker, if any.
+ * @returns Pure `{cron, timezone}` pair the editor binds to.
+ */
+export const initialDraft = (
+  loaded: ScheduleWithNext | undefined
+): Schedule =>
+  loaded === undefined
+    ? DEFAULT_SCHEDULE
+    : { cron: loaded.cron, timezone: loaded.timezone }
+
+/**
+ * True iff the draft no longer matches the persisted schedule and
+ * should therefore enable the Save button.
+ * @param draft Current editor state.
+ * @param loaded Last value pulled from the worker.
+ * @returns Whether `draft` differs from `loaded`.
+ */
+export const hasChanged = (
+  draft: Schedule,
+  loaded: ScheduleWithNext | undefined
+): boolean =>
+  loaded === undefined ||
+  draft.cron !== loaded.cron ||
+  draft.timezone !== loaded.timezone
+
+/**
+ * Shape-only gate before letting the user submit: 5 whitespace-separated
+ * fields and a non-empty timezone. The worker re-validates server-side.
+ * @param draft Current editor state.
+ * @returns Whether the Save button is allowed to fire.
+ */
+export const canSubmitSchedule = (draft: Schedule): boolean =>
+  draft.cron.trim().split(/\s+/).length === 5 &&
+  draft.cron.trim().length > 0 &&
+  draft.timezone.trim().length > 0

--- a/src/views/CommsView/tz-list.ts
+++ b/src/views/CommsView/tz-list.ts
@@ -1,0 +1,18 @@
+/** Curated IANA timezones offered in the schedule editor dropdown. */
+export const COMMON_TIMEZONES = [
+  'Etc/UTC',
+  'Europe/Moscow',
+  'Europe/Berlin',
+  'Europe/London',
+  'Europe/Madrid',
+  'Europe/Kyiv',
+  'Europe/Warsaw',
+  'Europe/Minsk',
+  'Europe/Rome',
+  'America/New_York',
+  'America/Los_Angeles',
+  'Asia/Tokyo',
+] as const
+
+/** Width of the IANA TZ string type (one of {@link COMMON_TIMEZONES}). */
+export type CommonTimezone = (typeof COMMON_TIMEZONES)[number]


### PR DESCRIPTION
## Summary

Stacked on top of [#248 (Stage 1)](https://github.com/communist-prometheus/admin-website/pull/248). Delivers the **Schedule editor** vertical slice (T2.1–T2.4 of [`tasks.md`](https://github.com/communist-prometheus/admin-website/blob/feat/23-stage-1-comms-crud/specs/comms-newsletter/tasks.md)).

### Worker
- `src/cron/{matcher,parse}.ts` — `matchesTick` with a DST-aware 5-min forgiveness window (R2.5) plus `validateCron`/`nextRunAt` helpers via `cron-parser`.
- `src/settings/repo.ts` — D1 UPSERT on `settings.schedule`; returns `{cron, timezone, nextRunAt}` recomputed atomically (R2.4).
- `src/schedule/{routes,handlers,validate}.ts` — `GET /api/schedule`, `PUT /api/schedule`; 422 with the parser message on bad cron or unknown IANA tz (R2.1, R2.2).

### Admin SPA
- `validation/schemas/schedule.ts` — Effect schemas mirroring worker types.
- `stores/schedule-{api,actions,state}.ts` + `schedule.ts` — Pinia store with `load`/`save`/`ensureLoaded`.
- `views/CommsView/ScheduleEditor.vue` + `TimezoneSelect.vue`, `humanise-cron.ts`, `schedule-draft-ops.ts`, `tz-list.ts` — crontab input, IANA tz dropdown, live humanised preview (`every Saturday at 12:00 (Europe/Moscow)`), next-run timestamp, error surface (R2.1, R2.2, R2.4).

### Drive-by lint fixes
Stage 1 PR has a few latent lint findings that surfaced when I ran `bun run validate` against Stage 2. Fixed in this PR so the stack stays green:
- Vue template depth ≤ 2 (flatten `CommsView` header, extract `TimezoneSelect`).
- Stylelint `selector-class-pattern` (`pill--on` → `pill-on`, `status--*` → `status-*`).
- `opacity: 0.5` → `50%` (alpha-value-notation).

## Test plan
- [ ] `bunx vitest run services/comms-worker/src/{cron,settings,schedule}` — 23/23 green.
- [ ] `bunx vitest run src/{stores/schedule-api.test.ts,views/CommsView/{humanise-cron,schedule-draft-ops}.test.ts}` — 22/22 green.
- [ ] `bun run validate` — type-check + biome + oxlint + eslint-jsdoc + vue-depth + stylelint all green.
- [ ] Manual smoke against `wrangler dev`: `GET /api/schedule` returns the seeded default; `PUT /api/schedule` saves a new cron; admin `/comms` shows the editor with live preview + next-run timestamp.

## Out of scope (Stage 3)
- Wiring `matchesTick` into the scheduled handler — that's T3.8.
- E2E Playwright for the editor is deferred to T7.4's `full-flow.spec.ts` (CF Access can't be mocked in vanilla Playwright without a live worker stub).

Refs: tickets#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)