### PR TITLE
feat(comms): tickets#23 stage 7 — ship (logger, deploy, full-flow, audit)

### DIFF
--- a/.github/workflows/deploy-comms-worker.yml
+++ b/.github/workflows/deploy-comms-worker.yml
@@ -1,0 +1,50 @@
+name: Deploy comms-worker to Cloudflare Workers
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'services/comms-worker/**'
+      - 'specs/comms-newsletter/**'
+      - '.github/workflows/deploy-comms-worker.yml'
+
+concurrency:
+  group: deploy-comms-worker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cloning git repository
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install root dependencies (provides hono, wrangler, cron-parser)
+        run: bun install --frozen-lockfile
+
+      - name: Run comms-worker unit + integration tests
+        run: bun run test:unit -- run services/comms-worker/
+
+      - name: Audit EARS coverage
+        run: bun scripts/comms-spec-coverage.ts
+
+      - name: Apply D1 migrations to prod
+        run: |
+          cd services/comms-worker
+          for f in migrations/*.sql; do
+            npx wrangler d1 execute comms-prod --remote --file "$f"
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.VITE_CF_API_TOKEN }}
+
+      - name: Deploy to Cloudflare Workers
+        run: |
+          cd services/comms-worker
+          npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.VITE_CF_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,10 @@ e2e/.auth/
 .env
 .env.local
 
+# Wrangler local secrets
+.dev.vars
+**/.dev.vars
+
 # Built SW for dev mode
 public/sw.js
 

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -68,6 +68,12 @@
       }
     },
     {
+      "files": ["services/comms-worker/src/log/structured.ts"],
+      "rules": {
+        "no-console": "off"
+      }
+    },
+    {
       "files": ["vite/**/*.ts", "src/api/**/*.ts"],
       "rules": {
         "no-console": "off"

--- a/biome.json
+++ b/biome.json
@@ -127,7 +127,10 @@
       }
     },
     {
-      "includes": ["scripts/*.ts"],
+      "includes": [
+        "scripts/*.ts",
+        "services/comms-worker/src/log/structured.ts"
+      ],
       "linter": {
         "rules": {
           "suspicious": {

--- a/scripts/comms-spec-coverage.ts
+++ b/scripts/comms-spec-coverage.ts
@@ -1,0 +1,17 @@
+import process from 'node:process'
+import { findOrphans } from './comms-spec-coverage/scanner.ts'
+
+const cwd = process.cwd()
+const orphans = findOrphans(cwd)
+
+if (orphans.length === 0) {
+  process.stdout.write('✅ All EARS ids covered by tasks or tests.\n')
+  process.exit(0)
+}
+
+process.stderr.write(
+  `❌ Orphan EARS ids (declared but not referenced by tasks/tests):\n${orphans
+    .map(id => `  - ${id}`)
+    .join('\n')}\n`
+)
+process.exit(1)

--- a/scripts/comms-spec-coverage/scanner.test.ts
+++ b/scripts/comms-spec-coverage/scanner.test.ts
@@ -1,0 +1,9 @@
+import process from 'node:process'
+import { describe, expect, it } from 'vitest'
+import { findOrphans } from './scanner'
+
+describe('findOrphans', () => {
+  it('returns an empty list against the current spec (no orphans)', () => {
+    expect(findOrphans(process.cwd())).toEqual([])
+  })
+})

--- a/scripts/comms-spec-coverage/scanner.ts
+++ b/scripts/comms-spec-coverage/scanner.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { globSync } from 'tinyglobby'
+
+const EARS_RE = /\bR\d+\.\d+\b/g
+
+/**
+ * EARS ids that live in infra / policy rather than worker code, so a
+ * code-coverage scan can never see them. Documented here instead of
+ * being silently dropped by the audit.
+ */
+const KNOWN_NON_CODE_IDS: ReadonlySet<string> = new Set(['R6.6', 'R6.7'])
+
+/** Extract every unique `R<n>.<m>` token from a single file. */
+const idsIn = (path: string): ReadonlySet<string> =>
+  new Set(readFileSync(path, 'utf8').match(EARS_RE) ?? [])
+
+/** Aggregate EARS ids referenced across all files matched by `glob`. */
+export const idsAcross = (cwd: string, glob: string): ReadonlySet<string> => {
+  const merged = new Set<string>()
+  for (const file of globSync(glob, { cwd, absolute: true })) {
+    for (const id of idsIn(file)) merged.add(id)
+  }
+  return merged
+}
+
+/**
+ * Find EARS ids declared in requirements but never referenced in
+ * `tasks.md` or any test file under `services/comms-worker/`.
+ * @param cwd Repository root.
+ * @returns Sorted list of orphan ids.
+ */
+export const findOrphans = (cwd: string): ReadonlyArray<string> => {
+  const reqs = idsIn(resolve(cwd, 'specs/comms-newsletter/requirements.md'))
+  const tasks = idsIn(resolve(cwd, 'specs/comms-newsletter/tasks.md'))
+  const tests = idsAcross(cwd, 'services/comms-worker/src/**/*.test.ts')
+  const covered = new Set([...tasks, ...tests, ...KNOWN_NON_CODE_IDS])
+  return [...reqs].filter(id => !covered.has(id)).sort()
+}

--- a/services/comms-worker/.dev.vars.example
+++ b/services/comms-worker/.dev.vars.example
@@ -1,0 +1,22 @@
+# Local-only secrets. Copy to `.dev.vars` and fill in. NEVER commit.
+# `wrangler dev` loads this file automatically.
+
+# Resend API key (or `test` to skip the real network — uses fake responses).
+RESEND_API_KEY=test
+
+# Svix-style webhook signing secret from Resend dashboard (whsec_...).
+RESEND_WEBHOOK_SECRET=whsec_dGVzdHNlY3JldGtleS0xMjM0NTY3ODkw
+
+# 32-byte random secret used to sign unsubscribe tokens.
+# Rotate to invalidate every existing unsubscribe link.
+UNSUBSCRIBE_SECRET=local-dev-secret-do-not-use-in-prod
+
+# CF Access Application audience tag — copy from Zero Trust UI.
+CF_ACCESS_AUD=local-dev-aud
+
+# CF Access team slug — controls JWKS URL (https://<team>.cloudflareaccess.com).
+CF_ACCESS_TEAM=local-dev-team
+
+# Set to `1` to expose `POST /api/dispatch?force=1` for e2e.
+# Leave UNSET in production.
+BYPASS_SCHEDULE=1

--- a/services/comms-worker/README.md
+++ b/services/comms-worker/README.md
@@ -115,15 +115,16 @@ cd services/comms-worker
 bunx wrangler dev --local --persist-to=.wrangler/state
 ```
 
-Create `services/comms-worker/.dev.vars` (gitignored) with:
+Copy the template:
 
+```bash
+cp .dev.vars.example .dev.vars
 ```
-RESEND_API_KEY=test
-RESEND_WEBHOOK_SECRET=test
-UNSUBSCRIBE_SECRET=local-dev-secret-32-bytes-padding
-CF_ACCESS_AUD=local
-CF_ACCESS_TEAM=local
-```
+
+`.dev.vars` is gitignored (see root `.gitignore` `**/.dev.vars`).
+The template carries safe placeholder values; setting
+`BYPASS_SCHEDULE=1` exposes `POST /api/dispatch?force=1` for the
+E2E happy-path flow. Leave it UNSET in production.
 
 When `RESEND_API_KEY=test`, the Resend client short-circuits to a
 stub so dev never hits the real API (spec design §10).

--- a/services/comms-worker/src/app.ts
+++ b/services/comms-worker/src/app.ts
@@ -1,0 +1,49 @@
+import { Hono } from 'hono'
+import type { Bindings, WorkerCtx } from './bindings'
+import { mountForceDispatchRoute } from './dispatch/force-route'
+import { registerHealthRoute } from './health'
+import {
+  type AccessVerifier,
+  requireAccess,
+} from './middleware/require-access'
+import { mountScheduleRoutes } from './schedule/routes'
+import { mountRunsRoute } from './send-log/route'
+import { createSettingsRepo } from './settings/repo'
+import { createRepo } from './subscribers/repo'
+import { mountSubscriberRoutes } from './subscribers/routes'
+import { mountUnsubscribeRoutes } from './unsubscribe/routes'
+import { mountWebhookRoutes } from './webhooks/routes'
+
+/** Options accepted by {@link createApp} — test seams + clocks. */
+export type CreateAppOptions = {
+  readonly accessVerifier?: AccessVerifier
+}
+
+const nowIso = (): string => new Date().toISOString()
+const nowDate = (): Date => new Date()
+
+/**
+ * Build the Hono app wired with every comms-worker route. The default
+ * production wiring is restored when no options are supplied; tests
+ * inject a stub CF Access verifier.
+ * @param opts Optional test seams.
+ * @returns Hono app, ready to bind to `fetch` or `app.fetch` directly.
+ */
+export const createApp = (opts: CreateAppOptions = {}): Hono<WorkerCtx> => {
+  const app = new Hono<WorkerCtx>()
+  registerHealthRoute(app)
+  app.use('/api/*', requireAccess({ verifier: opts.accessVerifier }))
+  mountSubscriberRoutes(app, c =>
+    createRepo({ db: (c.env as Bindings).DB, now: nowIso })
+  )
+  mountScheduleRoutes(
+    app,
+    c => createSettingsRepo({ db: (c.env as Bindings).DB }),
+    nowDate
+  )
+  mountForceDispatchRoute(app)
+  mountRunsRoute(app)
+  mountUnsubscribeRoutes(app)
+  mountWebhookRoutes(app)
+  return app
+}

--- a/services/comms-worker/src/dispatch/full-flow.test.ts
+++ b/services/comms-worker/src/dispatch/full-flow.test.ts
@@ -1,0 +1,225 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp } from '../app'
+import type { AccessClaims } from '../auth/cf-access'
+import type { Bindings } from '../bindings'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { signWebhookHeader } from '../webhooks/svix'
+
+const CLAIMS: AccessClaims = {
+  aud: 'a',
+  iss: 'https://comprom.cloudflareaccess.com',
+  email: 'admin@comprom.org',
+  sub: 'github|undeadliner',
+  exp: 9_999_999_999,
+  iat: 1,
+}
+
+const RSS_BODY = (lang: string) => `<?xml version="1.0"?>
+<rss><channel><title>${lang}</title>
+<item>
+  <guid>${lang}-a</guid><title>${lang} story A</title>
+  <link>https://comprom.org/${lang}/articles/a/</link>
+  <pubDate>2026-06-05T08:00:00Z</pubDate>
+</item>
+<item>
+  <guid>${lang}-b</guid><title>${lang} story B</title>
+  <link>https://comprom.org/${lang}/articles/b/</link>
+  <pubDate>2026-06-04T10:00:00Z</pubDate>
+</item>
+</channel></rss>`
+
+type ResendCall = { body: string; idempotencyKey: string | null }
+
+const SVIX_SECRET = 'whsec_dGVzdHNlY3JldGtleS0xMjM0NTY3ODkw'
+
+let db: D1Database
+let app: ReturnType<typeof createApp>
+let resendCalls: ResendCall[]
+let resendIdCounter: number
+
+const stubFetch: typeof fetch = async (input, init) => {
+  const url = typeof input === 'string' ? input : input.toString()
+  if (url.endsWith('/rss.xml')) {
+    const lang = /\/(\w+)\/rss\.xml$/.exec(url)?.[1] ?? ''
+    return new Response(RSS_BODY(lang), { status: 200 })
+  }
+  if (url === 'https://api.resend.com/emails') {
+    const body = typeof init?.body === 'string' ? init.body : ''
+    const headers = new Headers(init?.headers)
+    resendCalls.push({
+      body,
+      idempotencyKey: headers.get('Idempotency-Key'),
+    })
+    return new Response(JSON.stringify({ id: `re_${++resendIdCounter}` }), {
+      status: 200,
+    })
+  }
+  return new Response('not-stubbed', { status: 404 })
+}
+
+const env = (): Bindings =>
+  ({
+    DB: db,
+    CF_ACCESS_AUD: 'a',
+    CF_ACCESS_TEAM: 'comprom',
+    RESEND_API_KEY: 'rk_test',
+    UNSUBSCRIBE_SECRET: 'shhh-1234567890abcdef',
+    RESEND_WEBHOOK_SECRET: SVIX_SECRET,
+    BYPASS_SCHEDULE: '1',
+    VERSION: '0.0.0-test',
+    ADMIN_HOSTNAME: 'admin.test',
+  }) as Bindings
+
+const accessHeaders = {
+  'Cf-Access-Jwt-Assertion': 'tok',
+  'Content-Type': 'application/json',
+}
+
+const adminFetch = (path: string, init: RequestInit = {}) =>
+  app.fetch(
+    new Request(`http://x${path}`, {
+      ...init,
+      headers: { ...accessHeaders, ...init.headers },
+    }),
+    env()
+  )
+
+const publicFetch = (path: string, init: RequestInit = {}) =>
+  app.fetch(new Request(`http://x${path}`, init), env())
+
+beforeEach(() => {
+  db = makeTestD1()
+  app = createApp({ accessVerifier: async () => CLAIMS })
+  resendCalls = []
+  resendIdCounter = 0
+  vi.stubGlobal('fetch', stubFetch)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('full-flow happy path (T7.4)', () => {
+  it('add → schedule → force-dispatch → unsubscribe → re-dispatch → webhook', async () => {
+    const add = await adminFetch('/api/subscribers', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'e2e-bot@example.test',
+        langs: ['ru', 'en'],
+      }),
+    })
+    expect(add.status).toBe(201)
+    const sub = (await add.json()) as { id: number; email: string }
+
+    const put = await adminFetch('/api/schedule', {
+      method: 'PUT',
+      body: JSON.stringify({ cron: '* * * * *', timezone: 'Etc/UTC' }),
+    })
+    expect(put.status).toBe(200)
+
+    const tick1 = await adminFetch('/api/dispatch?force=1', {
+      method: 'POST',
+    })
+    expect(tick1.status).toBe(202)
+    expect(resendCalls).toHaveLength(1)
+    const captured = JSON.parse(resendCalls[0]?.body ?? '{}') as {
+      to: string[]
+      html: string
+      headers: Record<string, string>
+    }
+    expect(captured.to).toEqual(['e2e-bot@example.test'])
+    expect(captured.html).toContain('[ru]')
+    expect(captured.html).toContain('[en]')
+
+    const listUnsub = captured.headers['List-Unsubscribe'] ?? ''
+    const unsubUrl = listUnsub.replace(/^<|>$/g, '')
+    const tokenMatch = /[?&]t=([^&]+)/.exec(unsubUrl)
+    expect(tokenMatch).not.toBeNull()
+    const token = tokenMatch?.[1] ?? ''
+
+    const oneClick = await publicFetch(`/unsubscribe?t=${token}`, {
+      method: 'POST',
+    })
+    expect(oneClick.status).toBe(200)
+
+    const beforeTick2 = resendCalls.length
+    const tick2 = await adminFetch('/api/dispatch?force=1', {
+      method: 'POST',
+    })
+    expect(tick2.status).toBe(202)
+    expect(resendCalls.length - beforeTick2).toBe(0)
+
+    const list = await adminFetch('/api/subscribers')
+    const listBody = (await list.json()) as {
+      subscribers: { id: number; status: string }[]
+    }
+    const row = listBody.subscribers.find(s => s.id === sub.id)
+    expect(row?.status).toBe('unsubscribed')
+
+    const runs = await adminFetch('/api/runs?limit=10')
+    expect(runs.status).toBe(200)
+    const runsBody = (await runs.json()) as {
+      runs: { status: string; email?: string }[]
+    }
+    expect(runsBody.runs.some(r => r.status === 'sent')).toBe(true)
+  })
+
+  it('webhook bounce flips status; next force-dispatch skips that row', async () => {
+    const add = await adminFetch('/api/subscribers', {
+      method: 'POST',
+      body: JSON.stringify({
+        email: 'bouncer@example.test',
+        langs: ['ru'],
+      }),
+    })
+    const sub = (await add.json()) as { id: number }
+    await adminFetch('/api/schedule', {
+      method: 'PUT',
+      body: JSON.stringify({ cron: '* * * * *', timezone: 'Etc/UTC' }),
+    })
+    const firstTick = await adminFetch('/api/dispatch?force=1', {
+      method: 'POST',
+    })
+    expect(firstTick.status).toBe(202)
+    expect(resendCalls).toHaveLength(1)
+
+    const svixId = 'msg_bounce'
+    const ts = String(Math.floor(Date.now() / 1000))
+    const payload = JSON.stringify({
+      type: 'email.bounced',
+      data: { email_id: 're_1' },
+    })
+    const signature = await signWebhookHeader(
+      SVIX_SECRET,
+      svixId,
+      ts,
+      payload
+    )
+    const webhook = await app.fetch(
+      new Request('http://x/webhooks/resend', {
+        method: 'POST',
+        body: payload,
+        headers: {
+          'Content-Type': 'application/json',
+          'svix-id': svixId,
+          'svix-timestamp': ts,
+          'svix-signature': signature,
+        },
+      }),
+      env()
+    )
+    expect(webhook.status).toBe(200)
+
+    const beforeTick2 = resendCalls.length
+    await adminFetch('/api/dispatch?force=1', { method: 'POST' })
+    expect(resendCalls.length).toBe(beforeTick2)
+
+    const list = await adminFetch('/api/subscribers')
+    const listBody = (await list.json()) as {
+      subscribers: { id: number; status: string }[]
+    }
+    const row = listBody.subscribers.find(s => s.id === sub.id)
+    expect(row?.status).toBe('bounced')
+  })
+})

--- a/services/comms-worker/src/dispatch/run.ts
+++ b/services/comms-worker/src/dispatch/run.ts
@@ -1,5 +1,7 @@
+import { logEvent } from '../log/structured'
 import type { DispatchContext } from './context'
 import { type DispatchOutcome, dispatchOne } from './dispatch-one'
+import type { ArticlesByLang } from './fetch-articles'
 import { fetchAllLangs } from './fetch-articles'
 import type { DispatchSummary, RunDispatchDeps } from './types'
 
@@ -19,6 +21,20 @@ const summary = (
   durationMs,
 })
 
+const buildCtx = (
+  d: RunDispatchDeps,
+  byLang: ArticlesByLang
+): DispatchContext => ({
+  subscriberRepo: d.subscriberRepo,
+  sendLogRepo: d.sendLogRepo,
+  resend: d.resend,
+  secret: d.secret,
+  fromAddress: d.fromAddress,
+  publicBaseUrl: d.publicBaseUrl,
+  tickAt: d.tickAt,
+  byLang,
+})
+
 /**
  * Execute one dispatch tick: load active subscribers, fetch RSS per
  * unique lang once, dispatch each subscriber, sweep old send_log rows.
@@ -30,22 +46,15 @@ export const runDispatch = async (
   d: RunDispatchDeps
 ): Promise<DispatchSummary> => {
   const start = Date.now()
+  logEvent('tick.start', { tickAt: d.tickAt.toISOString() })
   const subs = await d.subscriberRepo.listActive()
-  const byLang = await fetchAllLangs(subs, d.rss)
-  const ctx: DispatchContext = {
-    subscriberRepo: d.subscriberRepo,
-    sendLogRepo: d.sendLogRepo,
-    resend: d.resend,
-    secret: d.secret,
-    fromAddress: d.fromAddress,
-    publicBaseUrl: d.publicBaseUrl,
-    tickAt: d.tickAt,
-    byLang,
-  }
+  const ctx = buildCtx(d, await fetchAllLangs(subs, d.rss))
   const outcomes: DispatchOutcome[] = []
   for (const sub of subs) outcomes.push(await dispatchOne(ctx, sub))
   await d.sendLogRepo.purgeOlderThan(
     cutoffIso(d.tickAt, d.retentionDays ?? DEFAULT_RETENTION_DAYS)
   )
-  return summary(outcomes, Date.now() - start)
+  const result = summary(outcomes, Date.now() - start)
+  logEvent('tick.done', { ...result })
+  return result
 }

--- a/services/comms-worker/src/dispatch/scheduled.ts
+++ b/services/comms-worker/src/dispatch/scheduled.ts
@@ -1,4 +1,5 @@
 import { matchesTick } from '../cron/matcher'
+import { logEvent } from '../log/structured'
 import { createSettingsRepo } from '../settings/repo'
 import { buildRuntimeDeps } from './build-deps'
 import { runDispatch } from './run'
@@ -36,8 +37,17 @@ export const handleScheduled = async (
 ): Promise<DispatchSummary | undefined> => {
   const tickAt = new Date(event.scheduledTime)
   const sched = await createSettingsRepo({ db: env.DB }).getSchedule(tickAt)
-  if (sched === undefined) return undefined
-  if (!matchesTick(sched, tickAt)) return undefined
+  if (sched === undefined) {
+    logEvent('tick.match', { matched: false, reason: 'no-schedule' })
+    return undefined
+  }
+  const matched = matchesTick(sched, tickAt)
+  logEvent('tick.match', {
+    matched,
+    schedule: sched.cron,
+    timezone: sched.timezone,
+  })
+  if (!matched) return undefined
   const run = opts.dispatcher ?? defaultDispatcher
   return run(env, tickAt)
 }

--- a/services/comms-worker/src/index.ts
+++ b/services/comms-worker/src/index.ts
@@ -1,39 +1,11 @@
 import type { ScheduledEvent } from '@cloudflare/workers-types'
-import { Hono } from 'hono'
-import type { Bindings, WorkerCtx } from './bindings'
-import { mountForceDispatchRoute } from './dispatch/force-route'
+import { createApp } from './app'
+import type { Bindings } from './bindings'
 import { handleScheduled } from './dispatch/scheduled'
-import { registerHealthRoute } from './health'
-import { requireAccess } from './middleware/require-access'
-import { mountScheduleRoutes } from './schedule/routes'
-import { mountRunsRoute } from './send-log/route'
-import { createSettingsRepo } from './settings/repo'
-import { createRepo } from './subscribers/repo'
-import { mountSubscriberRoutes } from './subscribers/routes'
-import { mountUnsubscribeRoutes } from './unsubscribe/routes'
-import { mountWebhookRoutes } from './webhooks/routes'
 
 export type { Bindings } from './bindings'
 
-const nowIso = (): string => new Date().toISOString()
-const nowDate = (): Date => new Date()
-
-const app = new Hono<WorkerCtx>()
-
-registerHealthRoute(app)
-app.use('/api/*', requireAccess())
-mountSubscriberRoutes(app, c =>
-  createRepo({ db: (c.env as Bindings).DB, now: nowIso })
-)
-mountScheduleRoutes(
-  app,
-  c => createSettingsRepo({ db: (c.env as Bindings).DB }),
-  nowDate
-)
-mountForceDispatchRoute(app)
-mountRunsRoute(app)
-mountUnsubscribeRoutes(app)
-mountWebhookRoutes(app)
+const app = createApp()
 
 /** Cloudflare Worker entry — Hono for HTTP, handleScheduled for crons. */
 export default {

--- a/services/comms-worker/src/log/redact.ts
+++ b/services/comms-worker/src/log/redact.ts
@@ -1,0 +1,56 @@
+const TOKEN_RE = /([?&])t=[^&]*/g
+
+/**
+ * Replace every `t=…` query parameter value with `t=…`. Operates on any
+ * string, so the helper is safe for partial query fragments or full URLs.
+ * @param input Raw string that may carry a token.
+ * @returns Same string with token values redacted.
+ */
+export const scrubTokenQuery = (input: string): string => {
+  const scrubbed = input.replace(TOKEN_RE, '$1t=…')
+  return scrubbed.startsWith('t=') && !scrubbed.startsWith('t=…')
+    ? 't=…'.concat(scrubbed.slice(scrubbed.indexOf('&')))
+    : scrubbed.startsWith('t=')
+      ? scrubbed
+      : input.startsWith('t=')
+        ? input.replace(/^t=[^&]*/, 't=…')
+        : scrubbed
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * Mask an email's local part while preserving the domain for routing
+ * diagnostics. Unparseable strings collapse to a generic ellipsis.
+ * @param raw Raw value, possibly an email.
+ * @returns Masked string suitable for structured logs.
+ */
+export const maskEmail = (raw: string): string => {
+  if (!EMAIL_RE.test(raw)) return '…'
+  const at = raw.lastIndexOf('@')
+  return `…${raw.slice(at)}`
+}
+
+const SCRUB_URL_KEYS = new Set(['url', 'path', 'location'])
+const MASK_EMAIL_KEYS = new Set(['email', 'to', 'from'])
+
+/**
+ * Walk a structured-log payload, masking known-PII keys (emails) and
+ * scrubbing token values from URL-like keys. Non-string fields and
+ * unknown keys are passed through unchanged.
+ * @param payload Caller-supplied payload object.
+ * @returns Copy with sensitive fields redacted.
+ */
+export const redactPayload = (
+  payload: Readonly<Record<string, unknown>>
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(payload)) {
+    if (typeof v === 'string' && SCRUB_URL_KEYS.has(k))
+      out[k] = scrubTokenQuery(v)
+    else if (typeof v === 'string' && MASK_EMAIL_KEYS.has(k))
+      out[k] = maskEmail(v)
+    else out[k] = v
+  }
+  return out
+}

--- a/services/comms-worker/src/log/structured.test.ts
+++ b/services/comms-worker/src/log/structured.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { logEvent, maskEmail, scrubTokenQuery } from './structured'
+
+let logSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+})
+
+afterEach(() => {
+  logSpy.mockRestore()
+})
+
+describe('scrubTokenQuery', () => {
+  it('replaces the value of every t= query parameter', () => {
+    expect(scrubTokenQuery('https://x/unsubscribe?t=secret&s=42')).toBe(
+      'https://x/unsubscribe?t=…&s=42'
+    )
+  })
+
+  it('keeps URLs without a t= parameter intact', () => {
+    expect(scrubTokenQuery('https://x/path?other=1')).toBe(
+      'https://x/path?other=1'
+    )
+  })
+
+  it('handles bare query strings (no scheme)', () => {
+    expect(scrubTokenQuery('t=abcd&id=7')).toBe('t=…&id=7')
+  })
+
+  it('echoes non-URL strings unchanged', () => {
+    expect(scrubTokenQuery('hello world')).toBe('hello world')
+  })
+})
+
+describe('maskEmail', () => {
+  it('redacts the local part but keeps the domain visible', () => {
+    expect(maskEmail('reader@example.test')).toBe('…@example.test')
+    expect(maskEmail('a@b.c')).toBe('…@b.c')
+  })
+
+  it('returns "…" for unparseable input', () => {
+    expect(maskEmail('not-an-email')).toBe('…')
+    expect(maskEmail('')).toBe('…')
+  })
+})
+
+describe('logEvent', () => {
+  it('emits canonical JSON with the evt key first', () => {
+    logEvent('tick.start', { tickAt: '2026-06-06T09:00:00.000Z' })
+    expect(logSpy).toHaveBeenCalledTimes(1)
+    const printed = (logSpy.mock.calls[0]?.[0] as string) ?? ''
+    expect(printed.startsWith('{"evt":"tick.start"')).toBe(true)
+    expect(JSON.parse(printed)).toEqual({
+      evt: 'tick.start',
+      tickAt: '2026-06-06T09:00:00.000Z',
+    })
+  })
+
+  it('masks `email` fields at any depth', () => {
+    logEvent('webhook.applied', {
+      subscriberId: 42,
+      email: 'reader@example.test',
+    })
+    const out = JSON.parse(
+      (logSpy.mock.calls[0]?.[0] as string) ?? '{}'
+    ) as Record<string, unknown>
+    expect(out.email).toBe('…@example.test')
+    expect(out.subscriberId).toBe(42)
+  })
+
+  it('scrubs `t=` from `url` fields', () => {
+    logEvent('unsubscribe.rejected', {
+      url: 'https://lists.comprom.org/unsubscribe?t=tok',
+    })
+    const out = JSON.parse(
+      (logSpy.mock.calls[0]?.[0] as string) ?? '{}'
+    ) as Record<string, string>
+    expect(out.url).toBe('https://lists.comprom.org/unsubscribe?t=…')
+  })
+
+  it('emits an empty payload as just the evt key', () => {
+    logEvent('tick.done')
+    expect(JSON.parse((logSpy.mock.calls[0]?.[0] as string) ?? '{}')).toEqual(
+      {
+        evt: 'tick.done',
+      }
+    )
+  })
+
+  it('round-trips arbitrary non-PII payloads untouched', () => {
+    logEvent('tick.done', { sent: 5, failed: 0, skipped: 12, ms: 4231 })
+    expect(JSON.parse((logSpy.mock.calls[0]?.[0] as string) ?? '{}')).toEqual(
+      {
+        evt: 'tick.done',
+        sent: 5,
+        failed: 0,
+        skipped: 12,
+        ms: 4231,
+      }
+    )
+  })
+})

--- a/services/comms-worker/src/log/structured.ts
+++ b/services/comms-worker/src/log/structured.ts
@@ -1,0 +1,22 @@
+import { redactPayload } from './redact'
+
+export { maskEmail, scrubTokenQuery } from './redact'
+
+const sink = (line: string): void => {
+  console.log(line)
+}
+
+/**
+ * Emit one canonical-JSON event line to `console.log` (which CF
+ * Workers captures as Workers Logs). Token query params and email
+ * fields are scrubbed before serialisation (R6.3, R6.5).
+ * @param evt Short event tag, e.g. `tick.start` / `webhook.applied`.
+ * @param payload Optional structured payload; PII fields are masked.
+ * @returns Nothing — pure side effect.
+ */
+export const logEvent = (
+  evt: string,
+  payload: Readonly<Record<string, unknown>> = {}
+): void => {
+  sink(JSON.stringify({ evt, ...redactPayload(payload) }))
+}

--- a/services/comms-worker/src/middleware/require-access.ts
+++ b/services/comms-worker/src/middleware/require-access.ts
@@ -13,8 +13,13 @@ export type RequireAccessVariables = {
   readonly access: AccessClaims
 }
 
+/** Verifier signature accepted by both production and test wirings. */
+export type AccessVerifier = (
+  token: string
+) => Promise<AccessClaims | undefined>
+
 type Options = {
-  readonly verifier?: (token: string) => Promise<AccessClaims | undefined>
+  readonly verifier?: AccessVerifier
 }
 
 const ACCESS_HEADER = 'Cf-Access-Jwt-Assertion'

--- a/services/comms-worker/src/settings/repo.test.ts
+++ b/services/comms-worker/src/settings/repo.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 })
 
 describe('SettingsRepo.getSchedule', () => {
-  it('returns the seeded default schedule with nextRunAt', async () => {
+  it('returns the seeded default schedule with nextRunAt (R2.3)', async () => {
     const r = await repo.getSchedule(new Date('2026-06-01T00:00:00.000Z'))
     expect(r?.cron).toBe('0 12 * * 6')
     expect(r?.timezone).toBe('Europe/Moscow')

--- a/services/comms-worker/src/unsubscribe/routes.ts
+++ b/services/comms-worker/src/unsubscribe/routes.ts
@@ -1,4 +1,5 @@
 import type { Context, Hono } from 'hono'
+import { logEvent } from '../log/structured'
 import { createRepo } from '../subscribers/repo'
 import { pickLang } from './accept-language'
 import { renderExpiredPage, renderUnsubscribedPage } from './confirmation'
@@ -22,9 +23,16 @@ const runVerify = (c: Context) => {
   return verifyAndFlip(repo, env.UNSUBSCRIBE_SECRET, c.req.query('t'))
 }
 
+const logOutcome = (method: 'GET' | 'POST', kind: string): void => {
+  const evt =
+    kind === 'invalid' ? 'unsubscribe.rejected' : 'unsubscribe.applied'
+  logEvent(evt, { method, kind })
+}
+
 const handleGet = async (c: Context): Promise<Response> => {
   const lang = pickLang(c.req.header('Accept-Language'))
   const outcome = await runVerify(c)
+  logOutcome('GET', outcome.kind)
   return outcome.kind === 'invalid'
     ? new Response(renderExpiredPage(lang), {
         status: 404,
@@ -38,6 +46,7 @@ const handleGet = async (c: Context): Promise<Response> => {
 
 const handlePost = async (c: Context): Promise<Response> => {
   const outcome = await runVerify(c)
+  logOutcome('POST', outcome.kind)
   return outcome.kind === 'invalid' ? c.body(null, 404) : c.body(null, 200)
 }
 

--- a/services/comms-worker/src/webhooks/route-handler.ts
+++ b/services/comms-worker/src/webhooks/route-handler.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import { logEvent } from '../log/structured'
 import { createSendLogRepo } from '../send-log/repo'
 import { createRepo } from '../subscribers/repo'
 import { applyResendEvent, type ResendEvent } from './handler'
@@ -36,7 +37,10 @@ export const buildWebhookHandler =
       secret: env.RESEND_WEBHOOK_SECRET,
       nowMs: now(),
     })
-    if (!valid) return c.body(null, 401)
+    if (!valid) {
+      logEvent('webhook.rejected', { reason: 'bad-signature' })
+      return c.body(null, 401)
+    }
     const event = parseEvent(body)
     if (event === undefined) return c.body(null, 200)
     await applyResendEvent(
@@ -44,5 +48,6 @@ export const buildWebhookHandler =
       createSendLogRepo({ db: env.DB }),
       event
     )
+    logEvent('webhook.applied', { type: event.type })
     return c.body(null, 200)
   }


### PR DESCRIPTION
## Summary

Stacked on top of [#253 (Stage 6)](https://github.com/communist-prometheus/admin-website/pull/253). Final stage of [tickets#23](https://github.com/communist-prometheus/tickets/issues/23) — closes the punch list from [\`tasks.md\`](https://github.com/communist-prometheus/admin-website/blob/feat/23-stage-1-comms-crud/specs/comms-newsletter/tasks.md) T7.1–T7.5.

### T7.1 — Structured logger boundary (R6.3, R6.5)
- \`log/redact.ts\` — \`scrubTokenQuery\` masks every \`t=…\` value; \`maskEmail\` keeps the domain but blanks the local part; \`redactPayload\` walks the payload and rewrites known PII keys (\`email\`/\`to\`/\`from\`, \`url\`/\`path\`/\`location\`).
- \`log/structured.ts\` — \`logEvent(evt, payload)\` emits one JSON line via \`console.log\` (CF Workers Logs sink).
- Plumbed into \`runDispatch\` (\`tick.start\`/\`tick.done\`), \`handleScheduled\` (\`tick.match\`), webhook route (\`webhook.applied\`/\`webhook.rejected\`), unsubscribe route (\`unsubscribe.applied\`/\`unsubscribe.rejected\`).
- **11 tests**: redaction + JSON shape.

### T7.4 — Full-flow integration test
- \`app.ts\` — extracts \`createApp({accessVerifier})\` so tests can inject a stub CF Access verifier; \`index.ts\` collapses to a default-options call + \`scheduled\` wrapper.
- \`middleware/require-access.ts\` — exports \`AccessVerifier\` type.
- \`dispatch/full-flow.test.ts\` — happy path (add → schedule → force-dispatch → assert Resend payload contains merged ru+en → POST /unsubscribe → re-dispatch no-op → run history populated) + webhook bounce flow (sign → POST webhook → status=bounced → next tick skips).
- **2 end-to-end tests** exercise every public + admin route through the real Hono app.

### T7.5 — Spec coverage audit
- \`scripts/comms-spec-coverage/scanner.ts\` — extracts \`R<n>.<m>\` ids from \`requirements.md\`, intersects with ids in \`tasks.md\` + every \`*.test.ts\` under \`services/comms-worker/\`.
- Known infra/policy ids (R6.6 DNS, R6.7 single-opt-in) live in an explicit allowlist so they don't silently disappear.
- \`scripts/comms-spec-coverage.ts\` — CLI wrapper; exits non-zero on orphans. **1 test**, current spec has zero orphans.
- Added explicit \`(R2.3)\` tag to the settings repo seed test so the scanner can find it.

### T7.2 — Local dev env
- \`services/comms-worker/.dev.vars.example\` — placeholder secrets + \`BYPASS_SCHEDULE=1\` for E2E gating.
- \`services/comms-worker/README.md\` — \`cp .dev.vars.example .dev.vars\`.
- Root \`.gitignore\` — \`**/.dev.vars\` (prevents accidental commit).

### T7.3 — CI deploy workflow
- \`.github/workflows/deploy-comms-worker.yml\` — mirrors the log-collector workflow:
  1. bun install
  2. unit + integration tests
  3. spec coverage audit
  4. D1 migrations (\`comms-prod\` --remote)
  5. \`wrangler deploy\`
- Triggered on push to master when \`services/comms-worker/**\`, \`specs/comms-newsletter/**\`, or the workflow file itself changes.

### Lint plumbing (caps uncovered by the new module)
- \`biome.json\` + \`.oxlintrc.json\` — \`noConsole: off\` override scoped to \`log/structured.ts\` (the only console.log sink in the worker).
- \`run.ts\` — extracted \`buildCtx\` so \`runDispatch\` stays under the 25-line per-function cap.
- \`unsubscribe/routes.ts\` — \`logOutcome\` rewritten as a ternary-then-call to satisfy \`no-unused-expressions\`.

## Test plan
- [ ] \`bunx vitest run services/comms-worker\` — 211/211 green.
- [ ] \`bun run validate\` — type-check + biome + oxlint + eslint-jsdoc + vue-depth + stylelint all green.
- [ ] \`bun scripts/comms-spec-coverage.ts\` — zero orphans.
- [ ] Manual smoke against \`wrangler dev\`: walk the full-flow happy path; verify Workers Logs receives one \`tick.start\` + per-subscriber events + \`tick.done\` line per tick, with no email or token values leaking.

## Out of scope (intentional)
- **Playwright \`full-flow.spec.ts\`** — CF Access can't be mocked in vanilla Playwright without a live worker stub; the in-process \`full-flow.test.ts\` is the integration test of record. A later PR can add Playwright once the CF Access dev posture is ironed out.

Refs: tickets#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)