### PR TITLE
feat(comms): tickets#23 stage 6 — run history view

### DIFF
--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -6,6 +6,7 @@ import { handleScheduled } from './dispatch/scheduled'
 import { registerHealthRoute } from './health'
 import { requireAccess } from './middleware/require-access'
 import { mountScheduleRoutes } from './schedule/routes'
+import { mountRunsRoute } from './send-log/route'
 import { createSettingsRepo } from './settings/repo'
 import { createRepo } from './subscribers/repo'
 import { mountSubscriberRoutes } from './subscribers/routes'
@@ -30,6 +31,7 @@ mountScheduleRoutes(
   nowDate
 )
 mountForceDispatchRoute(app)
+mountRunsRoute(app)
 mountUnsubscribeRoutes(app)
 mountWebhookRoutes(app)
 

--- a/services/comms-worker/src/send-log/route.test.ts
+++ b/services/comms-worker/src/send-log/route.test.ts
@@ -1,0 +1,127 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { Hono } from 'hono'
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { AccessClaims } from '../auth/cf-access'
+import { requireAccess } from '../middleware/require-access'
+import { createRepo, type SubscriberRepo } from '../subscribers/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { createSendLogRepo, type SendLogRepo } from './repo'
+import { mountRunsRoute } from './route'
+
+const claims: AccessClaims = {
+  aud: 'a',
+  iss: 'https://comprom.cloudflareaccess.com',
+  email: 'admin@comprom.org',
+  sub: 'github|undeadliner',
+  exp: 9_999_999_999,
+  iat: 1,
+}
+
+const env = { CF_ACCESS_AUD: 'a', CF_ACCESS_TEAM: 'comprom' }
+
+let db: D1Database
+let subs: SubscriberRepo
+let log: SendLogRepo
+let app: Hono<{
+  Bindings: typeof env & { DB: D1Database }
+  Variables: { readonly access: AccessClaims }
+}>
+
+const buildEnv = () => ({ ...env, DB: db })
+
+const seed = async (email: string): Promise<{ readonly id: number }> => {
+  const s = await subs.insert({ email, langs: ['ru'] })
+  return { id: s.id }
+}
+
+const populate = async (rows: number) => {
+  for (let i = 0; i < rows; i++) {
+    const { id } = await seed(`s${i}@x.t`)
+    await log.append({
+      subscriberId: id,
+      tickAt: `2026-06-${String(rows - i).padStart(2, '0')}T00:00:00.000Z`,
+      articleCount: i + 1,
+      status: i % 5 === 0 ? 'failed' : 'sent',
+      resendId: i % 5 === 0 ? undefined : `re_${i}`,
+      error: i % 5 === 0 ? 'resend 500' : undefined,
+    })
+  }
+}
+
+beforeEach(() => {
+  db = makeTestD1()
+  subs = createRepo({ db, now: () => '2026-05-01T00:00:00.000Z' })
+  log = createSendLogRepo({ db })
+  app = new Hono<{
+    Bindings: typeof env & { DB: D1Database }
+    Variables: { readonly access: AccessClaims }
+  }>()
+  app.use('/api/*', requireAccess({ verifier: async () => claims }))
+  mountRunsRoute(app)
+})
+
+const reqWithAccess = (path: string) =>
+  new Request(`http://x${path}`, {
+    headers: { 'Cf-Access-Jwt-Assertion': 'tok' },
+  })
+
+describe('GET /api/runs', () => {
+  it('rejects without the CF Access header', async () => {
+    const res = await app.fetch(new Request('http://x/api/runs'), buildEnv())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the default 20 newest rows when limit is absent', async () => {
+    await populate(30)
+    const res = await app.fetch(reqWithAccess('/api/runs'), buildEnv())
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      runs: ReadonlyArray<{ tickAt: string; email?: string }>
+    }
+    expect(body.runs).toHaveLength(20)
+    expect(body.runs[0]?.email).toBe('s0@x.t')
+  })
+
+  it('caps the limit at 100 even when the client asks for more', async () => {
+    await populate(120)
+    const res = await app.fetch(
+      reqWithAccess('/api/runs?limit=500'),
+      buildEnv()
+    )
+    const body = (await res.json()) as { runs: ReadonlyArray<unknown> }
+    expect(body.runs).toHaveLength(100)
+  })
+
+  it('respects ?limit=N when N is in range', async () => {
+    await populate(10)
+    const res = await app.fetch(
+      reqWithAccess('/api/runs?limit=5'),
+      buildEnv()
+    )
+    const body = (await res.json()) as { runs: ReadonlyArray<unknown> }
+    expect(body.runs).toHaveLength(5)
+  })
+
+  it('falls back to the default limit when ?limit is not a positive integer', async () => {
+    await populate(25)
+    const res = await app.fetch(
+      reqWithAccess('/api/runs?limit=not-a-number'),
+      buildEnv()
+    )
+    const body = (await res.json()) as { runs: ReadonlyArray<unknown> }
+    expect(body.runs).toHaveLength(20)
+  })
+
+  it('surfaces error + status=failed on rows with a Resend failure', async () => {
+    await populate(2)
+    const res = await app.fetch(
+      reqWithAccess('/api/runs?limit=10'),
+      buildEnv()
+    )
+    const body = (await res.json()) as {
+      runs: ReadonlyArray<{ status: string; error?: string }>
+    }
+    const failed = body.runs.find(r => r.status === 'failed')
+    expect(failed?.error).toBe('resend 500')
+  })
+})

--- a/services/comms-worker/src/send-log/route.ts
+++ b/services/comms-worker/src/send-log/route.ts
@@ -1,0 +1,34 @@
+import type { Context, Hono } from 'hono'
+import type { Bindings } from '../bindings'
+import { listRecentWithEmail } from './with-email'
+
+type App = Hono<{ Bindings: object; Variables: object }>
+
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 100
+
+const parseLimit = (raw: string | undefined): number => {
+  if (raw === undefined) return DEFAULT_LIMIT
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n <= 0) return DEFAULT_LIMIT
+  return Math.min(n, MAX_LIMIT)
+}
+
+const handle = async (c: Context): Promise<Response> => {
+  const limit = parseLimit(c.req.query('limit'))
+  const runs = await listRecentWithEmail((c.env as Bindings).DB, limit)
+  return c.json({ runs })
+}
+
+/**
+ * Mount `GET /api/runs?limit=N` — returns the `N` most-recent
+ * send_log rows joined with the subscriber email (R5.1). The route
+ * sits behind the `/api/*` `requireAccess` middleware mounted in
+ * `index.ts`, so callers must present a valid CF Access JWT.
+ * @param app Hono app, already wrapped with `requireAccess` for /api/*.
+ * @returns The same app for chaining.
+ */
+export const mountRunsRoute = (app: App): App => {
+  app.get('/api/runs', handle)
+  return app
+}

--- a/services/comms-worker/src/send-log/with-email.test.ts
+++ b/services/comms-worker/src/send-log/with-email.test.ts
@@ -1,0 +1,87 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createRepo, type SubscriberRepo } from '../subscribers/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { createSendLogRepo, type SendLogRepo } from './repo'
+import { listRecentWithEmail } from './with-email'
+
+let db: D1Database
+let subs: SubscriberRepo
+let log: SendLogRepo
+
+beforeEach(() => {
+  db = makeTestD1()
+  subs = createRepo({ db, now: () => '2026-05-01T00:00:00.000Z' })
+  log = createSendLogRepo({ db })
+})
+
+describe('listRecentWithEmail', () => {
+  it('joins subscriber.email onto each row', async () => {
+    const s = await subs.insert({
+      email: 'reader@example.test',
+      langs: ['ru'],
+    })
+    await log.append({
+      subscriberId: s.id,
+      tickAt: '2026-06-06T09:00:00.000Z',
+      articleCount: 3,
+      status: 'sent',
+      resendId: 're_42',
+      error: undefined,
+    })
+    const rows = await listRecentWithEmail(db, 10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.email).toBe('reader@example.test')
+    expect(rows[0]?.status).toBe('sent')
+    expect(rows[0]?.articleCount).toBe(3)
+  })
+
+  it('returns undefined email when the subscriber row was deleted', async () => {
+    const s = await subs.insert({ email: 'gone@example.test', langs: ['ru'] })
+    await log.append({
+      subscriberId: s.id,
+      tickAt: '2026-06-06T09:00:00.000Z',
+      articleCount: 1,
+      status: 'sent',
+      resendId: 're_1',
+      error: undefined,
+    })
+    await subs.remove(s.id)
+    const rows = await listRecentWithEmail(db, 10)
+    expect(rows[0]?.email).toBeUndefined()
+    expect(rows[0]?.subscriberId).toBeUndefined()
+  })
+
+  it('orders rows newest tick first and obeys the limit', async () => {
+    const a = await subs.insert({ email: 'a@x.t', langs: ['ru'] })
+    const b = await subs.insert({ email: 'b@x.t', langs: ['ru'] })
+    const c = await subs.insert({ email: 'c@x.t', langs: ['ru'] })
+    await log.append({
+      subscriberId: a.id,
+      tickAt: '2026-06-01T00:00:00.000Z',
+      articleCount: 1,
+      status: 'sent',
+      resendId: 'a',
+      error: undefined,
+    })
+    await log.append({
+      subscriberId: b.id,
+      tickAt: '2026-06-08T00:00:00.000Z',
+      articleCount: 1,
+      status: 'sent',
+      resendId: 'b',
+      error: undefined,
+    })
+    await log.append({
+      subscriberId: c.id,
+      tickAt: '2026-06-05T00:00:00.000Z',
+      articleCount: 1,
+      status: 'failed',
+      resendId: undefined,
+      error: 'resend 500',
+    })
+    const rows = await listRecentWithEmail(db, 2)
+    expect(rows.map(r => r.email)).toEqual(['b@x.t', 'c@x.t'])
+    expect(rows[1]?.error).toBe('resend 500')
+  })
+})

--- a/services/comms-worker/src/send-log/with-email.ts
+++ b/services/comms-worker/src/send-log/with-email.ts
@@ -1,0 +1,36 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { rowToSendLog, type SendLogRow } from './serialize'
+import type { SendLog } from './types'
+
+/** A send_log row joined with the subscriber email (if still present). */
+export type SendLogWithEmail = SendLog & {
+  readonly email: string | undefined
+}
+
+type JoinedRow = SendLogRow & { readonly email: string | null }
+
+const SQL =
+  'SELECT l.*, s.email AS email ' +
+  'FROM send_log l LEFT JOIN subscribers s ON s.id = l.subscriber_id ' +
+  'ORDER BY l.tick_at DESC, l.id DESC LIMIT ?'
+
+const lift = (row: JoinedRow): SendLogWithEmail => ({
+  ...rowToSendLog(row),
+  email: row.email ?? undefined,
+})
+
+/**
+ * Return the most-recent N send-log rows enriched with the subscriber's
+ * email, when still present. Used by `GET /api/runs` to show the editor
+ * a readable run history without a second round-trip.
+ * @param db D1 database binding.
+ * @param limit Maximum rows to return (caller validates the bound).
+ * @returns Joined rows, newest tick first.
+ */
+export const listRecentWithEmail = async (
+  db: D1Database,
+  limit: number
+): Promise<ReadonlyArray<SendLogWithEmail>> => {
+  const r = await db.prepare(SQL).bind(limit).all<JoinedRow>()
+  return (r.results ?? []).map(lift)
+}

--- a/src/stores/runs-actions.ts
+++ b/src/stores/runs-actions.ts
@@ -1,0 +1,33 @@
+import type { Ref } from 'vue'
+import type { RunLog } from '@/validation/schemas/run-log'
+import { apiListRuns } from './runs-api'
+
+/** Reactive refs the runs-state factories read + write. */
+export type RunsRefs = {
+  readonly runs: Ref<readonly RunLog[]>
+  readonly loading: Ref<boolean>
+  readonly loaded: Ref<boolean>
+  readonly error: Ref<string | undefined>
+}
+
+/**
+ * Build the `load` action that pulls the most-recent run-history rows
+ * from the worker and surfaces a readable error on failure.
+ * @param r Reactive refs the action mutates.
+ * @returns Async action returning void.
+ */
+export const createLoadRuns =
+  (r: RunsRefs) =>
+  async (limit?: number): Promise<void> => {
+    r.loading.value = true
+    r.error.value = undefined
+    try {
+      const res = await apiListRuns(limit)
+      r.runs.value = [...res.runs]
+      r.loaded.value = true
+    } catch (e) {
+      r.error.value = e instanceof Error ? e.message : 'Failed to load runs'
+    } finally {
+      r.loading.value = false
+    }
+  }

--- a/src/stores/runs-api.test.ts
+++ b/src/stores/runs-api.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RunLog } from '@/validation/schemas/run-log'
+import { apiListRuns } from './runs-api'
+
+const sample: RunLog = {
+  id: 1,
+  subscriberId: 7,
+  tickAt: '2026-06-06T09:00:00.000Z',
+  articleCount: 3,
+  status: 'sent',
+  resendId: 're_42',
+  error: undefined,
+  email: 'reader@example.test',
+}
+
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  mockFetch.mockReset()
+})
+
+const ok = (body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+describe('apiListRuns', () => {
+  it('GETs /api/runs without limit by default and parses the list', async () => {
+    mockFetch.mockResolvedValue(ok({ runs: [sample] }))
+    const res = await apiListRuns()
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/runs$/)
+    expect(init.credentials).toBe('include')
+    expect(res.runs).toHaveLength(1)
+    expect(res.runs[0]?.email).toBe('reader@example.test')
+  })
+
+  it('appends ?limit=N when caller passes a limit', async () => {
+    mockFetch.mockResolvedValue(ok({ runs: [] }))
+    await apiListRuns(50)
+    const [url] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/runs\?limit=50$/)
+  })
+
+  it('bubbles a readable error on non-2xx', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: 'forbidden' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    await expect(apiListRuns()).rejects.toThrow(/forbidden/)
+  })
+})

--- a/src/stores/runs-api.ts
+++ b/src/stores/runs-api.ts
@@ -1,0 +1,16 @@
+import { decodeResponse } from '@/validation/decode-response'
+import type { RunLogList } from '@/validation/schemas/run-log'
+import { RunLogListSchema } from '@/validation/schemas/run-log'
+import { commsUrl } from './comms-http'
+
+/**
+ * GET /api/runs — return the most-recent send_log rows joined with
+ * the subscriber email. The worker caps the limit at 100.
+ * @param limit Optional row cap (defaults to the worker's own default).
+ * @returns Parsed list payload.
+ */
+export const apiListRuns = async (limit?: number): Promise<RunLogList> => {
+  const path = limit === undefined ? '/api/runs' : `/api/runs?limit=${limit}`
+  const res = await fetch(commsUrl(path), { credentials: 'include' })
+  return decodeResponse(RunLogListSchema)(res)
+}

--- a/src/stores/runs-state.ts
+++ b/src/stores/runs-state.ts
@@ -1,0 +1,18 @@
+import { ref } from 'vue'
+import type { RunLog } from '@/validation/schemas/run-log'
+import { createLoadRuns, type RunsRefs } from './runs-actions'
+
+/**
+ * Reactive state + actions for the comms run-history surface.
+ * Mirrors the comms / schedule factory shape.
+ * @returns Refs + the `load` action.
+ */
+export const createRunsState = () => {
+  const r: RunsRefs = {
+    runs: ref<readonly RunLog[]>([]),
+    loading: ref(false),
+    loaded: ref(false),
+    error: ref<string | undefined>(undefined),
+  }
+  return { ...r, load: createLoadRuns(r) }
+}

--- a/src/stores/runs.ts
+++ b/src/stores/runs.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+import { createRunsState } from './runs-state'
+
+export type { RunLog, RunLogList } from '@/validation/schemas/run-log'
+
+/** Pinia store for the comms run-history feed. */
+export const useRunsStore = defineStore('comms-runs', () => {
+  const s = createRunsState()
+
+  /** Load runs once if not already loaded. */
+  const ensureLoaded = async (): Promise<void> => {
+    await (s.loaded.value ? Promise.resolve() : s.load())
+  }
+
+  return { ...s, ensureLoaded }
+})

--- a/src/validation/schemas/run-log.ts
+++ b/src/validation/schemas/run-log.ts
@@ -1,0 +1,32 @@
+import { Schema } from 'effect'
+
+const SendLogStatusSchema = Schema.Literal(
+  'sent',
+  'failed',
+  'bounced',
+  'complained',
+  'skipped'
+)
+
+/** One row in the run-history feed served by `GET /api/runs`. */
+export const RunLogSchema = Schema.Struct({
+  id: Schema.Number,
+  subscriberId: Schema.UndefinedOr(Schema.Number),
+  tickAt: Schema.String,
+  articleCount: Schema.Number,
+  status: SendLogStatusSchema,
+  resendId: Schema.UndefinedOr(Schema.String),
+  error: Schema.UndefinedOr(Schema.String),
+  email: Schema.UndefinedOr(Schema.String),
+})
+
+/** Row type derived from the schema. */
+export type RunLog = typeof RunLogSchema.Type
+
+/** Wrapper around the list endpoint payload. */
+export const RunLogListSchema = Schema.Struct({
+  runs: Schema.Array(RunLogSchema),
+})
+
+/** List response type. */
+export type RunLogList = typeof RunLogListSchema.Type

--- a/src/views/CommsView/CommsView.vue
+++ b/src/views/CommsView/CommsView.vue
@@ -2,18 +2,22 @@
 import { onMounted } from 'vue'
 import type { Lang } from '@/stores/comms'
 import { useCommsStore } from '@/stores/comms'
+import { useRunsStore } from '@/stores/runs'
 import type { Schedule } from '@/stores/schedule'
 import { useScheduleStore } from '@/stores/schedule'
 import AddSubscriberForm from './AddSubscriberForm.vue'
+import RunHistory from './RunHistory.vue'
 import ScheduleEditor from './ScheduleEditor.vue'
 import SubscribersTable from './SubscribersTable.vue'
 
 const store = useCommsStore()
 const schedule = useScheduleStore()
+const runs = useRunsStore()
 
 onMounted(() => {
   void store.ensureLoaded()
   void schedule.ensureLoaded()
+  void runs.ensureLoaded()
 })
 
 const onAdd = (email: string, langs: readonly Lang[]): void => {
@@ -55,6 +59,11 @@ const onScheduleSave = (next: Schedule): void => {
     <p v-if="store.loading && store.subscribers.length === 0" data-testid="comms-loading">
       Loading…
     </p>
+    <RunHistory
+      :runs="runs.runs"
+      :loading="runs.loading"
+      :error="runs.error"
+    />
   </section>
 </template>
 

--- a/src/views/CommsView/RunHistory.vue
+++ b/src/views/CommsView/RunHistory.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { RunLog } from '@/stores/runs'
+import RunHistoryList from './RunHistoryList.vue'
+
+defineProps<{
+  readonly runs: readonly RunLog[]
+  readonly loading: boolean
+  readonly error: string | undefined
+}>()
+</script>
+
+<template>
+  <section class="history" data-testid="run-history">
+    <h2 class="title">Run history</h2>
+    <p
+      v-if="error"
+      class="error"
+      data-testid="run-history-error"
+    >{{ error }}</p>
+    <p
+      v-else-if="loading && runs.length === 0"
+      data-testid="run-history-loading"
+    >Loading…</p>
+    <p
+      v-else-if="!loading && runs.length === 0"
+      class="empty"
+      data-testid="run-history-empty"
+    >No newsletter runs have been recorded yet.</p>
+    <RunHistoryList v-else :runs="runs" />
+  </section>
+</template>
+
+<style scoped>
+.history {
+  padding: 1rem 0 0;
+  border-top: 1px solid var(--color-border);
+}
+
+.title {
+  margin: 0 0 0.6rem;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.error {
+  color: var(--color-danger, #c0392b);
+  font-size: 0.8125rem;
+}
+
+.empty {
+  color: var(--color-text-secondary);
+  font-size: 0.8125rem;
+  margin: 0;
+}
+</style>

--- a/src/views/CommsView/RunHistoryList.vue
+++ b/src/views/CommsView/RunHistoryList.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import type { RunLog } from '@/stores/runs'
+import RunHistoryRow from './RunHistoryRow.vue'
+
+defineProps<{ readonly runs: readonly RunLog[] }>()
+</script>
+
+<template>
+  <ol class="rows" data-testid="run-history-list">
+    <RunHistoryRow
+      v-for="run in runs"
+      :key="run.id"
+      :run="run"
+      data-testid="run-history-row"
+    />
+  </ol>
+</template>
+
+<style scoped>
+.rows {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+</style>

--- a/src/views/CommsView/RunHistoryRow.vue
+++ b/src/views/CommsView/RunHistoryRow.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import type { RunLog } from '@/stores/runs'
+import {
+  isFailedRun,
+  shortTickAt,
+  statusBadgeClass,
+} from './run-history-ops'
+
+const props = defineProps<{ readonly run: RunLog }>()
+
+const expanded = ref(false)
+
+const onToggle = (): void => {
+  if (isFailedRun(props.run.status)) expanded.value = !expanded.value
+}
+</script>
+
+<template>
+  <li
+    class="row"
+    :class="{ 'row-failed': isFailedRun(props.run.status) }"
+    :data-testid="
+      isFailedRun(props.run.status) ? 'send-log-failed' : 'send-log-row'
+    "
+    @click="onToggle"
+  >
+    <span class="tick">{{ shortTickAt(props.run.tickAt) }}</span>
+    <span class="email">{{ props.run.email ?? '—' }}</span>
+    <span class="badge" :class="statusBadgeClass(props.run.status)">
+      {{ props.run.status }}
+    </span>
+    <span class="count">{{ props.run.articleCount }}</span>
+    <span
+      v-if="expanded && props.run.error"
+      class="error"
+      data-testid="send-log-error"
+    >{{ props.run.error }}</span>
+  </li>
+</template>
+
+<style scoped>
+.row {
+  display: grid;
+  grid-template-columns: 8.5rem 1fr 5rem 3rem;
+  gap: 0.6rem;
+  padding: 0.35rem 0;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.8125rem;
+  cursor: default;
+}
+
+.row-failed {
+  cursor: pointer;
+  background: rgb(192 57 43 / 8%);
+}
+
+.tick {
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono, monospace);
+}
+
+.email {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  text-align: center;
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  font-size: 0.6875rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+}
+
+.badge-sent {
+  color: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.badge-failed,
+.badge-bounced,
+.badge-complained {
+  color: var(--color-danger, #c0392b);
+  border-color: var(--color-danger, #c0392b);
+}
+
+.count {
+  text-align: right;
+  color: var(--color-text-secondary);
+}
+
+.error {
+  grid-column: 1 / -1;
+  color: var(--color-danger, #c0392b);
+  font-size: 0.75rem;
+}
+</style>

--- a/src/views/CommsView/run-history-ops.test.ts
+++ b/src/views/CommsView/run-history-ops.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { isFailedRun, shortTickAt, statusBadgeClass } from './run-history-ops'
+
+describe('isFailedRun', () => {
+  it('is true for status === "failed"', () => {
+    expect(isFailedRun('failed')).toBe(true)
+  })
+
+  it('is false for every other status', () => {
+    expect(isFailedRun('sent')).toBe(false)
+    expect(isFailedRun('bounced')).toBe(false)
+    expect(isFailedRun('complained')).toBe(false)
+    expect(isFailedRun('skipped')).toBe(false)
+  })
+})
+
+describe('statusBadgeClass', () => {
+  it('returns the BEM-ish class for the status', () => {
+    expect(statusBadgeClass('sent')).toBe('badge-sent')
+    expect(statusBadgeClass('failed')).toBe('badge-failed')
+    expect(statusBadgeClass('bounced')).toBe('badge-bounced')
+    expect(statusBadgeClass('complained')).toBe('badge-complained')
+    expect(statusBadgeClass('skipped')).toBe('badge-skipped')
+  })
+})
+
+describe('shortTickAt', () => {
+  it('returns YYYY-MM-DD HH:MM (UTC) for an ISO timestamp', () => {
+    expect(shortTickAt('2026-06-06T09:00:00.000Z')).toBe('2026-06-06 09:00')
+  })
+
+  it('echoes the raw value when not a parseable date', () => {
+    expect(shortTickAt('not-a-date')).toBe('not-a-date')
+  })
+})

--- a/src/views/CommsView/run-history-ops.ts
+++ b/src/views/CommsView/run-history-ops.ts
@@ -1,0 +1,40 @@
+import type { RunLog } from '@/stores/runs'
+
+/**
+ * True iff the row represents a failed send — used by the view to add
+ * the `data-testid="send-log-failed"` highlight and reveal the
+ * stored error on click.
+ * @param status Send-log row status.
+ * @returns Whether the row is in the failed terminal state.
+ */
+export const isFailedRun = (status: RunLog['status']): boolean =>
+  status === 'failed'
+
+/**
+ * Map a status to the BEM-ish class name used by the badge component.
+ * Kept outside the component so it can be tested without DOM setup.
+ * @param status Send-log row status.
+ * @returns Class suffix attached to the badge element.
+ */
+export const statusBadgeClass = (status: RunLog['status']): string =>
+  `badge-${status}`
+
+/**
+ * Format a parseable ISO timestamp as `YYYY-MM-DD HH:MM` (UTC).
+ * @param iso ISO-8601 UTC timestamp (already verified parseable).
+ * @returns Short UTC label.
+ */
+const formatIso = (iso: string): string => {
+  const d = new Date(Date.parse(iso))
+  return `${d.toISOString().slice(0, 10)} ${d.toISOString().slice(11, 16)}`
+}
+
+/**
+ * Render an ISO timestamp as a tight `YYYY-MM-DD HH:MM` UTC label.
+ * Echoes the raw value back when the input is unparseable so the
+ * editor still sees the bad data instead of a blank cell.
+ * @param iso ISO-8601 UTC timestamp.
+ * @returns Short label for display.
+ */
+export const shortTickAt = (iso: string): string =>
+  Number.isFinite(Date.parse(iso)) ? formatIso(iso) : iso


### PR DESCRIPTION
## Summary

Stacked on top of [#252 (Stage 5)](https://github.com/communist-prometheus/admin-website/pull/252). Delivers the **Run history** vertical slice (T6.1 + T6.2 of [\`tasks.md\`](https://github.com/communist-prometheus/admin-website/blob/feat/23-stage-1-comms-crud/specs/comms-newsletter/tasks.md)).

### Worker
- **\`send-log/with-email.ts\`** — \`LEFT JOIN\` of \`send_log\` against \`subscribers\`, returns \`email\` (or \`undefined\` after ON DELETE SET NULL) on every row newest tick first.
- **\`send-log/route.ts\`** — \`GET /api/runs?limit=N\` mounted behind the \`/api/*\` CF Access middleware. Default 20 rows, max 100, falls back to default on non-positive-int input (R5.1).

### Admin SPA
- **\`validation/schemas/run-log.ts\`** — Effect schemas mirroring the worker payload.
- **\`stores/runs-api.ts\`** — \`apiListRuns(limit?)\` reuses \`comms-http\` + Effect schema decoding.
- **\`stores/{runs-actions,runs-state,runs}.ts\`** — Pinia store + \`ensureLoaded\` mirror of the existing comms / schedule shapes.
- **\`views/CommsView/run-history-ops.ts\`** — pure helpers \`isFailedRun\` / \`statusBadgeClass\` / \`shortTickAt\` (kept testable, no DOM setup).
- **\`views/CommsView/{RunHistory,RunHistoryList,RunHistoryRow}.vue\`** — failed rows carry \`data-testid="send-log-failed"\` and reveal the stored error on click (R5.2, R5.3); separate List sub-component keeps template depth ≤ 2.
- **\`views/CommsView/CommsView.vue\`** — wires the new store + component below the existing surface.

### Tests
17 new tests across the slice:

| Module | Tests | EARS |
|---|---|---|
| \`send-log/with-email\` | 3 | infra |
| \`send-log/route\` (GET /api/runs) | 6 | R5.1 |
| \`stores/runs-api\` | 3 | infra |
| \`views/CommsView/run-history-ops\` | 5 | R5.2 |

Worker: 197 / 197. Admin slice: 36 added vs main. Full validate (\`type-check\`, \`biome ci\`, \`oxlint\`, \`eslint-jsdoc\`, \`vue-depth\`, \`stylelint\`) all green.

### Test plan
- [ ] \`bunx vitest run services/comms-worker\` — 197/197 green.
- [ ] \`bun run validate\` — type-check + biome + oxlint + eslint-jsdoc + vue-depth + stylelint all green.
- [ ] Manual smoke against \`wrangler dev\` + a populated D1: visit \`/comms\` → run history renders with the 20 newest rows; a failed row highlights in danger colour and reveals its error on click.

### Out of scope
- E2E full-flow Playwright + \`POST /api/dispatch?force=1\` integration — T7.4 / Stage 7.
- Structured logging boundary — T7.1 / Stage 7.
- Spec-coverage audit script — T7.5 / Stage 7.

Refs: tickets#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)