### PR TITLE
feat(comms): tickets#23 stage 5 — Resend webhook + bounce gating

### DIFF
--- a/services/comms-worker/src/bindings.ts
+++ b/services/comms-worker/src/bindings.ts
@@ -1,0 +1,22 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import type { AccessClaims } from './auth/cf-access'
+import type { DispatchEnv } from './dispatch/runtime-env'
+import type { RequireAccessEnv } from './middleware/require-access'
+import type { UnsubscribeEnv } from './unsubscribe/runtime-env'
+import type { WebhookEnv } from './webhooks/runtime-env'
+
+/** Combined worker bindings across all registered routes. */
+export type Bindings = RequireAccessEnv &
+  DispatchEnv &
+  UnsubscribeEnv &
+  WebhookEnv & {
+    readonly VERSION: string
+    readonly ADMIN_HOSTNAME: string
+    readonly DB: D1Database
+  }
+
+/** Per-request Hono variables exposed by the access middleware. */
+export type Vars = { readonly access: AccessClaims }
+
+/** Convenience alias used by every Hono mount helper. */
+export type WorkerCtx = { Bindings: Bindings; Variables: Vars }

--- a/services/comms-worker/src/dispatch/run.test.ts
+++ b/services/comms-worker/src/dispatch/run.test.ts
@@ -168,6 +168,32 @@ describe('runDispatch — Resend failure', () => {
   })
 })
 
+describe('runDispatch — skips bounced / complained (R4.6, R4.7)', () => {
+  it('does not send to subscribers whose status is bounced', async () => {
+    const s = await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await subs.setStatus(s.id, 'bounced')
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-05T00:00:00.000Z' })],
+    })
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    const summary = await runDispatch(baseDeps(rss.fn, resend.client))
+    expect(summary).toMatchObject({ sent: 0, failed: 0, skipped: 0 })
+    expect(resend.sends).toHaveLength(0)
+  })
+
+  it('does not send to subscribers whose status is complained', async () => {
+    const s = await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await subs.setStatus(s.id, 'complained')
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-05T00:00:00.000Z' })],
+    })
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    const summary = await runDispatch(baseDeps(rss.fn, resend.client))
+    expect(summary).toMatchObject({ sent: 0, failed: 0, skipped: 0 })
+    expect(resend.sends).toHaveLength(0)
+  })
+})
+
 describe('runDispatch — retention sweep', () => {
   it('purges send_log rows older than the retention window after the dispatch', async () => {
     const s = await subs.insert({ email: 'a@b.c', langs: ['ru'] })

--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -1,32 +1,18 @@
-import type { D1Database, ScheduledEvent } from '@cloudflare/workers-types'
+import type { ScheduledEvent } from '@cloudflare/workers-types'
 import { Hono } from 'hono'
-import type { AccessClaims } from './auth/cf-access'
+import type { Bindings, WorkerCtx } from './bindings'
 import { mountForceDispatchRoute } from './dispatch/force-route'
-import type { DispatchEnv } from './dispatch/runtime-env'
 import { handleScheduled } from './dispatch/scheduled'
 import { registerHealthRoute } from './health'
-import {
-  type RequireAccessEnv,
-  requireAccess,
-} from './middleware/require-access'
+import { requireAccess } from './middleware/require-access'
 import { mountScheduleRoutes } from './schedule/routes'
 import { createSettingsRepo } from './settings/repo'
 import { createRepo } from './subscribers/repo'
 import { mountSubscriberRoutes } from './subscribers/routes'
 import { mountUnsubscribeRoutes } from './unsubscribe/routes'
-import type { UnsubscribeEnv } from './unsubscribe/runtime-env'
+import { mountWebhookRoutes } from './webhooks/routes'
 
-/** Combined worker bindings across all registered routes. */
-export type Bindings = RequireAccessEnv &
-  DispatchEnv &
-  UnsubscribeEnv & {
-    readonly VERSION: string
-    readonly ADMIN_HOSTNAME: string
-    readonly DB: D1Database
-  }
-
-type Vars = { readonly access: AccessClaims }
-type WorkerCtx = { Bindings: Bindings; Variables: Vars }
+export type { Bindings } from './bindings'
 
 const nowIso = (): string => new Date().toISOString()
 const nowDate = (): Date => new Date()
@@ -45,6 +31,7 @@ mountScheduleRoutes(
 )
 mountForceDispatchRoute(app)
 mountUnsubscribeRoutes(app)
+mountWebhookRoutes(app)
 
 /** Cloudflare Worker entry — Hono for HTTP, handleScheduled for crons. */
 export default {

--- a/services/comms-worker/src/send-log/repo-impl.ts
+++ b/services/comms-worker/src/send-log/repo-impl.ts
@@ -1,0 +1,59 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { rowToSendLog, type SendLogRow } from './serialize'
+import type { NewSendLog, SendLog } from './types'
+
+const SQL_INSERT =
+  'INSERT INTO send_log (subscriber_id, tick_at, article_count, status, resend_id, error) ' +
+  'VALUES (?, ?, ?, ?, ?, ?)'
+const SQL_LIST =
+  'SELECT * FROM send_log ORDER BY tick_at DESC, id DESC LIMIT ?'
+const SQL_PURGE = 'DELETE FROM send_log WHERE tick_at < ?'
+const SQL_BY_RESEND_ID = 'SELECT * FROM send_log WHERE resend_id = ? LIMIT 1'
+
+/** Insert one log row. */
+export const append = async (
+  db: D1Database,
+  row: NewSendLog
+): Promise<void> => {
+  await db
+    .prepare(SQL_INSERT)
+    .bind(
+      row.subscriberId ?? null,
+      row.tickAt,
+      row.articleCount,
+      row.status,
+      row.resendId ?? null,
+      row.error ?? null
+    )
+    .run()
+}
+
+/** Return the most-recent N rows newest tick first. */
+export const listRecent = async (
+  db: D1Database,
+  limit: number
+): Promise<ReadonlyArray<SendLog>> => {
+  const r = await db.prepare(SQL_LIST).bind(limit).all<SendLogRow>()
+  return (r.results ?? []).map(rowToSendLog)
+}
+
+/** Delete rows older than the cutoff; returns rows-affected. */
+export const purgeOlderThan = async (
+  db: D1Database,
+  cutoffIsoUtc: string
+): Promise<number> => {
+  const r = await db.prepare(SQL_PURGE).bind(cutoffIsoUtc).run()
+  return r.meta.changes
+}
+
+/** Look up the (most-recent) row carrying a given Resend message id. */
+export const findByResendId = async (
+  db: D1Database,
+  resendId: string
+): Promise<SendLog | undefined> => {
+  const row = (await db
+    .prepare(SQL_BY_RESEND_ID)
+    .bind(resendId)
+    .first()) as SendLogRow | null
+  return row === null ? undefined : rowToSendLog(row)
+}

--- a/services/comms-worker/src/send-log/repo.test.ts
+++ b/services/comms-worker/src/send-log/repo.test.ts
@@ -91,6 +91,27 @@ describe('SendLogRepo.append + listRecent', () => {
   })
 })
 
+describe('SendLogRepo.findByResendId', () => {
+  it('returns the row carrying a known resend id', async () => {
+    await seedSubscribers([1, 2])
+    await repo.append({
+      subscriberId: 1,
+      tickAt: '2026-06-06T09:00:00.000Z',
+      articleCount: 1,
+      status: 'sent',
+      resendId: 're_known',
+      error: undefined,
+    })
+    const found = await repo.findByResendId('re_known')
+    expect(found?.subscriberId).toBe(1)
+    expect(found?.status).toBe('sent')
+  })
+
+  it('returns undefined when the resend id is unknown', async () => {
+    expect(await repo.findByResendId('re_ghost')).toBeUndefined()
+  })
+})
+
 describe('SendLogRepo.purgeOlderThan', () => {
   it('deletes only rows whose tick_at is older than the cutoff', async () => {
     await seedSubscribers([1, 2])

--- a/services/comms-worker/src/send-log/repo.ts
+++ b/services/comms-worker/src/send-log/repo.ts
@@ -1,5 +1,10 @@
 import type { D1Database } from '@cloudflare/workers-types'
-import { rowToSendLog, type SendLogRow } from './serialize'
+import {
+  append,
+  findByResendId,
+  listRecent,
+  purgeOlderThan,
+} from './repo-impl'
 import type { NewSendLog, SendLog } from './types'
 
 /** Repo facade for the `send_log` table. */
@@ -7,46 +12,10 @@ export type SendLogRepo = {
   readonly append: (row: NewSendLog) => Promise<void>
   readonly listRecent: (limit: number) => Promise<ReadonlyArray<SendLog>>
   readonly purgeOlderThan: (cutoffIsoUtc: string) => Promise<number>
+  readonly findByResendId: (resendId: string) => Promise<SendLog | undefined>
 }
 
 type Deps = { readonly db: D1Database }
-
-const SQL_INSERT =
-  'INSERT INTO send_log (subscriber_id, tick_at, article_count, status, resend_id, error) ' +
-  'VALUES (?, ?, ?, ?, ?, ?)'
-const SQL_LIST =
-  'SELECT * FROM send_log ORDER BY tick_at DESC, id DESC LIMIT ?'
-const SQL_PURGE = 'DELETE FROM send_log WHERE tick_at < ?'
-
-const append = async (db: D1Database, row: NewSendLog): Promise<void> => {
-  await db
-    .prepare(SQL_INSERT)
-    .bind(
-      row.subscriberId ?? null,
-      row.tickAt,
-      row.articleCount,
-      row.status,
-      row.resendId ?? null,
-      row.error ?? null
-    )
-    .run()
-}
-
-const listRecent = async (
-  db: D1Database,
-  limit: number
-): Promise<ReadonlyArray<SendLog>> => {
-  const r = await db.prepare(SQL_LIST).bind(limit).all<SendLogRow>()
-  return (r.results ?? []).map(rowToSendLog)
-}
-
-const purgeOlderThan = async (
-  db: D1Database,
-  cutoffIsoUtc: string
-): Promise<number> => {
-  const r = await db.prepare(SQL_PURGE).bind(cutoffIsoUtc).run()
-  return r.meta.changes
-}
 
 /**
  * Build a `send_log` repo bound to the given D1 database.
@@ -57,4 +26,5 @@ export const createSendLogRepo = (d: Deps): SendLogRepo => ({
   append: row => append(d.db, row),
   listRecent: limit => listRecent(d.db, limit),
   purgeOlderThan: cutoff => purgeOlderThan(d.db, cutoff),
+  findByResendId: resendId => findByResendId(d.db, resendId),
 })

--- a/services/comms-worker/src/webhooks/handler.ts
+++ b/services/comms-worker/src/webhooks/handler.ts
@@ -1,0 +1,51 @@
+import type { SendLogRepo } from '../send-log/repo'
+import type { SendLogStatus } from '../send-log/types'
+import type { SubscriberRepo } from '../subscribers/repo'
+import type { SubscriberStatus } from '../subscribers/types'
+
+const STATUS_MAP: Readonly<
+  Record<string, { sub: SubscriberStatus; log: SendLogStatus } | undefined>
+> = {
+  'email.bounced': { sub: 'bounced', log: 'bounced' },
+  'email.delivery_delayed': { sub: 'bounced', log: 'bounced' },
+  'email.complained': { sub: 'complained', log: 'complained' },
+}
+
+/** Minimum shape we read from the Resend event body. */
+export type ResendEvent = {
+  readonly type: string
+  readonly data?: { readonly email_id?: string }
+}
+
+const tickIso = (): string => new Date().toISOString()
+
+/**
+ * Apply a verified Resend webhook event: look the original send up by
+ * its Resend id, flip the subscriber status and append a marker log
+ * row. No-ops for unsupported event types or unknown ids (idempotent).
+ * @param subs Subscriber repo.
+ * @param log Send-log repo.
+ * @param event Parsed event body.
+ * @returns Nothing — side effects only.
+ */
+export const applyResendEvent = async (
+  subs: SubscriberRepo,
+  log: SendLogRepo,
+  event: ResendEvent
+): Promise<void> => {
+  const mapped = STATUS_MAP[event.type]
+  if (mapped === undefined) return
+  const resendId = event.data?.email_id
+  if (resendId === undefined || resendId === '') return
+  const original = await log.findByResendId(resendId)
+  if (original?.subscriberId === undefined) return
+  await subs.setStatus(original.subscriberId, mapped.sub)
+  await log.append({
+    subscriberId: original.subscriberId,
+    tickAt: tickIso(),
+    articleCount: 0,
+    status: mapped.log,
+    resendId,
+    error: undefined,
+  })
+}

--- a/services/comms-worker/src/webhooks/hmac-bytes.ts
+++ b/services/comms-worker/src/webhooks/hmac-bytes.ts
@@ -1,0 +1,52 @@
+const KEY_USAGE: ReadonlyArray<KeyUsage> = ['sign']
+
+const importHmacKey = (secretBytes: Uint8Array): Promise<CryptoKey> =>
+  crypto.subtle.importKey(
+    'raw',
+    secretBytes,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    [...KEY_USAGE]
+  )
+
+const toBase64 = (buf: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buf)
+  const bin = Array.from(bytes, b => String.fromCharCode(b)).join('')
+  return globalThis.btoa(bin)
+}
+
+/**
+ * Compute the standard-base64 HMAC-SHA256 signature of `message` under
+ * the given raw secret bytes. Distinct from {@link hmacSignBase64url}
+ * because Svix signatures use base64 (not base64url) encoding.
+ * @param secretBytes Raw secret bytes (post-base64-decode for `whsec_*`).
+ * @param message UTF-8 message bytes.
+ * @returns Standard base64-encoded signature.
+ */
+export const hmacSignBase64Bytes = async (
+  secretBytes: Uint8Array,
+  message: string
+): Promise<string> => {
+  const key = await importHmacKey(secretBytes)
+  const sig = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(message)
+  )
+  return toBase64(sig)
+}
+
+/**
+ * Constant-time comparison of two same-length strings.
+ * @param a First string.
+ * @param b Second string.
+ * @returns Whether the strings are byte-equal.
+ */
+export const constantTimeEqual = (a: string, b: string): boolean => {
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  }
+  return diff === 0
+}

--- a/services/comms-worker/src/webhooks/route-handler.ts
+++ b/services/comms-worker/src/webhooks/route-handler.ts
@@ -1,0 +1,48 @@
+import type { Context } from 'hono'
+import { createSendLogRepo } from '../send-log/repo'
+import { createRepo } from '../subscribers/repo'
+import { applyResendEvent, type ResendEvent } from './handler'
+import type { WebhookEnv } from './runtime-env'
+import { verifyWebhookSignature } from './svix'
+
+const readSignatureInputs = (c: Context, body: string) => ({
+  id: c.req.header('svix-id') ?? '',
+  timestamp: c.req.header('svix-timestamp') ?? '',
+  signatureHeader: c.req.header('svix-signature') ?? '',
+  body,
+})
+
+const parseEvent = (body: string): ResendEvent | undefined => {
+  try {
+    return JSON.parse(body) as ResendEvent
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Build the `POST /webhooks/resend` request handler bound to a
+ * deterministic `now` source (for tests).
+ * @param now Clock returning the current epoch in ms.
+ * @returns Hono handler.
+ */
+export const buildWebhookHandler =
+  (now: () => number) =>
+  async (c: Context): Promise<Response> => {
+    const env = c.env as WebhookEnv
+    const body = await c.req.text()
+    const valid = await verifyWebhookSignature({
+      ...readSignatureInputs(c, body),
+      secret: env.RESEND_WEBHOOK_SECRET,
+      nowMs: now(),
+    })
+    if (!valid) return c.body(null, 401)
+    const event = parseEvent(body)
+    if (event === undefined) return c.body(null, 200)
+    await applyResendEvent(
+      createRepo({ db: env.DB, now: () => new Date().toISOString() }),
+      createSendLogRepo({ db: env.DB }),
+      event
+    )
+    return c.body(null, 200)
+  }

--- a/services/comms-worker/src/webhooks/routes.test.ts
+++ b/services/comms-worker/src/webhooks/routes.test.ts
@@ -1,0 +1,153 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createSendLogRepo, type SendLogRepo } from '../send-log/repo'
+import { createRepo, type SubscriberRepo } from '../subscribers/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { mountWebhookRoutes, type WebhookEnv } from './routes'
+import { signWebhookHeader } from './svix'
+
+const SECRET = 'whsec_dGVzdHNlY3JldGtleS0xMjM0NTY3ODkw'
+const NOW_MS = 1_750_000_000_000
+const NOW_SEC = String(Math.floor(NOW_MS / 1000))
+const SVIX_ID = 'msg_1'
+
+const TICK_AT = '2026-06-06T09:00:00.000Z'
+
+let db: D1Database
+let subs: SubscriberRepo
+let log: SendLogRepo
+let app: Hono<{ Bindings: WebhookEnv }>
+
+const seed = async (
+  email: string,
+  resendId: string
+): Promise<{ readonly id: number }> => {
+  const s = await subs.insert({ email, langs: ['ru'] })
+  await log.append({
+    subscriberId: s.id,
+    tickAt: TICK_AT,
+    articleCount: 1,
+    status: 'sent',
+    resendId,
+    error: undefined,
+  })
+  return { id: s.id }
+}
+
+beforeEach(() => {
+  db = makeTestD1()
+  subs = createRepo({ db, now: () => '2026-05-01T00:00:00.000Z' })
+  log = createSendLogRepo({ db })
+  app = new Hono<{ Bindings: WebhookEnv }>()
+  mountWebhookRoutes(app, { now: () => NOW_MS })
+})
+
+const bindEnv = (): WebhookEnv =>
+  ({
+    DB: db,
+    RESEND_WEBHOOK_SECRET: SECRET,
+  }) as WebhookEnv
+
+const post = async (body: string, headers: Record<string, string>) =>
+  app.fetch(
+    new Request('http://x/webhooks/resend', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...headers },
+      body,
+    }),
+    bindEnv()
+  )
+
+const signedHeaders = async (
+  body: string
+): Promise<Record<string, string>> => ({
+  'svix-id': SVIX_ID,
+  'svix-timestamp': NOW_SEC,
+  'svix-signature': await signWebhookHeader(SECRET, SVIX_ID, NOW_SEC, body),
+})
+
+describe('POST /webhooks/resend — signature failures', () => {
+  it('returns 401 when the signature header is missing', async () => {
+    await seed('a@b.c', 're_1')
+    const res = await post(
+      JSON.stringify({ type: 'email.bounced', data: { email_id: 're_1' } }),
+      { 'svix-id': SVIX_ID, 'svix-timestamp': NOW_SEC }
+    )
+    expect(res.status).toBe(401)
+    expect((await subs.findById(1))?.status).toBe('active')
+  })
+
+  it('returns 401 on a tampered body', async () => {
+    const { id } = await seed('a@b.c', 're_1')
+    const body = JSON.stringify({
+      type: 'email.bounced',
+      data: { email_id: 're_1' },
+    })
+    const headers = await signedHeaders(body)
+    const tampered = `${body} `
+    const res = await post(tampered, headers)
+    expect(res.status).toBe(401)
+    expect((await subs.findById(id))?.status).toBe('active')
+  })
+})
+
+describe('POST /webhooks/resend — email.bounced (R3.10)', () => {
+  it('flips status to bounced + appends send_log row', async () => {
+    const { id } = await seed('a@b.c', 're_1')
+    const body = JSON.stringify({
+      type: 'email.bounced',
+      data: { email_id: 're_1' },
+    })
+    const res = await post(body, await signedHeaders(body))
+    expect(res.status).toBe(200)
+    expect((await subs.findById(id))?.status).toBe('bounced')
+    const logs = await log.listRecent(10)
+    expect(
+      logs.some(r => r.status === 'bounced' && r.resendId === 're_1')
+    ).toBe(true)
+  })
+})
+
+describe('POST /webhooks/resend — email.complained (R3.11)', () => {
+  it('flips status to complained + appends send_log row', async () => {
+    const { id } = await seed('a@b.c', 're_2')
+    const body = JSON.stringify({
+      type: 'email.complained',
+      data: { email_id: 're_2' },
+    })
+    const res = await post(body, await signedHeaders(body))
+    expect(res.status).toBe(200)
+    expect((await subs.findById(id))?.status).toBe('complained')
+    const logs = await log.listRecent(10)
+    expect(
+      logs.some(r => r.status === 'complained' && r.resendId === 're_2')
+    ).toBe(true)
+  })
+})
+
+describe('POST /webhooks/resend — other event types', () => {
+  it('returns 200 and is a no-op for non-bounce / non-complaint events', async () => {
+    const { id } = await seed('a@b.c', 're_3')
+    const body = JSON.stringify({
+      type: 'email.delivered',
+      data: { email_id: 're_3' },
+    })
+    const res = await post(body, await signedHeaders(body))
+    expect(res.status).toBe(200)
+    expect((await subs.findById(id))?.status).toBe('active')
+  })
+})
+
+describe('POST /webhooks/resend — unknown email_id', () => {
+  it('returns 200 (idempotent) and does not change any row', async () => {
+    await seed('a@b.c', 're_known')
+    const body = JSON.stringify({
+      type: 'email.bounced',
+      data: { email_id: 're_unknown' },
+    })
+    const res = await post(body, await signedHeaders(body))
+    expect(res.status).toBe(200)
+    expect((await subs.findById(1))?.status).toBe('active')
+  })
+})

--- a/services/comms-worker/src/webhooks/routes.ts
+++ b/services/comms-worker/src/webhooks/routes.ts
@@ -1,0 +1,28 @@
+import type { Hono } from 'hono'
+import { buildWebhookHandler } from './route-handler'
+import type { WebhookEnv } from './runtime-env'
+
+export type { WebhookEnv } from './runtime-env'
+
+type App = Hono<{ Bindings: WebhookEnv }>
+
+/** Options consumed by {@link mountWebhookRoutes}. */
+export type MountWebhookOptions = {
+  readonly now?: () => number
+}
+
+/**
+ * Mount `POST /webhooks/resend` — verifies the Svix-style signature
+ * with the worker's `RESEND_WEBHOOK_SECRET`, then maps the event to
+ * a subscriber status flip + a `send_log` marker row (R3.10–R3.12).
+ * @param app Hono app instance (no CF Access middleware on this prefix).
+ * @param opts Optional `now` seam for tests.
+ * @returns The same app for chaining.
+ */
+export const mountWebhookRoutes = (
+  app: App,
+  opts: MountWebhookOptions = {}
+): App => {
+  app.post('/webhooks/resend', buildWebhookHandler(opts.now ?? Date.now))
+  return app
+}

--- a/services/comms-worker/src/webhooks/runtime-env.ts
+++ b/services/comms-worker/src/webhooks/runtime-env.ts
@@ -1,0 +1,7 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+/** Bindings + secrets required by the Resend webhook route. */
+export type WebhookEnv = {
+  readonly DB: D1Database
+  readonly RESEND_WEBHOOK_SECRET: string
+}

--- a/services/comms-worker/src/webhooks/svix-helpers.ts
+++ b/services/comms-worker/src/webhooks/svix-helpers.ts
@@ -1,0 +1,40 @@
+import { constantTimeEqual } from './hmac-bytes'
+
+const WHSEC_PREFIX = 'whsec_'
+
+/** Decode a `whsec_*` shared secret into raw bytes. */
+export const decodeWebhookSecret = (
+  secret: string
+): Uint8Array | undefined => {
+  if (!secret.startsWith(WHSEC_PREFIX)) return undefined
+  try {
+    const bin = globalThis.atob(secret.slice(WHSEC_PREFIX.length))
+    return Uint8Array.from(bin, c => c.charCodeAt(0))
+  } catch {
+    return undefined
+  }
+}
+
+/** Pluck every `v1,*` signature from the (possibly multi-value) header. */
+export const extractV1Signatures = (header: string): ReadonlyArray<string> =>
+  header
+    .split(/\s+/)
+    .filter(s => s.startsWith('v1,'))
+    .map(s => s.slice(3))
+
+/** Constant-time membership test for a candidate signature. */
+export const anyMatches = (
+  expected: string,
+  presented: ReadonlyArray<string>
+): boolean => presented.some(s => constantTimeEqual(expected, s))
+
+/** Window-aware timestamp check used by both verify + auditing helpers. */
+export const timestampWithin = (
+  tsSecRaw: string,
+  nowMs: number,
+  windowMs: number
+): boolean => {
+  const tsSec = Number(tsSecRaw)
+  if (!Number.isFinite(tsSec)) return false
+  return Math.abs(nowMs - tsSec * 1000) <= windowMs
+}

--- a/services/comms-worker/src/webhooks/svix.test.ts
+++ b/services/comms-worker/src/webhooks/svix.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+import {
+  signWebhookHeader,
+  verifyWebhookSignature,
+  WEBHOOK_WINDOW_MS,
+} from './svix'
+
+const SECRET = 'whsec_dGVzdHNlY3JldGtleS0xMjM0NTY3ODkw'
+const OTHER = 'whsec_b3RoZXJzZWNyZXQtMTIzNDU2Nzg5MA=='
+const NOW_MS = 1_750_000_000_000
+const NOW_SEC = String(Math.floor(NOW_MS / 1000))
+const ID = 'msg_1'
+const BODY = '{"type":"email.bounced"}'
+
+describe('WEBHOOK_WINDOW_MS', () => {
+  it('is five minutes (the Svix recommendation)', () => {
+    expect(WEBHOOK_WINDOW_MS).toBe(5 * 60 * 1000)
+  })
+})
+
+describe('signWebhookHeader', () => {
+  it('returns a `v1,<base64-sig>` header value', async () => {
+    const header = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    expect(header.startsWith('v1,')).toBe(true)
+    expect(header.length).toBeGreaterThan('v1,'.length)
+  })
+
+  it('is deterministic for the same inputs', async () => {
+    const a = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    const b = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    expect(a).toBe(b)
+  })
+
+  it('differs when the secret changes', async () => {
+    const a = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    const b = await signWebhookHeader(OTHER, ID, NOW_SEC, BODY)
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('verifyWebhookSignature — happy path', () => {
+  it('returns true on a freshly-signed payload', async () => {
+    const header = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    expect(
+      await verifyWebhookSignature({
+        secret: SECRET,
+        id: ID,
+        timestamp: NOW_SEC,
+        body: BODY,
+        signatureHeader: header,
+        nowMs: NOW_MS,
+      })
+    ).toBe(true)
+  })
+
+  it('accepts a header that bundles multiple signatures for rotation', async () => {
+    const valid = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    const bogus = 'v1,Zm9vYmFy'
+    const combined = `${bogus} ${valid}`
+    expect(
+      await verifyWebhookSignature({
+        secret: SECRET,
+        id: ID,
+        timestamp: NOW_SEC,
+        body: BODY,
+        signatureHeader: combined,
+        nowMs: NOW_MS,
+      })
+    ).toBe(true)
+  })
+})
+
+describe('verifyWebhookSignature — failure modes', () => {
+  it('returns false when the body has been tampered with', async () => {
+    const header = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    expect(
+      await verifyWebhookSignature({
+        secret: SECRET,
+        id: ID,
+        timestamp: NOW_SEC,
+        body: `${BODY} `,
+        signatureHeader: header,
+        nowMs: NOW_MS,
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when the secret used to verify is wrong', async () => {
+    const header = await signWebhookHeader(SECRET, ID, NOW_SEC, BODY)
+    expect(
+      await verifyWebhookSignature({
+        secret: OTHER,
+        id: ID,
+        timestamp: NOW_SEC,
+        body: BODY,
+        signatureHeader: header,
+        nowMs: NOW_MS,
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when the timestamp is older than 5 min', async () => {
+    const oldSec = String(Math.floor(NOW_MS / 1000) - 6 * 60)
+    const header = await signWebhookHeader(SECRET, ID, oldSec, BODY)
+    expect(
+      await verifyWebhookSignature({
+        secret: SECRET,
+        id: ID,
+        timestamp: oldSec,
+        body: BODY,
+        signatureHeader: header,
+        nowMs: NOW_MS,
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when the timestamp is more than 5 min in the future', async () => {
+    const futureSec = String(Math.floor(NOW_MS / 1000) + 6 * 60)
+    const header = await signWebhookHeader(SECRET, ID, futureSec, BODY)
+    expect(
+      await verifyWebhookSignature({
+        secret: SECRET,
+        id: ID,
+        timestamp: futureSec,
+        body: BODY,
+        signatureHeader: header,
+        nowMs: NOW_MS,
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when the timestamp is not numeric', async () => {
+    expect(
+      await verifyWebhookSignature({
+        secret: SECRET,
+        id: ID,
+        timestamp: 'NaN',
+        body: BODY,
+        signatureHeader: 'v1,Zm9v',
+        nowMs: NOW_MS,
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when no v1 entries are present', async () => {
+    expect(
+      await verifyWebhookSignature({
+        secret: SECRET,
+        id: ID,
+        timestamp: NOW_SEC,
+        body: BODY,
+        signatureHeader: 'v2,Zm9v',
+        nowMs: NOW_MS,
+      })
+    ).toBe(false)
+  })
+
+  it('returns false when the secret prefix is missing or malformed', async () => {
+    expect(
+      await verifyWebhookSignature({
+        secret: 'not-a-whsec-secret',
+        id: ID,
+        timestamp: NOW_SEC,
+        body: BODY,
+        signatureHeader: 'v1,Zm9v',
+        nowMs: NOW_MS,
+      })
+    ).toBe(false)
+  })
+})

--- a/services/comms-worker/src/webhooks/svix.ts
+++ b/services/comms-worker/src/webhooks/svix.ts
@@ -1,0 +1,67 @@
+import { hmacSignBase64Bytes } from './hmac-bytes'
+import {
+  anyMatches,
+  decodeWebhookSecret,
+  extractV1Signatures,
+  timestampWithin,
+} from './svix-helpers'
+
+/** Svix freshness window: rejects timestamps older / newer than 5 min. */
+export const WEBHOOK_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * Build the standard `svix-signature` header value (`v1,<base64-sig>`)
+ * for `(secret, id, timestamp, body)` — exposed so the route's unit
+ * tests can produce a signature without rolling their own crypto.
+ * @param secret `whsec_*` shared secret.
+ * @param id Value of the `svix-id` header.
+ * @param timestamp Value of the `svix-timestamp` header (Unix seconds).
+ * @param body Raw request body (the exact bytes the server received).
+ * @returns Ready-to-send header value.
+ */
+export const signWebhookHeader = async (
+  secret: string,
+  id: string,
+  timestamp: string,
+  body: string
+): Promise<string> => {
+  const bytes = decodeWebhookSecret(secret)
+  if (bytes === undefined) return 'v1,'
+  const sig = await hmacSignBase64Bytes(bytes, `${id}.${timestamp}.${body}`)
+  return `v1,${sig}`
+}
+
+/** Inputs accepted by {@link verifyWebhookSignature}. */
+export type VerifyInput = {
+  readonly secret: string
+  readonly id: string
+  readonly timestamp: string
+  readonly body: string
+  readonly signatureHeader: string
+  readonly nowMs: number
+}
+
+/**
+ * Verify a `svix-signature` header against the body + headers as Svix
+ * specifies: HMAC-SHA256 of `${id}.${timestamp}.${body}`, base64, then
+ * constant-time compared against every `v1,*` entry in the header.
+ * @param input Signature inputs (see {@link VerifyInput}).
+ * @returns `true` only when at least one valid signature is present
+ *   AND the timestamp is within {@link WEBHOOK_WINDOW_MS}.
+ */
+export const verifyWebhookSignature = async (
+  input: VerifyInput
+): Promise<boolean> => {
+  const bytes = decodeWebhookSecret(input.secret)
+  if (bytes === undefined) return false
+  if (!timestampWithin(input.timestamp, input.nowMs, WEBHOOK_WINDOW_MS)) {
+    return false
+  }
+  const presented = extractV1Signatures(input.signatureHeader)
+  if (presented.length === 0) return false
+  const expected = await hmacSignBase64Bytes(
+    bytes,
+    `${input.id}.${input.timestamp}.${input.body}`
+  )
+  return anyMatches(expected, presented)
+}


### PR DESCRIPTION
## Summary

Stacked on top of [#251 (Stage 4)](https://github.com/communist-prometheus/admin-website/pull/251). Delivers the **Resend webhook** vertical slice (T5.1–T5.3 of [\`tasks.md\`](https://github.com/communist-prometheus/admin-website/blob/feat/23-stage-1-comms-crud/specs/comms-newsletter/tasks.md)).

### Worker
- **\`webhooks/hmac-bytes.ts\`** — WebCrypto HMAC-SHA256 over raw bytes (Svix's \`whsec_*\` secret decodes to bytes), standard base64 output, constant-time string compare.
- **\`webhooks/svix-helpers.ts\`** — decode \`whsec_*\`, pluck every \`v1,*\` signature candidate from the (possibly multi-value) header, window-aware timestamp check.
- **\`webhooks/svix.ts\`** — \`signWebhookHeader\` (test seam) + 5-min freshness window verifier \`verifyWebhookSignature\` (R3.10, R3.12).
- **\`webhooks/handler.ts\`** — \`applyResendEvent\` maps \`email.bounced\` + \`email.delivery_delayed\` → \`bounced\`, \`email.complained\` → \`complained\`; idempotent on unknown event types / unknown email_id (R3.10, R3.11, R4.7).
- **\`webhooks/route-handler.ts\` + \`routes.ts\`** — \`POST /webhooks/resend\` reads the raw body, verifies signature, parses the event, applies it. 401 on signature failure with no mutation (R3.12); 200 on success or no-op.

### Repo + plumbing
- **\`send-log/{repo,repo-impl}.ts\`** — adds \`findByResendId(id)\` used by the webhook to map an inbound event back to its subscriber. Repo split for the 50-line cap.
- **\`bindings.ts\`** — combined \`Bindings\` + \`WorkerCtx\` types extracted from \`index.ts\` so the entry stays under the 50-line cap; entry re-exports \`Bindings\`.
- **\`index.ts\`** — mounts the public \`/webhooks/resend\` route outside the \`/api/*\` CF Access middleware (design §9.3 step 4 bypass).
- **\`dispatch/run.test.ts\`** — adds explicit R4.6 / R4.7 coverage: subscribers with \`status='bounced'\` or \`'complained'\` are skipped by the next dispatch tick.

### Tests
23 new tests, 180/180 worker green:

| Module | Tests | EARS |
|---|---|---|
| \`svix\` (sign + verify) | 13 | R3.10, R3.12 |
| webhook \`routes\` (auth + body + event handling) | 6 | R3.10, R3.11, R3.12, R4.7 |
| \`send-log\` \`findByResendId\` | 2 | infra |
| \`dispatch\` skip-bounced / skip-complained | 2 | R4.6, R4.7 |

### Test plan
- [ ] \`bunx vitest run services/comms-worker\` — 180/180 green.
- [ ] \`bun run validate\` — type-check + biome + oxlint + eslint-jsdoc + vue-depth + stylelint all green.
- [ ] Manual smoke against \`wrangler dev\`: replay a Resend bounce payload with a forged \`svix-signature\` → 401, no mutation; replay with the right signature → 200, subscriber row flips to \`bounced\`, send_log gains a marker.

### Out of scope
- Admin SPA run-history view — T6.x / Stage 6.
- E2E full-flow Playwright — T7.4 / Stage 7.
- Structured \`severity=warn\` log on R3.12 sig failures — folded into the Stage 7 structured logger (T7.1).
- \`email.delivery_delayed\` retry semantics — currently mapped to \`bounced\` for the v1 hard-bounce category (matches spec §11 retry matrix); a softer "delay then retry" is post-MVP.

Refs: tickets#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)