### PR TITLE
feat(comms): tickets#23 stage 4 — public unsubscribe surface

### DIFF
--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -13,10 +13,13 @@ import { mountScheduleRoutes } from './schedule/routes'
 import { createSettingsRepo } from './settings/repo'
 import { createRepo } from './subscribers/repo'
 import { mountSubscriberRoutes } from './subscribers/routes'
+import { mountUnsubscribeRoutes } from './unsubscribe/routes'
+import type { UnsubscribeEnv } from './unsubscribe/runtime-env'
 
 /** Combined worker bindings across all registered routes. */
 export type Bindings = RequireAccessEnv &
-  DispatchEnv & {
+  DispatchEnv &
+  UnsubscribeEnv & {
     readonly VERSION: string
     readonly ADMIN_HOSTNAME: string
     readonly DB: D1Database
@@ -41,6 +44,7 @@ mountScheduleRoutes(
   nowDate
 )
 mountForceDispatchRoute(app)
+mountUnsubscribeRoutes(app)
 
 /** Cloudflare Worker entry — Hono for HTTP, handleScheduled for crons. */
 export default {

--- a/services/comms-worker/src/unsubscribe/accept-language.test.ts
+++ b/services/comms-worker/src/unsubscribe/accept-language.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { pickLang } from './accept-language'
+
+describe('pickLang — supported direct hits', () => {
+  it('returns the single direct lang code when supported', () => {
+    expect(pickLang('ru')).toBe('ru')
+    expect(pickLang('en')).toBe('en')
+    expect(pickLang('it')).toBe('it')
+  })
+
+  it('strips the region tag (ru-RU → ru)', () => {
+    expect(pickLang('ru-RU')).toBe('ru')
+    expect(pickLang('en-US')).toBe('en')
+  })
+})
+
+describe('pickLang — quality-weighted preferences', () => {
+  it('picks the highest-q supported entry', () => {
+    expect(pickLang('fr;q=0.9,ru;q=0.8,en;q=0.1')).toBe('ru')
+  })
+
+  it('respects order when all q values are equal', () => {
+    expect(pickLang('it,es,en')).toBe('it')
+  })
+
+  it('skips entries explicitly suppressed with q=0', () => {
+    expect(pickLang('ru;q=0,en;q=0.5')).toBe('en')
+  })
+
+  it('parses Accept-Language tolerant of whitespace', () => {
+    expect(pickLang(' ru-RU , en ; q=0.5 ')).toBe('ru')
+  })
+})
+
+describe('pickLang — fallbacks', () => {
+  it('falls back to English when nothing supported is offered', () => {
+    expect(pickLang('fr,de;q=0.8')).toBe('en')
+  })
+
+  it('falls back to English when the header is absent or empty', () => {
+    expect(pickLang(undefined)).toBe('en')
+    expect(pickLang('')).toBe('en')
+    expect(pickLang('   ')).toBe('en')
+  })
+
+  it('treats the catch-all "*" as English', () => {
+    expect(pickLang('*')).toBe('en')
+  })
+})

--- a/services/comms-worker/src/unsubscribe/accept-language.ts
+++ b/services/comms-worker/src/unsubscribe/accept-language.ts
@@ -1,0 +1,45 @@
+import { LANGS, type Lang } from '../subscribers/types'
+
+const SUPPORTED = new Set<string>(LANGS)
+const FALLBACK: Lang = 'en'
+
+type Entry = { readonly tag: string; readonly q: number }
+
+const parseEntry = (raw: string, index: number): Entry | undefined => {
+  const trimmed = raw.trim()
+  if (trimmed === '') return undefined
+  const [tagPart, ...params] = trimmed.split(';')
+  const tag = (tagPart ?? '').trim().toLowerCase()
+  if (tag === '') return undefined
+  const qParam = params.map(p => p.trim()).find(p => p.startsWith('q='))
+  const q = qParam === undefined ? 1 : Number(qParam.slice(2))
+  return Number.isFinite(q) && q > 0
+    ? { tag, q: q - index * 1e-6 }
+    : undefined
+}
+
+const baseTag = (tag: string): string => {
+  const dash = tag.indexOf('-')
+  return dash === -1 ? tag : tag.slice(0, dash)
+}
+
+/**
+ * Pick the best-matching supported language from an HTTP
+ * Accept-Language header, falling back to English. Region tags are
+ * stripped (`ru-RU` → `ru`); `q=0` and `*` are treated as opt-outs.
+ * @param header Raw `Accept-Language` value or `undefined`.
+ * @returns One of the supported {@link Lang} codes.
+ */
+export const pickLang = (header: string | undefined): Lang => {
+  if (header === undefined) return FALLBACK
+  const entries = header
+    .split(',')
+    .map(parseEntry)
+    .filter((e): e is Entry => e !== undefined)
+    .sort((a, b) => b.q - a.q)
+  for (const e of entries) {
+    const base = baseTag(e.tag)
+    if (SUPPORTED.has(base)) return base as Lang
+  }
+  return FALLBACK
+}

--- a/services/comms-worker/src/unsubscribe/confirmation.test.ts
+++ b/services/comms-worker/src/unsubscribe/confirmation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { renderExpiredPage, renderUnsubscribedPage } from './confirmation'
+
+describe('renderUnsubscribedPage', () => {
+  it('returns a full HTML5 document with the lang attribute set', () => {
+    const html = renderUnsubscribedPage('en')
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(html).toMatch(/<html lang="en">/)
+  })
+
+  it('uses the English chrome by default', () => {
+    const html = renderUnsubscribedPage('en')
+    expect(html).toContain('You have been unsubscribed')
+    expect(html).toContain('mailto:public@comprom.org')
+  })
+
+  it('switches to Russian chrome when requested', () => {
+    const html = renderUnsubscribedPage('ru')
+    expect(html).toContain('Вы отписаны')
+    expect(html).toMatch(/<html lang="ru">/)
+  })
+
+  it('switches to Italian chrome when requested', () => {
+    const html = renderUnsubscribedPage('it')
+    expect(html).toContain('Sei stato disiscritto')
+  })
+
+  it('does not contain raw script tags (no XSS injection vectors)', () => {
+    const html = renderUnsubscribedPage('en')
+    expect(html).not.toMatch(/<script\b/i)
+  })
+})
+
+describe('renderExpiredPage', () => {
+  it('returns a localised "link expired" page in the requested lang', () => {
+    const en = renderExpiredPage('en')
+    expect(en).toContain('This link has expired')
+    expect(en).toMatch(/<html lang="en">/)
+    const ru = renderExpiredPage('ru')
+    expect(ru).toContain('недействительна')
+    expect(ru).toMatch(/<html lang="ru">/)
+  })
+
+  it('still surfaces the public mailto for support', () => {
+    expect(renderExpiredPage('en')).toContain('mailto:public@comprom.org')
+  })
+})

--- a/services/comms-worker/src/unsubscribe/confirmation.ts
+++ b/services/comms-worker/src/unsubscribe/confirmation.ts
@@ -1,0 +1,55 @@
+import { htmlEscape } from '../digest/escape'
+import type { Lang } from '../subscribers/types'
+import {
+  CONFIRMATION,
+  type ConfirmationChrome,
+  RE_SUBSCRIBE_MAILTO,
+} from './i18n'
+
+const STYLE =
+  '<style>body{font-family:system-ui,Segoe UI,sans-serif;' +
+  'max-width:32rem;margin:3rem auto;padding:0 1rem;' +
+  'color:#222;line-height:1.5}h1{font-size:1.5rem;margin-bottom:0.5rem}' +
+  '.cta{display:inline-block;margin-top:1.25rem;padding:0.5rem 0.9rem;' +
+  'border:1px solid currentColor;border-radius:0.375rem;' +
+  'text-decoration:none;color:inherit}</style>'
+
+const renderPage = (
+  lang: Lang,
+  c: ConfirmationChrome,
+  heading: string,
+  body: string
+): string =>
+  [
+    '<!DOCTYPE html>',
+    `<html lang="${lang}"><head>`,
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width,initial-scale=1" />',
+    `<title>${htmlEscape(c.title)}</title>`,
+    STYLE,
+    '</head><body>',
+    `<h1>${htmlEscape(heading)}</h1>`,
+    `<p>${htmlEscape(body)}</p>`,
+    `<a class="cta" href="${RE_SUBSCRIBE_MAILTO}">${htmlEscape(c.reSubscribeLabel)}</a>`,
+    '</body></html>',
+  ].join('')
+
+/**
+ * Render the success confirmation page shown after a token validates.
+ * @param lang Lang code chosen from Accept-Language by the route handler.
+ * @returns Full HTML document body.
+ */
+export const renderUnsubscribedPage = (lang: Lang): string => {
+  const c = CONFIRMATION[lang]
+  return renderPage(lang, c, c.unsubscribedHeading, c.unsubscribedBody)
+}
+
+/**
+ * Render the generic 404 page for invalid / tampered tokens (R4.5).
+ * @param lang Lang code chosen from Accept-Language.
+ * @returns Full HTML document body.
+ */
+export const renderExpiredPage = (lang: Lang): string => {
+  const c = CONFIRMATION[lang]
+  return renderPage(lang, c, c.expiredHeading, c.expiredBody)
+}

--- a/services/comms-worker/src/unsubscribe/handler.ts
+++ b/services/comms-worker/src/unsubscribe/handler.ts
@@ -1,0 +1,32 @@
+import type { SubscriberRepo } from '../subscribers/repo'
+import { verifyUnsubscribeToken } from './token'
+
+/** Outcomes of the public unsubscribe verify+flip pipeline. */
+export type UnsubscribeOutcome =
+  | { readonly kind: 'unsubscribed' }
+  | { readonly kind: 'already' }
+  | { readonly kind: 'invalid' }
+
+/**
+ * Verify the token, look up the subscriber, and (only when active)
+ * flip status to `unsubscribed`. Already-unsubscribed rows return
+ * `already` so the route can keep its 200-idempotent contract (R4.4).
+ * @param repo Subscriber repo bound to the current request's D1.
+ * @param secret Shared UNSUBSCRIBE_SECRET used to verify the token.
+ * @param token Raw `t` query parameter, possibly undefined.
+ * @returns Discriminated outcome consumed by the route renderer.
+ */
+export const verifyAndFlip = async (
+  repo: SubscriberRepo,
+  secret: string,
+  token: string | undefined
+): Promise<UnsubscribeOutcome> => {
+  if (token === undefined || token === '') return { kind: 'invalid' }
+  const verified = await verifyUnsubscribeToken(token, secret)
+  if (verified === undefined) return { kind: 'invalid' }
+  const found = await repo.findById(verified.id)
+  if (found === undefined) return { kind: 'invalid' }
+  if (found.status !== 'active') return { kind: 'already' }
+  await repo.setStatus(verified.id, 'unsubscribed')
+  return { kind: 'unsubscribed' }
+}

--- a/services/comms-worker/src/unsubscribe/i18n-cyrillic.ts
+++ b/services/comms-worker/src/unsubscribe/i18n-cyrillic.ts
@@ -1,0 +1,37 @@
+import type { ConfirmationChrome } from './i18n-types'
+
+/** Russian confirmation chrome (ru). */
+export const CONF_RU: ConfirmationChrome = {
+  title: 'Отписка — Коммунистический Прометей',
+  unsubscribedHeading: 'Вы отписаны',
+  unsubscribedBody:
+    'Вы больше не будете получать рассылку Коммунистического Прометея на этот адрес.',
+  reSubscribeLabel: 'Подписаться снова по почте',
+  expiredHeading: 'Эта ссылка больше недействительна',
+  expiredBody:
+    'Ссылка для отписки устарела. Если вы всё ещё хотите отписаться, свяжитесь с нами.',
+}
+
+/** Ukrainian confirmation chrome (uk). */
+export const CONF_UK: ConfirmationChrome = {
+  title: 'Скасовано — Комуністичний Прометей',
+  unsubscribedHeading: 'Ви відписалися',
+  unsubscribedBody:
+    'Ви більше не отримуватимете розсилку Комуністичного Прометея на цю адресу.',
+  reSubscribeLabel: 'Підписатися знову електронною поштою',
+  expiredHeading: 'Це посилання більше не дійсне',
+  expiredBody:
+    'Посилання для відписки застаріло. Якщо ви все ще хочете відписатися, зв’яжіться з нами.',
+}
+
+/** Belarusian confirmation chrome (bl). */
+export const CONF_BL: ConfirmationChrome = {
+  title: 'Адпіска — Камуністычны Праметэй',
+  unsubscribedHeading: 'Вы адпісаныя',
+  unsubscribedBody:
+    'Вы больш не атрымаеце рассылку Камуністычнага Праметэя на гэты адрас.',
+  reSubscribeLabel: 'Падпісацца зноў па пошце',
+  expiredHeading: 'Гэтая спасылка больш не дзейнічае',
+  expiredBody:
+    'Спасылка для адпіскі састарэла. Калі вы ўсё яшчэ хочаце адпісацца, звяжыцеся з намі.',
+}

--- a/services/comms-worker/src/unsubscribe/i18n-latin.ts
+++ b/services/comms-worker/src/unsubscribe/i18n-latin.ts
@@ -1,0 +1,49 @@
+import type { ConfirmationChrome } from './i18n-types'
+
+/** English confirmation chrome (en). */
+export const CONF_EN: ConfirmationChrome = {
+  title: 'Unsubscribed — Communist Prometheus',
+  unsubscribedHeading: 'You have been unsubscribed',
+  unsubscribedBody:
+    'You will no longer receive the Communist Prometheus newsletter at this address.',
+  reSubscribeLabel: 'Re-subscribe by email',
+  expiredHeading: 'This link has expired',
+  expiredBody:
+    'The unsubscribe link is no longer valid. If you still want to unsubscribe, contact us.',
+}
+
+/** Italian confirmation chrome (it). */
+export const CONF_IT: ConfirmationChrome = {
+  title: 'Disiscritto — Prometeo Comunista',
+  unsubscribedHeading: 'Sei stato disiscritto',
+  unsubscribedBody:
+    'Non riceverai più la newsletter di Prometeo Comunista a questo indirizzo.',
+  reSubscribeLabel: 'Iscriviti di nuovo via email',
+  expiredHeading: 'Questo link è scaduto',
+  expiredBody:
+    'Il link di disiscrizione non è più valido. Se vuoi ancora disiscriverti, contattaci.',
+}
+
+/** Spanish confirmation chrome (es). */
+export const CONF_ES: ConfirmationChrome = {
+  title: 'Cancelado — Prometeo Comunista',
+  unsubscribedHeading: 'Te has dado de baja',
+  unsubscribedBody:
+    'Ya no recibirás el boletín de Prometeo Comunista en esta dirección.',
+  reSubscribeLabel: 'Volver a suscribirse por correo',
+  expiredHeading: 'Este enlace ha caducado',
+  expiredBody:
+    'El enlace de cancelación ya no es válido. Si todavía deseas cancelarte, contáctanos.',
+}
+
+/** Polish confirmation chrome (pl). */
+export const CONF_PL: ConfirmationChrome = {
+  title: 'Wypisano — Komunistyczny Prometeusz',
+  unsubscribedHeading: 'Zostałeś wypisany',
+  unsubscribedBody:
+    'Nie będziesz już otrzymywać newslettera Komunistycznego Prometeusza pod tym adresem.',
+  reSubscribeLabel: 'Zapisz się ponownie przez e-mail',
+  expiredHeading: 'Ten link wygasł',
+  expiredBody:
+    'Link do wypisania się jest już nieważny. Jeśli nadal chcesz się wypisać, skontaktuj się z nami.',
+}

--- a/services/comms-worker/src/unsubscribe/i18n-types.ts
+++ b/services/comms-worker/src/unsubscribe/i18n-types.ts
@@ -1,0 +1,9 @@
+/** Localised chrome strings for the public unsubscribe surface. */
+export type ConfirmationChrome = {
+  readonly title: string
+  readonly unsubscribedHeading: string
+  readonly unsubscribedBody: string
+  readonly reSubscribeLabel: string
+  readonly expiredHeading: string
+  readonly expiredBody: string
+}

--- a/services/comms-worker/src/unsubscribe/i18n.ts
+++ b/services/comms-worker/src/unsubscribe/i18n.ts
@@ -1,0 +1,20 @@
+import type { Lang } from '../subscribers/types'
+import { CONF_BL, CONF_RU, CONF_UK } from './i18n-cyrillic'
+import { CONF_EN, CONF_ES, CONF_IT, CONF_PL } from './i18n-latin'
+import type { ConfirmationChrome } from './i18n-types'
+
+export type { ConfirmationChrome } from './i18n-types'
+
+/** In-worker dictionary for the public unsubscribe surface. */
+export const CONFIRMATION: Readonly<Record<Lang, ConfirmationChrome>> = {
+  en: CONF_EN,
+  ru: CONF_RU,
+  it: CONF_IT,
+  es: CONF_ES,
+  uk: CONF_UK,
+  pl: CONF_PL,
+  bl: CONF_BL,
+}
+
+/** Shared mailto target used by every confirmation page. */
+export const RE_SUBSCRIBE_MAILTO = 'mailto:public@comprom.org'

--- a/services/comms-worker/src/unsubscribe/routes.test.ts
+++ b/services/comms-worker/src/unsubscribe/routes.test.ts
@@ -1,0 +1,155 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createRepo, type SubscriberRepo } from '../subscribers/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { mountUnsubscribeRoutes, type UnsubscribeEnv } from './routes'
+import { signUnsubscribeToken } from './token'
+
+const SECRET = 'shhh-secret-1234567890abcdef'
+
+let db: D1Database
+let subs: SubscriberRepo
+let app: Hono<{ Bindings: UnsubscribeEnv }>
+
+const seedActive = async (email: string): Promise<number> => {
+  const s = await subs.insert({ email, langs: ['ru'] })
+  return s.id
+}
+
+beforeEach(() => {
+  db = makeTestD1()
+  subs = createRepo({ db, now: () => '2026-05-01T00:00:00.000Z' })
+  app = new Hono<{ Bindings: UnsubscribeEnv }>()
+  mountUnsubscribeRoutes(app)
+})
+
+const env: UnsubscribeEnv = (() => {
+  const proxy = { UNSUBSCRIBE_SECRET: SECRET } as UnsubscribeEnv & {
+    DB: D1Database
+  }
+  return proxy as UnsubscribeEnv
+})()
+
+const bindEnv = (): UnsubscribeEnv =>
+  ({
+    DB: db,
+    UNSUBSCRIBE_SECRET: SECRET,
+  }) as UnsubscribeEnv
+
+describe('GET /unsubscribe', () => {
+  it('returns 404 with the expired page when the token is missing', async () => {
+    const res = await app.fetch(
+      new Request('http://x/unsubscribe'),
+      bindEnv()
+    )
+    expect(res.status).toBe(404)
+    expect(res.headers.get('Content-Type')).toMatch(/^text\/html/)
+    expect(await res.text()).toContain('expired')
+  })
+
+  it('returns 404 with the expired page when the token is tampered', async () => {
+    await seedActive('a@b.c')
+    const res = await app.fetch(
+      new Request('http://x/unsubscribe?t=42.tampered'),
+      bindEnv()
+    )
+    expect(res.status).toBe(404)
+    expect(await res.text()).toContain('expired')
+  })
+
+  it('returns 404 when the token validates but the subscriber is unknown', async () => {
+    const ghostToken = await signUnsubscribeToken(999, SECRET)
+    const res = await app.fetch(
+      new Request(`http://x/unsubscribe?t=${ghostToken}`),
+      bindEnv()
+    )
+    expect(res.status).toBe(404)
+    expect(await res.text()).toContain('expired')
+  })
+
+  it('flips status to unsubscribed + stamps unsubscribed_at on a valid GET', async () => {
+    const id = await seedActive('a@b.c')
+    const token = await signUnsubscribeToken(id, SECRET)
+    const res = await app.fetch(
+      new Request(`http://x/unsubscribe?t=${token}`),
+      bindEnv()
+    )
+    expect(res.status).toBe(200)
+    expect(await res.text()).toContain('unsubscribed')
+    const after = await subs.findById(id)
+    expect(after?.status).toBe('unsubscribed')
+    expect(after?.unsubscribedAt).toBeDefined()
+  })
+
+  it('is idempotent for an already-unsubscribed row (200, no state churn)', async () => {
+    const id = await seedActive('a@b.c')
+    await subs.setStatus(id, 'unsubscribed')
+    const before = (await subs.findById(id))?.unsubscribedAt
+    const token = await signUnsubscribeToken(id, SECRET)
+    const res = await app.fetch(
+      new Request(`http://x/unsubscribe?t=${token}`),
+      bindEnv()
+    )
+    expect(res.status).toBe(200)
+    const after = await subs.findById(id)
+    expect(after?.status).toBe('unsubscribed')
+    expect(after?.unsubscribedAt).toBe(before)
+  })
+
+  it('honours Accept-Language for the rendered confirmation', async () => {
+    const id = await seedActive('a@b.c')
+    const token = await signUnsubscribeToken(id, SECRET)
+    const res = await app.fetch(
+      new Request(`http://x/unsubscribe?t=${token}`, {
+        headers: { 'Accept-Language': 'ru-RU,ru;q=0.9,en;q=0.5' },
+      }),
+      bindEnv()
+    )
+    const body = await res.text()
+    expect(body).toMatch(/<html lang="ru">/)
+    expect(body).toContain('Вы отписаны')
+  })
+})
+
+describe('POST /unsubscribe (RFC 8058 one-click)', () => {
+  it('returns 200 with empty body on a valid token', async () => {
+    const id = await seedActive('a@b.c')
+    const token = await signUnsubscribeToken(id, SECRET)
+    const res = await app.fetch(
+      new Request(`http://x/unsubscribe?t=${token}`, { method: 'POST' }),
+      bindEnv()
+    )
+    expect(res.status).toBe(200)
+    expect((await res.text()).length).toBe(0)
+    const after = await subs.findById(id)
+    expect(after?.status).toBe('unsubscribed')
+  })
+
+  it('returns 404 on a tampered token, no mutation', async () => {
+    const id = await seedActive('a@b.c')
+    const res = await app.fetch(
+      new Request('http://x/unsubscribe?t=42.bogus', { method: 'POST' }),
+      bindEnv()
+    )
+    expect(res.status).toBe(404)
+    const after = await subs.findById(id)
+    expect(after?.status).toBe('active')
+  })
+
+  it('is idempotent on a second one-click (still 200)', async () => {
+    const id = await seedActive('a@b.c')
+    const token = await signUnsubscribeToken(id, SECRET)
+    await app.fetch(
+      new Request(`http://x/unsubscribe?t=${token}`, { method: 'POST' }),
+      bindEnv()
+    )
+    const res = await app.fetch(
+      new Request(`http://x/unsubscribe?t=${token}`, { method: 'POST' }),
+      bindEnv()
+    )
+    expect(res.status).toBe(200)
+  })
+})
+
+void env

--- a/services/comms-worker/src/unsubscribe/routes.ts
+++ b/services/comms-worker/src/unsubscribe/routes.ts
@@ -1,0 +1,55 @@
+import type { Context, Hono } from 'hono'
+import { createRepo } from '../subscribers/repo'
+import { pickLang } from './accept-language'
+import { renderExpiredPage, renderUnsubscribedPage } from './confirmation'
+import { verifyAndFlip } from './handler'
+import type { UnsubscribeEnv } from './runtime-env'
+
+export type { UnsubscribeEnv } from './runtime-env'
+
+type App = Hono<{ Bindings: UnsubscribeEnv }>
+
+const HTML_HEADERS = {
+  'Content-Type': 'text/html; charset=utf-8',
+}
+
+const runVerify = (c: Context) => {
+  const env = c.env as UnsubscribeEnv
+  const repo = createRepo({
+    db: env.DB,
+    now: () => new Date().toISOString(),
+  })
+  return verifyAndFlip(repo, env.UNSUBSCRIBE_SECRET, c.req.query('t'))
+}
+
+const handleGet = async (c: Context): Promise<Response> => {
+  const lang = pickLang(c.req.header('Accept-Language'))
+  const outcome = await runVerify(c)
+  return outcome.kind === 'invalid'
+    ? new Response(renderExpiredPage(lang), {
+        status: 404,
+        headers: HTML_HEADERS,
+      })
+    : new Response(renderUnsubscribedPage(lang), {
+        status: 200,
+        headers: HTML_HEADERS,
+      })
+}
+
+const handlePost = async (c: Context): Promise<Response> => {
+  const outcome = await runVerify(c)
+  return outcome.kind === 'invalid' ? c.body(null, 404) : c.body(null, 200)
+}
+
+/**
+ * Mount the public unsubscribe surface: GET renders an HTML
+ * confirmation in the visitor's preferred language, POST honours
+ * the RFC-8058 one-click contract with a 200 empty body.
+ * @param app Hono app instance (no CF Access middleware on this prefix).
+ * @returns The same app for chaining.
+ */
+export const mountUnsubscribeRoutes = (app: App): App => {
+  app.get('/unsubscribe', handleGet)
+  app.post('/unsubscribe', handlePost)
+  return app
+}

--- a/services/comms-worker/src/unsubscribe/runtime-env.ts
+++ b/services/comms-worker/src/unsubscribe/runtime-env.ts
@@ -1,0 +1,7 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+/** Bindings + secrets required by the public unsubscribe routes. */
+export type UnsubscribeEnv = {
+  readonly DB: D1Database
+  readonly UNSUBSCRIBE_SECRET: string
+}


### PR DESCRIPTION
## Summary

Stacked on top of [#250 (Stage 3)](https://github.com/communist-prometheus/admin-website/pull/250). Delivers the **public unsubscribe surface** (T4.1 of [\`tasks.md\`](https://github.com/communist-prometheus/admin-website/blob/feat/23-stage-1-comms-crud/specs/comms-newsletter/tasks.md)).

### Worker
- \`unsubscribe/accept-language.ts\` — quality-weighted Accept-Language parser. Strips region tags (\`ru-RU\` → \`ru\`), respects \`q=\` weights, treats \`q=0\` and \`*\` as opt-outs, falls back to English when nothing supported is offered.
- \`unsubscribe/confirmation.ts\` + \`i18n.ts\` + \`i18n-types.ts\` + \`i18n-cyrillic.ts\` + \`i18n-latin.ts\` — two pages (success + "link expired") rendered as full HTML5 documents with the visitor's \`<html lang>\` set; chrome localised in all 7 supported languages, shared \`mailto:public@comprom.org\` CTA.
- \`unsubscribe/handler.ts\` — \`verifyAndFlip(repo, secret, t)\`: HMAC verify, look up, flip \`status='unsubscribed'\` only when active, idempotent for already-unsubscribed rows (R4.4).
- \`unsubscribe/routes.ts\` — \`GET /unsubscribe?t=\` renders confirmation in Accept-Language pick (R4.2); 404 with the expired page on tampered / missing / unknown-id tokens (R4.5). \`POST /unsubscribe?t=\` honours the RFC-8058 one-click contract — 200 empty body on success, 404 empty body on bad token (R4.3).
- \`unsubscribe/runtime-env.ts\` — bindings type sliced from the full worker \`Bindings\`.
- \`src/index.ts\` — mount public routes **outside** the \`/api/*\` CF Access middleware (matches design §9.3 step 4 bypass policy); worker \`Bindings\` type now includes \`UnsubscribeEnv\`.

### Tests
25 new tests, 157/157 worker green:

| Module | Tests | EARS |
|---|---|---|
| \`accept-language\` | 9 | R4.2 |
| \`confirmation\` renderer | 7 | R4.2, R4.5 |
| \`routes\` (GET ×6, POST ×3) | 9 | R4.2, R4.3, R4.4, R4.5 |

### Test plan
- [ ] \`bunx vitest run services/comms-worker\` — 157/157 green.
- [ ] \`bun run validate\` — type-check + biome + oxlint + eslint-jsdoc + vue-depth + stylelint all green.
- [ ] Manual smoke against \`wrangler dev\`: forge an unsubscribe URL with \`signUnsubscribeToken\` → GET renders the right-lang confirmation; POST returns 200 empty; second POST still 200 (idempotent); tampered token returns 404.

### Out of scope
- Resend webhook (\`POST /webhooks/resend\`) — T5.x / Stage 5.
- Admin SPA run-history view — T6.x / Stage 6.
- E2E full-flow Playwright — T7.4 / Stage 7.
- Structured \`severity=warn\` logging on R4.5 failures — folded into the Stage 7 structured logger (T7.1) so we don't pre-pin the log shape.

Refs: tickets#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)