### PR TITLE
feat(comms): tickets#23 — design + a11y + perf rebuild + walkthrough

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -101,6 +101,7 @@
         "playwright.config.ts",
         "playwright.config.prod.ts",
         "playwright.config.realmode.ts",
+        "playwright.config.walkthrough.ts",
         "e2e/auth/setup.ts",
         "e2e-realmode/global-setup.ts",
         "eslint.config.js",

--- a/e2e/comms-walkthrough/install-routes.ts
+++ b/e2e/comms-walkthrough/install-routes.ts
@@ -1,0 +1,85 @@
+import type { Page, Route } from '@playwright/test'
+import { createMockState, type MockState, mockHandlers } from './mock-state'
+
+export type { MockState } from './mock-state'
+
+const COMMS_PATTERN = '**/lists.comprom.org/api/**'
+const SUB_BY_ID = /\/api\/subscribers\/(\d+)$/
+
+type Handlers = ReturnType<typeof mockHandlers>
+type FulfillBody = Parameters<Route['fulfill']>[0]
+type Reply = FulfillBody | undefined
+
+const collectionRoute = (
+  url: string,
+  method: string,
+  h: Handlers,
+  req: Route['request'] extends () => infer R ? R : never
+): Reply => {
+  if (url.endsWith('/api/subscribers') && method === 'GET')
+    return h.listSubs()
+  if (url.endsWith('/api/subscribers') && method === 'POST') {
+    return h.postSubscriber(req.postDataJSON())
+  }
+  if (url.endsWith('/api/schedule') && method === 'GET')
+    return h.getSchedule()
+  if (url.endsWith('/api/schedule') && method === 'PUT') {
+    return h.putSchedule(req.postDataJSON())
+  }
+  if (url.includes('/api/runs') && method === 'GET') return h.listRuns()
+  if (url.endsWith('/api/dispatch?force=1') && method === 'POST') {
+    return h.forceDispatch()
+  }
+  return undefined
+}
+
+const itemRoute = (
+  url: string,
+  method: string,
+  h: Handlers,
+  req: ReturnType<Route['request']>
+): Reply => {
+  const m = SUB_BY_ID.exec(url)
+  if (m === null) return undefined
+  const id = Number(m[1])
+  if (method === 'PATCH') {
+    return h.patchSubscriber(id, req.postDataJSON().langs)
+  }
+  if (method === 'DELETE') {
+    const r = h.deleteSubscriber(id)
+    return { status: r.status, body: r.body }
+  }
+  return undefined
+}
+
+/**
+ * Replay an HTTP intercept against the mock store.
+ * @param state Mutable mock state shared across handlers.
+ * @param route Playwright route intercept handle.
+ */
+const dispatch = async (state: MockState, route: Route): Promise<void> => {
+  const handlers = mockHandlers(state)
+  const req = route.request()
+  const url = req.url()
+  const method = req.method()
+  const reply =
+    collectionRoute(url, method, handlers, req) ??
+    itemRoute(url, method, handlers, req)
+  if (reply === undefined) {
+    await route.fallback()
+    return
+  }
+  await route.fulfill(reply)
+}
+
+/**
+ * Install the comms-worker mock onto a Playwright page. Returns the
+ * mock state so test scenes can also drive it directly.
+ * @param page Playwright page handle.
+ * @returns Mock state for direct manipulation.
+ */
+export const installCommsMocks = async (page: Page): Promise<MockState> => {
+  const state = createMockState()
+  await page.route(COMMS_PATTERN, route => dispatch(state, route))
+  return state
+}

--- a/e2e/comms-walkthrough/mock-state.ts
+++ b/e2e/comms-walkthrough/mock-state.ts
@@ -1,0 +1,174 @@
+import type { Route } from '@playwright/test'
+
+type Subscriber = {
+  readonly id: number
+  readonly email: string
+  readonly langs: readonly string[]
+  readonly status: 'active' | 'unsubscribed' | 'bounced' | 'complained'
+  readonly createdAt: string
+  readonly lastSentAt: string | undefined
+  readonly unsubscribedAt: string | undefined
+}
+
+type RunRow = {
+  readonly id: number
+  readonly subscriberId: number | undefined
+  readonly tickAt: string
+  readonly articleCount: number
+  readonly status: 'sent' | 'failed' | 'bounced' | 'complained' | 'skipped'
+  readonly resendId: string | undefined
+  readonly error: string | undefined
+  readonly email: string | undefined
+}
+
+const seed: Subscriber[] = [
+  {
+    id: 1,
+    email: 'editorial@example.test',
+    langs: ['ru', 'en'],
+    status: 'active',
+    createdAt: '2026-05-21T10:15:00.000Z',
+    lastSentAt: '2026-06-04T09:00:00.000Z',
+    unsubscribedAt: undefined,
+  },
+  {
+    id: 2,
+    email: 'reader-it@example.test',
+    langs: ['it'],
+    status: 'active',
+    createdAt: '2026-05-25T18:42:00.000Z',
+    lastSentAt: undefined,
+    unsubscribedAt: undefined,
+  },
+  {
+    id: 3,
+    email: 'lapsed-pl@example.test',
+    langs: ['pl'],
+    status: 'unsubscribed',
+    createdAt: '2026-04-10T08:30:00.000Z',
+    lastSentAt: '2026-05-28T12:00:00.000Z',
+    unsubscribedAt: '2026-05-29T20:11:00.000Z',
+  },
+]
+
+const seedRuns: RunRow[] = [
+  {
+    id: 11,
+    subscriberId: 1,
+    tickAt: '2026-06-04T09:00:00.000Z',
+    articleCount: 3,
+    status: 'sent',
+    resendId: 're_demo_1',
+    error: undefined,
+    email: 'editorial@example.test',
+  },
+  {
+    id: 12,
+    subscriberId: 2,
+    tickAt: '2026-06-04T09:00:00.000Z',
+    articleCount: 2,
+    status: 'sent',
+    resendId: 're_demo_2',
+    error: undefined,
+    email: 'reader-it@example.test',
+  },
+]
+
+/** Live mock state mutated by every intercept call. */
+export type MockState = {
+  subscribers: Subscriber[]
+  schedule: { cron: string; timezone: string; nextRunAt: string }
+  runs: RunRow[]
+  nextId: number
+  nextRunId: number
+}
+
+const computeNextRun = (cron: string): string =>
+  cron === '0 9 * * 1'
+    ? '2026-06-08T06:00:00.000Z'
+    : cron === '0 12 * * 6'
+      ? '2026-06-06T09:00:00.000Z'
+      : '2026-06-07T00:00:00.000Z'
+
+/** Build a fresh stateful mock store for one walkthrough run. */
+export const createMockState = (): MockState => ({
+  subscribers: seed.map(s => ({ ...s, langs: [...s.langs] })),
+  schedule: {
+    cron: '0 12 * * 6',
+    timezone: 'Europe/Moscow',
+    nextRunAt: '2026-06-06T09:00:00.000Z',
+  },
+  runs: seedRuns.map(r => ({ ...r })),
+  nextId: 4,
+  nextRunId: 14,
+})
+
+const json = (
+  body: unknown,
+  status = 200
+): Parameters<Route['fulfill']>[0] => ({
+  status,
+  contentType: 'application/json',
+  body: JSON.stringify(body),
+})
+
+/** Handlers wired in `page.route` — see `scenario.spec.ts`. */
+export const mockHandlers = (s: MockState) => ({
+  listSubs: () => json({ subscribers: s.subscribers }),
+  getSchedule: () => json(s.schedule),
+  listRuns: () => json({ runs: s.runs }),
+  postSubscriber: (body: { email: string; langs: string[] }) => {
+    const row: Subscriber = {
+      id: s.nextId++,
+      email: body.email,
+      langs: body.langs,
+      status: 'active',
+      createdAt: '2026-06-06T09:00:00.000Z',
+      lastSentAt: undefined,
+      unsubscribedAt: undefined,
+    }
+    s.subscribers = [...s.subscribers, row]
+    return json(row, 201)
+  },
+  patchSubscriber: (id: number, langs: string[]) => {
+    s.subscribers = s.subscribers.map(r =>
+      r.id === id ? { ...r, langs } : r
+    )
+    const updated = s.subscribers.find(r => r.id === id)
+    return updated === undefined
+      ? json({ error: 'not_found' }, 404)
+      : json(updated)
+  },
+  deleteSubscriber: (id: number) => {
+    s.subscribers = s.subscribers.filter(r => r.id !== id)
+    return { status: 204, body: '' }
+  },
+  putSchedule: (body: { cron: string; timezone: string }) => {
+    s.schedule = {
+      cron: body.cron,
+      timezone: body.timezone,
+      nextRunAt: computeNextRun(body.cron),
+    }
+    return json(s.schedule)
+  },
+  /** Simulate a force-dispatch by appending a fresh "sent" row. */
+  forceDispatch: () => {
+    const target = s.subscribers.find(r => r.status === 'active')
+    if (target !== undefined) {
+      s.runs = [
+        {
+          id: s.nextRunId++,
+          subscriberId: target.id,
+          tickAt: '2026-06-06T09:05:00.000Z',
+          articleCount: 4,
+          status: 'sent',
+          resendId: `re_demo_${s.nextRunId}`,
+          error: undefined,
+          email: target.email,
+        },
+        ...s.runs,
+      ]
+    }
+    return json({ sent: 1, failed: 0, skipped: 0, durationMs: 412 }, 202)
+  },
+})

--- a/e2e/comms-walkthrough/overlay.ts
+++ b/e2e/comms-walkthrough/overlay.ts
@@ -1,0 +1,147 @@
+import type { Page } from '@playwright/test'
+
+/** Stylesheet that powers the storyboard: hides dev chrome, centers the
+ * `/comms` view, ships caption + highlight + intro components. */
+export const OVERLAY_CSS = `
+[aria-label="Dev notification triggers"],
+[data-testid="trace-overlay"],
+[data-testid*="sw-debug"],
+.dev-trigger,
+.trace-overlay,
+.sw-debug-panel { display: none !important; }
+
+.comms { margin: 0 auto !important; padding: 2rem 2rem 4rem !important; }
+
+.tutorial-caption {
+  position: fixed; inset: 0 0 auto 0; z-index: 9000;
+  display: flex; align-items: center; justify-content: center;
+  padding: 1.3rem 2.5rem; min-height: 4.5rem;
+  background: linear-gradient(180deg,
+    rgb(20 20 20 / 95%), rgb(20 20 20 / 70%)) !important;
+  color: #fff !important;
+  font: 700 1.55rem/1.3 system-ui, "Segoe UI", sans-serif !important;
+  text-shadow: 0 1px 3px rgb(0 0 0 / 60%);
+  border-bottom: 3px solid #ee6f57;
+  transform: translateY(-100%); transition: transform 0.45s ease;
+  pointer-events: none;
+}
+.tutorial-caption.is-visible { transform: translateY(0); }
+
+.tutorial-highlight {
+  outline: 3px solid #ee6f57 !important;
+  outline-offset: 4px !important;
+  box-shadow:
+    0 0 0 8px rgba(238,111,87,0.35),
+    0 0 24px 8px rgba(238,111,87,0.45) !important;
+  border-radius: 0.5rem !important;
+  transition: outline 0.2s, box-shadow 0.2s;
+  position: relative;
+  z-index: 5;
+}
+
+.tutorial-card {
+  position: fixed; inset: 0; z-index: 10000;
+  display: flex; flex-direction: column; align-items: center;
+  justify-content: center; gap: 1.2rem;
+  background: #0a0a0a;
+  color: #fff; padding: 4rem;
+  opacity: 0; transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+.tutorial-card.is-visible { opacity: 1; pointer-events: auto; }
+.tutorial-card .eyebrow {
+  font: 700 0.95rem/1 system-ui; letter-spacing: 0.22em;
+  text-transform: uppercase; color: #ee6f57;
+}
+.tutorial-card .title {
+  font: 800 4rem/1.05 system-ui; max-width: 60rem; text-align: center;
+}
+.tutorial-card .sub {
+  font: 400 1.6rem/1.4 system-ui; max-width: 50rem;
+  text-align: center; color: hsl(0,0%,75%);
+}
+.tutorial-card .footer {
+  position: absolute; bottom: 3rem; font: 500 1rem/1 system-ui;
+  color: hsl(0,0%,55%);
+}
+`
+
+/** Install the storyboard stylesheet and seed empty caption + card nodes. */
+export const installOverlay = async (page: Page): Promise<void> => {
+  await page.addStyleTag({ content: OVERLAY_CSS })
+  await page.evaluate(() => {
+    const caption = document.createElement('div')
+    caption.id = 'tutorial-caption'
+    caption.className = 'tutorial-caption'
+    document.body.appendChild(caption)
+    const card = document.createElement('div')
+    card.id = 'tutorial-card'
+    card.className = 'tutorial-card'
+    card.innerHTML =
+      '<div class="eyebrow" id="card-eyebrow"></div>' +
+      '<div class="title" id="card-title"></div>' +
+      '<div class="sub" id="card-sub"></div>' +
+      '<div class="footer">Communist Prometheus · Newsletter</div>'
+    document.body.appendChild(card)
+  })
+}
+
+/** Show or hide the top caption banner. */
+export const setCaption = (page: Page, text: string): Promise<void> =>
+  page.evaluate(t => {
+    const el = document.getElementById('tutorial-caption')
+    if (el === null) return
+    el.textContent = t
+    if (t === '') el.classList.remove('is-visible')
+    else el.classList.add('is-visible')
+  }, text)
+
+/** Show / hide the full-screen title card. */
+export const showCard = (
+  page: Page,
+  parts: {
+    readonly eyebrow: string
+    readonly title: string
+    readonly sub: string
+  }
+): Promise<void> =>
+  page.evaluate(p => {
+    const root = document.getElementById('tutorial-card')
+    const e = document.getElementById('card-eyebrow')
+    const t = document.getElementById('card-title')
+    const s = document.getElementById('card-sub')
+    if (root === null || e === null || t === null || s === null) return
+    e.textContent = p.eyebrow
+    t.textContent = p.title
+    s.textContent = p.sub
+    root.classList.add('is-visible')
+  }, parts)
+
+export const hideCard = (page: Page): Promise<void> =>
+  page.evaluate(() => {
+    document.getElementById('tutorial-card')?.classList.remove('is-visible')
+  })
+
+/** Apply a glowing outline to a target. Returns a cleanup function. */
+export const highlightSelector = async (
+  page: Page,
+  selector: string
+): Promise<() => Promise<void>> => {
+  await page.evaluate(sel => {
+    document.querySelectorAll('.tutorial-highlight').forEach(n => {
+      n.classList.remove('tutorial-highlight')
+    })
+    document.querySelector(sel)?.classList.add('tutorial-highlight')
+  }, selector)
+  return () =>
+    page.evaluate(sel => {
+      document.querySelector(sel)?.classList.remove('tutorial-highlight')
+    }, selector)
+}
+
+export const clearHighlight = (page: Page): Promise<void> =>
+  page.evaluate(() => {
+    document.querySelectorAll('.tutorial-highlight').forEach(n => {
+      n.classList.remove('tutorial-highlight')
+    })
+  })

--- a/e2e/comms-walkthrough/scenario.spec.ts
+++ b/e2e/comms-walkthrough/scenario.spec.ts
@@ -1,0 +1,412 @@
+import { expect, type Page, test } from '@playwright/test'
+import { installCommsMocks, type MockState } from './install-routes'
+import {
+  clearHighlight,
+  hideCard,
+  highlightSelector,
+  installOverlay,
+  showCard,
+} from './overlay'
+
+test.describe.configure({ mode: 'serial' })
+
+const sleep = (ms: number) =>
+  new Promise<void>(resolve => setTimeout(resolve, ms))
+
+const titleCard = async (
+  page: Page,
+  parts: { eyebrow: string; title: string; sub: string }
+): Promise<void> => {
+  await showCard(page, parts)
+  await sleep(2_200)
+  await hideCard(page)
+  await sleep(350)
+}
+
+type RecipientStrings = {
+  readonly title: string
+  readonly head: string
+  readonly body: string
+  readonly cta: string
+}
+
+const RECIPIENT_RU: RecipientStrings = {
+  title: 'Russian / ru',
+  head: 'Вы отписаны',
+  body:
+    'Вы больше не будете получать рассылку Коммунистического ' +
+    'Прометея на этот адрес.',
+  cta: 'Подписаться снова по почте',
+}
+
+const RECIPIENT_EN: RecipientStrings = {
+  title: 'English / en',
+  head: 'You have been unsubscribed',
+  body:
+    'You will no longer receive the Communist Prometheus newsletter ' +
+    'at this address.',
+  cta: 'Re-subscribe by email',
+}
+
+const showFullScreenOverlay = (
+  page: Page,
+  id: string,
+  html: string
+): Promise<void> =>
+  page.evaluate(
+    ({ overlayId, body }) => {
+      const existing = document.getElementById(overlayId)
+      if (existing !== null) existing.remove()
+      const root = document.createElement('div')
+      root.id = overlayId
+      root.style.cssText =
+        'position:fixed;inset:0;z-index:9500;' +
+        "background:#0a0a0a;font-family:'Inter',system-ui,sans-serif;" +
+        'display:flex;align-items:center;justify-content:center;' +
+        'padding:3rem;color:#fff;opacity:0;transition:opacity 0.25s'
+      root.innerHTML = body
+      document.body.appendChild(root)
+      requestAnimationFrame(() => {
+        root.style.opacity = '1'
+      })
+    },
+    { overlayId: id, body: html }
+  )
+
+const hideFullScreenOverlay = (page: Page, id: string): Promise<void> =>
+  page.evaluate(overlayId => {
+    const el = document.getElementById(overlayId)
+    if (el !== null) {
+      el.style.opacity = '0'
+      setTimeout(() => {
+        el.remove()
+      }, 300)
+    }
+  }, id)
+
+const inboxOverlayHtml = `
+<div style="max-width:46rem;width:100%;background:#1a1a1a;
+border-radius:0.75rem;padding:0;color:#fff;
+box-shadow:0 20px 60px rgb(0 0 0 / 50%);
+border:1px solid #2a2a2a;overflow:hidden">
+  <div style="background:#222;padding:0.6rem 1rem;display:flex;
+  align-items:center;gap:0.4rem;border-bottom:1px solid #2a2a2a">
+    <span style="width:12px;height:12px;border-radius:50%;
+    background:#ff5f56;display:inline-block"></span>
+    <span style="width:12px;height:12px;border-radius:50%;
+    background:#ffbd2e;display:inline-block"></span>
+    <span style="width:12px;height:12px;border-radius:50%;
+    background:#27c93f;display:inline-block"></span>
+    <span style="margin-left:1rem;color:hsl(0,0%,55%);font-size:0.8rem">
+    Gmail · inbox</span>
+  </div>
+  <div style="padding:1.5rem 1.75rem">
+    <div style="display:flex;justify-content:space-between;
+    align-items:flex-start;border-bottom:1px solid #2a2a2a;
+    padding-bottom:1rem;margin-bottom:1rem;gap:1.5rem">
+      <div style="display:flex;align-items:center;gap:0.75rem;
+      min-width:0">
+        <div style="width:2.5rem;height:2.5rem;border-radius:50%;
+        background:#ee6f57;display:flex;align-items:center;
+        justify-content:center;font-weight:700;flex-shrink:0">КП</div>
+        <div style="min-width:0">
+          <div style="font-weight:600">Communist Prometheus</div>
+          <div style="font-size:0.85rem;color:hsl(0,0%,65%)">
+          newsletter@comprom.org</div>
+        </div>
+      </div>
+      <a style="display:inline-flex;align-items:center;
+      padding:0.45rem 0.95rem;background:transparent;color:#ee6f57;
+      border:2px solid #ee6f57;border-radius:0.45rem;
+      text-decoration:none;font-weight:700;font-size:0.85rem;
+      white-space:nowrap;outline:3px solid rgb(238 111 87 / 30%);
+      outline-offset:3px">Unsubscribe</a>
+    </div>
+    <div style="font-weight:700;font-size:1.2rem;
+    margin-bottom:0.5rem">Дайджест за неделю — 4 новые статьи</div>
+    <div style="color:hsl(0,0%,65%);font-size:0.9rem;line-height:1.6">
+    С момента вашего последнего дайджеста: подборка свежих материалов
+    на ru и en…</div>
+  </div>
+  <div style="padding:1rem 1.75rem;background:rgb(238 111 87 / 8%);
+  border-top:1px solid #2a2a2a;font-size:0.85rem;
+  color:hsl(0,0%,75%)">
+    <strong style="color:#ee6f57">RFC 8058</strong> — клик по кнопке
+    отправляет одиночный POST на lists.comprom.org/unsubscribe и
+    подтверждает отписку без открытия страницы.
+  </div>
+</div>`
+
+const recipientCardHtml = (s: RecipientStrings) => `
+<article style="max-width:36rem;width:100%;background:#1a1a1a;
+border-radius:1rem;padding:2.5rem 2rem;color:#fff;
+box-shadow:0 20px 60px rgb(0 0 0 / 50%);
+border:1px solid #2a2a2a">
+  <div style="font-size:0.7rem;text-transform:uppercase;
+  letter-spacing:0.2em;color:#ee6f57;margin-bottom:1.25rem;
+  font-weight:700">${s.title}</div>
+  <h1 style="margin:0 0 0.75rem;font-size:1.75rem;font-weight:800;
+  line-height:1.2">${s.head}</h1>
+  <p style="margin:0 0 1.5rem;color:hsl(0,0%,65%);font-size:1rem;
+  line-height:1.55">${s.body}</p>
+  <a style="display:inline-flex;align-items:center;
+  padding:0.7rem 1.15rem;background:transparent;color:#ee6f57;
+  border:2px solid #ee6f57;border-radius:0.5rem;
+  text-decoration:none;font-weight:700;font-size:0.95rem">
+  ${s.cta}</a>
+</article>`
+
+const addFakeFailedRun = (state: MockState): void => {
+  state.runs = [
+    {
+      id: state.nextRunId++,
+      subscriberId: state.subscribers[0]?.id,
+      tickAt: '2026-06-06T09:05:00.000Z',
+      articleCount: 4,
+      status: 'sent',
+      resendId: `re_demo_${state.nextRunId}`,
+      error: undefined,
+      email: state.subscribers[0]?.email,
+    },
+    {
+      id: state.nextRunId++,
+      subscriberId: state.subscribers[1]?.id,
+      tickAt: '2026-06-06T09:05:00.000Z',
+      articleCount: 2,
+      status: 'failed',
+      resendId: undefined,
+      error: 'resend 503: пример ошибки доставки (демо)',
+      email: state.subscribers[1]?.email,
+    },
+    ...state.runs,
+  ]
+}
+
+test('comms walkthrough recording', async ({ page }) => {
+  const state = await installCommsMocks(page)
+
+  await page.addInitScript(() => {
+    localStorage.setItem('gh_token', 'mock-token')
+    document.documentElement.setAttribute('data-theme', 'dark')
+  })
+  await page.goto('/')
+  await page.goto('/comms')
+  await page.waitForSelector('[data-testid="comms-view"]')
+  await page.waitForSelector('[data-testid="schedule-editor"]')
+  await page.waitForSelector('[data-testid="add-subscriber-form"]')
+
+  await installOverlay(page)
+
+  await test.step('Scene 0 — intro', async () => {
+    await showCard(page, {
+      eyebrow: 'Видео-инструкция',
+      title: 'Управление рассылкой',
+      sub: '/comms — подписчики, расписание, история отправок',
+    })
+    await sleep(3_500)
+    await hideCard(page)
+    await sleep(500)
+  })
+
+  await test.step('Scene 1 — overview', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 1',
+      title: 'Что есть на странице',
+      sub: 'Три блока: расписание, подписчики, история',
+    })
+    const a = await highlightSelector(page, '[data-testid="schedule-editor"]')
+    await sleep(1_400)
+    await a()
+    const b = await highlightSelector(
+      page,
+      '[data-testid="add-subscriber-form"]'
+    )
+    await sleep(1_400)
+    await b()
+    await sleep(500)
+  })
+
+  await test.step('Scene 2 — add subscriber', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 2',
+      title: 'Добавить подписчика',
+      sub: 'Email + языки рассылки + кнопка',
+    })
+    const form = page.getByTestId('add-subscriber-form')
+    const clear = await highlightSelector(
+      page,
+      '[data-testid="add-subscriber-form"]'
+    )
+    await form
+      .getByTestId('add-subscriber-email')
+      .fill('demo-reader@example.test')
+    await sleep(800)
+    await form.getByTestId('lang-toggle-ru').click()
+    await sleep(400)
+    await form.getByTestId('lang-toggle-en').click()
+    await sleep(800)
+    await form.getByTestId('add-subscriber-submit').click()
+    await expect(
+      page
+        .getByTestId('subscriber-row')
+        .filter({ hasText: 'demo-reader@example.test' })
+    ).toBeVisible()
+    await sleep(1_500)
+    await clear()
+  })
+
+  await test.step('Scene 3 — edit langs', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 3',
+      title: 'Изменить языки подписчика',
+      sub: 'Клик по бейджу — мгновенно сохраняется',
+    })
+    const row = page
+      .getByTestId('subscriber-row')
+      .filter({ hasText: 'demo-reader@example.test' })
+    await row.scrollIntoViewIfNeeded()
+    await sleep(800)
+    await row.getByTestId('lang-toggle-it').click()
+    await sleep(700)
+    await row.getByTestId('lang-toggle-en').click()
+    await sleep(1_400)
+  })
+
+  await test.step('Scene 4 — remove subscriber', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 4',
+      title: 'Удалить подписчика',
+      sub: 'Кнопка ✕ — без подтверждения, без отмены',
+    })
+    const row = page
+      .getByTestId('subscriber-row')
+      .filter({ hasText: 'demo-reader@example.test' })
+    await row.getByTestId('subscriber-remove').click()
+    await expect(
+      page
+        .getByTestId('subscriber-row')
+        .filter({ hasText: 'demo-reader@example.test' })
+    ).toHaveCount(0)
+    await sleep(1_400)
+  })
+
+  await test.step('Scene 5 — schedule', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 5',
+      title: 'Настроить расписание',
+      sub: 'Crontab + IANA timezone + сохранение',
+    })
+    await page.evaluate(() => window.scrollTo({ top: 0, behavior: 'smooth' }))
+    await sleep(700)
+    const clear = await highlightSelector(
+      page,
+      '[data-testid="schedule-editor"]'
+    )
+    const cron = page.getByTestId('schedule-cron')
+    await cron.click()
+    await cron.fill('0 9 * * 1')
+    await sleep(700)
+    await page.getByTestId('schedule-timezone').selectOption('Europe/Moscow')
+    await sleep(900)
+    await page.getByTestId('schedule-save').click()
+    await expect(page.getByTestId('schedule-next-run')).toContainText(
+      '2026-06-08'
+    )
+    await sleep(1_800)
+    await clear()
+  })
+
+  await test.step('Scene 6 — run history happy path', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 6',
+      title: 'История отправок',
+      sub: 'После каждого запуска — новая строка',
+    })
+    state.runs = [
+      {
+        id: state.nextRunId++,
+        subscriberId: state.subscribers[0]?.id,
+        tickAt: '2026-06-06T09:05:00.000Z',
+        articleCount: 4,
+        status: 'sent',
+        resendId: `re_demo_${state.nextRunId}`,
+        error: undefined,
+        email: state.subscribers[0]?.email,
+      },
+      ...state.runs,
+    ]
+    await page.reload()
+    await page.waitForSelector('[data-testid="run-history-list"]')
+    await installOverlay(page)
+    const list = page.getByTestId('run-history-list')
+    await list.scrollIntoViewIfNeeded()
+    const clear = await highlightSelector(
+      page,
+      '[data-testid="run-history-list"]'
+    )
+    await sleep(2_200)
+    await clear()
+  })
+
+  await test.step('Scene 6b — failed-row demo', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 6 · пример',
+      title: 'Если запуск падает',
+      sub: 'Красная строка — клик раскрывает текст ошибки',
+    })
+    addFakeFailedRun(state)
+    await page.reload()
+    await page.waitForSelector('[data-testid="run-history-list"]')
+    await installOverlay(page)
+    const list = page.getByTestId('run-history-list')
+    await list.scrollIntoViewIfNeeded()
+    await sleep(700)
+    const failedRow = page.getByTestId('send-log-failed').first()
+    await failedRow.click()
+    await sleep(2_500)
+  })
+
+  await test.step('Scene 7 — native unsubscribe (RFC 8058)', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 7',
+      title: 'Кнопка отписки в почтовом клиенте',
+      sub: 'Gmail, Apple Mail, Outlook — нативная кнопка сверху письма',
+    })
+    await showFullScreenOverlay(page, 'mail-bar', inboxOverlayHtml)
+    await sleep(5_000)
+    await hideFullScreenOverlay(page, 'mail-bar')
+    await sleep(450)
+  })
+
+  await test.step('Scene 7b — confirmation page in recipient language', async () => {
+    await titleCard(page, {
+      eyebrow: 'Сцена 7 · продолжение',
+      title: 'Страница подтверждения',
+      sub: 'Открывается на языке подписчика — по Accept-Language',
+    })
+    await showFullScreenOverlay(
+      page,
+      'recipient-page',
+      recipientCardHtml(RECIPIENT_RU)
+    )
+    await sleep(3_200)
+    await showFullScreenOverlay(
+      page,
+      'recipient-page',
+      recipientCardHtml(RECIPIENT_EN)
+    )
+    await sleep(3_200)
+    await hideFullScreenOverlay(page, 'recipient-page')
+    await sleep(450)
+  })
+
+  await test.step('Scene 8 — outro', async () => {
+    await showCard(page, {
+      eyebrow: 'Готово',
+      title: 'Подробнее — в editor-user-guide.md',
+      sub: 'services/comms-worker/docs/',
+    })
+    await sleep(3_500)
+    await clearHighlight(page)
+  })
+})

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -124,6 +124,7 @@ export default [
       '**/*.spec.ts',
       'scripts/**/*.ts',
       'e2e/helpers/**/*.ts',
+      'e2e/comms-walkthrough/**/*.ts',
       'e2e-realmode/helpers/**/*.ts',
       'e2e-realmode/global-setup.ts',
     ],

--- a/playwright.config.walkthrough.ts
+++ b/playwright.config.walkthrough.ts
@@ -1,0 +1,40 @@
+import process from 'node:process'
+import { defineConfig } from '@playwright/test'
+
+process.env.MOCK_OAUTH = 'true'
+
+/**
+ * Dedicated config for the comms walkthrough recording. Single
+ * Chromium project, full-HD viewport, video forced on.
+ */
+export default defineConfig({
+  testDir: './e2e/comms-walkthrough',
+  timeout: 5 * 60 * 1000,
+  expect: { timeout: 10_000 },
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  outputDir: 'test-results/walkthrough',
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+    viewport: { width: 1920, height: 1080 },
+    deviceScaleFactor: 1,
+    colorScheme: 'dark',
+    video: {
+      mode: 'on',
+      size: { width: 1920, height: 1080 },
+    },
+    launchOptions: { slowMo: 350 },
+    actionTimeout: 10_000,
+  },
+  projects: [{ name: 'walkthrough' }],
+  webServer: {
+    command:
+      'bun scripts/kill-port.ts 5173 && bun run build:e2e && bun run preview:test',
+    env: { VITE_MOCK_AUTH: 'true' },
+    port: 5173,
+    reuseExistingServer: true,
+    timeout: 180_000,
+  },
+})

--- a/scripts/check-vue-template-depth/config.ts
+++ b/scripts/check-vue-template-depth/config.ts
@@ -17,6 +17,15 @@ export const config: Config = {
     'src/views/SettingsView/InviteDialog.vue',
     'src/views/SettingsView/MemberRow.vue',
     'src/views/SettingsView/MembersSection.vue',
+    'src/views/CommsView/SubscribersTable.vue',
+    'src/views/CommsView/SubscriberRow.vue',
+    'src/views/CommsView/RunHistoryList.vue',
+    'src/views/CommsView/RunHistoryRow.vue',
+    'src/views/CommsView/AddSubscriberForm.vue',
+    'src/views/CommsView/TimezoneSelect.vue',
+    'src/views/CommsView/ScheduleEditor.vue',
+    'src/views/CommsView/CommsView.vue',
+    'src/views/CommsView/CommsSection.vue',
   ],
 } as const
 

--- a/services/comms-worker/docs/a11y-audit.md
+++ b/services/comms-worker/docs/a11y-audit.md
@@ -1,0 +1,98 @@
+# Comms — A11y Audit (WCAG 2.1 AAA target)
+
+The admin SPA and the public unsubscribe surface both target AAA.
+Findings below are split by severity. Frontend-dev implements every
+**blocker** and **major**; minors land if cheap.
+
+## Severity counts
+
+- **Blockers:** 8
+- **Majors:** 7
+- **Minors:** 5
+- **Nits:** 3
+
+## 1. Blockers
+
+| # | Where | WCAG | Fix |
+|---|---|---|---|
+| B1 | `AddSubscriberForm.vue:36` (email input) | 3.3.2 / 4.1.2 | `<input>` has only `placeholder=` — add `aria-label="Subscriber email"` AND a visible `<label>` via a wrapping `.field` block. |
+| B2 | `AddSubscriberForm.vue:52` (form-level error) | 3.3.1 | The error `<p data-testid="add-subscriber-error">` is not associated with the input. Add `aria-invalid="true"` to the input when error set + `aria-describedby="add-subscriber-error-id"`; give the `<p>` that id. |
+| B3 | `ScheduleEditor.vue` (cron / tz / save) | 1.3.1 | `aria-label="Crontab expression"` already present on input but no visible label. Add label block. Apply error association on the schedule error. |
+| B4 | `SubscriberStatusBadge.vue` and `RunHistoryRow.vue` (status pills) | 1.4.1 | Status is communicated by colour alone (red, green, orange). Add a visually-hidden `.sr-only` suffix `"status: bounced"` and an aria-label to the badge. Pair every colour with an icon glyph (✓ ✕ ⚠) so colour-blind users have a second channel. |
+| B5 | `RunHistoryRow.vue:24` (`@click="onToggle"` on `<li>`) | 2.1.1 / 4.1.2 | Failed rows are clickable to reveal error but have NO keyboard handler and no `role="button"`. Change the clickable container to a `<button>` for failed rows (or add `tabindex="0"` + `role="button"` + `@keydown.enter.space.prevent="onToggle"`). |
+| B6 | `RunHistoryRow.vue` (expanded error) | 4.1.2 | When the error reveal opens, no screen-reader announcement. Add `aria-expanded="…"` to the trigger + `aria-controls="row-error-{id}"` and the error element with that id. |
+| B7 | `LangTogglePills.vue:25` (pill size) | 2.5.5 (AAA) | Current touch target 14×24 px. Min 32×32 with 8 px spacing (small-target waiver) or full 44×44. See design-spec.md §7. |
+| B8 | Every interactive control | 2.4.7 | No `:focus-visible` styles. Browsers' default outline is removed by `button { background:transparent; … }` in places. Add the global `:focus-visible` ring from design-spec.md §5. |
+
+## 2. Majors
+
+| # | Where | WCAG | Fix |
+|---|---|---|---|
+| M1 | `CommsView.vue:38` | 1.3.1 | The `<h1>Newsletter</h1>` is followed by `<p class="lead">` then `<ScheduleEditor>`. Wrap the lead in `<header>` and tie each section to its own `<section>` + `<h2>` per design-spec.md §4. Right now `RunHistory` is the only `<h2>`; Schedule and Subscribers are anonymous. |
+| M2 | `SubscribersTable.vue` + `RunHistoryList.vue` | 1.3.1 | Both are `<ol>` of grid rows. Run history is tabular data — convert to `<table>` with `<thead>`. Subscribers has fixed columns (email, langs, status, action) — use `<table>` there too. |
+| M3 | `ScheduleEditor.vue` (Save button disabled state) | 4.1.2 | When draft == saved, the button is `disabled` but no `aria-describedby` explains why. Add a sr-only "Schedule is already saved" message and reference it. |
+| M4 | `AddSubscriberForm.vue` (saving state) | 4.1.3 | Button text flips to "Adding…" but no `aria-live="polite"` region announces the result. Add a sr-only `<output role="status" aria-live="polite">` in the form that updates on success / fail. |
+| M5 | Locale of admin UI | 3.1.1 | Confirm `AppLayout` wraps `<router-view>` in `<main>`. If missing, add `<main>` landmark. |
+| M6 | `RunHistoryRow.vue` (`cursor: pointer` on failed only) | 1.3.3 / 2.5.5 | Cursor is the only affordance saying "expandable". Add an explicit ▸ → ▾ chevron column. |
+| M7 | Public unsubscribe page (`confirmation.ts`) | 2.4.4 | The mailto CTA has no `?subject=` — recipient's mail client opens empty. Add `?subject=Subscribe%20to%20newsletter`. |
+
+## 3. Minors
+
+| # | Where | WCAG | Fix |
+|---|---|---|---|
+| N1 | `LangTogglePills.vue:29` (aria-pressed) | 4.1.2 | Already correct. No fix. |
+| N2 | `TimezoneSelect.vue:22` (combobox) | 3.3.2 | Has `aria-label="Timezone"` but no visible label. Add visible `<label>` per design-spec.md §5. |
+| N3 | `RunHistory.vue:23` (empty state text) | 1.3.1 | Wrap in `role="status"` so async load is announced. |
+| N4 | `RunHistoryRow.vue:55` (`background: rgb(192 57 43 / 8%)`) | 1.4.3 | Tinted failed row needs contrast check against its text. With `--color-danger-subtle` at 8 % alpha the contrast remains within range; verify when implementing. |
+| N5 | `SubscriberStatusBadge.vue` (font-weight 700) | none | Consistent with lang pills — no fix. |
+
+## 4. Nits
+
+- `ScheduleEditor.vue:21`: `defineEmits` uses tuple — fine.
+- `RunHistoryList.vue:8`: empty `defineProps` — fine.
+- `CommsView.vue:37`: testid OK.
+
+## 5. New tokens (mirrored in design-spec.md §1)
+
+- `--color-focus-ring` — used by every `:focus-visible` rule
+- `--color-success` / `--color-warning` / `--color-muted` — status
+  pill colours
+- `--color-danger` — promote the existing fallback chain to a real
+  token
+- `--color-danger-subtle` — tinted background for failed rows
+- `--color-surface-hover` — row hover state
+
+## 6. Tests to add
+
+| File | What it asserts |
+|---|---|
+| `e2e/comms/a11y.spec.ts` (NEW) | `axe-core` scan of `/comms` with 0 violations; tab order matches reading order; focus visible on every interactive control |
+| `e2e/comms/keyboard.spec.ts` (NEW) | Enter / Space on failed-row trigger expands the error; second Enter collapses; Tab moves to next row; aria-expanded toggles |
+| `e2e/comms/contrast.spec.ts` (NEW) | Lighthouse desktop + mobile against `/comms`, Best Practices ≥ 95, Accessibility = 100 |
+| `e2e/unsubscribe/page.spec.ts` (NEW) | Visit `/unsubscribe?t=…` in both `prefers-color-scheme` modes; assert contrast and `<html lang>` |
+
+## 7. Public unsubscribe page — checklist
+
+- [ ] `<html lang="…">` matches `Accept-Language` pick (done)
+- [ ] `<meta name="viewport">` present (done)
+- [ ] Single `<h1>` per page (done)
+- [ ] Mailto CTA carries `subject=` and `body=` for context
+- [ ] Light-theme override via `@media (prefers-color-scheme: light)`
+- [ ] Card surface contrast ≥ 7:1 against text (AAA)
+- [ ] No interactive control smaller than 32×32 px
+- [ ] Respect `prefers-reduced-motion: reduce` (skip transitions)
+- [ ] Page renders without JavaScript (SSR HTML — already does)
+- [ ] No tracking pixels or external requests
+
+## 8. Top 10 priority order
+
+1. **B8** — global `:focus-visible` ring (unblocks every other a11y win)
+2. **B5** — keyboard handler on failed-row trigger
+3. **B4** — sr-only suffix + icon glyph on status pills
+4. **M2** — convert lists to `<table>` (subscribers + runs)
+5. **B1 / B3** — visible labels on every form input
+6. **B6** — aria-expanded + aria-controls on row expansion
+7. **B7** — bump lang pill touch target to 32×32 with 8 px gap
+8. **B2** — error association via aria-describedby + aria-invalid
+9. **M4** — sr-only `<output>` for async save status
+10. Public-page checklist items

--- a/services/comms-worker/docs/design-spec.md
+++ b/services/comms-worker/docs/design-spec.md
@@ -1,0 +1,362 @@
+# Comms — Design Spec
+
+Implementation contract for the frontend-developer. Every rule is
+copy-paste-ready: no further design clarification needed.
+
+## 1. Token table
+
+The token system lives in `src/assets/styles/_variables.scss`. Map
+every visible style in `src/views/CommsView/*.vue` to one of these.
+Tokens marked **NEW** must be added to `_variables.scss` in BOTH the
+default `:root` (dark) block AND the `:root[data-theme='light']`
+block AND the system-light fallback `@media (prefers-color-scheme:
+light) :root:not([data-theme])`.
+
+### Existing tokens — use these
+
+| Style | Token |
+|---|---|
+| body text | `--color-text-primary` |
+| muted / lead text | `--color-text-secondary` |
+| page background | `--color-background` |
+| section / card surface | `--color-surface` |
+| elevated surface (input bg) | `--color-surface-elevated` |
+| primary action / accent | `--color-accent` |
+| accent hover | `--color-accent-hover` |
+| divider / 1 px border | `--color-border` |
+| body font | `--font-sans` |
+| tabular / code | `--font-mono` |
+| small radius (badge, pill, input) | `--radius-sm` (0.5 rem) |
+| section radius | `--radius-md` (0.75 rem) |
+| card radius | `--radius-lg` (1 rem) |
+| spacing scale | `--spacing-xs … --spacing-2xl` |
+| content frame width | `--content-medium` (72 rem) for `/comms` |
+| frame padding | `--content-frame-padding` |
+| transitions | `--transition-fast` / `--transition-base` |
+| shadows | `--shadow-sm` / `--shadow-md` / `--shadow-lg` |
+
+### NEW tokens — add to `_variables.scss`
+
+| Token | Dark | Light | Purpose |
+|---|---|---|---|
+| `--color-success` | `hsl(150, 55%, 55%)` | `hsl(150, 60%, 35%)` | status "sent" pill |
+| `--color-danger` | `hsl(0, 65%, 60%)` | `hsl(0, 70%, 45%)` | status "failed" / "bounced" / "complained", form errors |
+| `--color-warning` | `hsl(38, 90%, 60%)` | `hsl(38, 80%, 45%)` | status "skipped" / "delivery_delayed" |
+| `--color-muted` | `hsl(0, 0%, 50%)` | `hsl(0, 0%, 60%)` | status "unsubscribed" pill |
+| `--color-focus-ring` | `hsl(28, 85%, 65%)` | `hsl(28, 85%, 55%)` | 2 px outline on every interactive element on `:focus-visible` |
+| `--color-surface-hover` | `hsl(0, 0%, 18%)` | `hsl(0, 0%, 96%)` | row hover state |
+| `--color-danger-subtle` | `hsl(0, 65%, 60%, 0.08)` | `hsl(0, 70%, 45%, 0.08)` | failed row background tint |
+
+Justification — admin and public surfaces both need a true 5-status
+colour vocabulary; tying them to tokens keeps the public unsubscribe
+HTML consistent with the admin.
+
+## 2. Page chrome
+
+`/comms` route already sits inside `<AppLayout>` via Vue Router; the
+view renders inside `<main class="app-main">` automatically.
+
+`CommsView.vue` must NOT render its own header — the `<h1>` it ships
+today is the section title for the page, not a duplicate of
+`AppHeader`. Keep it but treat it as a page-level `<h1>` (one per
+route, matches existing pages).
+
+## 3. Layout / container
+
+```css
+.comms {
+  max-width: var(--content-medium);   /* 72 rem */
+  margin: 0 auto;
+  padding:
+    var(--spacing-lg)              /* top */
+    var(--content-frame-padding)   /* left + right */
+    var(--spacing-2xl);            /* bottom — breathing room */
+  display: grid;
+  gap: var(--spacing-xl);
+}
+```
+
+Vertical rhythm between sections: `var(--spacing-xl)` (3 rem).
+
+## 4. Section template
+
+Every top-level section (Schedule, Subscribers, Run history) follows
+the same pattern:
+
+```html
+<section class="comms-section">
+  <header class="comms-section-head">
+    <h2 class="comms-section-title">Schedule</h2>
+    <p class="comms-section-lead">Editor-controlled cron + tz.</p>
+  </header>
+  <div class="comms-section-body">
+    <!-- form / list / table -->
+  </div>
+</section>
+```
+
+```css
+.comms-section { display: grid; gap: var(--spacing-sm); }
+.comms-section-head { display: grid; gap: var(--spacing-xs); }
+.comms-section-title {
+  margin: 0;
+  font: 700 1.15rem/1.2 var(--font-sans);
+  color: var(--color-text-primary);
+}
+.comms-section-lead {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+.comms-section-body {
+  padding: var(--spacing-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+```
+
+No more `border-bottom` separators between sections (current pattern
+in `ScheduleEditor`/`AddSubscriberForm`/`RunHistory`). The surface
+card replaces the divider line.
+
+## 5. Form elements
+
+Single base ruleset to be applied across `ScheduleEditor`,
+`TimezoneSelect`, `AddSubscriberForm`:
+
+```css
+.field {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+.field-label {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+.field-input,
+.field-select {
+  appearance: none;
+  width: 100%;
+  padding: 0.55rem 0.85rem;        /* 44 px touch hit area at 16 px root */
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font: 400 0.95rem/1.4 var(--font-sans);
+  transition: border-color var(--transition-fast);
+}
+.field-input:hover,
+.field-select:hover { border-color: var(--color-text-secondary); }
+.field-input:focus-visible,
+.field-select:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-focus-ring);
+}
+.field-input[aria-invalid='true'] { border-color: var(--color-danger); }
+.field-error {
+  font-size: 0.8125rem;
+  color: var(--color-danger);
+}
+```
+
+**Buttons** — three variants:
+
+```css
+.btn { 
+  display: inline-flex; align-items: center; gap: var(--spacing-xs);
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-sm);
+  font: 600 0.95rem/1 var(--font-sans);
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+.btn:disabled { opacity: 50%; cursor: not-allowed; }
+.btn-primary {
+  background: var(--color-accent); color: var(--color-background);
+  border: 1px solid var(--color-accent);
+}
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-accent-hover); border-color: var(--color-accent-hover);
+}
+.btn-ghost {
+  background: transparent; color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+.btn-ghost:hover:not(:disabled) {
+  color: var(--color-text-primary); border-color: var(--color-text-primary);
+}
+.btn-danger {
+  background: transparent; color: var(--color-danger);
+  border: 1px solid transparent;
+}
+.btn-danger:hover:not(:disabled) {
+  background: var(--color-danger-subtle);
+  border-color: var(--color-danger);
+}
+```
+
+## 6. Row patterns
+
+Both `SubscriberRow` and `RunHistoryRow` switch from `<li>` grid to a
+real **`<table>`** semantic structure. Pure visual change is minimal;
+screen-reader users get the row/column model they expect.
+
+Subscribers table columns: Email · Languages · Status · Actions (✕).
+
+Run history columns: Tick (UTC) · Email · Status · Articles ·
+Error (only visible when row expanded).
+
+```css
+.comms-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+.comms-table th,
+.comms-table td {
+  padding: var(--spacing-sm) var(--spacing-xs);
+  border-top: 1px solid var(--color-border);
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+  vertical-align: middle;
+}
+.comms-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-top: none;
+  border-bottom: 1px solid var(--color-border);
+}
+.comms-table tr:hover { background: var(--color-surface-hover); }
+.comms-table tr.is-failed { background: var(--color-danger-subtle); }
+.comms-table tr.is-failed:hover { background: var(--color-danger-subtle); }
+```
+
+### Status pill mapping
+
+| Status | Token |
+|---|---|
+| `active` | `--color-accent` |
+| `sent` | `--color-success` |
+| `unsubscribed` | `--color-muted` |
+| `bounced`, `complained`, `failed` | `--color-danger` |
+| `skipped` | `--color-warning` |
+
+```css
+.status {
+  display: inline-flex; align-items: center;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid currentColor;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+.status-active { color: var(--color-accent); }
+.status-sent { color: var(--color-success); }
+.status-unsubscribed { color: var(--color-muted); }
+.status-bounced,
+.status-complained,
+.status-failed { color: var(--color-danger); }
+.status-skipped { color: var(--color-warning); }
+```
+
+Plus a **screen-reader-only suffix** explaining the status in words
+— see a11y-audit.md §3.
+
+## 7. Lang toggle pills
+
+Today: 0.6875 rem font, 0.1 rem padding — that's 14×24 px tap target.
+AAA requires 44×44 px OR 24×24 px with 8 px spacing.
+
+```css
+.pill {
+  min-width: 2.5rem;
+  min-height: 2rem;            /* 32 px — within "small target" rule */
+  padding: 0.35rem 0.55rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: 700 0.8125rem/1 var(--font-sans);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+.pill:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+.pill-on {
+  background: var(--color-accent);
+  color: var(--color-background);
+  border-color: var(--color-accent);
+}
+.pill:disabled { opacity: 50%; cursor: not-allowed; }
+```
+
+Gap between pills: `var(--spacing-xs)` (0.5 rem) — ensures 8 px
+spacing for the small-target waiver.
+
+## 8. Public unsubscribe page
+
+`services/comms-worker/src/unsubscribe/confirmation.ts` is served
+from `lists.comprom.org/unsubscribe`. It is OUTSIDE the admin SPA so
+it must not depend on admin tokens.
+
+The visual treatment **must mirror the public website** at
+`comprom.org`. Read whatever public-website artefacts exist in the
+repo (`public-website*` directory or sibling repo) to align fonts +
+palette. If none, default to:
+
+| Property | Value |
+|---|---|
+| Background | `#0e0e0e` (always dark; public site is dark-first) |
+| Surface | `#1a1a1a` (centered card) |
+| Text primary | `hsl(0, 0%, 95%)` |
+| Text secondary | `hsl(0, 0%, 65%)` |
+| Accent | `#ee6f57` (same as admin dark accent) |
+| Font stack | `'Inter', system-ui, -apple-system, sans-serif` |
+| Heading weight | 800 |
+| Body weight | 400 |
+| Card max-width | `min(36rem, 100% - 2rem)` |
+| Card padding | `2.5rem 2rem` |
+| Card radius | `1rem` |
+| CTA button | accent-bordered, accent text, transparent background; hover fills accent |
+
+The page MUST respect the visitor's `prefers-color-scheme: light` via
+a media query — visitors land here from email, on whatever device
+they have. Set a `--color-bg` + `--color-surface` token pair in a
+`<style>` block, define light overrides via the media query.
+
+Both pages keep `<html lang="…">` set by `Accept-Language` (already
+implemented).
+
+## 9. Don'ts
+
+- ❌ No inline `style="…"` attributes.
+- ❌ No hex literals in SFC `<style>` blocks. `#ee6f57` etc. live in
+  `_variables.scss` only.
+- ❌ No `rgba(192, 57, 43, 0.08)` literals — use
+  `var(--color-danger-subtle)` instead.
+- ❌ No `var(--color-text)` — the token is `--color-text-primary`.
+- ❌ No `var(--color-danger, #c0392b)` fallback chains — once
+  `--color-danger` is in the token system, the fallback is dead code.
+- ❌ No `opacity: 0.5` — use `opacity: 50%` (existing stylelint rule).
+- ❌ No `transition: all` — name the properties explicitly.
+- ❌ No `<div>` where a `<section>` / `<header>` / `<table>` / `<th>`
+  / `<td>` is semantically correct.

--- a/services/comms-worker/docs/editor-user-guide.md
+++ b/services/comms-worker/docs/editor-user-guide.md
@@ -1,0 +1,230 @@
+# Newsletter — Editor User Guide
+
+This guide walks the **editor** through every day-to-day task in the
+newsletter admin surface at `admin.comprom.org/comms`.
+
+> **Audience:** anyone added to the `communist-prometheus/admins`
+> GitHub team. Audience members do NOT need to be developers — every
+> action below is point-and-click in the admin UI.
+
+> **Audience:** аудитория — редакторы из команды
+> `communist-prometheus/admins`. Технических знаний не требуется.
+
+---
+
+## 1. Access requirements
+
+Before the first login the org admin must have:
+
+1. Added your GitHub login to the `communist-prometheus/admins` team
+   (`gh api orgs/communist-prometheus/teams/admins/memberships/<login>
+   -X PUT -f role=member`).
+2. Provisioned the CF Access policy that maps the team to the
+   `lists.comprom.org/api/*` application (one-time, see
+   `services/comms-worker/README.md`).
+
+Once both are done, opening `admin.comprom.org/comms` triggers a
+GitHub OAuth flow the first time per browser session; the Access
+cookie is then shared with `lists.comprom.org` automatically.
+
+---
+
+## 2. The `/comms` surface at a glance
+
+`/comms` is composed of three live sections, top-to-bottom:
+
+| Section            | What it shows                                       |
+|--------------------|-----------------------------------------------------|
+| **Schedule editor**| Current crontab + IANA timezone + next-run preview  |
+| **Subscribers**    | Add form + table of every subscriber row            |
+| **Run history**    | Last 20 dispatch attempts, newest first             |
+
+All three load on first visit; no buttons need to be clicked.
+
+---
+
+## 3. Adding a subscriber (R1.2)
+
+1. Scroll to the **Add subscriber** row above the table.
+2. Type the recipient email into the leftmost input.
+3. Click each language tag the subscriber wants in their digest
+   (`en` `ru` `it` `es` `uk` `pl` `bl`). Selected pills turn accent-
+   coloured.
+4. Press **Add subscriber**.
+
+**What you should see:**
+
+- The new row appears at the bottom of the table within ~250 ms.
+- The form clears, ready for the next entry.
+- Status badge of the new row reads **ACTIVE**.
+
+**Validation rules:**
+
+- Email must match `<local>@<domain>.<tld>` shape (R1.4).
+- At least one language must be selected (R1.5).
+- Re-adding an already-active email returns the inline error
+  *"subscriber already exists"* (R1.5).
+- An email previously **unsubscribed** can be re-added as a fresh row
+  (R4.4) — the old row stays in the table for auditing.
+
+---
+
+## 4. Editing a subscriber's languages (R1.3)
+
+Each subscriber row carries the same language pills used in the add
+form. Click any pill to toggle that language on or off. Changes
+persist on the next click — no Save button.
+
+> **Note:** turning off every language is not allowed; the worker
+> rejects an empty `langs[]` array with a 422.
+
+---
+
+## 5. Removing a subscriber (R1.6)
+
+The trash button at the right end of every row hard-deletes that
+subscriber after a single click. There is no undo.
+
+**Use `Remove` when:**
+
+- The address was added by mistake.
+- The owner asked to be deleted (data deletion request — different
+  from unsubscribe).
+
+**Use `Unsubscribe` (status flip) when:**
+
+- A bounce arrives via the Resend webhook.
+- The recipient clicks the in-email unsubscribe link themselves.
+
+The history of removed rows is gone forever, so prefer
+**unsubscribe** unless the goal really is hard deletion.
+
+---
+
+## 6. Setting the dispatch schedule (R2.1–R2.4)
+
+The schedule editor sits at the very top of `/comms`.
+
+1. Type any standard 5-field crontab into the **Crontab** input.
+   Examples:
+   - `0 12 * * 6` — every Saturday at 12:00 (the seed default).
+   - `0 9 * * 1` — every Monday at 09:00.
+   - `*/30 * * * *` — every 30 minutes (testing only).
+2. Pick an IANA timezone from the **Timezone** dropdown.
+3. The **preview line** updates live:
+   > *"every Saturday at 12:00 (Europe/Moscow)"*
+4. Press **Save schedule**.
+
+**What you should see:**
+
+- The button shows **Saving…** briefly.
+- The **Next run** timestamp updates to the new computed value
+  (server-side, via `cron-parser`).
+- An invalid crontab surfaces the parser's error message inline
+  without losing your draft.
+
+**Tip:** the worker tolerates a 5-minute window after each scheduled
+fire time (R2.5), so a slightly-late heartbeat still dispatches that
+tick.
+
+---
+
+## 7. Manual dispatch (dev / e2e only)
+
+In production the dispatch fires automatically on the saved schedule;
+the editor does not need to do anything.
+
+In **local dev** and the **e2e** environment the worker exposes
+`POST /api/dispatch?force=1` for manual triggers. It is gated by the
+`BYPASS_SCHEDULE=1` env var — in prod it returns 404 unconditionally.
+
+For local testing (after `wrangler dev`):
+
+```bash
+curl -X POST "http://127.0.0.1:8787/api/dispatch?force=1" \
+     -H "Cf-Access-Jwt-Assertion: <local-stub-jwt>"
+```
+
+The response is `202 {sent, failed, skipped, durationMs}`.
+
+---
+
+## 8. Viewing the run history (R5.1–R5.3)
+
+The **Run history** section lists the 20 most-recent dispatch
+attempts, newest tick first.
+
+Each row shows:
+
+| Column     | Meaning                                                 |
+|------------|---------------------------------------------------------|
+| Tick       | UTC moment the dispatch attempt happened                |
+| Email      | Recipient (or `—` if the row was deleted)               |
+| Status     | `sent` / `failed` / `bounced` / `complained` / `skipped`|
+| Articles   | Articles in the digest that went out                    |
+
+Failed rows are highlighted in danger colour. **Click a failed row**
+to reveal the captured error message (R5.3) — usually the verbatim
+status code returned by Resend.
+
+---
+
+## 9. What recipients see (R4.1–R4.5)
+
+Every digest carries two unsubscribe surfaces:
+
+- **`List-Unsubscribe` header** + **`List-Unsubscribe-Post:
+  List-Unsubscribe=One-Click`** — modern mail clients (Gmail, Apple
+  Mail) render a one-click unsubscribe button next to the From line.
+- **Footer link** in HTML + plain-text body — for older clients.
+
+Both target `https://lists.comprom.org/unsubscribe?t=<token>` where
+`<token>` is a per-subscriber HMAC (R4.5). The link survives forever
+unless the worker's `UNSUBSCRIBE_SECRET` is rotated.
+
+**Confirmation page** (R4.2):
+
+- A `GET` from a browser renders an HTML page in the visitor's
+  preferred language (best-match against `Accept-Language`) with the
+  message "You have been unsubscribed" plus a *Re-subscribe by email*
+  CTA pointing at `public@comprom.org`.
+- A `POST` from a mail provider (RFC 8058 one-click) returns 200 with
+  an empty body. The subscriber's status flips to `unsubscribed` in
+  both cases.
+
+The flow is idempotent — second clicks return 200 without state
+churn.
+
+---
+
+## 10. Resend webhook (automated bounce / complaint handling)
+
+When Resend reports `email.bounced`, `email.delivery_delayed`, or
+`email.complained`, the corresponding subscriber's status auto-flips
+to `bounced` or `complained` (R3.10–R3.11). Such subscribers are
+skipped by every subsequent dispatch (R4.6, R4.7).
+
+The editor does not interact with this surface; it shows up only as a
+status badge change on the subscriber row + a new line in the run
+history.
+
+---
+
+## 11. Troubleshooting
+
+| Symptom                             | What to check                                                      |
+|-------------------------------------|--------------------------------------------------------------------|
+| **401 on every action**             | GitHub team membership; re-login via the OAuth flow                |
+| **Add returns 422 / 409**           | Email shape; duplicate active row; empty langs array               |
+| **Schedule preview blank**          | Crontab not 5 fields; unknown IANA tz                              |
+| **Next run still old after save**   | Hard-refresh — the store caches until next mount                   |
+| **Subscriber missing after add**    | Look at run history — likely a bounce flipped the row              |
+| **No emails arriving**              | Run history shows `failed`? Click row, read error; check Resend UI |
+
+---
+
+## 12. References
+
+- Spec: [`specs/comms-newsletter/`](../../../specs/comms-newsletter/)
+- API surface: [`README.md`](../README.md)
+- Local-dev env: [`.dev.vars.example`](../.dev.vars.example)

--- a/services/comms-worker/docs/perf-audit.md
+++ b/services/comms-worker/docs/perf-audit.md
@@ -1,0 +1,219 @@
+# Comms — Performance Audit
+
+Target: preserve the Lighthouse 100/100/100/100 baseline on `/comms`
+(desktop + mobile) per project standard. Findings below are sorted
+by leverage.
+
+## Severity counts
+
+- **Regression risks:** 3
+- **Opportunities:** 6
+- **Nits:** 3
+
+## 1. Findings
+
+### R1 — Three sequential `ensureLoaded` calls in `CommsView.onMounted` *(regression)*
+
+`CommsView.vue:14` fires:
+
+```ts
+void store.ensureLoaded()       // GET /api/subscribers
+void schedule.ensureLoaded()    // GET /api/schedule
+void runs.ensureLoaded()        // GET /api/runs
+```
+
+The `void` makes them fire-and-forget — so they run concurrently in
+JS but the network still serialises them through the browser's
+HTTP/2 connection (with `credentials: 'include'` they all need
+the same CF Access cookie roundtrip).
+
+**Fix:** they already fire in parallel by virtue of being three
+separate microtasks. Confirm the worker bursts back 3 responses
+without blocking. No code change needed — flagged because the
+pattern *looks* sequential; verify the network panel shows 3
+concurrent requests.
+
+### R2 — `RunHistory` block above the fold causes CLS *(regression risk)*
+
+`CommsView.vue` puts `RunHistory` AFTER subscribers in the template
+flow. The runs API often returns faster than subscribers (no JOIN
+on the worker — wait, it DOES join — irrelevant; varies by D1
+warmth). Either order can land first, pushing the other section.
+
+**Fix:** reserve vertical space via `min-height` on each section's
+loading state, or load all three in parallel and render only after
+all settle (worse UX). Recommend the `min-height` approach:
+
+```css
+.comms-section[data-loading='true'] { min-height: 12rem; }
+```
+
+### R3 — `vue` runtime in initial bundle is unavoidable but `effect` is bigger than it needs to be *(regression risk)*
+
+Project ships Effect.js for runtime schema validation. The schemas
+`Subscriber` / `Schedule` / `RunLog` import `effect` directly. Once
+Effect is in the vendor chunk, the marginal cost of more schemas is
+near zero — confirmed. No fix needed; flagged because if anyone
+removes Effect from another route the comms-worker bundle would
+double in cost.
+
+### O1 — Lazy-mount `RunHistory` after subscribers paint *(opportunity, ~80 ms TBT)*
+
+`RunHistory` renders up to 20 rows. Each `RunHistoryRow` is a
+`<li>` with grid layout, click handler, conditional `aria-expanded`,
+`statusBadgeClass` call, `shortTickAt` call. Total ~120 reactive
+operations per mount.
+
+**Fix:** defer the mount with `<Suspense>` or a `nextTick` delay:
+
+```ts
+const showRuns = ref(false)
+onMounted(() => {
+  void store.ensureLoaded()
+  void schedule.ensureLoaded()
+  nextTick(() => {
+    showRuns.value = true
+    void runs.ensureLoaded()
+  })
+})
+```
+
+Template:
+
+```html
+<RunHistory v-if="showRuns" … />
+<p v-else class="comms-section-skeleton" />
+```
+
+Predicted Lighthouse delta: +1 LCP point on slow CPU.
+
+### O2 — `humaniseCron` runs per keystroke via `computed` *(opportunity, ~5 ms / keystroke)*
+
+`ScheduleEditor.vue:34`:
+
+```ts
+const preview = computed(
+  () => `${humaniseCron(draft.value.cron)} (${draft.value.timezone})`
+)
+```
+
+`humaniseCron` runs 4 regex `.exec`s. At 5 ms / call × N keystrokes
+per second the cron field can stutter on low-end mobile.
+
+**Fix:** memoise via the existing `computed` — already done.
+`computed` is cached by reactive deps, so the cost only fires on
+draft mutation. No fix needed. Flagged because if the function gets
+heavier it should be `useMemo`-style cached or moved to a worker.
+
+### O3 — `LangTogglePills` re-renders entire pill list on every toggle *(opportunity, ~3 ms)*
+
+Each `SubscriberRow` has its own `LangTogglePills` instance. On
+toggle, the pills component re-renders all 7 buttons even though
+only the clicked one changed.
+
+**Fix:** Vue 3 already keys list items by lang code (`:key="lang"`),
+so the VDOM diff is shallow. No fix needed unless profiling shows a
+real hotspot.
+
+### O4 — `runHistory` row click currently triggers full row re-render *(opportunity, ~2 ms)*
+
+`RunHistoryRow.vue:14` has `const expanded = ref(false)` inside the
+component. Toggling it re-renders the row body. Cheap, but if 20
+rows expand at once (mass click) the cost compounds.
+
+**Fix:** Vue 3's reactivity is granular enough — only the expanded
+`<span>` branch re-renders. No action.
+
+### O5 — Effect `Schema.decodeUnknownSync` runs on every list response *(opportunity, ~10 ms for 20 runs)*
+
+`src/validation/decode-response.ts:18`:
+
+```ts
+return Schema.decodeUnknownSync(schema)(json)
+```
+
+Synchronous Effect decode walks every field of every row. For 100
+subscribers + 20 runs that's ~120 deep walks per route mount.
+
+**Fix:** decode is necessary for security (server response
+validation), but cache the decoder result on the store so a re-render
+doesn't re-decode:
+
+```ts
+const cached = Object.freeze(decoded.runs)
+r.runs.value = cached
+```
+
+Vue's reactivity won't deep-clone frozen arrays, saving the proxy
+overhead. Predicted: +2 ms on warm cache loads.
+
+### O6 — `TimezoneSelect` ships 12 IANA options upfront *(opportunity, but trivial)*
+
+`tz-list.ts` ships 12 zone names. Bundled cost ~150 bytes. Could be
+lazy but not worth the indirection.
+
+**Fix:** none.
+
+## 2. Patches the frontend-dev should land
+
+| # | Patch | Predicted delta |
+|---|---|---|
+| P1 | Add `min-height` on loading sections to prevent CLS | LCP → +1 |
+| P2 | Lazy-mount `RunHistory` after `nextTick` | TBT → -80 ms |
+| P3 | `Object.freeze(response.runs)` in the runs-store action | render → -2 ms |
+| P4 | Confirm `vue-router` lazy-loads `/comms` chunk (already does — verify in dist) | bundle |
+| P5 | Add a `e2e/comms/lighthouse.spec.ts` that locks Performance ≥ 95 | — |
+
+## 3. Bundle / chunk table
+
+Run `bun run build` before the implementation pass and capture:
+
+```
+dist/client/assets/CommsView-<hash>.js     size
+dist/client/assets/index-<hash>.js         size delta
+dist/client/style.css                      size delta
+```
+
+Acceptance criterion: `CommsView` chunk under 30 kB gzipped, total
+route under 250 kB gzipped (matches existing routes per memory).
+
+## 4. Lighthouse predictions
+
+Current state (estimated from desktop preview):
+
+| Metric | Current | After patches |
+|---|---|---|
+| Performance | 92–97 | 98–100 |
+| Accessibility | 85 (per a11y-audit blockers) | 100 |
+| Best Practices | 92 | 100 |
+| SEO | 100 | 100 |
+
+After a11y-audit fixes + perf patches, the route should match the
+existing 100/100/100/100 baseline.
+
+## 5. Tests to add
+
+- `e2e/comms/lighthouse.spec.ts` — Lighthouse Performance ≥ 95,
+  Accessibility = 100, Best Practices ≥ 95, SEO = 100, desktop and
+  mobile.
+- `src/views/CommsView/CommsView.test.ts` (NEW) — Vue Test Utils
+  mount + assert `RunHistory` is NOT in the DOM on the first
+  microtask after mount (lazy-mount lock).
+- `src/stores/runs-state.test.ts` (NEW) — assert that after a load,
+  `runs.value` is frozen (`Object.isFrozen`).
+
+## 6. Top 5 priority order
+
+1. **P1** — `min-height` placeholders to kill CLS (cheap, big LCP win)
+2. **P2** — defer `RunHistory` mount (medium effort, big TBT win)
+3. **P3** — freeze decoded arrays in stores (one-line per store)
+4. Lighthouse smoke spec to lock the wins
+5. Confirm bundle chunk size after build
+
+## 7. Tooling recommendations
+
+- `vite-plugin-bundle-visualizer` — one-time analysis, do NOT ship in
+  prod build. Run via `bun run build:analyze` (add to package.json
+  scripts if helpful).
+- Don't add `vite-plugin-inspect` permanently — it's a dev-only
+  diagnostic.

--- a/services/comms-worker/docs/video-script.md
+++ b/services/comms-worker/docs/video-script.md
@@ -1,0 +1,231 @@
+# Newsletter Editor Walkthrough — Video Script
+
+> **Target runtime:** ~7 minutes
+> **Audience:** editors (Russian-speaking)
+> **Voice-over language:** Russian (literal speech content)
+> **On-screen UI language:** English (the admin SPA is English-only)
+> **Recommended capture:** 1920×1080, 30 fps, Loom / OBS
+> **Companion doc:** [editor-user-guide.md](./editor-user-guide.md)
+
+## Pre-flight checklist (before recording)
+
+- [ ] Local `bunx wrangler dev --local` running for `comms-worker`.
+- [ ] Admin SPA running on `localhost:5173` with comms base pointed
+      at the local worker (`VITE_COMMS_BASE=http://127.0.0.1:8787`).
+- [ ] `BYPASS_SCHEDULE=1` set in `.dev.vars` so manual dispatch
+      works for the demo.
+- [ ] DB seeded with two demo subscribers + one schedule row so the
+      RunHistory section is not empty.
+- [ ] Browser zoom at 110 % so text is legible at 1080p.
+- [ ] Recorder cursor highlight ON.
+
+---
+
+## Scene 1 — Intro (0:00 – 0:30)
+
+**On screen:** Title slide → `admin.comprom.org/comms` view.
+
+**Action:** open `/comms`, sit on the page for 5 s so the viewer
+sees the layout.
+
+**Voice-over:**
+
+> «Привет. В этом видео я покажу, как редактор рассылки управляет
+> подписчиками Communist Prometheus. Мы рассмотрим четыре сценария:
+> добавление и удаление подписчика, настройку расписания, ручной
+> запуск рассылки и просмотр истории, а также — что видит получатель
+> при отписке. Поехали».
+
+---
+
+## Scene 2 — Adding a subscriber (0:30 – 1:30)
+
+**On screen:** `/comms` → focus on the **Subscribers** section.
+
+**Action sequence:**
+
+1. Click into the email input.
+2. Type `demo-reader@example.test`.
+3. Click the `ru` pill, then the `en` pill (both turn accent
+   colour).
+4. Press **Add subscriber**.
+5. Pause 2 s so the new row animates into the table.
+
+**Voice-over:**
+
+> «Чтобы добавить подписчика, листаем до формы «Add subscriber».
+> Вводим email, выбираем языки рассылки — здесь редактор выбирает,
+> на каких языках человек хочет получать дайджест. Жмём «Add
+> subscriber» и видим новую строку с бейджем «ACTIVE». Email
+> проверяется по форме и должен быть валидным; повторное добавление
+> того же активного адреса вернёт ошибку».
+
+**Cut-in note:** zoom-in on the new row's **ACTIVE** badge for 1 s.
+
+---
+
+## Scene 3 — Editing subscriber languages (1:30 – 2:15)
+
+**On screen:** the row just added.
+
+**Action sequence:**
+
+1. Click the `it` pill on that row — it turns on.
+2. Click the `en` pill on that row — it turns off.
+3. Pause 1 s.
+
+**Voice-over:**
+
+> «Список языков можно менять прямо в строке — одним кликом по
+> бейджу. Сохранение происходит сразу, без отдельной кнопки. Если
+> снять все языки сразу — изменение не сохранится: подписчик должен
+> получать хотя бы один язык».
+
+---
+
+## Scene 4 — Removing a subscriber (2:15 – 2:45)
+
+**On screen:** the row just edited.
+
+**Action sequence:**
+
+1. Hover over the trash button at the end of the row.
+2. Click it.
+3. Pause 1 s; the row disappears.
+
+**Voice-over:**
+
+> «Удалить подписчика — корзина справа. Это жёсткое удаление: запись
+> исчезает совсем, отменить нельзя. Если подписчик сам нажал «отписаться»
+> или письмо вернулось как bounce — статус подписчика меняется
+> автоматически, удалять руками не нужно».
+
+---
+
+## Scene 5 — Schedule editor (2:45 – 4:00)
+
+**On screen:** scroll to the top → **Schedule editor**.
+
+**Action sequence:**
+
+1. Click into the **Crontab** input.
+2. Clear it and type `0 9 * * 1` (every Monday 09:00).
+3. Open the **Timezone** dropdown and pick `Europe/Moscow`.
+4. Pause 1 s — preview line updates ("every Monday at 09:00
+   (Europe/Moscow)").
+5. Click **Save schedule**.
+6. Pause 1 s — Next run timestamp updates.
+
+**Voice-over:**
+
+> «Расписание задаётся в формате crontab — это пять полей, минуты,
+> часы, день, месяц, день недели. Вводим выражение, выбираем
+> таймзону. Прямо под полем — расшифровка по-человечески, чтобы не
+> ошибиться. Под ней — точное время следующего запуска по UTC. Если
+> синтаксис некорректный, при сохранении подсветится ошибка от
+> парсера — мы ничего не потеряем. Жмём «Save» — следующий тик
+> теперь будет в указанный момент».
+
+**Cut-in note:** zoom on the **Next run:** line for 2 s so the
+viewer sees the recomputed timestamp.
+
+---
+
+## Scene 6 — Force-dispatch + run history (4:00 – 5:30)
+
+**On screen:** terminal window beside the browser (split screen if
+possible).
+
+**Action sequence:**
+
+1. Switch to terminal.
+2. Run:
+   ```bash
+   curl -X POST "http://127.0.0.1:8787/api/dispatch?force=1" \
+        -H "Cf-Access-Jwt-Assertion: stub-jwt"
+   ```
+3. Show the JSON response (`{"sent": 1, "failed": 0, ...}`).
+4. Switch back to the browser; scroll to **Run history**.
+5. Hard-reload (Ctrl+F5) so the store re-fetches.
+6. Point cursor at the brand-new top row — status `sent`, the demo
+   email, 3 articles.
+7. Show a failed row from earlier (seeded). Click it.
+8. The error message expands underneath.
+
+**Voice-over:**
+
+> «Чтобы запустить рассылку вручную — например, для проверки шаблона
+> — есть закрытая ручка POST `/api/dispatch?force=1`. В проде она
+> вернёт 404, но в dev и e2e она работает, если выставлен флаг
+> `BYPASS_SCHEDULE=1`. Зовём, видим краткий отчёт: сколько отправлено,
+> сколько провалилось. Возвращаемся в админку, перезагружаем — в
+> разделе «Run history» появилась свежая строка. История хранится 90
+> дней, новые тики сверху. Провалившиеся отправки подсвечиваются
+> красным; кликнув на них, видим точное сообщение об ошибке от
+> Resend».
+
+---
+
+## Scene 7 — Recipient unsubscribe flow (5:30 – 6:30)
+
+**On screen:** mail client (real or stub) → confirmation page.
+
+**Action sequence:**
+
+1. Open the digest email sent during Scene 6.
+2. Point at the Gmail / Apple Mail one-click **Unsubscribe** button
+   at the top (just point — DO NOT click in the live demo).
+3. Instead, scroll to the footer and click the
+   **«Отписаться» / "Unsubscribe"** link.
+4. New tab opens at `lists.comprom.org/unsubscribe?t=…` — confirmation
+   page in Russian (because `Accept-Language: ru-RU`).
+5. Switch back to admin `/comms` → reload → the subscriber's status
+   badge is now **UNSUBSCRIBED**.
+
+**Voice-over:**
+
+> «У каждого получателя есть два способа отписаться. Современные
+> почтовые клиенты — Gmail, Apple Mail — показывают кнопку
+> «Unsubscribe» в шапке письма; она работает по протоколу RFC 8058
+> и не требует подтверждения. Старые клиенты используют ссылку из
+> футера письма. Она открывает страницу подтверждения на
+> `lists.comprom.org` — на языке получателя, по заголовку
+> Accept-Language. Сразу после клика — статус подписчика в админке
+> меняется на UNSUBSCRIBED, и на следующих рассылках мы его
+> пропустим».
+
+---
+
+## Scene 8 — Outro (6:30 – 7:00)
+
+**On screen:** quick montage of all three sections (3 s each), then
+final slide with the user-guide URL.
+
+**Voice-over:**
+
+> «Это весь интерфейс. Подробнее — в editor-user-guide.md в
+> репозитории comms-worker. Спасибо за просмотр».
+
+---
+
+## Recording tips
+
+- Hide bookmarks bar and notifications before each take.
+- Use a separate Chrome profile with `gh_token` cookie pre-set so
+  CF Access doesn't prompt mid-demo.
+- Capture with the system clock visible — viewers like seeing the
+  worker's structured logs roll in real-time.
+- If a take goes wrong, restart from the nearest scene boundary —
+  every scene above is self-contained.
+
+---
+
+## Post-production checklist
+
+- [ ] Trim leading 5 s and trailing 3 s of every scene.
+- [ ] Add scene-title cards (1 s, fade) between cuts.
+- [ ] Burn in the voice-over from `voiceover.txt` (export the
+      Russian lines from this file).
+- [ ] Final pass: ensure no real email leaks on screen — every demo
+      address uses the `example.test` TLD reserved by RFC 6761.
+- [ ] Upload to Loom (private link first → review → make public).

--- a/services/comms-worker/src/unsubscribe/confirmation-style.ts
+++ b/services/comms-worker/src/unsubscribe/confirmation-style.ts
@@ -1,0 +1,34 @@
+/** Inline `<style>` block shared by both confirmation pages. Matches
+ * the comprom.org public visual language: dark by default with a
+ * `prefers-color-scheme: light` override. */
+export const CONFIRMATION_STYLE = `<style>
+:root{
+  --bg:#0e0e0e;--surface:#1a1a1a;--text:hsl(0,0%,95%);
+  --muted:hsl(0,0%,65%);--accent:#ee6f57;
+}
+@media (prefers-color-scheme: light){
+  :root{
+    --bg:hsl(0,0%,98%);--surface:hsl(0,0%,100%);--text:hsl(0,0%,13%);
+    --muted:hsl(0,0%,40%);--accent:#c25434;
+  }
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--text);
+  font-family:'Inter',system-ui,-apple-system,sans-serif;line-height:1.5}
+main{min-height:100vh;display:flex;align-items:center;
+  justify-content:center;padding:2rem 1rem}
+.card{max-width:min(36rem,100%);width:100%;background:var(--surface);
+  border-radius:1rem;padding:2.5rem 2rem;
+  box-shadow:0 10px 30px rgb(0 0 0 / 30%)}
+h1{margin:0 0 0.75rem;font-size:1.75rem;font-weight:800;line-height:1.2;
+  color:var(--text)}
+p{margin:0 0 1.5rem;color:var(--muted);font-size:1rem}
+.cta{display:inline-flex;align-items:center;padding:0.7rem 1.15rem;
+  background:transparent;color:var(--accent);
+  border:2px solid var(--accent);border-radius:0.5rem;
+  text-decoration:none;font-weight:700;font-size:0.95rem;
+  transition:background 150ms,color 150ms}
+.cta:hover{background:var(--accent);color:var(--bg)}
+.cta:focus-visible{outline:2px solid var(--accent);outline-offset:3px}
+@media (prefers-reduced-motion: reduce){.cta{transition:none}}
+</style>`

--- a/services/comms-worker/src/unsubscribe/confirmation.ts
+++ b/services/comms-worker/src/unsubscribe/confirmation.ts
@@ -1,18 +1,11 @@
 import { htmlEscape } from '../digest/escape'
 import type { Lang } from '../subscribers/types'
+import { CONFIRMATION_STYLE } from './confirmation-style'
 import {
   CONFIRMATION,
   type ConfirmationChrome,
   RE_SUBSCRIBE_MAILTO,
 } from './i18n'
-
-const STYLE =
-  '<style>body{font-family:system-ui,Segoe UI,sans-serif;' +
-  'max-width:32rem;margin:3rem auto;padding:0 1rem;' +
-  'color:#222;line-height:1.5}h1{font-size:1.5rem;margin-bottom:0.5rem}' +
-  '.cta{display:inline-block;margin-top:1.25rem;padding:0.5rem 0.9rem;' +
-  'border:1px solid currentColor;border-radius:0.375rem;' +
-  'text-decoration:none;color:inherit}</style>'
 
 const renderPage = (
   lang: Lang,
@@ -26,12 +19,12 @@ const renderPage = (
     '<meta charset="utf-8" />',
     '<meta name="viewport" content="width=device-width,initial-scale=1" />',
     `<title>${htmlEscape(c.title)}</title>`,
-    STYLE,
-    '</head><body>',
+    CONFIRMATION_STYLE,
+    '</head><body><main><article class="card">',
     `<h1>${htmlEscape(heading)}</h1>`,
     `<p>${htmlEscape(body)}</p>`,
     `<a class="cta" href="${RE_SUBSCRIBE_MAILTO}">${htmlEscape(c.reSubscribeLabel)}</a>`,
-    '</body></html>',
+    '</article></main></body></html>',
   ].join('')
 
 /**

--- a/services/comms-worker/src/unsubscribe/i18n.ts
+++ b/services/comms-worker/src/unsubscribe/i18n.ts
@@ -16,5 +16,8 @@ export const CONFIRMATION: Readonly<Record<Lang, ConfirmationChrome>> = {
   bl: CONF_BL,
 }
 
-/** Shared mailto target used by every confirmation page. */
-export const RE_SUBSCRIBE_MAILTO = 'mailto:public@comprom.org'
+/** Shared mailto target used by every confirmation page. Carries a
+ * subject line so the recipient's mail client opens with context. */
+export const RE_SUBSCRIBE_MAILTO =
+  'mailto:public@comprom.org' +
+  '?subject=Re-subscribe%20to%20the%20Communist%20Prometheus%20newsletter'

--- a/src/assets/styles/_variables.scss
+++ b/src/assets/styles/_variables.scss
@@ -2,11 +2,20 @@
   --color-background: hsl(0, 0%, 10%);
   --color-surface: hsl(0, 0%, 13%);
   --color-surface-elevated: hsl(0, 0%, 16%);
+  --color-surface-hover: hsl(0, 0%, 18%);
   --color-accent: #ee6f57;
   --color-accent-hover: #f18771;
   --color-text-primary: hsl(0, 0%, 95%);
   --color-text-secondary: hsl(0, 0%, 65%);
   --color-border: hsl(0, 0%, 25%);
+
+  /* Status palette — used by comms run-history + status badges. */
+  --color-success: hsl(150, 55%, 55%);
+  --color-danger: hsl(0, 65%, 60%);
+  --color-warning: hsl(38, 90%, 60%);
+  --color-muted: hsl(0, 0%, 50%);
+  --color-danger-subtle: hsl(0, 65%, 60%, 0.08);
+  --color-focus-ring: hsl(28, 85%, 65%);
 
   --spacing-xs: 0.5rem;
   --spacing-sm: 1rem;
@@ -85,11 +94,19 @@
   --color-background: hsl(0, 0%, 100%);
   --color-surface: hsl(0, 0%, 98%);
   --color-surface-elevated: hsl(0, 0%, 100%);
+  --color-surface-hover: hsl(0, 0%, 96%);
   --color-text-primary: hsl(0, 0%, 13%);
   --color-text-secondary: hsl(0, 0%, 40%);
   --color-border: hsl(0, 0%, 90%);
   --color-accent: #c25434;
   --color-accent-hover: #a84428;
+
+  --color-success: hsl(150, 60%, 35%);
+  --color-danger: hsl(0, 70%, 45%);
+  --color-warning: hsl(38, 80%, 45%);
+  --color-muted: hsl(0, 0%, 60%);
+  --color-danger-subtle: hsl(0, 70%, 45%, 0.08);
+  --color-focus-ring: hsl(28, 85%, 55%);
 
   color-scheme: light;
 }

--- a/src/stores/comms-actions.ts
+++ b/src/stores/comms-actions.ts
@@ -24,7 +24,7 @@ export const createLoad = (r: CommsRefs) => async (): Promise<void> => {
   r.loading.value = true
   try {
     const res = await apiListSubscribers()
-    r.subscribers.value = res.subscribers
+    r.subscribers.value = Object.freeze([...res.subscribers])
     r.loaded.value = true
   } finally {
     r.loading.value = false

--- a/src/stores/runs-actions.ts
+++ b/src/stores/runs-actions.ts
@@ -23,7 +23,7 @@ export const createLoadRuns =
     r.error.value = undefined
     try {
       const res = await apiListRuns(limit)
-      r.runs.value = [...res.runs]
+      r.runs.value = Object.freeze([...res.runs])
       r.loaded.value = true
     } catch (e) {
       r.error.value = e instanceof Error ? e.message : 'Failed to load runs'

--- a/src/views/CommsView/AddSubscriberForm.vue
+++ b/src/views/CommsView/AddSubscriberForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { Lang } from '@/stores/comms'
 import { canSubmitNewSubscriber } from './draft-ops'
 import LangTogglePills from './LangTogglePills.vue'
@@ -12,44 +12,75 @@ const emit = defineEmits<{
 const email = ref('')
 const langs = ref<readonly Lang[]>([])
 const error = ref<string | undefined>(undefined)
+const announce = ref<string>('')
 
 const setLangs = (next: readonly Lang[]): void => {
   langs.value = next
 }
+
+const isInvalid = computed(() => error.value !== undefined)
 
 const submit = async (): Promise<void> => {
   if (!canSubmitNewSubscriber(email.value, langs.value)) return
   error.value = undefined
   try {
     emit('add', email.value.trim(), langs.value)
+    announce.value = `Subscriber ${email.value.trim()} added.`
     email.value = ''
     langs.value = []
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to add'
+    announce.value = `Failed to add subscriber: ${error.value}`
   }
 }
 </script>
 
 <template>
-  <form class="add-form" data-testid="add-subscriber-form" @submit.prevent="submit">
-    <input
-      v-model="email"
-      type="email"
-      class="email"
-      placeholder="recipient@example.org"
-      data-testid="add-subscriber-email"
-      :disabled="saving"
-    />
-    <LangTogglePills :langs="langs" :disabled="saving" @change="setLangs" />
+  <form
+    class="add-form"
+    data-testid="add-subscriber-form"
+    aria-labelledby="add-form-title"
+    @submit.prevent="submit"
+  >
+    <span id="add-form-title" class="sr-only">Add subscriber</span>
+    <label class="field">
+      <span class="field-label">Email</span>
+      <input
+        v-model="email"
+        type="email"
+        class="field-input"
+        placeholder="recipient@example.org"
+        data-testid="add-subscriber-email"
+        :disabled="saving"
+        :aria-invalid="isInvalid || undefined"
+        :aria-describedby="isInvalid ? 'add-subscriber-error' : undefined"
+        required
+      />
+    </label>
+    <label class="field">
+      <span class="field-label">Languages</span>
+      <LangTogglePills :langs="langs" :disabled="saving" @change="setLangs" />
+    </label>
     <button
       type="submit"
-      class="submit"
+      class="btn btn-primary submit"
       data-testid="add-subscriber-submit"
       :disabled="saving || !canSubmitNewSubscriber(email, langs)"
     >
       {{ saving ? 'Adding…' : 'Add subscriber' }}
     </button>
-    <p v-if="error" class="error" data-testid="add-subscriber-error">{{ error }}</p>
+    <p
+      v-if="error"
+      id="add-subscriber-error"
+      class="error"
+      data-testid="add-subscriber-error"
+    >{{ error }}</p>
+    <output
+      class="sr-only"
+      role="status"
+      aria-live="polite"
+      data-testid="add-subscriber-announce"
+    >{{ announce }}</output>
   </form>
 </template>
 
@@ -57,40 +88,95 @@ const submit = async (): Promise<void> => {
 .add-form {
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 0.6rem;
-  align-items: center;
-  padding: 0.75rem 0;
-  border-bottom: 1px solid var(--color-border);
+  gap: var(--spacing-sm);
+  align-items: end;
 }
 
-.email {
-  padding: 0.4rem 0.55rem;
+.field {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.field-label {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+.field-input {
+  appearance: none;
+  width: 100%;
+  padding: 0.55rem 0.85rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--color-background);
-  color: var(--color-text);
-  font-size: 0.875rem;
+  font: 400 0.95rem/1.4 var(--font-sans);
+  transition: border-color var(--transition-fast);
 }
 
-.submit {
-  padding: 0.4rem 0.85rem;
+.field-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-focus-ring);
+}
+
+.field-input:hover:not(:disabled) {
+  border-color: var(--color-text-secondary);
+}
+
+.field-input[aria-invalid='true'] {
+  border-color: var(--color-danger);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 1rem;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-accent);
+  font: 600 0.95rem/1 var(--font-sans);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.btn-primary {
   background: var(--color-accent);
   color: var(--color-background);
-  font-weight: 600;
-  cursor: pointer;
+  border: 1px solid var(--color-accent);
 }
 
-.submit:disabled {
+.btn-primary:disabled {
   opacity: 50%;
   cursor: not-allowed;
+}
+
+.btn-primary:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
 }
 
 .error {
   grid-column: 1 / -1;
   margin: 0;
-  color: var(--color-danger, #c0392b);
+  color: var(--color-danger);
   font-size: 0.8125rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 </style>

--- a/src/views/CommsView/CommsSection.vue
+++ b/src/views/CommsView/CommsSection.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+defineProps<{
+  readonly title: string
+  readonly lead: string
+}>()
+</script>
+
+<template>
+  <section class="section">
+    <header class="head">
+      <h2 class="title">{{ title }}</h2>
+      <p class="lead">{{ lead }}</p>
+    </header>
+    <div class="body">
+      <slot />
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.section {
+  display: grid;
+  gap: var(--spacing-sm);
+  min-height: 6rem;
+}
+
+.head {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.title {
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: var(--color-text-primary);
+}
+
+.lead {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+
+.body {
+  display: grid;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-md);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+</style>

--- a/src/views/CommsView/CommsView.vue
+++ b/src/views/CommsView/CommsView.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { nextTick, onMounted, ref } from 'vue'
 import type { Lang } from '@/stores/comms'
 import { useCommsStore } from '@/stores/comms'
 import { useRunsStore } from '@/stores/runs'
 import type { Schedule } from '@/stores/schedule'
 import { useScheduleStore } from '@/stores/schedule'
 import AddSubscriberForm from './AddSubscriberForm.vue'
+import CommsSection from './CommsSection.vue'
 import RunHistory from './RunHistory.vue'
 import ScheduleEditor from './ScheduleEditor.vue'
 import SubscribersTable from './SubscribersTable.vue'
@@ -14,10 +15,15 @@ const store = useCommsStore()
 const schedule = useScheduleStore()
 const runs = useRunsStore()
 
+const showRuns = ref(false)
+
 onMounted(() => {
   void store.ensureLoaded()
   void schedule.ensureLoaded()
-  void runs.ensureLoaded()
+  void nextTick(() => {
+    showRuns.value = true
+    void runs.ensureLoaded()
+  })
 })
 
 const onAdd = (email: string, langs: readonly Lang[]): void => {
@@ -38,47 +44,97 @@ const onScheduleSave = (next: Schedule): void => {
 </script>
 
 <template>
-  <section class="comms" data-testid="comms-view">
-    <h1 class="title">Newsletter</h1>
-    <p class="lead">
-      Editor list — subscribers receive the weekly digest of new
-      articles on the languages they pick.
-    </p>
-    <ScheduleEditor
-      :schedule="schedule.schedule"
-      :saving="schedule.saving"
-      :error="schedule.error"
-      @save="onScheduleSave"
-    />
-    <AddSubscriberForm :saving="store.saving" @add="onAdd" />
-    <SubscribersTable
-      :subscribers="store.subscribers"
-      @langs="onLangs"
-      @remove="onRemove"
-    />
-    <p v-if="store.loading && store.subscribers.length === 0" data-testid="comms-loading">
-      Loading…
-    </p>
-    <RunHistory
-      :runs="runs.runs"
-      :loading="runs.loading"
-      :error="runs.error"
-    />
+  <section class="comms" data-testid="comms-view" aria-labelledby="comms-title">
+    <header class="head">
+      <h1 id="comms-title" class="title">Newsletter</h1>
+      <p class="lead">
+        Editor list — subscribers receive the weekly digest of new
+        articles on the languages they pick.
+      </p>
+    </header>
+    <CommsSection
+      title="Schedule"
+      lead="Crontab + IANA timezone; saved values trigger the dispatch loop."
+    >
+      <ScheduleEditor
+        :schedule="schedule.schedule"
+        :saving="schedule.saving"
+        :error="schedule.error"
+        @save="onScheduleSave"
+      />
+    </CommsSection>
+    <CommsSection
+      title="Subscribers"
+      lead="Each row receives the digest in the languages it has selected."
+    >
+      <AddSubscriberForm :saving="store.saving" @add="onAdd" />
+      <SubscribersTable
+        :subscribers="store.subscribers"
+        @langs="onLangs"
+        @remove="onRemove"
+      />
+      <p
+        v-if="store.loading && store.subscribers.length === 0"
+        class="loading"
+        role="status"
+        data-testid="comms-loading"
+      >
+        Loading…
+      </p>
+    </CommsSection>
+    <CommsSection
+      title="Run history"
+      lead="Last twenty dispatch attempts. Click a failed row to read its error."
+    >
+      <RunHistory
+        v-if="showRuns"
+        :runs="runs.runs"
+        :loading="runs.loading"
+        :error="runs.error"
+      />
+      <p
+        v-else
+        class="loading"
+        role="status"
+        data-testid="run-history-skeleton"
+      >
+        Loading run history…
+      </p>
+    </CommsSection>
   </section>
 </template>
 
 <style scoped>
 .comms {
-  max-width: 920px;
-  padding: 1.25rem;
+  max-width: var(--content-medium);
+  margin: 0 auto;
+  padding: var(--spacing-lg) var(--content-frame-padding) var(--spacing-2xl);
+  display: grid;
+  gap: var(--spacing-xl);
+}
+
+.head {
+  display: grid;
+  gap: var(--spacing-xs);
 }
 
 .title {
-  margin: 0 0 0.25rem;
+  margin: 0;
+  font-weight: 700;
+  font-size: 1.75rem;
+  color: var(--color-text-primary);
 }
 
 .lead {
   color: var(--color-text-secondary);
-  margin: 0.25rem 0 0;
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.loading {
+  margin: 0;
+  padding: var(--spacing-sm) 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
 }
 </style>

--- a/src/views/CommsView/LangTogglePills.vue
+++ b/src/views/CommsView/LangTogglePills.vue
@@ -17,7 +17,12 @@ const onClick = (lang: Lang): void => {
 </script>
 
 <template>
-  <span class="lang-toggle" data-testid="lang-toggle">
+  <span
+    class="lang-toggle"
+    data-testid="lang-toggle"
+    role="group"
+    aria-label="Subscriber languages"
+  >
     <button
       v-for="lang in ALL_LANGS"
       :key="lang"
@@ -38,29 +43,45 @@ const onClick = (lang: Lang): void => {
 .lang-toggle {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  gap: var(--spacing-xs);
 }
 
 .pill {
-  font-size: 0.6875rem;
-  letter-spacing: 0.05em;
-  font-weight: 700;
-  padding: 0.1rem 0.4rem;
+  min-width: 2.5rem;
+  min-height: 2rem;
+  padding: 0.35rem 0.6rem;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: transparent;
   color: var(--color-text-secondary);
-  cursor: pointer;
+  font: 700 0.8125rem/1 var(--font-sans);
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.pill-on {
-  color: var(--color-accent);
-  border-color: var(--color-accent);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .pill:disabled {
   cursor: not-allowed;
   opacity: 50%;
+}
+
+.pill:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.pill:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+.pill-on {
+  background: var(--color-accent);
+  color: var(--color-background);
+  border-color: var(--color-accent);
 }
 </style>

--- a/src/views/CommsView/RunHistory.vue
+++ b/src/views/CommsView/RunHistory.vue
@@ -10,44 +10,41 @@ defineProps<{
 </script>
 
 <template>
-  <section class="history" data-testid="run-history">
-    <h2 class="title">Run history</h2>
+  <div class="history" data-testid="run-history">
     <p
       v-if="error"
       class="error"
+      role="alert"
       data-testid="run-history-error"
     >{{ error }}</p>
     <p
       v-else-if="loading && runs.length === 0"
+      class="status"
+      role="status"
       data-testid="run-history-loading"
     >Loading…</p>
     <p
       v-else-if="!loading && runs.length === 0"
-      class="empty"
+      class="status"
+      role="status"
       data-testid="run-history-empty"
     >No newsletter runs have been recorded yet.</p>
     <RunHistoryList v-else :runs="runs" />
-  </section>
+  </div>
 </template>
 
 <style scoped>
 .history {
-  padding: 1rem 0 0;
-  border-top: 1px solid var(--color-border);
-}
-
-.title {
-  margin: 0 0 0.6rem;
-  font-size: 1rem;
-  font-weight: 700;
+  min-height: 8rem;
 }
 
 .error {
-  color: var(--color-danger, #c0392b);
+  color: var(--color-danger);
   font-size: 0.8125rem;
+  margin: 0;
 }
 
-.empty {
+.status {
   color: var(--color-text-secondary);
   font-size: 0.8125rem;
   margin: 0;

--- a/src/views/CommsView/RunHistoryList.vue
+++ b/src/views/CommsView/RunHistoryList.vue
@@ -6,20 +6,54 @@ defineProps<{ readonly runs: readonly RunLog[] }>()
 </script>
 
 <template>
-  <ol class="rows" data-testid="run-history-list">
-    <RunHistoryRow
-      v-for="run in runs"
-      :key="run.id"
-      :run="run"
-      data-testid="run-history-row"
-    />
-  </ol>
+  <table class="rows" data-testid="run-history-list">
+    <thead>
+      <tr>
+        <th scope="col" class="th-tick">Tick (UTC)</th>
+        <th scope="col" class="th-email">Email</th>
+        <th scope="col" class="th-status">Status</th>
+        <th scope="col" class="th-count">Articles</th>
+      </tr>
+    </thead>
+    <tbody>
+      <RunHistoryRow v-for="run in runs" :key="run.id" :run="run" />
+    </tbody>
+  </table>
 </template>
 
 <style scoped>
 .rows {
-  margin: 0;
-  padding: 0;
-  list-style: none;
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.rows th {
+  padding: var(--spacing-xs);
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.th-tick {
+  width: 11rem;
+  font-family: var(--font-mono);
+}
+
+.th-email {
+  width: auto;
+}
+
+.th-status {
+  width: 8rem;
+}
+
+.th-count {
+  width: 5rem;
+  text-align: right;
 }
 </style>

--- a/src/views/CommsView/RunHistoryRow.vue
+++ b/src/views/CommsView/RunHistoryRow.vue
@@ -1,102 +1,165 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import type { RunLog } from '@/stores/runs'
-import {
-  isFailedRun,
-  shortTickAt,
-  statusBadgeClass,
-} from './run-history-ops'
+import { isFailedRun, shortTickAt, statusBadgeClass } from './run-history-ops'
 
 const props = defineProps<{ readonly run: RunLog }>()
 
 const expanded = ref(false)
 
-const onToggle = (): void => {
-  if (isFailedRun(props.run.status)) expanded.value = !expanded.value
+const expandable = computed(
+  () => isFailedRun(props.run.status) && props.run.error !== undefined
+)
+const errorId = computed(() => `run-error-${props.run.id}`)
+
+const onActivate = (): void => {
+  if (expandable.value) expanded.value = !expanded.value
+}
+
+const onKey = (e: KeyboardEvent): void => {
+  if (!expandable.value) return
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault()
+    expanded.value = !expanded.value
+  }
+}
+
+const ICON: Readonly<Record<RunLog['status'], string>> = {
+  sent: '✓',
+  failed: '✕',
+  bounced: '✕',
+  complained: '✕',
+  skipped: '·',
 }
 </script>
 
 <template>
-  <li
+  <tr
     class="row"
-    :class="{ 'row-failed': isFailedRun(props.run.status) }"
+    :class="{ 'row-failed': isFailedRun(run.status), 'is-expanded': expanded }"
     :data-testid="
-      isFailedRun(props.run.status) ? 'send-log-failed' : 'send-log-row'
+      isFailedRun(run.status) ? 'send-log-failed' : 'send-log-row'
     "
-    @click="onToggle"
+    :role="expandable ? 'button' : undefined"
+    :tabindex="expandable ? 0 : undefined"
+    :aria-expanded="expandable ? expanded : undefined"
+    :aria-controls="expandable ? errorId : undefined"
+    @click="onActivate"
+    @keydown="onKey"
   >
-    <span class="tick">{{ shortTickAt(props.run.tickAt) }}</span>
-    <span class="email">{{ props.run.email ?? '—' }}</span>
-    <span class="badge" :class="statusBadgeClass(props.run.status)">
-      {{ props.run.status }}
-    </span>
-    <span class="count">{{ props.run.articleCount }}</span>
-    <span
-      v-if="expanded && props.run.error"
-      class="error"
-      data-testid="send-log-error"
-    >{{ props.run.error }}</span>
-  </li>
+    <td class="tick">{{ shortTickAt(run.tickAt) }}</td>
+    <td class="email">{{ run.email ?? '—' }}</td>
+    <td>
+      <span
+        class="badge"
+        :class="statusBadgeClass(run.status)"
+        :aria-label="`Run status: ${run.status}`"
+      >
+        <span class="badge-icon" aria-hidden="true">{{ ICON[run.status] }}</span>
+        <span>{{ run.status }}</span>
+      </span>
+    </td>
+    <td class="count">{{ run.articleCount }}</td>
+  </tr>
+  <tr
+    v-if="expanded && run.error"
+    :id="errorId"
+    class="error-row"
+    data-testid="send-log-error"
+  >
+    <td colspan="4">{{ run.error }}</td>
+  </tr>
 </template>
 
 <style scoped>
 .row {
-  display: grid;
-  grid-template-columns: 8.5rem 1fr 5rem 3rem;
-  gap: 0.6rem;
-  padding: 0.35rem 0;
-  border-bottom: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-border);
   font-size: 0.8125rem;
-  cursor: default;
+  color: var(--color-text-primary);
+}
+
+.row td {
+  padding: var(--spacing-xs);
+  vertical-align: middle;
+}
+
+.row:hover {
+  background: var(--color-surface-hover);
 }
 
 .row-failed {
   cursor: pointer;
-  background: rgb(192 57 43 / 8%);
+  background: var(--color-danger-subtle);
+}
+
+.row-failed:hover {
+  background: var(--color-danger-subtle);
+}
+
+.row[tabindex='0']:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
 }
 
 .tick {
+  font-family: var(--font-mono);
   color: var(--color-text-secondary);
-  font-family: var(--font-mono, monospace);
 }
 
 .email {
+  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
+.count {
+  text-align: right;
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+}
+
 .badge {
-  text-align: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid currentcolor;
   text-transform: uppercase;
   font-weight: 700;
-  letter-spacing: 0.05em;
-  font-size: 0.6875rem;
-  padding: 0.1rem 0.35rem;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
+  letter-spacing: 0.06em;
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+}
+
+.badge-icon {
+  font-size: 0.65rem;
+  line-height: 1;
 }
 
 .badge-sent {
-  color: var(--color-accent);
-  border-color: var(--color-accent);
+  color: var(--color-success);
 }
 
 .badge-failed,
 .badge-bounced,
 .badge-complained {
-  color: var(--color-danger, #c0392b);
-  border-color: var(--color-danger, #c0392b);
+  color: var(--color-danger);
 }
 
-.count {
-  text-align: right;
-  color: var(--color-text-secondary);
+.badge-skipped {
+  color: var(--color-warning);
 }
 
-.error {
-  grid-column: 1 / -1;
-  color: var(--color-danger, #c0392b);
+.error-row {
+  background: var(--color-danger-subtle);
+}
+
+.error-row td {
+  padding: var(--spacing-xs) var(--spacing-md);
+  color: var(--color-danger);
   font-size: 0.75rem;
+  font-family: var(--font-mono);
 }
 </style>

--- a/src/views/CommsView/ScheduleEditor.vue
+++ b/src/views/CommsView/ScheduleEditor.vue
@@ -42,22 +42,28 @@ const canSave = computed(
     !props.saving
 )
 
+const isInvalid = computed(() => props.error !== undefined)
+
 const submit = (): void => emit('save', { ...draft.value })
 </script>
 
 <template>
   <form class="editor" data-testid="schedule-editor" @submit.prevent="submit">
-    <input
-      v-model="draft.cron"
-      type="text"
-      class="cron"
-      data-testid="schedule-cron"
-      aria-label="Crontab expression"
-      placeholder="0 12 * * 6"
-      autocomplete="off"
-      spellcheck="false"
-      :disabled="saving"
-    />
+    <label class="field">
+      <span class="field-label">Crontab expression</span>
+      <input
+        v-model="draft.cron"
+        type="text"
+        class="field-input cron"
+        data-testid="schedule-cron"
+        placeholder="0 12 * * 6"
+        autocomplete="off"
+        spellcheck="false"
+        :disabled="saving"
+        :aria-invalid="isInvalid || undefined"
+        :aria-describedby="isInvalid ? 'schedule-error-msg' : undefined"
+      />
+    </label>
     <TimezoneSelect v-model="draft.timezone" :disabled="saving" />
     <p class="preview" data-testid="schedule-preview">{{ preview }}</p>
     <p class="next" data-testid="schedule-next-run">
@@ -65,13 +71,18 @@ const submit = (): void => emit('save', { ...draft.value })
     </p>
     <button
       type="submit"
-      class="save"
+      class="btn save"
       data-testid="schedule-save"
       :disabled="!canSave"
     >
       {{ saving ? 'Saving…' : 'Save schedule' }}
     </button>
-    <p v-if="error" class="error" data-testid="schedule-error">{{ error }}</p>
+    <p
+      v-if="error"
+      id="schedule-error-msg"
+      class="error"
+      data-testid="schedule-error"
+    >{{ error }}</p>
   </form>
 </template>
 
@@ -79,23 +90,48 @@ const submit = (): void => emit('save', { ...draft.value })
 .editor {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 0.55rem;
-  padding: 1rem 0;
-  border-bottom: 1px solid var(--color-border);
+  gap: var(--spacing-sm);
+}
+
+.field {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.field-label {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+.field-input {
+  appearance: none;
+  width: 100%;
+  padding: 0.55rem 0.85rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font: 400 0.95rem/1.4 var(--font-sans);
+  transition: border-color var(--transition-fast);
+}
+
+.field-input:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-focus-ring);
+}
+
+.field-input[aria-invalid='true'] {
+  border-color: var(--color-danger);
 }
 
 .cron {
-  padding: 0.4rem 0.55rem;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-background);
-  color: var(--color-text);
-  font-size: 0.875rem;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
 }
 
 .preview {
-  margin: 0.3rem 0 0;
+  margin: 0.25rem 0 0;
   color: var(--color-text-secondary);
   font-size: 0.8125rem;
 }
@@ -104,18 +140,24 @@ const submit = (): void => emit('save', { ...draft.value })
   margin: 0;
   color: var(--color-text-secondary);
   font-size: 0.8125rem;
-  font-family: var(--font-mono, monospace);
+  font-family: var(--font-mono);
+}
+
+.btn {
+  justify-self: start;
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-sm);
+  font: 600 0.95rem/1 var(--font-sans);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
 }
 
 .save {
-  justify-self: start;
-  padding: 0.4rem 0.85rem;
-  border-radius: var(--radius-sm);
   border: 1px solid var(--color-accent);
   background: var(--color-accent);
   color: var(--color-background);
-  font-weight: 700;
-  cursor: pointer;
 }
 
 .save:disabled {
@@ -123,9 +165,19 @@ const submit = (): void => emit('save', { ...draft.value })
   cursor: not-allowed;
 }
 
+.save:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.save:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
+}
+
 .error {
   margin: 0;
-  color: var(--color-danger, #c0392b);
+  color: var(--color-danger);
   font-size: 0.8125rem;
 }
 </style>

--- a/src/views/CommsView/SubscriberRow.vue
+++ b/src/views/CommsView/SubscriberRow.vue
@@ -4,7 +4,6 @@ import LangTogglePills from './LangTogglePills.vue'
 import SubscriberStatusBadge from './SubscriberStatusBadge.vue'
 
 defineProps<{ readonly entry: Subscriber }>()
-
 const emit = defineEmits<{
   langs: [id: number, langs: readonly Lang[]]
   remove: [id: number]
@@ -12,46 +11,80 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <li class="subscriber-row" data-testid="subscriber-row">
-    <span class="email" data-testid="subscriber-email">{{ entry.email }}</span>
-    <LangTogglePills
-      :langs="entry.langs"
-      :disabled="entry.status !== 'active'"
-      @change="langs => emit('langs', entry.id, langs)"
-    />
-    <SubscriberStatusBadge :status="entry.status" />
-    <button
-      type="button"
-      class="remove"
-      data-testid="subscriber-remove"
-      @click="emit('remove', entry.id)"
-    >
-      ✕
-    </button>
-  </li>
+  <tr class="subscriber-row" data-testid="subscriber-row">
+    <td class="email" data-testid="subscriber-email">{{ entry.email }}</td>
+    <td>
+      <LangTogglePills
+        :langs="entry.langs"
+        :disabled="entry.status !== 'active'"
+        @change="langs => emit('langs', entry.id, langs)"
+      />
+    </td>
+    <td>
+      <SubscriberStatusBadge :status="entry.status" />
+    </td>
+    <td class="actions">
+      <button
+        type="button"
+        class="remove"
+        data-testid="subscriber-remove"
+        :aria-label="`Remove ${entry.email}`"
+        @click="emit('remove', entry.id)"
+      >
+        ✕
+      </button>
+    </td>
+  </tr>
 </template>
 
 <style scoped>
 .subscriber-row {
-  list-style: none;
-  display: grid;
-  grid-template-columns: 1fr auto auto auto;
-  gap: 0.6rem;
-  align-items: center;
-  padding: 0.65rem 0;
   border-top: 1px solid var(--color-border);
 }
 
-.email {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+.subscriber-row:hover {
+  background: var(--color-surface-hover);
+}
+
+.subscriber-row td {
+  padding: var(--spacing-sm) var(--spacing-xs);
   font-size: 0.875rem;
+  vertical-align: middle;
+  color: var(--color-text-primary);
+}
+
+.email {
+  font-family: var(--font-mono);
+}
+
+.actions {
+  text-align: right;
 }
 
 .remove {
-  border: none;
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-secondary);
   cursor: pointer;
   font-size: 1rem;
+  line-height: 1;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.remove:hover {
+  background: var(--color-danger-subtle);
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+
+.remove:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
 }
 </style>

--- a/src/views/CommsView/SubscriberStatusBadge.vue
+++ b/src/views/CommsView/SubscriberStatusBadge.vue
@@ -1,16 +1,25 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { Subscriber } from '@/stores/comms'
 
 const props = defineProps<{ readonly status: Subscriber['status'] }>()
 
-const label = (): string =>
-  props.status === 'active'
-    ? 'active'
-    : props.status === 'unsubscribed'
-      ? 'unsubscribed'
-      : props.status === 'bounced'
-        ? 'bounced'
-        : 'complained'
+const ICON: Readonly<Record<Subscriber['status'], string>> = {
+  active: '●',
+  unsubscribed: '○',
+  bounced: '⚠',
+  complained: '⚠',
+}
+
+const LABEL: Readonly<Record<Subscriber['status'], string>> = {
+  active: 'Active subscriber',
+  unsubscribed: 'Unsubscribed by recipient',
+  bounced: 'Address bounces — skipped',
+  complained: 'Marked as spam — skipped',
+}
+
+const icon = computed(() => ICON[props.status])
+const label = computed(() => LABEL[props.status])
 </script>
 
 <template>
@@ -18,32 +27,43 @@ const label = (): string =>
     class="status"
     :class="`status-${status}`"
     :data-testid="`subscriber-status-${status}`"
+    :aria-label="label"
   >
-    {{ label() }}
+    <span class="icon" aria-hidden="true">{{ icon }}</span>
+    <span class="text">{{ status }}</span>
   </span>
 </template>
 
 <style scoped>
 .status {
-  display: inline-block;
-  font-size: 0.6875rem;
-  letter-spacing: 0.05em;
-  font-weight: 700;
-  padding: 0.1rem 0.45rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.15rem 0.5rem;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--color-border);
-  color: var(--color-text-secondary);
+  border: 1px solid currentcolor;
   text-transform: uppercase;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--color-text-secondary);
+}
+
+.icon {
+  font-size: 0.65rem;
+  line-height: 1;
 }
 
 .status-active {
   color: var(--color-accent);
-  border-color: var(--color-accent);
+}
+
+.status-unsubscribed {
+  color: var(--color-muted);
 }
 
 .status-bounced,
 .status-complained {
-  color: var(--color-danger, #c0392b);
-  border-color: var(--color-danger, #c0392b);
+  color: var(--color-danger);
 }
 </style>

--- a/src/views/CommsView/SubscribersTable.vue
+++ b/src/views/CommsView/SubscribersTable.vue
@@ -3,7 +3,6 @@ import type { Lang, Subscriber } from '@/stores/comms'
 import SubscriberRow from './SubscriberRow.vue'
 
 defineProps<{ readonly subscribers: readonly Subscriber[] }>()
-
 const emit = defineEmits<{
   langs: [id: number, langs: readonly Lang[]]
   remove: [id: number]
@@ -11,20 +10,75 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <ul class="subscribers" data-testid="subscribers-table">
-    <SubscriberRow
-      v-for="s in subscribers"
-      :key="s.id"
-      :entry="s"
-      @langs="(id, langs) => emit('langs', id, langs)"
-      @remove="id => emit('remove', id)"
-    />
-  </ul>
+  <table
+    v-if="subscribers.length > 0"
+    class="subs-table"
+    data-testid="subscribers-table"
+  >
+    <thead>
+      <tr>
+        <th scope="col" class="th-email">Email</th>
+        <th scope="col" class="th-langs">Languages</th>
+        <th scope="col" class="th-status">Status</th>
+        <th scope="col" class="th-actions"><span class="sr-only">Actions</span></th>
+      </tr>
+    </thead>
+    <tbody>
+      <SubscriberRow
+        v-for="entry in subscribers"
+        :key="entry.id"
+        :entry="entry"
+        @langs="(id, l) => emit('langs', id, l)"
+        @remove="id => emit('remove', id)"
+      />
+    </tbody>
+  </table>
 </template>
 
 <style scoped>
-.subscribers {
-  margin: 0;
+.subs-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.subs-table th {
+  padding: var(--spacing-xs);
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.th-email {
+  width: 38%;
+}
+
+.th-langs {
+  width: 36%;
+}
+
+.th-status {
+  width: 18%;
+}
+
+.th-actions {
+  width: 8%;
+  text-align: right;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
   padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 </style>

--- a/src/views/CommsView/TimezoneSelect.vue
+++ b/src/views/CommsView/TimezoneSelect.vue
@@ -16,28 +16,56 @@ const onChange = (e: Event): void => {
 </script>
 
 <template>
-  <select
-    :value="props.modelValue"
-    class="tz"
-    data-testid="schedule-timezone"
-    aria-label="Timezone"
-    :disabled="props.disabled"
-    @change="onChange"
-  >
-    <option v-for="tz in COMMON_TIMEZONES" :key="tz" :value="tz">
-      {{ tz }}
-    </option>
-  </select>
+  <label class="field">
+    <span class="field-label">Timezone</span>
+    <select
+      :value="props.modelValue"
+      class="field-select tz"
+      data-testid="schedule-timezone"
+      :disabled="props.disabled"
+      @change="onChange"
+    >
+      <option v-for="tz in COMMON_TIMEZONES" :key="tz" :value="tz">
+        {{ tz }}
+      </option>
+    </select>
+  </label>
 </template>
 
 <style scoped>
-.tz {
-  padding: 0.4rem 0.55rem;
+.field {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.field-label {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+.field-select {
+  appearance: none;
+  width: 100%;
+  padding: 0.55rem 0.85rem;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-primary);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--color-background);
-  color: var(--color-text);
-  font-size: 0.875rem;
-  font-family: var(--font-mono, monospace);
+  font: 400 0.95rem/1.4 var(--font-sans);
+  transition: border-color var(--transition-fast);
+}
+
+.field-select:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-focus-ring);
+}
+
+.field-select:hover:not(:disabled) {
+  border-color: var(--color-text-secondary);
+}
+
+.tz {
+  font-family: var(--font-mono);
 }
 </style>


### PR DESCRIPTION
## Summary

Stacked on top of [#254 (Stage 7)](https://github.com/communist-prometheus/admin-website/pull/254). Closes out the design/a11y/perf rebuild on top of the seven-stage delivery + adds the walkthrough recording infrastructure.

## Audits delivered (services/comms-worker/docs/)

- [\`design-spec.md\`](../blob/feat/23-walkthrough-video/services/comms-worker/docs/design-spec.md) — token table, page chrome, container width, section template, form / row / lang-pill patterns, public-page treatment, don'ts.
- [\`a11y-audit.md\`](../blob/feat/23-walkthrough-video/services/comms-worker/docs/a11y-audit.md) — 8 blockers + 7 majors + 5 minors + 3 nits against WCAG 2.1 AAA.
- [\`perf-audit.md\`](../blob/feat/23-walkthrough-video/services/comms-worker/docs/perf-audit.md) — 3 regression risks + 6 opportunities + concrete patches.
- [\`editor-user-guide.md\`](../blob/feat/23-walkthrough-video/services/comms-worker/docs/editor-user-guide.md) — point-and-click editor manual.
- [\`video-script.md\`](../blob/feat/23-walkthrough-video/services/comms-worker/docs/video-script.md) — 7-minute storyboard for the editor walkthrough.

## Token system extended (\`src/assets/styles/_variables.scss\`)

New tokens mirrored in \`:root\` (dark), \`:root[data-theme='light']\`, and the system-light \`@media\` block:

\`--color-success\` · \`--color-danger\` · \`--color-warning\` · \`--color-muted\` · \`--color-focus-ring\` · \`--color-surface-hover\` · \`--color-danger-subtle\`.

Eliminates every hard-coded \`#c0392b\` / \`rgb(192 57 43 / 8%)\` / \`var(--color-text)\` chain in CommsView SFCs.

## CommsView rebuild

- Container \`var(--content-medium)\` (72rem) centered with proper rhythm.
- New \`CommsSection.vue\` shared template (heading + lead + surface card body).
- Visible \`<label>\` blocks on every form field; \`aria-invalid\` + \`aria-describedby\` on error states; sr-only \`<output role="status" aria-live="polite">\` for async announcements.
- Lang pills bumped to 32×32 with 8px gap (AAA small-target waiver).
- Status pills pair colour with an icon glyph + \`aria-label\` so colour-blind users get a second channel.
- Subscribers + run history converted from \`<ol>\`/\`<li>\` grid to semantic \`<table>\` with \`<thead>\` + \`<th scope="col">\`.
- Failed-row trigger gains \`role="button"\` + \`tabindex="0"\` + keyboard handler + \`aria-expanded\` + \`aria-controls\`.
- Global \`:focus-visible\` ring on every interactive control.

## Public unsubscribe page hardening

- \`confirmation.ts\` + new \`confirmation-style.ts\` (split for 50-line cap).
- Dark-first palette mirroring public-website style with \`@media (prefers-color-scheme: light)\` override; \`prefers-reduced-motion\` honoured; \`<main><article>\` semantic structure.
- \`RE_SUBSCRIBE_MAILTO\` now carries \`?subject=…\` so the recipient's mail client opens with context.

## Perf patches

- \`CommsView.vue\` — \`RunHistory\` lazy-mounts after \`nextTick\` (perf P2). Skeleton placeholder reserves vertical space (P1).
- \`runs-actions.ts\` + \`comms-actions.ts\` — \`Object.freeze\` decoded response arrays (perf P3) to skip Vue's proxy overhead on long lists.

## Walkthrough recording infrastructure

- \`playwright.config.walkthrough.ts\` — full-HD video config with dark \`colorScheme\`, slowMo, scoped output dir.
- \`e2e/comms-walkthrough/{mock-state,install-routes,overlay,scenario.spec}.ts\` — stateful in-process mocks for every comms-worker route; CSS overlay system (caption banner, glow highlight, full-screen title cards); 8-scene scenario including RFC 8058 Gmail mock-up + localised confirmation cards (ru / en).

## Test plan

- [x] \`bun run validate\` — type-check + biome + oxlint + eslint-jsdoc + vue-depth + stylelint EXIT 0.
- [x] \`bunx vitest run services/comms-worker src/views/CommsView src/stores\` — 280 / 280 green.
- [x] \`npx playwright test --config playwright.config.walkthrough.ts\` — produces \`comms-walkthrough.mp4\` (~70s, 1920×1080, dark theme, RFC 8058 demo + localised confirmation cards).

Refs: tickets#23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)