### PR TITLE
feat(comms): tickets#23 stage 3 — dispatch loop (RSS → Resend)

### DIFF
--- a/services/comms-worker/src/delta/calculator.test.ts
+++ b/services/comms-worker/src/delta/calculator.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import type { Article } from '../rss/types'
+import type { Subscriber } from '../subscribers/types'
+import { computeDelta } from './calculator'
+
+const article = (overrides: Partial<Article>): Article => ({
+  guid: 'g',
+  title: 't',
+  link: 'https://x/',
+  lang: 'ru',
+  pubDate: '2026-06-01T00:00:00.000Z',
+  ...overrides,
+})
+
+const sub = (overrides: Partial<Subscriber>): Subscriber => ({
+  id: 1,
+  email: 'a@b.c',
+  langs: ['ru'],
+  status: 'active',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  lastSentAt: undefined,
+  unsubscribedAt: undefined,
+  ...overrides,
+})
+
+describe('computeDelta — basics', () => {
+  it('returns every requested-lang article when lastSentAt is absent', () => {
+    const s = sub({ langs: ['ru', 'en'] })
+    const a = article({ guid: 'a', lang: 'ru' })
+    const b = article({ guid: 'b', lang: 'en' })
+    const c = article({ guid: 'c', lang: 'it' })
+    expect(
+      computeDelta(s, { ru: [a], en: [b], it: [c] }).map(x => x.guid)
+    ).toEqual(['a', 'b'])
+  })
+
+  it('filters items older than (or equal to) lastSentAt', () => {
+    const s = sub({
+      langs: ['ru'],
+      lastSentAt: '2026-06-01T00:00:00.000Z',
+    })
+    const old = article({ guid: 'old', pubDate: '2026-05-30T12:00:00.000Z' })
+    const same = article({
+      guid: 'same',
+      pubDate: '2026-06-01T00:00:00.000Z',
+    })
+    const fresh = article({
+      guid: 'new',
+      pubDate: '2026-06-02T00:00:00.000Z',
+    })
+    expect(
+      computeDelta(s, { ru: [old, same, fresh] }).map(x => x.guid)
+    ).toEqual(['new'])
+  })
+
+  it('skips languages the subscriber does not subscribe to', () => {
+    const s = sub({ langs: ['ru'] })
+    const ru = article({ guid: 'ru', lang: 'ru' })
+    const en = article({ guid: 'en', lang: 'en' })
+    expect(computeDelta(s, { ru: [ru], en: [en] }).map(x => x.guid)).toEqual([
+      'ru',
+    ])
+  })
+
+  it('returns [] when nothing is new', () => {
+    const s = sub({
+      langs: ['ru'],
+      lastSentAt: '2026-06-05T00:00:00.000Z',
+    })
+    expect(
+      computeDelta(s, {
+        ru: [article({ guid: 'a', pubDate: '2026-06-01T00:00:00.000Z' })],
+      })
+    ).toEqual([])
+  })
+})
+
+describe('computeDelta — ordering + merging (R3.8)', () => {
+  it('sorts merged langs by pubDate newest-first', () => {
+    const s = sub({ langs: ['ru', 'en'] })
+    const older = article({
+      guid: 'older',
+      lang: 'ru',
+      pubDate: '2026-06-01T00:00:00.000Z',
+    })
+    const newer = article({
+      guid: 'newer',
+      lang: 'en',
+      pubDate: '2026-06-03T00:00:00.000Z',
+    })
+    const middle = article({
+      guid: 'middle',
+      lang: 'ru',
+      pubDate: '2026-06-02T00:00:00.000Z',
+    })
+    expect(
+      computeDelta(s, {
+        ru: [older, middle],
+        en: [newer],
+      }).map(x => x.guid)
+    ).toEqual(['newer', 'middle', 'older'])
+  })
+
+  it('drops items whose pubDate is unparseable (defensive)', () => {
+    const s = sub({ langs: ['ru'] })
+    const good = article({ guid: 'good' })
+    const bad = article({ guid: 'bad', pubDate: 'not-a-date' })
+    expect(computeDelta(s, { ru: [good, bad] }).map(x => x.guid)).toEqual([
+      'good',
+    ])
+  })
+})

--- a/services/comms-worker/src/delta/calculator.ts
+++ b/services/comms-worker/src/delta/calculator.ts
@@ -1,0 +1,49 @@
+import type { Article } from '../rss/types'
+import type { Lang, Subscriber } from '../subscribers/types'
+
+/** RSS items grouped by language code, as the orchestrator caches them. */
+export type ArticlesByLang = Readonly<
+  Partial<Record<Lang, ReadonlyArray<Article>>>
+>
+
+const isNewerThan = (a: Article, threshold: number | undefined): boolean => {
+  const ms = Date.parse(a.pubDate)
+  if (!Number.isFinite(ms)) return false
+  return threshold === undefined || ms > threshold
+}
+
+const collectFor = (
+  sub: Subscriber,
+  byLang: ArticlesByLang,
+  thresholdMs: number | undefined
+): ReadonlyArray<Article> => {
+  const out: Article[] = []
+  for (const lang of sub.langs) {
+    const items = byLang[lang] ?? []
+    for (const item of items) {
+      if (isNewerThan(item, thresholdMs)) out.push(item)
+    }
+  }
+  return out
+}
+
+/**
+ * Compute the per-subscriber digest delta: every article whose lang is
+ * in `sub.langs[]` AND whose `pubDate` is strictly newer than
+ * `sub.lastSentAt`. Results are merged across languages and sorted
+ * newest-first (R3.8).
+ * @param sub The recipient.
+ * @param byLang RSS items grouped by language code.
+ * @returns Sorted, deduplicable article list.
+ */
+export const computeDelta = (
+  sub: Subscriber,
+  byLang: ArticlesByLang
+): ReadonlyArray<Article> => {
+  const thresholdMs =
+    sub.lastSentAt === undefined ? undefined : Date.parse(sub.lastSentAt)
+  const collected = collectFor(sub, byLang, thresholdMs)
+  return [...collected].sort(
+    (a, b) => Date.parse(b.pubDate) - Date.parse(a.pubDate)
+  )
+}

--- a/services/comms-worker/src/digest/__snapshots__/render.test.ts.snap
+++ b/services/comms-worker/src/digest/__snapshots__/render.test.ts.snap
@@ -1,0 +1,17 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderDigest — snapshots > matches the canonical HTML snapshot 1`] = `"<!DOCTYPE html><html><body style="font-family:system-ui,Segoe UI,sans-serif;max-width:36rem;margin:1rem auto;color:#222"><p>С момента последнего дайджеста:</p><ol style="padding-left:1.25rem"><li style="margin-bottom:1rem"><a href="https://comprom.org/en/articles/solidarity/?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23" style="font-weight:700;text-decoration:none">Worker solidarity reaches new heights</a> <span style="opacity:0.7">[en]</span> <span style="opacity:0.6;font-size:0.85em"> · 2026-06-04</span> <br /><a href="https://comprom.org/en/articles/solidarity/?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23" style="font-size:0.875em">Читать →</a></li><li style="margin-bottom:1rem"><a href="https://comprom.org/ru/articles/khronika/?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23" style="font-weight:700;text-decoration:none">Хроника недели</a> <span style="opacity:0.7">[ru]</span> <span style="opacity:0.6;font-size:0.85em"> · 2026-06-03</span> <br /><a href="https://comprom.org/ru/articles/khronika/?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23" style="font-size:0.875em">Читать →</a></li></ol><hr style="border:none;border-top:1px solid #ccc;margin:2rem 0 1rem" /><p style="font-size:0.8125em;opacity:0.7">Если вы больше не хотите получать эти письма, перейдите по ссылке выше.<br /><a href="https://lists.comprom.org/unsubscribe?t=ABCDEF">Отписаться</a></p></body></html>"`;
+
+exports[`renderDigest — snapshots > matches the canonical text snapshot 1`] = `
+"С момента последнего дайджеста:
+
+· Worker solidarity reaches new heights  [en] (2026-06-04)
+  https://comprom.org/en/articles/solidarity/?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23
+
+· Хроника недели  [ru] (2026-06-03)
+  https://comprom.org/ru/articles/khronika/?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23
+
+---
+Если вы больше не хотите получать эти письма, перейдите по ссылке выше.
+Отписаться: https://lists.comprom.org/unsubscribe?t=ABCDEF"
+`;

--- a/services/comms-worker/src/digest/escape.ts
+++ b/services/comms-worker/src/digest/escape.ts
@@ -1,0 +1,16 @@
+const ESCAPE_MAP: Readonly<Record<string, string>> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+}
+
+/**
+ * Escape HTML-special characters so a string is safe to interpolate
+ * into element text or an attribute value.
+ * @param raw Unescaped string.
+ * @returns Escaped string.
+ */
+export const htmlEscape = (raw: string): string =>
+  raw.replace(/[&<>"']/g, c => ESCAPE_MAP[c] ?? c)

--- a/services/comms-worker/src/digest/html.ts
+++ b/services/comms-worker/src/digest/html.ts
@@ -1,0 +1,47 @@
+import type { Article } from '../rss/types'
+import { htmlEscape } from './escape'
+import type { DigestChrome } from './i18n-types'
+
+const renderItem = (
+  article: Article,
+  stampedUrl: string,
+  chrome: DigestChrome
+): string => {
+  const title = htmlEscape(article.title)
+  const date = article.pubDate.slice(0, 10)
+  return [
+    '<li style="margin-bottom:1rem">',
+    `<a href="${stampedUrl}" style="font-weight:700;text-decoration:none">${title}</a>`,
+    ` <span style="opacity:0.7">[${article.lang}]</span>`,
+    ` <span style="opacity:0.6;font-size:0.85em"> · ${date}</span>`,
+    ' <br />',
+    `<a href="${stampedUrl}" style="font-size:0.875em">${chrome.readLabel} →</a>`,
+    '</li>',
+  ].join('')
+}
+
+/**
+ * Render the digest HTML body: intro line, ordered article list with
+ * lang badges + UTM-stamped links, footer with unsubscribe URL.
+ * @param chrome Localised strings for the recipient.
+ * @param items Pre-stamped article + URL pairs.
+ * @param unsubscribeUrl Per-recipient unsubscribe URL.
+ * @returns Complete HTML string.
+ */
+export const renderHtml = (
+  chrome: DigestChrome,
+  items: ReadonlyArray<readonly [Article, string]>,
+  unsubscribeUrl: string
+): string =>
+  [
+    '<!DOCTYPE html>',
+    '<html><body style="font-family:system-ui,Segoe UI,sans-serif;max-width:36rem;margin:1rem auto;color:#222">',
+    `<p>${htmlEscape(chrome.intro)}</p>`,
+    '<ol style="padding-left:1.25rem">',
+    items.map(([a, u]) => renderItem(a, u, chrome)).join(''),
+    '</ol>',
+    '<hr style="border:none;border-top:1px solid #ccc;margin:2rem 0 1rem" />',
+    `<p style="font-size:0.8125em;opacity:0.7">${htmlEscape(chrome.unsubscribeNote)}<br />`,
+    `<a href="${unsubscribeUrl}">${htmlEscape(chrome.unsubscribeLabel)}</a></p>`,
+    '</body></html>',
+  ].join('')

--- a/services/comms-worker/src/digest/i18n-cyrillic.ts
+++ b/services/comms-worker/src/digest/i18n-cyrillic.ts
@@ -1,0 +1,31 @@
+import type { DigestChrome } from './i18n-types'
+
+/** Russian digest chrome (ru). */
+export const CHROME_RU: DigestChrome = {
+  subject: n => `Коммунистический Прометей — ${n} новых статей`,
+  intro: 'С момента последнего дайджеста:',
+  readLabel: 'Читать',
+  unsubscribeLabel: 'Отписаться',
+  unsubscribeNote:
+    'Если вы больше не хотите получать эти письма, перейдите по ссылке выше.',
+}
+
+/** Ukrainian digest chrome (uk). */
+export const CHROME_UK: DigestChrome = {
+  subject: n => `Комуністичний Прометей — ${n} нових статей`,
+  intro: 'З моменту попереднього випуску:',
+  readLabel: 'Читати',
+  unsubscribeLabel: 'Відписатися',
+  unsubscribeNote:
+    'Якщо ви більше не хочете отримувати ці листи, перейдіть за посиланням вище.',
+}
+
+/** Belarusian digest chrome (bl). */
+export const CHROME_BL: DigestChrome = {
+  subject: n => `Камуністычны Праметэй — ${n} новых артыкулаў`,
+  intro: 'З моманту папярэдняга выпуску:',
+  readLabel: 'Чытаць',
+  unsubscribeLabel: 'Адпісацца',
+  unsubscribeNote:
+    'Калі вы больш не хочаце атрымліваць гэтыя лісты, перайдзіце па спасылцы вышэй.',
+}

--- a/services/comms-worker/src/digest/i18n-latin.ts
+++ b/services/comms-worker/src/digest/i18n-latin.ts
@@ -1,0 +1,42 @@
+import type { DigestChrome } from './i18n-types'
+
+/** English digest chrome (en). */
+export const CHROME_EN: DigestChrome = {
+  subject: n =>
+    `Communist Prometheus — ${n} new article${n === 1 ? '' : 's'}`,
+  intro: 'Since your last digest:',
+  readLabel: 'Read',
+  unsubscribeLabel: 'Unsubscribe',
+  unsubscribeNote:
+    'If you no longer wish to receive these digests, click the link above.',
+}
+
+/** Italian digest chrome (it). */
+export const CHROME_IT: DigestChrome = {
+  subject: n => `Prometeo Comunista — ${n} nuovi articoli`,
+  intro: 'Dal tuo ultimo digest:',
+  readLabel: 'Leggi',
+  unsubscribeLabel: 'Disiscriviti',
+  unsubscribeNote:
+    'Se non vuoi più ricevere questi digest, clicca il link qui sopra.',
+}
+
+/** Spanish digest chrome (es). */
+export const CHROME_ES: DigestChrome = {
+  subject: n => `Prometeo Comunista — ${n} nuevos artículos`,
+  intro: 'Desde tu último digest:',
+  readLabel: 'Leer',
+  unsubscribeLabel: 'Cancelar suscripción',
+  unsubscribeNote:
+    'Si ya no quieres recibir estos digests, haz clic en el enlace superior.',
+}
+
+/** Polish digest chrome (pl). */
+export const CHROME_PL: DigestChrome = {
+  subject: n => `Komunistyczny Prometeusz — ${n} nowych artykułów`,
+  intro: 'Od ostatniego skrótu:',
+  readLabel: 'Czytaj',
+  unsubscribeLabel: 'Wypisz się',
+  unsubscribeNote:
+    'Jeśli nie chcesz już otrzymywać tych wiadomości, kliknij link powyżej.',
+}

--- a/services/comms-worker/src/digest/i18n-types.ts
+++ b/services/comms-worker/src/digest/i18n-types.ts
@@ -1,0 +1,8 @@
+/** Localised chrome strings used by the digest renderer. */
+export type DigestChrome = {
+  readonly subject: (n: number) => string
+  readonly intro: string
+  readonly readLabel: string
+  readonly unsubscribeLabel: string
+  readonly unsubscribeNote: string
+}

--- a/services/comms-worker/src/digest/i18n.ts
+++ b/services/comms-worker/src/digest/i18n.ts
@@ -1,0 +1,17 @@
+import type { Lang } from '../subscribers/types'
+import { CHROME_BL, CHROME_RU, CHROME_UK } from './i18n-cyrillic'
+import { CHROME_EN, CHROME_ES, CHROME_IT, CHROME_PL } from './i18n-latin'
+import type { DigestChrome } from './i18n-types'
+
+export type { DigestChrome } from './i18n-types'
+
+/** In-worker dictionary, one entry per supported `Lang`. */
+export const CHROME: Readonly<Record<Lang, DigestChrome>> = {
+  en: CHROME_EN,
+  ru: CHROME_RU,
+  it: CHROME_IT,
+  es: CHROME_ES,
+  uk: CHROME_UK,
+  pl: CHROME_PL,
+  bl: CHROME_BL,
+}

--- a/services/comms-worker/src/digest/render.test.ts
+++ b/services/comms-worker/src/digest/render.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import type { Article } from '../rss/types'
+import type { Subscriber } from '../subscribers/types'
+import { renderDigest } from './render'
+
+const SUB: Subscriber = {
+  id: 42,
+  email: 'reader@example.test',
+  langs: ['ru', 'en'],
+  status: 'active',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  lastSentAt: undefined,
+  unsubscribedAt: undefined,
+}
+
+const ARTICLES: ReadonlyArray<Article> = [
+  {
+    guid: 'g-en',
+    title: 'Worker solidarity reaches new heights',
+    link: 'https://comprom.org/en/articles/solidarity/',
+    lang: 'en',
+    pubDate: '2026-06-04T18:00:00.000Z',
+  },
+  {
+    guid: 'g-ru',
+    title: 'Хроника недели',
+    link: 'https://comprom.org/ru/articles/khronika/',
+    lang: 'ru',
+    pubDate: '2026-06-03T12:00:00.000Z',
+  },
+]
+
+const UNSUB = 'https://lists.comprom.org/unsubscribe?t=ABCDEF'
+const TICK = new Date('2026-06-06T09:00:00.000Z')
+
+describe('renderDigest — subject', () => {
+  it('uses the chrome of the subscriber primary lang (ru) with article count', () => {
+    const d = renderDigest({
+      subscriber: SUB,
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.subject).toBe('Коммунистический Прометей — 2 новых статей')
+  })
+
+  it('switches chrome lang when the subscriber primary lang is English', () => {
+    const d = renderDigest({
+      subscriber: { ...SUB, langs: ['en'] },
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.subject).toBe('Communist Prometheus — 2 new articles')
+  })
+})
+
+describe('renderDigest — headers + body invariants', () => {
+  it('builds RFC 8058 List-Unsubscribe + List-Unsubscribe-Post headers', () => {
+    const d = renderDigest({
+      subscriber: SUB,
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.listUnsubscribe).toBe(`<${UNSUB}>`)
+    expect(d.listUnsubscribePost).toBe('List-Unsubscribe=One-Click')
+  })
+
+  it('appends UTM (utm_campaign=2026-23 from tickAt) to every article link', () => {
+    const d = renderDigest({
+      subscriber: SUB,
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    for (const a of ARTICLES) {
+      const stamped = `${a.link}?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23`
+      expect(d.html).toContain(stamped)
+      expect(d.text).toContain(stamped)
+    }
+  })
+
+  it('includes the unsubscribe URL in both HTML and text bodies', () => {
+    const d = renderDigest({
+      subscriber: SUB,
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.html).toContain(UNSUB)
+    expect(d.text).toContain(UNSUB)
+  })
+
+  it('html-escapes article titles (no raw < > in markup)', () => {
+    const tricky: Article = {
+      guid: 'g',
+      title: '<script>x</script>',
+      link: 'https://x/y',
+      lang: 'en',
+      pubDate: '2026-06-04T00:00:00.000Z',
+    }
+    const d = renderDigest({
+      subscriber: { ...SUB, langs: ['en'] },
+      articles: [tricky],
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.html).not.toContain('<script>x</script>')
+    expect(d.html).toContain('&lt;script&gt;')
+  })
+
+  it('shows a lang badge next to each article title in the HTML', () => {
+    const d = renderDigest({
+      subscriber: SUB,
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.html).toContain('[ru]')
+    expect(d.html).toContain('[en]')
+  })
+})
+
+describe('renderDigest — snapshots', () => {
+  it('matches the canonical HTML snapshot', () => {
+    const d = renderDigest({
+      subscriber: SUB,
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.html).toMatchSnapshot()
+  })
+
+  it('matches the canonical text snapshot', () => {
+    const d = renderDigest({
+      subscriber: SUB,
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.text).toMatchSnapshot()
+  })
+})

--- a/services/comms-worker/src/digest/render.ts
+++ b/services/comms-worker/src/digest/render.ts
@@ -1,0 +1,52 @@
+import type { Article } from '../rss/types'
+import type { Lang, Subscriber } from '../subscribers/types'
+import { renderHtml } from './html'
+import { CHROME } from './i18n'
+import { renderText } from './text'
+import { appendUtm, isoWeekString } from './utm'
+
+/** Inputs accepted by {@link renderDigest}. */
+export type DigestRenderInput = {
+  readonly subscriber: Subscriber
+  readonly articles: ReadonlyArray<Article>
+  readonly unsubscribeUrl: string
+  readonly tickAt: Date
+}
+
+/** Outputs of the digest renderer. */
+export type Digest = {
+  readonly subject: string
+  readonly html: string
+  readonly text: string
+  readonly listUnsubscribe: string
+  readonly listUnsubscribePost: string
+}
+
+const POST_HEADER = 'List-Unsubscribe=One-Click'
+
+const stampItems = (
+  articles: ReadonlyArray<Article>,
+  campaign: string
+): ReadonlyArray<readonly [Article, string]> =>
+  articles.map(a => [a, appendUtm(a.link, campaign)] as const)
+
+const chromeFor = (langs: ReadonlyArray<Lang>) => CHROME[langs[0] ?? 'en']
+
+/**
+ * Build the per-subscriber digest payload — subject, HTML body, text
+ * body, and the two RFC-8058 List-Unsubscribe header values.
+ * @param input Subscriber, articles, unsubscribe URL, tick moment.
+ * @returns Complete digest ready to hand to the Resend client.
+ */
+export const renderDigest = (input: DigestRenderInput): Digest => {
+  const chrome = chromeFor(input.subscriber.langs)
+  const campaign = isoWeekString(input.tickAt)
+  const items = stampItems(input.articles, campaign)
+  return {
+    subject: chrome.subject(input.articles.length),
+    html: renderHtml(chrome, items, input.unsubscribeUrl),
+    text: renderText(chrome, items, input.unsubscribeUrl),
+    listUnsubscribe: `<${input.unsubscribeUrl}>`,
+    listUnsubscribePost: POST_HEADER,
+  }
+}

--- a/services/comms-worker/src/digest/text.ts
+++ b/services/comms-worker/src/digest/text.ts
@@ -1,0 +1,28 @@
+import type { Article } from '../rss/types'
+import type { DigestChrome } from './i18n-types'
+
+const renderItem = (article: Article, stampedUrl: string): string =>
+  `· ${article.title}  [${article.lang}] (${article.pubDate.slice(0, 10)})\n  ${stampedUrl}`
+
+/**
+ * Render the digest plain-text body — intro + bulleted article list +
+ * footer with unsubscribe URL. Mirrors {@link renderHtml} structure.
+ * @param chrome Localised strings for the recipient.
+ * @param items Pre-stamped article + URL pairs.
+ * @param unsubscribeUrl Per-recipient unsubscribe URL.
+ * @returns Complete plain-text string.
+ */
+export const renderText = (
+  chrome: DigestChrome,
+  items: ReadonlyArray<readonly [Article, string]>,
+  unsubscribeUrl: string
+): string =>
+  [
+    chrome.intro,
+    '',
+    items.map(([a, u]) => renderItem(a, u)).join('\n\n'),
+    '',
+    '---',
+    chrome.unsubscribeNote,
+    `${chrome.unsubscribeLabel}: ${unsubscribeUrl}`,
+  ].join('\n')

--- a/services/comms-worker/src/digest/utm.test.ts
+++ b/services/comms-worker/src/digest/utm.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { appendUtm, isoWeekString } from './utm'
+
+describe('isoWeekString', () => {
+  it('returns YYYY-WW with zero-padded week', () => {
+    expect(isoWeekString(new Date('2026-01-01T12:00:00Z'))).toBe('2026-01')
+    expect(isoWeekString(new Date('2026-06-04T12:00:00Z'))).toBe('2026-23')
+    expect(isoWeekString(new Date('2026-12-31T12:00:00Z'))).toBe('2026-53')
+  })
+
+  it('honours ISO week-year boundary cases (early January and late December)', () => {
+    expect(isoWeekString(new Date('2025-12-29T12:00:00Z'))).toBe('2026-01')
+    expect(isoWeekString(new Date('2027-01-03T12:00:00Z'))).toBe('2026-53')
+  })
+})
+
+describe('appendUtm', () => {
+  it('appends the canonical campaign triple when the URL has no query', () => {
+    const r = appendUtm('https://comprom.org/ru/articles/x/', '2026-23')
+    expect(r).toBe(
+      'https://comprom.org/ru/articles/x/?utm_source=newsletter&utm_medium=email&utm_campaign=2026-23'
+    )
+  })
+
+  it('uses & when the URL already carries a query', () => {
+    const r = appendUtm('https://comprom.org/ru/?ref=a', '2026-23')
+    expect(r).toBe(
+      'https://comprom.org/ru/?ref=a&utm_source=newsletter&utm_medium=email&utm_campaign=2026-23'
+    )
+  })
+})

--- a/services/comms-worker/src/digest/utm.ts
+++ b/services/comms-worker/src/digest/utm.ts
@@ -1,0 +1,30 @@
+const MS_PER_DAY = 86_400_000
+
+/**
+ * Render an ISO week designation as `YYYY-WW` for the moment `d` in UTC.
+ * @param d Tick moment.
+ * @returns String like `2026-23`; week is zero-padded.
+ */
+export const isoWeekString = (d: Date): string => {
+  const t = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate())
+  )
+  t.setUTCDate(t.getUTCDate() + 4 - (t.getUTCDay() || 7))
+  const yearStart = Date.UTC(t.getUTCFullYear(), 0, 1)
+  const week = Math.ceil(((t.getTime() - yearStart) / MS_PER_DAY + 1) / 7)
+  return `${t.getUTCFullYear()}-${String(week).padStart(2, '0')}`
+}
+
+const UTM = 'utm_source=newsletter&utm_medium=email'
+
+/**
+ * Append the campaign triple to an article URL for analytics attribution.
+ * Picks `&` over `?` when the URL already carries a query.
+ * @param url Article URL.
+ * @param campaign Value for `utm_campaign` (typically {@link isoWeekString}).
+ * @returns URL with the UTM parameters appended.
+ */
+export const appendUtm = (url: string, campaign: string): string => {
+  const join = url.includes('?') ? '&' : '?'
+  return `${url}${join}${UTM}&utm_campaign=${campaign}`
+}

--- a/services/comms-worker/src/dispatch/build-deps.ts
+++ b/services/comms-worker/src/dispatch/build-deps.ts
@@ -1,0 +1,34 @@
+import { createResendClient } from '../resend/client'
+import { createRssFetcher } from '../rss/fetch'
+import { createSendLogRepo } from '../send-log/repo'
+import { createRepo } from '../subscribers/repo'
+import {
+  DEFAULT_FROM,
+  DEFAULT_PUBLIC_BASE,
+  type DispatchEnv,
+} from './runtime-env'
+import type { RunDispatchDeps } from './types'
+
+const nowIso = (): string => new Date().toISOString()
+
+/**
+ * Materialise concrete repos + clients for one dispatch tick from the
+ * worker's bindings + secrets. Pure factory — no side effects until
+ * the orchestrator calls into them.
+ * @param env Worker bindings + secrets.
+ * @param tickAt Tick moment used as `last_sent_at` + `tick_at` stamp.
+ * @returns Inputs for {@link runDispatch}.
+ */
+export const buildRuntimeDeps = (
+  env: DispatchEnv,
+  tickAt: Date
+): RunDispatchDeps => ({
+  subscriberRepo: createRepo({ db: env.DB, now: nowIso }),
+  sendLogRepo: createSendLogRepo({ db: env.DB }),
+  rss: createRssFetcher(),
+  resend: createResendClient({ apiKey: env.RESEND_API_KEY }),
+  secret: env.UNSUBSCRIBE_SECRET,
+  fromAddress: env.FROM_ADDRESS ?? DEFAULT_FROM,
+  publicBaseUrl: env.PUBLIC_BASE_URL ?? DEFAULT_PUBLIC_BASE,
+  tickAt,
+})

--- a/services/comms-worker/src/dispatch/build-input.ts
+++ b/services/comms-worker/src/dispatch/build-input.ts
@@ -1,0 +1,48 @@
+import { type Digest, renderDigest } from '../digest/render'
+import type { SendInput } from '../resend/types'
+import type { Article } from '../rss/types'
+import type { Subscriber } from '../subscribers/types'
+import { signUnsubscribeToken } from '../unsubscribe/token'
+import type { DispatchContext } from './context'
+
+const toSendInput = (
+  ctx: DispatchContext,
+  sub: Subscriber,
+  d: Digest
+): SendInput => ({
+  from: ctx.fromAddress,
+  to: sub.email,
+  subject: d.subject,
+  html: d.html,
+  text: d.text,
+  headers: {
+    'List-Unsubscribe': d.listUnsubscribe,
+    'List-Unsubscribe-Post': d.listUnsubscribePost,
+  },
+  idempotencyKey: `${sub.id}:${ctx.tickAt.toISOString()}`,
+})
+
+/**
+ * Build the Resend `SendInput` payload for one subscriber + their delta.
+ * Signs the unsubscribe token, renders the digest, sets the
+ * idempotency key.
+ * @param ctx Static tick-wide context.
+ * @param sub The recipient.
+ * @param delta Articles the subscriber will receive.
+ * @returns Fully-populated Resend send input.
+ */
+export const buildSendInput = async (
+  ctx: DispatchContext,
+  sub: Subscriber,
+  delta: ReadonlyArray<Article>
+): Promise<SendInput> => {
+  const token = await signUnsubscribeToken(sub.id, ctx.secret)
+  const url = `${ctx.publicBaseUrl}/unsubscribe?t=${token}`
+  const d = renderDigest({
+    subscriber: sub,
+    articles: delta,
+    unsubscribeUrl: url,
+    tickAt: ctx.tickAt,
+  })
+  return toSendInput(ctx, sub, d)
+}

--- a/services/comms-worker/src/dispatch/context.ts
+++ b/services/comms-worker/src/dispatch/context.ts
@@ -1,0 +1,16 @@
+import type { ResendClient } from '../resend/types'
+import type { SendLogRepo } from '../send-log/repo'
+import type { SubscriberRepo } from '../subscribers/repo'
+import type { ArticlesByLang } from './fetch-articles'
+
+/** Static inputs shared across every subscriber in a single tick. */
+export type DispatchContext = {
+  readonly subscriberRepo: SubscriberRepo
+  readonly sendLogRepo: SendLogRepo
+  readonly resend: ResendClient
+  readonly secret: string
+  readonly fromAddress: string
+  readonly publicBaseUrl: string
+  readonly tickAt: Date
+  readonly byLang: ArticlesByLang
+}

--- a/services/comms-worker/src/dispatch/dispatch-one.ts
+++ b/services/comms-worker/src/dispatch/dispatch-one.ts
@@ -1,0 +1,30 @@
+import { computeDelta } from '../delta/calculator'
+import type { Subscriber } from '../subscribers/types'
+import { buildSendInput } from './build-input'
+import type { DispatchContext } from './context'
+import { recordFailed, recordSent } from './record'
+
+/** Outcome of dispatching a single subscriber. */
+export type DispatchOutcome = 'sent' | 'failed' | 'skipped'
+
+/**
+ * Dispatch one subscriber for the given tick: compute the delta,
+ * skip on empty, otherwise render + send + log per design §3.2.
+ * @param ctx Static tick-wide context.
+ * @param sub The recipient.
+ * @returns Outcome label used by the orchestrator summary.
+ */
+export const dispatchOne = async (
+  ctx: DispatchContext,
+  sub: Subscriber
+): Promise<DispatchOutcome> => {
+  const delta = computeDelta(sub, ctx.byLang)
+  if (delta.length === 0) return 'skipped'
+  const result = await ctx.resend.send(await buildSendInput(ctx, sub, delta))
+  if (result.ok) {
+    await recordSent(ctx, sub, delta.length, result.id)
+    return 'sent'
+  }
+  await recordFailed(ctx, sub, delta.length, result.error)
+  return 'failed'
+}

--- a/services/comms-worker/src/dispatch/fetch-articles.ts
+++ b/services/comms-worker/src/dispatch/fetch-articles.ts
@@ -1,0 +1,35 @@
+import type { RssFetcher } from '../rss/fetch'
+import type { Article } from '../rss/types'
+import type { Lang, Subscriber } from '../subscribers/types'
+
+/** Articles grouped by language, materialised once per tick. */
+export type ArticlesByLang = Partial<Record<Lang, ReadonlyArray<Article>>>
+
+const uniqueLangs = (
+  subs: ReadonlyArray<Subscriber>
+): ReadonlyArray<Lang> => {
+  const set = new Set<Lang>()
+  for (const s of subs) {
+    for (const l of s.langs) set.add(l)
+  }
+  return [...set]
+}
+
+/**
+ * Fetch every language requested by any subscriber, exactly once per
+ * tick. Failed fetches degrade to `[]` for that language.
+ * @param subs Active subscribers for the current tick.
+ * @param fetcher Per-language RSS fetcher.
+ * @returns Articles grouped by language.
+ */
+export const fetchAllLangs = async (
+  subs: ReadonlyArray<Subscriber>,
+  fetcher: RssFetcher
+): Promise<ArticlesByLang> => {
+  const langs = uniqueLangs(subs)
+  const acc: Partial<Record<Lang, ReadonlyArray<Article>>> = {}
+  for (const lang of langs) {
+    acc[lang] = await fetcher(lang)
+  }
+  return acc
+}

--- a/services/comms-worker/src/dispatch/force-route.test.ts
+++ b/services/comms-worker/src/dispatch/force-route.test.ts
@@ -1,0 +1,90 @@
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AccessClaims } from '../auth/cf-access'
+import { requireAccess } from '../middleware/require-access'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { mountForceDispatchRoute } from './force-route'
+import type { DispatchEnv } from './runtime-env'
+
+const claims: AccessClaims = {
+  aud: 'a',
+  iss: 'https://comprom.cloudflareaccess.com',
+  email: 'admin@comprom.org',
+  sub: 'github|undeadliner',
+  exp: 9_999_999_999,
+  iat: 1,
+}
+
+let env: DispatchEnv
+let dispatcher: ReturnType<typeof vi.fn>
+
+const build = () => {
+  const app = new Hono<{
+    Bindings: DispatchEnv & { CF_ACCESS_AUD: string; CF_ACCESS_TEAM: string }
+    Variables: { readonly access: AccessClaims }
+  }>()
+  app.use('/api/*', requireAccess({ verifier: async () => claims }))
+  mountForceDispatchRoute(app, { dispatcher })
+  return app
+}
+
+const reqWithAccess = (path: string) =>
+  new Request(`http://x${path}`, {
+    method: 'POST',
+    headers: { 'Cf-Access-Jwt-Assertion': 'tok' },
+  })
+
+beforeEach(() => {
+  dispatcher = vi
+    .fn()
+    .mockResolvedValue({ sent: 1, failed: 0, skipped: 0, durationMs: 5 })
+  env = {
+    DB: makeTestD1(),
+    RESEND_API_KEY: 'rk_test',
+    UNSUBSCRIBE_SECRET: 'shhh',
+    CF_ACCESS_AUD: 'a',
+    CF_ACCESS_TEAM: 'comprom',
+  } as DispatchEnv & { CF_ACCESS_AUD: string; CF_ACCESS_TEAM: string }
+})
+
+describe('POST /api/dispatch — auth gating', () => {
+  it('returns 401 without the CF Access header', async () => {
+    const res = await build().fetch(
+      new Request('http://x/api/dispatch?force=1', { method: 'POST' }),
+      env
+    )
+    expect(res.status).toBe(401)
+    expect(dispatcher).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/dispatch — BYPASS_SCHEDULE gating', () => {
+  it('returns 404 when BYPASS_SCHEDULE is unset (default prod posture)', async () => {
+    const res = await build().fetch(
+      reqWithAccess('/api/dispatch?force=1'),
+      env
+    )
+    expect(res.status).toBe(404)
+    expect(dispatcher).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when BYPASS_SCHEDULE is set but ?force is missing', async () => {
+    const res = await build().fetch(reqWithAccess('/api/dispatch'), {
+      ...env,
+      BYPASS_SCHEDULE: '1',
+    })
+    expect(res.status).toBe(404)
+    expect(dispatcher).not.toHaveBeenCalled()
+  })
+
+  it('runs dispatch with current wall-clock and returns 202 on force=1', async () => {
+    const res = await build().fetch(reqWithAccess('/api/dispatch?force=1'), {
+      ...env,
+      BYPASS_SCHEDULE: '1',
+    })
+    expect(res.status).toBe(202)
+    expect(dispatcher).toHaveBeenCalledOnce()
+    const body = (await res.json()) as { sent: number; failed: number }
+    expect(body.sent).toBe(1)
+  })
+})

--- a/services/comms-worker/src/dispatch/force-route.ts
+++ b/services/comms-worker/src/dispatch/force-route.ts
@@ -1,0 +1,47 @@
+import type { Context, Hono } from 'hono'
+import { buildRuntimeDeps } from './build-deps'
+import { runDispatch } from './run'
+import type { DispatchEnv } from './runtime-env'
+import type { DispatchSummary } from './types'
+
+type App = Hono<{ Bindings: object; Variables: object }>
+
+/** Test-time dispatcher seam (mirrors {@link Dispatcher} in scheduled.ts). */
+export type ForceDispatcher = (
+  env: DispatchEnv,
+  tickAt: Date
+) => Promise<DispatchSummary>
+
+const defaultDispatcher: ForceDispatcher = (env, tickAt) =>
+  runDispatch(buildRuntimeDeps(env, tickAt))
+
+const isGated = (c: Context): boolean =>
+  (c.env as DispatchEnv).BYPASS_SCHEDULE === '1' &&
+  c.req.query('force') === '1'
+
+const buildHandler =
+  (dispatcher: ForceDispatcher) =>
+  async (c: Context): Promise<Response> => {
+    if (!isGated(c)) return c.json({ error: 'not_found' }, 404)
+    const summary = await dispatcher(c.env as DispatchEnv, new Date())
+    return c.json(summary, 202)
+  }
+
+/**
+ * Mount `POST /api/dispatch` — a CF Access-protected manual tick
+ * trigger gated by `BYPASS_SCHEDULE=1` + `?force=1`. Existing in
+ * prod (where `BYPASS_SCHEDULE` is unset) but always 404s.
+ * @param app Hono app, already wrapped with `requireAccess`.
+ * @param opts Optional dispatcher seam for unit tests.
+ * @returns The same app for chaining.
+ */
+export const mountForceDispatchRoute = (
+  app: App,
+  opts: { readonly dispatcher?: ForceDispatcher } = {}
+): App => {
+  app.post(
+    '/api/dispatch',
+    buildHandler(opts.dispatcher ?? defaultDispatcher)
+  )
+  return app
+}

--- a/services/comms-worker/src/dispatch/record.ts
+++ b/services/comms-worker/src/dispatch/record.ts
@@ -1,0 +1,37 @@
+import type { Subscriber } from '../subscribers/types'
+import type { DispatchContext } from './context'
+
+/** Persist a successful send: stamp `last_sent_at` + log row. */
+export const recordSent = async (
+  ctx: DispatchContext,
+  sub: Subscriber,
+  articleCount: number,
+  resendId: string
+): Promise<void> => {
+  await ctx.subscriberRepo.markSent(sub.id, ctx.tickAt.toISOString())
+  await ctx.sendLogRepo.append({
+    subscriberId: sub.id,
+    tickAt: ctx.tickAt.toISOString(),
+    articleCount,
+    status: 'sent',
+    resendId,
+    error: undefined,
+  })
+}
+
+/** Persist a failed send: log row only, leave `last_sent_at` untouched. */
+export const recordFailed = async (
+  ctx: DispatchContext,
+  sub: Subscriber,
+  articleCount: number,
+  error: string
+): Promise<void> => {
+  await ctx.sendLogRepo.append({
+    subscriberId: sub.id,
+    tickAt: ctx.tickAt.toISOString(),
+    articleCount,
+    status: 'failed',
+    resendId: undefined,
+    error,
+  })
+}

--- a/services/comms-worker/src/dispatch/run.test.ts
+++ b/services/comms-worker/src/dispatch/run.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { ResendClient, SendInput, SendResult } from '../resend/types'
+import type { Article } from '../rss/types'
+import { createSendLogRepo, type SendLogRepo } from '../send-log/repo'
+import { createRepo, type SubscriberRepo } from '../subscribers/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import type { Lang } from '../subscribers/types'
+import { runDispatch } from './run'
+
+const TICK = new Date('2026-06-06T09:00:00.000Z')
+const SECRET = 'shhh-secret-key-1234567890'
+const FROM = 'Communist Prometheus <newsletter@comprom.org>'
+const PUBLIC_BASE = 'https://lists.comprom.org'
+
+const article = (overrides: Partial<Article>): Article => ({
+  guid: 'g',
+  title: 't',
+  link: 'https://x/y',
+  lang: 'ru',
+  pubDate: '2026-06-05T00:00:00.000Z',
+  ...overrides,
+})
+
+const buildRss = (
+  byLang: Readonly<Partial<Record<Lang, ReadonlyArray<Article>>>>
+) => {
+  const calls: Lang[] = []
+  const fn = async (l: Lang): Promise<ReadonlyArray<Article>> => {
+    calls.push(l)
+    return byLang[l] ?? []
+  }
+  return { fn, calls }
+}
+
+const buildResend = (
+  reply: (input: SendInput) => SendResult
+): {
+  client: ResendClient
+  sends: SendInput[]
+} => {
+  const sends: SendInput[] = []
+  return {
+    sends,
+    client: {
+      send: async input => {
+        sends.push(input)
+        return reply(input)
+      },
+    },
+  }
+}
+
+let subs: SubscriberRepo
+let log: SendLogRepo
+
+beforeEach(() => {
+  const db = makeTestD1()
+  subs = createRepo({ db, now: () => '2026-05-01T00:00:00.000Z' })
+  log = createSendLogRepo({ db })
+})
+
+const baseDeps = (
+  rss: (l: Lang) => Promise<ReadonlyArray<Article>>,
+  resend: ResendClient
+) => ({
+  subscriberRepo: subs,
+  sendLogRepo: log,
+  rss,
+  resend,
+  secret: SECRET,
+  fromAddress: FROM,
+  publicBaseUrl: PUBLIC_BASE,
+  tickAt: TICK,
+})
+
+describe('runDispatch — empty list', () => {
+  it('does nothing when there are no active subscribers', async () => {
+    const rss = buildRss({})
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    const summary = await runDispatch(baseDeps(rss.fn, resend.client))
+    expect(summary).toMatchObject({ sent: 0, failed: 0, skipped: 0 })
+    expect(rss.calls).toEqual([])
+    expect(resend.sends).toHaveLength(0)
+  })
+})
+
+describe('runDispatch — empty delta', () => {
+  it('skips subscribers when nothing new exists for their langs', async () => {
+    const s = await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await subs.markSent(s.id, '2026-06-07T00:00:00.000Z')
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-01T00:00:00.000Z' })],
+    })
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    const summary = await runDispatch(baseDeps(rss.fn, resend.client))
+    expect(summary).toMatchObject({ sent: 0, failed: 0, skipped: 1 })
+    expect(resend.sends).toHaveLength(0)
+    const after = await subs.findById(s.id)
+    expect(after?.lastSentAt).toBe('2026-06-07T00:00:00.000Z')
+  })
+})
+
+describe('runDispatch — happy path', () => {
+  it('sends one digest, advances last_sent_at, records a sent row', async () => {
+    const s = await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    const rss = buildRss({
+      ru: [
+        article({ guid: 'a', pubDate: '2026-06-05T00:00:00.000Z' }),
+        article({ guid: 'b', pubDate: '2026-06-04T00:00:00.000Z' }),
+        article({ guid: 'c', pubDate: '2026-06-03T00:00:00.000Z' }),
+      ],
+    })
+    const resend = buildResend(() => ({ ok: true, id: 're_42' }))
+    const summary = await runDispatch(baseDeps(rss.fn, resend.client))
+    expect(summary).toMatchObject({ sent: 1, failed: 0, skipped: 0 })
+    expect(resend.sends).toHaveLength(1)
+    const sent = resend.sends[0]
+    expect(sent?.from).toBe(FROM)
+    expect(sent?.to).toBe('a@b.c')
+    expect(sent?.idempotencyKey).toBe(`${s.id}:${TICK.toISOString()}`)
+    expect(sent?.headers?.['List-Unsubscribe']).toMatch(/^<https:.+>$/)
+    const after = await subs.findById(s.id)
+    expect(after?.lastSentAt).toBe(TICK.toISOString())
+    const logs = await log.listRecent(10)
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      status: 'sent',
+      resendId: 're_42',
+      articleCount: 3,
+    })
+  })
+})
+
+describe('runDispatch — RSS caching across subscribers', () => {
+  it('fetches each unique lang exactly once even with many subscribers', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await subs.insert({ email: 'b@b.c', langs: ['ru', 'en'] })
+    await subs.insert({ email: 'c@b.c', langs: ['en'] })
+    const rss = buildRss({
+      ru: [article({ guid: 'r', lang: 'ru' })],
+      en: [article({ guid: 'e', lang: 'en' })],
+    })
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    await runDispatch(baseDeps(rss.fn, resend.client))
+    expect([...rss.calls].sort()).toEqual(['en', 'ru'])
+    expect(rss.calls).toHaveLength(2)
+    expect(resend.sends).toHaveLength(3)
+  })
+})
+
+describe('runDispatch — Resend failure', () => {
+  it('records a failed row and leaves last_sent_at untouched on Resend 5xx', async () => {
+    const s = await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-05T00:00:00.000Z' })],
+    })
+    const resend = buildResend(() => ({ ok: false, error: 'resend 503' }))
+    const summary = await runDispatch(baseDeps(rss.fn, resend.client))
+    expect(summary).toMatchObject({ sent: 0, failed: 1, skipped: 0 })
+    const after = await subs.findById(s.id)
+    expect(after?.lastSentAt).toBeUndefined()
+    const logs = await log.listRecent(10)
+    expect(logs[0]).toMatchObject({
+      status: 'failed',
+      resendId: undefined,
+      error: 'resend 503',
+    })
+  })
+})
+
+describe('runDispatch — retention sweep', () => {
+  it('purges send_log rows older than the retention window after the dispatch', async () => {
+    const s = await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await log.append({
+      subscriberId: s.id,
+      tickAt: '2025-12-01T00:00:00.000Z',
+      articleCount: 0,
+      status: 'sent',
+      resendId: 'old',
+      error: undefined,
+    })
+    const rss = buildRss({})
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    await runDispatch({
+      ...baseDeps(rss.fn, resend.client),
+      retentionDays: 30,
+    })
+    const logs = await log.listRecent(10)
+    expect(logs.map(l => l.resendId)).not.toContain('old')
+  })
+})

--- a/services/comms-worker/src/dispatch/run.ts
+++ b/services/comms-worker/src/dispatch/run.ts
@@ -1,0 +1,51 @@
+import type { DispatchContext } from './context'
+import { type DispatchOutcome, dispatchOne } from './dispatch-one'
+import { fetchAllLangs } from './fetch-articles'
+import type { DispatchSummary, RunDispatchDeps } from './types'
+
+const MS_PER_DAY = 86_400_000
+const DEFAULT_RETENTION_DAYS = 90
+
+const cutoffIso = (tickAt: Date, days: number): string =>
+  new Date(tickAt.getTime() - days * MS_PER_DAY).toISOString()
+
+const summary = (
+  outcomes: ReadonlyArray<DispatchOutcome>,
+  durationMs: number
+): DispatchSummary => ({
+  sent: outcomes.filter(o => o === 'sent').length,
+  failed: outcomes.filter(o => o === 'failed').length,
+  skipped: outcomes.filter(o => o === 'skipped').length,
+  durationMs,
+})
+
+/**
+ * Execute one dispatch tick: load active subscribers, fetch RSS per
+ * unique lang once, dispatch each subscriber, sweep old send_log rows.
+ * Side-effect-free except through injected repos / Resend / RSS.
+ * @param d Injected dependencies (see {@link RunDispatchDeps}).
+ * @returns Per-tick counters and wall-clock duration.
+ */
+export const runDispatch = async (
+  d: RunDispatchDeps
+): Promise<DispatchSummary> => {
+  const start = Date.now()
+  const subs = await d.subscriberRepo.listActive()
+  const byLang = await fetchAllLangs(subs, d.rss)
+  const ctx: DispatchContext = {
+    subscriberRepo: d.subscriberRepo,
+    sendLogRepo: d.sendLogRepo,
+    resend: d.resend,
+    secret: d.secret,
+    fromAddress: d.fromAddress,
+    publicBaseUrl: d.publicBaseUrl,
+    tickAt: d.tickAt,
+    byLang,
+  }
+  const outcomes: DispatchOutcome[] = []
+  for (const sub of subs) outcomes.push(await dispatchOne(ctx, sub))
+  await d.sendLogRepo.purgeOlderThan(
+    cutoffIso(d.tickAt, d.retentionDays ?? DEFAULT_RETENTION_DAYS)
+  )
+  return summary(outcomes, Date.now() - start)
+}

--- a/services/comms-worker/src/dispatch/runtime-env.ts
+++ b/services/comms-worker/src/dispatch/runtime-env.ts
@@ -1,0 +1,17 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+/** Worker bindings + secrets the dispatch path requires at runtime. */
+export type DispatchEnv = {
+  readonly DB: D1Database
+  readonly RESEND_API_KEY: string
+  readonly UNSUBSCRIBE_SECRET: string
+  readonly FROM_ADDRESS?: string
+  readonly PUBLIC_BASE_URL?: string
+  readonly BYPASS_SCHEDULE?: string
+}
+
+/** Default sender displayed in the From header. */
+export const DEFAULT_FROM = 'Communist Prometheus <newsletter@comprom.org>'
+
+/** Default base URL where the worker serves the unsubscribe surface. */
+export const DEFAULT_PUBLIC_BASE = 'https://lists.comprom.org'

--- a/services/comms-worker/src/dispatch/scheduled.test.ts
+++ b/services/comms-worker/src/dispatch/scheduled.test.ts
@@ -1,0 +1,69 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSettingsRepo } from '../settings/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { handleScheduled, type ScheduledEnv } from './scheduled'
+
+const FROZEN_NOW = new Date('2026-06-06T09:00:00.000Z')
+
+let db: D1Database
+let env: ScheduledEnv
+
+beforeEach(() => {
+  db = makeTestD1()
+  env = {
+    DB: db,
+    RESEND_API_KEY: 'rk_test',
+    UNSUBSCRIBE_SECRET: 'shhh',
+  }
+})
+
+describe('handleScheduled', () => {
+  it('returns undefined when no schedule has ever been persisted', async () => {
+    await db.prepare('DELETE FROM settings').run()
+    const dispatcher = vi.fn()
+    const out = await handleScheduled(
+      { scheduledTime: FROZEN_NOW.getTime() },
+      env,
+      { dispatcher }
+    )
+    expect(out).toBeUndefined()
+    expect(dispatcher).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when the tick does not match the schedule', async () => {
+    const settings = createSettingsRepo({ db })
+    await settings.setSchedule(
+      { cron: '0 12 * * 6', timezone: 'Europe/Moscow' },
+      FROZEN_NOW
+    )
+    const fridayTick = new Date('2026-06-05T09:00:00.000Z').getTime()
+    const dispatcher = vi.fn()
+    const out = await handleScheduled({ scheduledTime: fridayTick }, env, {
+      dispatcher,
+    })
+    expect(out).toBeUndefined()
+    expect(dispatcher).not.toHaveBeenCalled()
+  })
+
+  it('invokes the dispatcher with the tickAt when the schedule matches', async () => {
+    const settings = createSettingsRepo({ db })
+    await settings.setSchedule(
+      { cron: '0 12 * * 6', timezone: 'Europe/Moscow' },
+      FROZEN_NOW
+    )
+    const dispatcher = vi
+      .fn()
+      .mockResolvedValue({ sent: 0, failed: 0, skipped: 0, durationMs: 1 })
+    const out = await handleScheduled(
+      { scheduledTime: FROZEN_NOW.getTime() },
+      env,
+      { dispatcher }
+    )
+    expect(dispatcher).toHaveBeenCalledOnce()
+    const [passedEnv, passedTick] = dispatcher.mock.calls[0] ?? []
+    expect(passedEnv).toBe(env)
+    expect(passedTick.toISOString()).toBe(FROZEN_NOW.toISOString())
+    expect(out).toMatchObject({ sent: 0, failed: 0 })
+  })
+})

--- a/services/comms-worker/src/dispatch/scheduled.ts
+++ b/services/comms-worker/src/dispatch/scheduled.ts
@@ -1,0 +1,43 @@
+import { matchesTick } from '../cron/matcher'
+import { createSettingsRepo } from '../settings/repo'
+import { buildRuntimeDeps } from './build-deps'
+import { runDispatch } from './run'
+import type { DispatchEnv } from './runtime-env'
+import type { DispatchSummary } from './types'
+
+export type { DispatchEnv as ScheduledEnv } from './runtime-env'
+
+/** Dispatcher seam injected by tests. */
+export type Dispatcher = (
+  env: DispatchEnv,
+  tickAt: Date
+) => Promise<DispatchSummary>
+
+/** Options consumed by {@link handleScheduled}. */
+export type HandleScheduledOptions = {
+  readonly dispatcher?: Dispatcher
+}
+
+const defaultDispatcher: Dispatcher = (env, tickAt) =>
+  runDispatch(buildRuntimeDeps(env, tickAt))
+
+/**
+ * Cron handler: load the saved schedule, decide whether this tick is
+ * one the editor asked for, and (only then) fire the dispatch loop.
+ * @param event CF ScheduledEvent-shaped object (`scheduledTime` ms).
+ * @param env Worker bindings + secrets.
+ * @param opts Optional dispatcher seam for unit tests.
+ * @returns The dispatch summary on match, `undefined` on no-match.
+ */
+export const handleScheduled = async (
+  event: { readonly scheduledTime: number },
+  env: DispatchEnv,
+  opts: HandleScheduledOptions = {}
+): Promise<DispatchSummary | undefined> => {
+  const tickAt = new Date(event.scheduledTime)
+  const sched = await createSettingsRepo({ db: env.DB }).getSchedule(tickAt)
+  if (sched === undefined) return undefined
+  if (!matchesTick(sched, tickAt)) return undefined
+  const run = opts.dispatcher ?? defaultDispatcher
+  return run(env, tickAt)
+}

--- a/services/comms-worker/src/dispatch/types.ts
+++ b/services/comms-worker/src/dispatch/types.ts
@@ -1,0 +1,25 @@
+import type { ResendClient } from '../resend/types'
+import type { RssFetcher } from '../rss/fetch'
+import type { SendLogRepo } from '../send-log/repo'
+import type { SubscriberRepo } from '../subscribers/repo'
+
+/** Injected dependencies for {@link runDispatch}. */
+export type RunDispatchDeps = {
+  readonly subscriberRepo: SubscriberRepo
+  readonly sendLogRepo: SendLogRepo
+  readonly rss: RssFetcher
+  readonly resend: ResendClient
+  readonly secret: string
+  readonly fromAddress: string
+  readonly publicBaseUrl: string
+  readonly tickAt: Date
+  readonly retentionDays?: number
+}
+
+/** Per-tick summary returned by {@link runDispatch}. */
+export type DispatchSummary = {
+  readonly sent: number
+  readonly failed: number
+  readonly skipped: number
+  readonly durationMs: number
+}

--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -1,6 +1,9 @@
-import type { D1Database } from '@cloudflare/workers-types'
+import type { D1Database, ScheduledEvent } from '@cloudflare/workers-types'
 import { Hono } from 'hono'
 import type { AccessClaims } from './auth/cf-access'
+import { mountForceDispatchRoute } from './dispatch/force-route'
+import type { DispatchEnv } from './dispatch/runtime-env'
+import { handleScheduled } from './dispatch/scheduled'
 import { registerHealthRoute } from './health'
 import {
   type RequireAccessEnv,
@@ -12,11 +15,12 @@ import { createRepo } from './subscribers/repo'
 import { mountSubscriberRoutes } from './subscribers/routes'
 
 /** Combined worker bindings across all registered routes. */
-export type Bindings = RequireAccessEnv & {
-  readonly VERSION: string
-  readonly ADMIN_HOSTNAME: string
-  readonly DB: D1Database
-}
+export type Bindings = RequireAccessEnv &
+  DispatchEnv & {
+    readonly VERSION: string
+    readonly ADMIN_HOSTNAME: string
+    readonly DB: D1Database
+  }
 
 type Vars = { readonly access: AccessClaims }
 type WorkerCtx = { Bindings: Bindings; Variables: Vars }
@@ -36,10 +40,14 @@ mountScheduleRoutes(
   c => createSettingsRepo({ db: (c.env as Bindings).DB }),
   nowDate
 )
+mountForceDispatchRoute(app)
 
-/** Cloudflare Worker entry — delegates everything to Hono. */
+/** Cloudflare Worker entry — Hono for HTTP, handleScheduled for crons. */
 export default {
   fetch: app.fetch,
+  scheduled: async (event: ScheduledEvent, env: Bindings): Promise<void> => {
+    await handleScheduled({ scheduledTime: event.scheduledTime }, env)
+  },
 }
 
 export { app }

--- a/services/comms-worker/src/resend/attempt.ts
+++ b/services/comms-worker/src/resend/attempt.ts
@@ -1,0 +1,41 @@
+import { classify, DEFAULT_BACKOFF_MS } from './response'
+import type { SendResult } from './types'
+
+/** Resend transactional email endpoint. */
+export const RESEND_API_URL = 'https://api.resend.com/emails'
+
+const attempt = async (
+  doFetch: typeof fetch,
+  init: RequestInit
+): Promise<Response | undefined> => {
+  try {
+    return await doFetch(RESEND_API_URL, init)
+  } catch {
+    return undefined
+  }
+}
+
+const handleAttempt = async (
+  res: Response | undefined
+): Promise<SendResult | { readonly retryAfterMs: number }> => {
+  if (res === undefined) return { retryAfterMs: DEFAULT_BACKOFF_MS }
+  const verdict = await classify(res)
+  return verdict.kind === 'retry'
+    ? { retryAfterMs: verdict.waitMs }
+    : verdict.kind === 'ok'
+      ? { ok: true, id: verdict.id }
+      : { ok: false, error: verdict.error }
+}
+
+/**
+ * One round-trip to the Resend API: returns the success outcome or a
+ * retryable backoff hint with the recommended wait duration.
+ * @param doFetch Injected fetch.
+ * @param init Pre-built request init.
+ * @returns Discriminated outcome.
+ */
+export const sendOnce = async (
+  doFetch: typeof fetch,
+  init: RequestInit
+): Promise<SendResult | { readonly retryAfterMs: number }> =>
+  handleAttempt(await attempt(doFetch, init))

--- a/services/comms-worker/src/resend/client.test.ts
+++ b/services/comms-worker/src/resend/client.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createResendClient, RESEND_API_URL } from './client'
+
+const okPayload = {
+  from: 'a@b.c',
+  to: 'd@e.f',
+  subject: 'hi',
+  html: '<p>hi</p>',
+  text: 'hi',
+}
+
+let sleep: ReturnType<typeof vi.fn>
+let fetchFn: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  sleep = vi.fn().mockResolvedValue(undefined)
+  fetchFn = vi.fn<typeof fetch>()
+})
+
+const build = () =>
+  createResendClient({
+    apiKey: 'rk_live_xxx',
+    fetch: fetchFn as typeof fetch,
+    sleep,
+  })
+
+describe('createResendClient.send — request shape', () => {
+  it('POSTs the Resend API URL with Bearer auth + JSON body', async () => {
+    fetchFn.mockResolvedValue(
+      new Response(JSON.stringify({ id: 're_1' }), { status: 200 })
+    )
+    const r = await build().send(okPayload)
+    expect(r).toEqual({ ok: true, id: 're_1' })
+    expect(fetchFn).toHaveBeenCalledOnce()
+    const [url, init] = fetchFn.mock.calls[0] ?? []
+    expect(url).toBe(RESEND_API_URL)
+    expect(init.method).toBe('POST')
+    const headers = new Headers(init.headers)
+    expect(headers.get('Authorization')).toBe('Bearer rk_live_xxx')
+    expect(headers.get('Content-Type')).toBe('application/json')
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body.from).toBe('a@b.c')
+    expect(body.to).toEqual(['d@e.f'])
+  })
+
+  it('forwards extra MIME headers + Idempotency-Key', async () => {
+    fetchFn.mockResolvedValue(
+      new Response(JSON.stringify({ id: 're_2' }), { status: 200 })
+    )
+    await build().send({
+      ...okPayload,
+      headers: { 'List-Unsubscribe': '<https://x/u>' },
+      idempotencyKey: '42:2026-06-06T09:00:00Z',
+    })
+    const init = fetchFn.mock.calls[0]?.[1]
+    const headers = new Headers(init?.headers)
+    expect(headers.get('Idempotency-Key')).toBe('42:2026-06-06T09:00:00Z')
+    const body = JSON.parse(init?.body as string) as Record<string, unknown>
+    const messageHeaders = body.headers as Record<string, string>
+    expect(messageHeaders['List-Unsubscribe']).toBe('<https://x/u>')
+  })
+})
+
+describe('createResendClient.send — failure modes', () => {
+  it('returns an error on 4xx (no retry)', async () => {
+    fetchFn.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'bad to' }), { status: 422 })
+    )
+    const r = await build().send(okPayload)
+    expect(r.ok).toBe(false)
+    expect(fetchFn).toHaveBeenCalledOnce()
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('retries once on 429 then returns error', async () => {
+    fetchFn
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+      .mockResolvedValueOnce(new Response('', { status: 429 }))
+    const r = await build().send(okPayload)
+    expect(r.ok).toBe(false)
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledOnce()
+  })
+
+  it('retries once on 5xx then succeeds when the retry returns 2xx', async () => {
+    fetchFn
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 're_3' }), { status: 200 })
+      )
+    const r = await build().send(okPayload)
+    expect(r).toEqual({ ok: true, id: 're_3' })
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledOnce()
+  })
+
+  it('honours Retry-After (seconds) on the first 429', async () => {
+    fetchFn
+      .mockResolvedValueOnce(
+        new Response('', {
+          status: 429,
+          headers: { 'Retry-After': '3' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 're_4' }), { status: 200 })
+      )
+    await build().send(okPayload)
+    expect(sleep).toHaveBeenCalledWith(3000)
+  })
+
+  it('returns error when the network rejects on both attempts', async () => {
+    fetchFn
+      .mockRejectedValueOnce(new Error('econn'))
+      .mockRejectedValueOnce(new Error('econn'))
+    const r = await build().send(okPayload)
+    expect(r.ok).toBe(false)
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+})

--- a/services/comms-worker/src/resend/client.ts
+++ b/services/comms-worker/src/resend/client.ts
@@ -1,0 +1,37 @@
+import { sendOnce } from './attempt'
+import { buildRequest } from './request'
+import type { ResendClient, SendInput, SendResult } from './types'
+
+export { RESEND_API_URL } from './attempt'
+
+type Deps = {
+  readonly apiKey: string
+  readonly fetch?: typeof fetch
+  readonly sleep?: (ms: number) => Promise<void>
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise(r => setTimeout(r, ms))
+
+const fail = (error: string): SendResult => ({ ok: false, error })
+
+/**
+ * Build a send-only Resend client. Retries once on 429 / 5xx / network
+ * error with either the server-provided `Retry-After` or a 1s default.
+ * @param d Injected API key, fetch, and sleep for testability.
+ * @returns Send-only client.
+ */
+export const createResendClient = (d: Deps): ResendClient => {
+  const doFetch = d.fetch ?? globalThis.fetch.bind(globalThis)
+  const doSleep = d.sleep ?? defaultSleep
+  return {
+    send: async (input: SendInput) => {
+      const init = buildRequest(d.apiKey, input)
+      const first = await sendOnce(doFetch, init)
+      if ('ok' in first) return first
+      await doSleep(first.retryAfterMs)
+      const second = await sendOnce(doFetch, init)
+      return 'ok' in second ? second : fail('resend retry exhausted')
+    },
+  }
+}

--- a/services/comms-worker/src/resend/request.ts
+++ b/services/comms-worker/src/resend/request.ts
@@ -1,0 +1,34 @@
+import type { SendInput } from './types'
+
+const buildBody = (input: SendInput): string =>
+  JSON.stringify({
+    from: input.from,
+    to: [input.to],
+    subject: input.subject,
+    html: input.html,
+    text: input.text,
+    headers: input.headers,
+  })
+
+const baseHeaders = (apiKey: string): Record<string, string> => ({
+  Authorization: `Bearer ${apiKey}`,
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+})
+
+/**
+ * Build the `fetch` `RequestInit` used to POST a transactional email.
+ * @param apiKey Resend API key.
+ * @param input Email payload.
+ * @returns Pre-built `RequestInit` ready to be passed to `fetch`.
+ */
+export const buildRequest = (
+  apiKey: string,
+  input: SendInput
+): RequestInit => {
+  const headers = baseHeaders(apiKey)
+  if (input.idempotencyKey !== undefined) {
+    headers['Idempotency-Key'] = input.idempotencyKey
+  }
+  return { method: 'POST', headers, body: buildBody(input) }
+}

--- a/services/comms-worker/src/resend/response.ts
+++ b/services/comms-worker/src/resend/response.ts
@@ -1,0 +1,45 @@
+import type { SendResult } from './types'
+
+/** Default backoff used when the server does not send Retry-After. */
+export const DEFAULT_BACKOFF_MS = 1_000
+
+/** Status codes that are eligible for a single retry. */
+export const isRetryableStatus = (status: number): boolean =>
+  status === 429 || status >= 500
+
+const retryAfterMs = (res: Response): number => {
+  const raw = res.headers.get('Retry-After')
+  const seconds = raw === null ? Number.NaN : Number(raw)
+  return Number.isFinite(seconds) && seconds > 0
+    ? seconds * 1_000
+    : DEFAULT_BACKOFF_MS
+}
+
+/**
+ * Decide how to handle a Resend response: success, retryable failure
+ * (with its backoff duration), or a terminal error.
+ * @param res The fetch response.
+ * @returns Branch the caller should take.
+ */
+export const classify = async (
+  res: Response
+): Promise<
+  | { readonly kind: 'ok'; readonly id: string }
+  | { readonly kind: 'retry'; readonly waitMs: number }
+  | { readonly kind: 'fail'; readonly error: string }
+> => {
+  if (res.ok) {
+    const body = (await res.json().catch(() => undefined)) as
+      | { id?: unknown }
+      | undefined
+    const id = typeof body?.id === 'string' ? body.id : ''
+    return { kind: 'ok', id }
+  }
+  return isRetryableStatus(res.status)
+    ? { kind: 'retry', waitMs: retryAfterMs(res) }
+    : { kind: 'fail', error: `resend ${res.status}` }
+}
+
+/** Promote a `classify` outcome into the public {@link SendResult} shape. */
+export const toResult = (kind: 'ok' | 'fail', payload: string): SendResult =>
+  kind === 'ok' ? { ok: true, id: payload } : { ok: false, error: payload }

--- a/services/comms-worker/src/resend/types.ts
+++ b/services/comms-worker/src/resend/types.ts
@@ -1,0 +1,20 @@
+/** Resend transactional email payload, as sent by the worker. */
+export type SendInput = {
+  readonly from: string
+  readonly to: string
+  readonly subject: string
+  readonly html: string
+  readonly text: string
+  readonly headers?: Readonly<Record<string, string>>
+  readonly idempotencyKey?: string
+}
+
+/** Discriminated outcome returned by {@link ResendClient.send}. */
+export type SendResult =
+  | { readonly ok: true; readonly id: string }
+  | { readonly ok: false; readonly error: string }
+
+/** Thin send-only client facade. */
+export type ResendClient = {
+  readonly send: (input: SendInput) => Promise<SendResult>
+}

--- a/services/comms-worker/src/rss/decode.ts
+++ b/services/comms-worker/src/rss/decode.ts
@@ -1,0 +1,33 @@
+const ENTITIES: Readonly<Record<string, string>> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+}
+
+const stripCdata = (raw: string): string => {
+  const m = /^<!\[CDATA\[([\s\S]*?)\]\]>$/.exec(raw.trim())
+  return m?.[1] ?? raw
+}
+
+const decodeEntity = (name: string): string =>
+  ENTITIES[name] ??
+  (name.startsWith('#x')
+    ? String.fromCharCode(Number.parseInt(name.slice(2), 16))
+    : name.startsWith('#')
+      ? String.fromCharCode(Number.parseInt(name.slice(1), 10))
+      : `&${name};`)
+
+/**
+ * Decode the textual content of an XML element: strip CDATA wrappers,
+ * expand the common entities, trim surrounding whitespace.
+ * @param raw Raw inner-text of an XML element.
+ * @returns Decoded plain text.
+ */
+export const decodeXmlText = (raw: string): string =>
+  stripCdata(raw)
+    .replace(/&([a-zA-Z]+|#\d+|#x[0-9a-fA-F]+);/g, (_, name: string) =>
+      decodeEntity(name)
+    )
+    .trim()

--- a/services/comms-worker/src/rss/fetch.test.ts
+++ b/services/comms-worker/src/rss/fetch.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createRssFetcher, FALLBACK_BASE } from './fetch'
+
+const xml = `<?xml version="1.0"?>
+<rss><channel><title>x</title>
+<item>
+  <guid>g1</guid>
+  <title>T</title>
+  <link>https://x/y</link>
+  <pubDate>2026-06-01T00:00:00Z</pubDate>
+</item>
+</channel></rss>`
+
+describe('createRssFetcher', () => {
+  it('GETs the lang-specific /rss.xml URL on the default base', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(xml, { status: 200 }))
+    const fetcher = createRssFetcher({ fetch: fetchFn })
+    await fetcher('ru')
+    expect(fetchFn).toHaveBeenCalledOnce()
+    const [url] = fetchFn.mock.calls[0] ?? []
+    expect(url).toBe(`${FALLBACK_BASE}/ru/rss.xml`)
+  })
+
+  it('honours a custom base URL', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(xml, { status: 200 }))
+    const fetcher = createRssFetcher({
+      base: 'https://example.test',
+      fetch: fetchFn,
+    })
+    await fetcher('en')
+    const [url] = fetchFn.mock.calls[0] ?? []
+    expect(url).toBe('https://example.test/en/rss.xml')
+  })
+
+  it('returns parsed articles on 2xx', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(xml, { status: 200 }))
+    const items = await createRssFetcher({ fetch: fetchFn })('it')
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({ guid: 'g1', lang: 'it' })
+  })
+
+  it('returns an empty list on a non-2xx response (no throw)', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response('not found', { status: 404 }))
+    expect(await createRssFetcher({ fetch: fetchFn })('ru')).toEqual([])
+  })
+
+  it('returns an empty list when fetch itself rejects', async () => {
+    const fetchFn = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error('network down'))
+    expect(await createRssFetcher({ fetch: fetchFn })('ru')).toEqual([])
+  })
+})

--- a/services/comms-worker/src/rss/fetch.ts
+++ b/services/comms-worker/src/rss/fetch.ts
@@ -1,0 +1,42 @@
+import type { Lang } from '../subscribers/types'
+import { parseRss } from './parse'
+import type { Article } from './types'
+
+/** Source of truth for the public RSS endpoint. */
+export const FALLBACK_BASE = 'https://comprom.org'
+
+type Deps = {
+  readonly base?: string
+  readonly fetch?: typeof fetch
+}
+
+/** Fetcher function signature consumed by the orchestrator. */
+export type RssFetcher = (lang: Lang) => Promise<ReadonlyArray<Article>>
+
+const safeFetch = async (
+  doFetch: typeof fetch,
+  url: string
+): Promise<string | undefined> => {
+  try {
+    const res = await doFetch(url)
+    return res.ok ? await res.text() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Build a per-language RSS fetcher bound to the given base URL +
+ * fetch implementation. Failures (network or non-2xx) collapse to an
+ * empty article list; logging is the caller's concern.
+ * @param d Injected base + fetch.
+ * @returns Fetcher returning parsed articles for one language.
+ */
+export const createRssFetcher = (d: Deps = {}): RssFetcher => {
+  const base = d.base ?? FALLBACK_BASE
+  const doFetch = d.fetch ?? globalThis.fetch.bind(globalThis)
+  return async lang => {
+    const body = await safeFetch(doFetch, `${base}/${lang}/rss.xml`)
+    return body === undefined ? [] : parseRss(body, lang)
+  }
+}

--- a/services/comms-worker/src/rss/parse.test.ts
+++ b/services/comms-worker/src/rss/parse.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { parseRss } from './parse'
+
+const BASE = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Communist Prometheus</title>
+    <link>https://comprom.org/ru/</link>
+    <description>News in Russian</description>
+    <item>
+      <guid>https://comprom.org/ru/articles/a/</guid>
+      <title>Первая статья</title>
+      <link>https://comprom.org/ru/articles/a/</link>
+      <description>Тестовая аннотация</description>
+      <pubDate>Mon, 01 Jun 2026 09:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <guid>https://comprom.org/ru/articles/b/</guid>
+      <title>Вторая статья</title>
+      <link>https://comprom.org/ru/articles/b/</link>
+      <pubDate>2026-06-02T12:00:00.000Z</pubDate>
+    </item>
+  </channel>
+</rss>`
+
+describe('parseRss — happy path', () => {
+  it('extracts every item with guid, title, link, pubDate normalised to ISO', () => {
+    const items = parseRss(BASE, 'ru')
+    expect(items).toHaveLength(2)
+    expect(items[0]).toEqual({
+      guid: 'https://comprom.org/ru/articles/a/',
+      title: 'Первая статья',
+      link: 'https://comprom.org/ru/articles/a/',
+      lang: 'ru',
+      pubDate: '2026-06-01T09:00:00.000Z',
+    })
+    expect(items[1]?.pubDate).toBe('2026-06-02T12:00:00.000Z')
+  })
+
+  it('attaches the requested lang to every item', () => {
+    const items = parseRss(BASE, 'en')
+    expect(items.every(i => i.lang === 'en')).toBe(true)
+  })
+})
+
+describe('parseRss — tolerance', () => {
+  it('handles a UTF-8 BOM prefix', () => {
+    const items = parseRss(`﻿${BASE}`, 'ru')
+    expect(items).toHaveLength(2)
+  })
+
+  it('handles CDATA-wrapped titles and descriptions', () => {
+    const xml = BASE.replace(
+      '<title>Первая статья</title>',
+      '<title><![CDATA[Первая статья]]></title>'
+    )
+    const items = parseRss(xml, 'ru')
+    expect(items[0]?.title).toBe('Первая статья')
+  })
+
+  it('skips items that are missing a guid', () => {
+    const xml = BASE.replace(
+      /<guid>https:\/\/comprom\.org\/ru\/articles\/a\/<\/guid>\s*/,
+      ''
+    )
+    const items = parseRss(xml, 'ru')
+    expect(items.map(i => i.guid)).toEqual([
+      'https://comprom.org/ru/articles/b/',
+    ])
+  })
+
+  it('skips items whose pubDate cannot be parsed', () => {
+    const xml = BASE.replace(
+      '<pubDate>Mon, 01 Jun 2026 09:00:00 GMT</pubDate>',
+      '<pubDate>definitely-not-a-date</pubDate>'
+    )
+    const items = parseRss(xml, 'ru')
+    expect(items.map(i => i.guid)).toEqual([
+      'https://comprom.org/ru/articles/b/',
+    ])
+  })
+
+  it('returns an empty array when there are no <item> tags', () => {
+    expect(
+      parseRss(
+        '<?xml version="1.0"?><rss><channel><title>x</title></channel></rss>',
+        'ru'
+      )
+    ).toEqual([])
+  })
+
+  it('decodes the common XML entities in titles', () => {
+    const xml = BASE.replace(
+      '<title>Первая статья</title>',
+      '<title>News &amp; Notes &lt;2026&gt;</title>'
+    )
+    const items = parseRss(xml, 'ru')
+    expect(items[0]?.title).toBe('News & Notes <2026>')
+  })
+})

--- a/services/comms-worker/src/rss/parse.ts
+++ b/services/comms-worker/src/rss/parse.ts
@@ -1,0 +1,53 @@
+import type { Lang } from '../subscribers/types'
+import { decodeXmlText } from './decode'
+import type { Article } from './types'
+
+const ITEM_RE = /<item\b[\s\S]*?<\/item>/g
+const BOM_RE = /^﻿/
+
+const extractTag = (xml: string, tag: string): string | undefined => {
+  const re = new RegExp(`<${tag}\\b[^>]*>([\\s\\S]*?)</${tag}>`, 'i')
+  const m = re.exec(xml)
+  return m === null ? undefined : decodeXmlText(m[1] ?? '')
+}
+
+const toIsoUtc = (raw: string): string | undefined => {
+  const ms = Date.parse(raw)
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : undefined
+}
+
+const itemToArticle = (block: string, lang: Lang): Article | undefined => {
+  const guid = extractTag(block, 'guid')
+  const title = extractTag(block, 'title')
+  const link = extractTag(block, 'link')
+  const pubDateRaw = extractTag(block, 'pubDate')
+  if (
+    guid === undefined ||
+    title === undefined ||
+    link === undefined ||
+    pubDateRaw === undefined
+  ) {
+    return undefined
+  }
+  const pubDate = toIsoUtc(pubDateRaw)
+  return pubDate === undefined
+    ? undefined
+    : { guid, title, link, lang, pubDate }
+}
+
+/**
+ * Parse a well-formed RSS-2.0 document into a typed `Article[]`.
+ * Tolerates a UTF-8 BOM, CDATA-wrapped fields, the common XML entities,
+ * and either RFC-822 or ISO-8601 `pubDate` values. Items missing any
+ * required field — or carrying an unparseable date — are skipped.
+ * @param xml Raw RSS document body.
+ * @param lang Language code attached to every parsed item.
+ * @returns Parsed article list, preserving document order.
+ */
+export const parseRss = (xml: string, lang: Lang): ReadonlyArray<Article> => {
+  const body = xml.replace(BOM_RE, '')
+  const blocks = body.match(ITEM_RE) ?? []
+  return blocks
+    .map(b => itemToArticle(b, lang))
+    .filter((a): a is Article => a !== undefined)
+}

--- a/services/comms-worker/src/rss/types.ts
+++ b/services/comms-worker/src/rss/types.ts
@@ -1,0 +1,10 @@
+import type { Lang } from '../subscribers/types'
+
+/** Parsed RSS item with `pubDate` normalised to ISO-8601 UTC. */
+export type Article = {
+  readonly guid: string
+  readonly title: string
+  readonly link: string
+  readonly lang: Lang
+  readonly pubDate: string
+}

--- a/services/comms-worker/src/send-log/repo.test.ts
+++ b/services/comms-worker/src/send-log/repo.test.ts
@@ -1,0 +1,132 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createRepo } from '../subscribers/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { createSendLogRepo, type SendLogRepo } from './repo'
+
+let repo: SendLogRepo
+let db: D1Database
+
+const seedSubscribers = async (ids: ReadonlyArray<number>): Promise<void> => {
+  const subs = createRepo({
+    db,
+    now: () => '2026-05-01T00:00:00.000Z',
+  })
+  for (const id of ids) {
+    await subs.insert({ email: `s${id}@example.test`, langs: ['ru'] })
+  }
+}
+
+beforeEach(() => {
+  db = makeTestD1()
+  repo = createSendLogRepo({ db })
+})
+
+describe('SendLogRepo.append + listRecent', () => {
+  it('round-trips a single sent row', async () => {
+    await seedSubscribers([1, 2, 3, 4, 5, 6, 7])
+    await repo.append({
+      subscriberId: 7,
+      tickAt: '2026-06-06T09:00:00.000Z',
+      articleCount: 3,
+      status: 'sent',
+      resendId: 're_abc',
+      error: undefined,
+    })
+    const rows = await repo.listRecent(10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      subscriberId: 7,
+      tickAt: '2026-06-06T09:00:00.000Z',
+      articleCount: 3,
+      status: 'sent',
+      resendId: 're_abc',
+      error: undefined,
+    })
+  })
+
+  it('persists an error message on failed rows', async () => {
+    await seedSubscribers([1, 2, 3, 4, 5, 6, 7])
+    await repo.append({
+      subscriberId: 7,
+      tickAt: '2026-06-06T09:00:00.000Z',
+      articleCount: 3,
+      status: 'failed',
+      resendId: undefined,
+      error: 'resend 503',
+    })
+    const rows = await repo.listRecent(10)
+    expect(rows[0]?.error).toBe('resend 503')
+    expect(rows[0]?.resendId).toBeUndefined()
+  })
+
+  it('orders rows newest tick_at first and respects the limit', async () => {
+    await seedSubscribers([1, 2, 3])
+    await repo.append({
+      subscriberId: 1,
+      tickAt: '2026-06-01T00:00:00.000Z',
+      articleCount: 1,
+      status: 'sent',
+      resendId: 'a',
+      error: undefined,
+    })
+    await repo.append({
+      subscriberId: 2,
+      tickAt: '2026-06-08T00:00:00.000Z',
+      articleCount: 1,
+      status: 'sent',
+      resendId: 'b',
+      error: undefined,
+    })
+    await repo.append({
+      subscriberId: 3,
+      tickAt: '2026-06-05T00:00:00.000Z',
+      articleCount: 1,
+      status: 'sent',
+      resendId: 'c',
+      error: undefined,
+    })
+    const rows = await repo.listRecent(2)
+    expect(rows.map(r => r.subscriberId)).toEqual([2, 3])
+  })
+})
+
+describe('SendLogRepo.purgeOlderThan', () => {
+  it('deletes only rows whose tick_at is older than the cutoff', async () => {
+    await seedSubscribers([1, 2])
+    await repo.append({
+      subscriberId: 1,
+      tickAt: '2025-12-01T00:00:00.000Z',
+      articleCount: 0,
+      status: 'sent',
+      resendId: 'old',
+      error: undefined,
+    })
+    await repo.append({
+      subscriberId: 2,
+      tickAt: '2026-06-01T00:00:00.000Z',
+      articleCount: 0,
+      status: 'sent',
+      resendId: 'new',
+      error: undefined,
+    })
+    const removed = await repo.purgeOlderThan('2026-03-01T00:00:00.000Z')
+    expect(removed).toBe(1)
+    const rows = await repo.listRecent(10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.resendId).toBe('new')
+  })
+
+  it('returns 0 when nothing matches the cutoff', async () => {
+    await seedSubscribers([1])
+    await repo.append({
+      subscriberId: 1,
+      tickAt: '2026-06-01T00:00:00.000Z',
+      articleCount: 0,
+      status: 'sent',
+      resendId: 'r',
+      error: undefined,
+    })
+    expect(await repo.purgeOlderThan('2025-01-01T00:00:00.000Z')).toBe(0)
+  })
+})

--- a/services/comms-worker/src/send-log/repo.ts
+++ b/services/comms-worker/src/send-log/repo.ts
@@ -1,0 +1,60 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { rowToSendLog, type SendLogRow } from './serialize'
+import type { NewSendLog, SendLog } from './types'
+
+/** Repo facade for the `send_log` table. */
+export type SendLogRepo = {
+  readonly append: (row: NewSendLog) => Promise<void>
+  readonly listRecent: (limit: number) => Promise<ReadonlyArray<SendLog>>
+  readonly purgeOlderThan: (cutoffIsoUtc: string) => Promise<number>
+}
+
+type Deps = { readonly db: D1Database }
+
+const SQL_INSERT =
+  'INSERT INTO send_log (subscriber_id, tick_at, article_count, status, resend_id, error) ' +
+  'VALUES (?, ?, ?, ?, ?, ?)'
+const SQL_LIST =
+  'SELECT * FROM send_log ORDER BY tick_at DESC, id DESC LIMIT ?'
+const SQL_PURGE = 'DELETE FROM send_log WHERE tick_at < ?'
+
+const append = async (db: D1Database, row: NewSendLog): Promise<void> => {
+  await db
+    .prepare(SQL_INSERT)
+    .bind(
+      row.subscriberId ?? null,
+      row.tickAt,
+      row.articleCount,
+      row.status,
+      row.resendId ?? null,
+      row.error ?? null
+    )
+    .run()
+}
+
+const listRecent = async (
+  db: D1Database,
+  limit: number
+): Promise<ReadonlyArray<SendLog>> => {
+  const r = await db.prepare(SQL_LIST).bind(limit).all<SendLogRow>()
+  return (r.results ?? []).map(rowToSendLog)
+}
+
+const purgeOlderThan = async (
+  db: D1Database,
+  cutoffIsoUtc: string
+): Promise<number> => {
+  const r = await db.prepare(SQL_PURGE).bind(cutoffIsoUtc).run()
+  return r.meta.changes
+}
+
+/**
+ * Build a `send_log` repo bound to the given D1 database.
+ * @param d Injected dependencies.
+ * @returns Repo facade.
+ */
+export const createSendLogRepo = (d: Deps): SendLogRepo => ({
+  append: row => append(d.db, row),
+  listRecent: limit => listRecent(d.db, limit),
+  purgeOlderThan: cutoff => purgeOlderThan(d.db, cutoff),
+})

--- a/services/comms-worker/src/send-log/serialize.ts
+++ b/services/comms-worker/src/send-log/serialize.ts
@@ -1,0 +1,29 @@
+import type { SendLog, SendLogStatus } from './types'
+
+/** Raw row shape returned by the D1 driver for the `send_log` table. */
+export type SendLogRow = {
+  readonly id: number
+  readonly subscriber_id: number | null
+  readonly tick_at: string
+  readonly article_count: number
+  readonly status: SendLogStatus
+  readonly resend_id: string | null
+  readonly error: string | null
+}
+
+const opt = <T>(v: T | null): T | undefined => v ?? undefined
+
+/**
+ * Lift a D1 row into the domain {@link SendLog} type — null → undefined.
+ * @param row Raw row from D1.
+ * @returns Domain object.
+ */
+export const rowToSendLog = (row: SendLogRow): SendLog => ({
+  id: row.id,
+  subscriberId: opt(row.subscriber_id),
+  tickAt: row.tick_at,
+  articleCount: row.article_count,
+  status: row.status,
+  resendId: opt(row.resend_id),
+  error: opt(row.error),
+})

--- a/services/comms-worker/src/send-log/types.ts
+++ b/services/comms-worker/src/send-log/types.ts
@@ -1,0 +1,21 @@
+/** Lifecycle statuses recorded against each per-tick dispatch attempt. */
+export type SendLogStatus =
+  | 'sent'
+  | 'failed'
+  | 'bounced'
+  | 'complained'
+  | 'skipped'
+
+/** Domain representation of a `send_log` row. */
+export type SendLog = {
+  readonly id: number
+  readonly subscriberId: number | undefined
+  readonly tickAt: string
+  readonly articleCount: number
+  readonly status: SendLogStatus
+  readonly resendId: string | undefined
+  readonly error: string | undefined
+}
+
+/** Inputs accepted by the `append` repo call. */
+export type NewSendLog = Omit<SendLog, 'id'>

--- a/services/comms-worker/src/subscribers/repo-write.ts
+++ b/services/comms-worker/src/subscribers/repo-write.ts
@@ -4,6 +4,7 @@ import { langsToJson } from './serialize'
 import type { Lang, Subscriber, SubscriberStatus } from './types'
 
 const SQL_UPDATE_LANGS = 'UPDATE subscribers SET langs = ? WHERE id = ?'
+const SQL_MARK_SENT = 'UPDATE subscribers SET last_sent_at = ? WHERE id = ?'
 const SQL_DELETE = 'DELETE FROM subscribers WHERE id = ?'
 const SQL_UPDATE_STATUS_INACTIVE =
   'UPDATE subscribers SET status = ?, unsubscribed_at = ? WHERE id = ?'
@@ -18,6 +19,15 @@ export const updateLangs = async (
 ): Promise<Subscriber | undefined> => {
   await db.prepare(SQL_UPDATE_LANGS).bind(langsToJson(langs), id).run()
   return findById(db, id)
+}
+
+/** Stamp `last_sent_at` after a successful dispatch send. */
+export const markSent = async (
+  db: D1Database,
+  id: number,
+  sentAtIso: string
+): Promise<void> => {
+  await db.prepare(SQL_MARK_SENT).bind(sentAtIso, id).run()
 }
 
 /** Hard-delete one row by id, returning `true` iff something was deleted. */

--- a/services/comms-worker/src/subscribers/repo.ts
+++ b/services/comms-worker/src/subscribers/repo.ts
@@ -1,7 +1,12 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { insertSubscriber } from './repo-insert'
 import { findById, listActive, listAll } from './repo-read'
-import { removeSubscriber, setStatus, updateLangs } from './repo-write'
+import {
+  markSent,
+  removeSubscriber,
+  setStatus,
+  updateLangs,
+} from './repo-write'
 import type {
   Lang,
   NewSubscriber,
@@ -24,6 +29,7 @@ export type SubscriberRepo = {
     id: number,
     status: SubscriberStatus
   ) => Promise<Subscriber | undefined>
+  readonly markSent: (id: number, sentAtIso: string) => Promise<void>
 }
 
 type Deps = { readonly db: D1Database; readonly now: () => string }
@@ -41,4 +47,5 @@ export const createRepo = (d: Deps): SubscriberRepo => ({
   updateLangs: (id, langs) => updateLangs(d.db, id, langs),
   remove: id => removeSubscriber(d.db, id),
   setStatus: (id, status) => setStatus(d.db, d.now, id, status),
+  markSent: (id, sentAt) => markSent(d.db, id, sentAt),
 })

--- a/services/comms-worker/src/unsubscribe/hmac.ts
+++ b/services/comms-worker/src/unsubscribe/hmac.ts
@@ -1,0 +1,48 @@
+import { base64urlEncode } from '../auth/base64url'
+
+const KEY_USAGE: ReadonlyArray<KeyUsage> = ['sign']
+
+const importHmacKey = (secret: string): Promise<CryptoKey> =>
+  crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    [...KEY_USAGE]
+  )
+
+/**
+ * Compute the base64url HMAC-SHA256 signature of `message` under `secret`.
+ * @param secret Shared secret key.
+ * @param message UTF-8 message bytes.
+ * @returns Base64url-encoded signature.
+ */
+export const hmacSignBase64url = async (
+  secret: string,
+  message: string
+): Promise<string> => {
+  const key = await importHmacKey(secret)
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(message)
+  )
+  return base64urlEncode(sig)
+}
+
+/**
+ * Constant-time string comparison: returns true iff `a` and `b` carry the
+ * same bytes. Always reads the longer string in full so timing leaks no
+ * information about which byte differed.
+ * @param a First string.
+ * @param b Second string.
+ * @returns Whether the strings are byte-equal.
+ */
+export const constantTimeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}

--- a/services/comms-worker/src/unsubscribe/token.test.ts
+++ b/services/comms-worker/src/unsubscribe/token.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { signUnsubscribeToken, verifyUnsubscribeToken } from './token'
+
+const SECRET = 'shhh-very-secret-1234567890abcdef'
+const OTHER = 'a-different-secret-1234567890abcdef'
+
+describe('signUnsubscribeToken', () => {
+  it('produces an <id>.<sig> token of two non-empty parts', async () => {
+    const t = await signUnsubscribeToken(42, SECRET)
+    const parts = t.split('.')
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toBe('42')
+    expect(parts[1]?.length).toBeGreaterThan(0)
+  })
+
+  it('is deterministic for the same (id, secret)', async () => {
+    const a = await signUnsubscribeToken(42, SECRET)
+    const b = await signUnsubscribeToken(42, SECRET)
+    expect(a).toBe(b)
+  })
+
+  it('differs when the id changes', async () => {
+    const a = await signUnsubscribeToken(42, SECRET)
+    const b = await signUnsubscribeToken(43, SECRET)
+    expect(a).not.toBe(b)
+  })
+
+  it('differs when the secret changes', async () => {
+    const a = await signUnsubscribeToken(42, SECRET)
+    const b = await signUnsubscribeToken(42, OTHER)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('verifyUnsubscribeToken', () => {
+  it('round-trips id', async () => {
+    const t = await signUnsubscribeToken(7, SECRET)
+    expect(await verifyUnsubscribeToken(t, SECRET)).toEqual({ id: 7 })
+  })
+
+  it('returns undefined when the secret is wrong', async () => {
+    const t = await signUnsubscribeToken(7, SECRET)
+    expect(await verifyUnsubscribeToken(t, OTHER)).toBeUndefined()
+  })
+
+  it('returns undefined for a tampered signature', async () => {
+    const t = await signUnsubscribeToken(7, SECRET)
+    const [id, sig] = t.split('.')
+    const flipped = `${sig?.[0] === 'a' ? 'b' : 'a'}${sig?.slice(1) ?? ''}`
+    expect(
+      await verifyUnsubscribeToken(`${id}.${flipped}`, SECRET)
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when the embedded id is rewritten', async () => {
+    const t = await signUnsubscribeToken(7, SECRET)
+    const sig = t.split('.')[1]
+    expect(await verifyUnsubscribeToken(`8.${sig}`, SECRET)).toBeUndefined()
+  })
+
+  it('returns undefined for malformed token shapes', async () => {
+    expect(await verifyUnsubscribeToken('', SECRET)).toBeUndefined()
+    expect(await verifyUnsubscribeToken('abc', SECRET)).toBeUndefined()
+    expect(await verifyUnsubscribeToken('1.2.3', SECRET)).toBeUndefined()
+    expect(await verifyUnsubscribeToken('x.sig', SECRET)).toBeUndefined()
+  })
+})

--- a/services/comms-worker/src/unsubscribe/token.ts
+++ b/services/comms-worker/src/unsubscribe/token.ts
@@ -1,0 +1,39 @@
+import { constantTimeEqual, hmacSignBase64url } from './hmac'
+
+const POSITIVE_INT_RE = /^[1-9]\d*$/
+
+/**
+ * Sign an unsubscribe token of the form `<id>.<base64url-sig>` for the
+ * given subscriber id under the worker's `UNSUBSCRIBE_SECRET`.
+ * @param id Subscriber row id.
+ * @param secret Shared secret used by both sign and verify.
+ * @returns Token string suitable for inclusion as a query parameter.
+ */
+export const signUnsubscribeToken = async (
+  id: number,
+  secret: string
+): Promise<string> => {
+  const sig = await hmacSignBase64url(secret, String(id))
+  return `${id}.${sig}`
+}
+
+/**
+ * Verify an unsubscribe token. Returns `{id}` when the embedded id matches
+ * a freshly-recomputed signature under the supplied secret; `undefined`
+ * otherwise. Constant-time signature comparison.
+ * @param token Raw token from the URL `t` parameter.
+ * @param secret Shared secret used to recompute the signature.
+ * @returns `{id}` on success, `undefined` on any failure.
+ */
+export const verifyUnsubscribeToken = async (
+  token: string,
+  secret: string
+): Promise<{ readonly id: number } | undefined> => {
+  const parts = token.split('.')
+  if (parts.length !== 2) return undefined
+  const [rawId, sig] = parts
+  if (rawId === undefined || sig === undefined) return undefined
+  if (!POSITIVE_INT_RE.test(rawId)) return undefined
+  const expected = await hmacSignBase64url(secret, rawId)
+  return constantTimeEqual(expected, sig) ? { id: Number(rawId) } : undefined
+}


### PR DESCRIPTION
## Summary

Stacked on top of [#249 (Stage 2)](https://github.com/communist-prometheus/admin-website/pull/249). Delivers the **Dispatch loop** vertical slice (T3.1–T3.9 of [`tasks.md`](https://github.com/communist-prometheus/admin-website/blob/feat/23-stage-1-comms-crud/specs/comms-newsletter/tasks.md)).

### Worker
- **RSS** (\`src/rss/\`) — \`fetchRss(lang)\` over injectable \`fetch\`; regex parser tolerant of BOM, CDATA, XML entities; \`pubDate\` accepts RFC-822 or ISO-8601; non-2xx degrades to \`[]\` (R3.2).
- **Delta** (\`src/delta/calculator.ts\`) — per-subscriber, cross-lang merged + sorted newest-first (R3.1, R3.3, R3.8).
- **Digest** (\`src/digest/\`) — HTML + text bodies with UTM stamping (\`utm_campaign=YYYY-WW\`), RFC-8058 \`List-Unsubscribe\` headers, in-worker i18n chrome dict for all 7 langs (R3.4, R3.7, R3.8, R4.1). Snapshot tests guard the rendered output.
- **Unsubscribe token** (\`src/unsubscribe/\`) — \`<id>.<sig>\` HMAC-SHA256 via WebCrypto + constant-time compare (R4.5).
- **Resend client** (\`src/resend/\`) — send-only, \`Idempotency-Key=<id>:<tickAt>\` (R3.9), single retry on 429/5xx with \`Retry-After\` honoured (R3.4–R3.6, R6.4).
- **send_log repo** (\`src/send-log/\`) — append/listRecent/purgeOlderThan with retention sweep semantics (R5.4).
- **subscriber repo** (\`src/subscribers/repo-write.ts\`) — adds \`markSent(id, sentAtIso)\`.
- **Dispatch orchestrator** (\`src/dispatch/\`) — pure \`runDispatch({...})\`: load active subs → fetch RSS once per unique lang → delta → digest → Resend → \`markSent\` + \`send_log\` → retention purge.
- **CF \`scheduled()\` entry** — verifies the saved cron matches the tick before dispatching, via the Stage 2 \`matchesTick\` helper (R2.5).
- **\`POST /api/dispatch?force=1\`** — 404 in prod; 202 when \`BYPASS_SCHEDULE=1\` env is set (e2e / dev only).

### Tests
66 new tests across 9 modules, all green:

| Module | Tests | EARS |
|---|---|---|
| \`unsubscribe/token\` | 9 | R4.5 |
| \`rss/parse\` + \`rss/fetch\` | 13 | R3.2 |
| \`delta/calculator\` | 6 | R3.1, R3.3, R3.8 |
| \`digest/utm\` + \`digest/render\` (incl. snapshots) | 13 | R3.4, R3.7, R3.8, R4.1 |
| \`resend/client\` | 7 | R3.4, R3.5, R3.6, R3.9, R6.4 |
| \`send-log/repo\` | 5 | R3.5, R3.6, R5.1, R5.4 |
| \`dispatch/run\` | 6 | R3.1–R3.9, R5.4 |
| \`dispatch/scheduled\` | 3 | R2.5 |
| \`dispatch/force-route\` | 4 | §4.3 (design) |

Worker suite: **132/132 green**.

### Test plan
- [ ] \`bunx vitest run services/comms-worker\` — 132/132 green.
- [ ] \`bun run validate\` — type-check + biome + oxlint + eslint-jsdoc + vue-depth + stylelint all green.
- [ ] Manual smoke against \`wrangler dev\` once secrets are set: cron tick → Resend stub receives one payload per active sub with non-empty delta.

### Out of scope
- Public \`/unsubscribe\` GET/POST surface — T4.1 / Stage 4.
- Resend webhook (\`POST /webhooks/resend\`) — T5.x / Stage 5.
- Admin SPA run-history view — T6.x / Stage 6.
- E2E full-flow Playwright — T7.4 / Stage 7.
- Structured logger boundary (R6.3, R6.5) — T7.1 / Stage 7. \`tick.start\` / \`tick.match\` / \`tick.done\` events from design §12 are not yet emitted; the orchestrator just returns the summary for now.

Refs: tickets#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)