### PR TITLE
fix(sso): satisfy validate pipeline; deploy SPA with mint-session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ e2e/.auth/
 # Built SW for dev mode
 public/sw.js
 
+# Session-local helpers (CF API tokens, ad-hoc provisioning scripts).
+.tmp/
+
 # Auto-generated type definitions
 src/components.d.ts
 .wrangler

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
       "!!.wrangler",
       "!!public/vendor",
       "!!e2e-toolkit",
-      "!!.claude"
+      "!!.claude",
+      "!!.tmp"
     ],
     "ignoreUnknown": false
   },
@@ -108,7 +109,8 @@
         "src/router/index.ts",
         "worker.ts",
         "services/log-collector/src/index.ts",
-        "services/comms-worker/src/index.ts"
+        "services/comms-worker/src/index.ts",
+        "services/auth-worker/src/index.ts"
       ],
       "linter": {
         "rules": {

--- a/services/auth-worker/src/cookie.test.ts
+++ b/services/auth-worker/src/cookie.test.ts
@@ -61,8 +61,8 @@ describe('readSessionCookie', () => {
   })
 
   it('extracts the session value when it is alongside other cookies', () => {
-    expect(
-      readSessionCookie('foo=bar; comprom_session=XYZ; other=zzz')
-    ).toBe('XYZ')
+    expect(readSessionCookie('foo=bar; comprom_session=XYZ; other=zzz')).toBe(
+      'XYZ'
+    )
   })
 })

--- a/services/auth-worker/src/cookie.ts
+++ b/services/auth-worker/src/cookie.ts
@@ -58,5 +58,7 @@ export const readSessionCookie = (
   if (header === undefined || header === '') return undefined
   const entries = header.split(';').map(p => p.trim())
   const match = entries.find(p => p.startsWith(`${SESSION_COOKIE}=`))
-  return match === undefined ? undefined : match.slice(SESSION_COOKIE.length + 1)
+  return match === undefined
+    ? undefined
+    : match.slice(SESSION_COOKIE.length + 1)
 }

--- a/services/auth-worker/src/jwt/claims-guard.ts
+++ b/services/auth-worker/src/jwt/claims-guard.ts
@@ -1,0 +1,27 @@
+import type { SessionClaims } from './types'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const isStringArray = (x: unknown): x is readonly string[] =>
+  Array.isArray(x) && x.every(item => typeof item === 'string')
+
+/**
+ * Structural type guard for the decoded SSO JWT payload. Used after
+ * `JSON.parse` to fail fast without sprinkling `as` assertions over
+ * the rest of the verify path.
+ * @param value Result of `JSON.parse`.
+ * @returns True iff value matches the `SessionClaims` shape.
+ */
+export const isSessionClaims = (value: unknown): value is SessionClaims => {
+  if (!isObject(value)) return false
+  return (
+    typeof value['sub'] === 'string' &&
+    typeof value['login'] === 'string' &&
+    isStringArray(value['teams']) &&
+    typeof value['iat'] === 'number' &&
+    typeof value['exp'] === 'number' &&
+    typeof value['aud'] === 'string' &&
+    typeof value['iss'] === 'string'
+  )
+}

--- a/services/auth-worker/src/jwt/jwt-roundtrip.test.ts
+++ b/services/auth-worker/src/jwt/jwt-roundtrip.test.ts
@@ -56,12 +56,18 @@ describe('jwt roundtrip', () => {
       ttlSeconds: 10,
     })
     const future = () => NOW_MS + 60_000
-    const claims = await verifySessionJwt(tok, { secret: SECRET, now: future })
+    const claims = await verifySessionJwt(tok, {
+      secret: SECRET,
+      now: future,
+    })
     expect(claims).toBeUndefined()
   })
 
   it('rejects a structurally malformed token', async () => {
-    const claims = await verifySessionJwt('not.a.jwt', { secret: SECRET, now })
+    const claims = await verifySessionJwt('not.a.jwt', {
+      secret: SECRET,
+      now,
+    })
     expect(claims).toBeUndefined()
   })
 

--- a/services/auth-worker/src/jwt/sign.ts
+++ b/services/auth-worker/src/jwt/sign.ts
@@ -19,19 +19,11 @@ export type SignSessionInput = {
   readonly ttlSeconds?: number
 }
 
-/**
- * Sign an SSO session JWT (HS256). `iat`/`exp` are filled from the
- * injected clock; `aud`/`iss` are pinned from the protocol constants.
- * @param input Signer input — login, teams, secret, optional clock + ttl.
- * @returns Signed JWT in compact serialisation form.
- */
-export const signSessionJwt = async (
-  input: SignSessionInput
-): Promise<string> => {
+const buildPayload = (input: SignSessionInput): SessionClaims => {
   const clock = input.now ?? (() => Date.now())
   const ttl = input.ttlSeconds ?? JWT_TTL_SECONDS
   const nowSec = Math.floor(clock() / 1000)
-  const payload: SessionClaims = {
+  return {
     sub: input.login,
     login: input.login,
     teams: input.teams,
@@ -40,6 +32,18 @@ export const signSessionJwt = async (
     aud: JWT_AUDIENCE,
     iss: JWT_ISSUER,
   }
+}
+
+/**
+ * Sign an SSO session JWT (HS256). `iat`/`exp` come from the
+ * injected clock; `aud`/`iss` are pinned by the protocol.
+ * @param input Login, teams, secret, optional clock + ttl.
+ * @returns Signed JWT in compact serialisation form.
+ */
+export const signSessionJwt = async (
+  input: SignSessionInput
+): Promise<string> => {
+  const payload = buildPayload(input)
   const head = base64urlEncode(JSON.stringify(HEADER))
   const body = base64urlEncode(JSON.stringify(payload))
   const data = `${head}.${body}`

--- a/services/auth-worker/src/jwt/signature.ts
+++ b/services/auth-worker/src/jwt/signature.ts
@@ -1,0 +1,26 @@
+import { base64urlDecode } from './base64url'
+import { importHs256Key } from './hmac-key'
+
+/**
+ * Verify the HMAC-SHA256 signature attached to `data`. The function
+ * is intentionally narrow so the rest of the verify path stays linear
+ * — callers compose `parts.length === 3` + this check, no other
+ * cryptography happens elsewhere.
+ * @param data Unsigned `<head>.<body>` portion of the JWT.
+ * @param signature Base64url-encoded signature segment.
+ * @param secret HS256 secret.
+ * @returns True iff the signature matches.
+ */
+export const checkSignature = async (
+  data: string,
+  signature: string,
+  secret: string
+): Promise<boolean> => {
+  const key = await importHs256Key(secret)
+  return globalThis.crypto.subtle.verify(
+    'HMAC',
+    key,
+    base64urlDecode(signature),
+    new TextEncoder().encode(data)
+  )
+}

--- a/services/auth-worker/src/jwt/verify.ts
+++ b/services/auth-worker/src/jwt/verify.ts
@@ -1,42 +1,14 @@
 import { base64urlDecode } from './base64url'
-import { importHs256Key } from './hmac-key'
-import {
-  JWT_AUDIENCE,
-  JWT_ISSUER,
-  type SessionClaims,
-} from './types'
+import { isSessionClaims } from './claims-guard'
+import { checkSignature } from './signature'
+import { JWT_AUDIENCE, JWT_ISSUER, type SessionClaims } from './types'
 
-const isObject = (x: unknown): x is Record<string, unknown> =>
-  x !== null && typeof x === 'object'
-
-const isStringArray = (x: unknown): x is readonly string[] =>
-  Array.isArray(x) && x.every(item => typeof item === 'string')
-
-const isSessionClaims = (value: unknown): value is SessionClaims => {
-  if (!isObject(value)) return false
-  return (
-    typeof value['sub'] === 'string' &&
-    typeof value['login'] === 'string' &&
-    isStringArray(value['teams']) &&
-    typeof value['iat'] === 'number' &&
-    typeof value['exp'] === 'number' &&
-    typeof value['aud'] === 'string' &&
-    typeof value['iss'] === 'string'
-  )
-}
-
-const checkSignature = async (
-  data: string,
-  signature: string,
-  secret: string
-): Promise<boolean> => {
-  const key = await importHs256Key(secret)
-  return globalThis.crypto.subtle.verify(
-    'HMAC',
-    key,
-    base64urlDecode(signature),
-    new TextEncoder().encode(data)
-  )
+const decodeBody = (body: string | undefined): unknown => {
+  try {
+    return JSON.parse(new TextDecoder().decode(base64urlDecode(body ?? '')))
+  } catch {
+    return undefined
+  }
 }
 
 /** Optional clock injection for tests. */
@@ -47,8 +19,8 @@ export type VerifyOpts = {
 
 /**
  * Verify an SSO JWT and return the decoded claims on success.
- * Returns undefined for malformed input, bad signatures, wrong
- * audience/issuer, or expired tokens. Never throws on bad input.
+ * Returns undefined for any failure mode (bad shape, bad signature,
+ * wrong audience/issuer, expired). Never throws on untrusted input.
  * @param token Compact-serialised JWT.
  * @param opts Secret + optional clock for tests.
  * @returns Decoded session claims, or undefined.
@@ -65,13 +37,7 @@ export const verifySessionJwt = async (
     () => false
   )
   if (!validSig) return undefined
-  const decoded = ((): unknown => {
-    try {
-      return JSON.parse(new TextDecoder().decode(base64urlDecode(body ?? '')))
-    } catch {
-      return undefined
-    }
-  })()
+  const decoded = decodeBody(body)
   if (!isSessionClaims(decoded)) return undefined
   const nowSec = Math.floor((opts.now ?? (() => Date.now()))() / 1000)
   return decoded.aud === JWT_AUDIENCE &&

--- a/services/auth-worker/src/session-handler.test.ts
+++ b/services/auth-worker/src/session-handler.test.ts
@@ -1,14 +1,7 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp } from './app'
-import { SESSION_COOKIE } from './cookie'
 import type { Bindings } from './bindings'
+import { SESSION_COOKIE } from './cookie'
 
 const ENV: Bindings = {
   VERSION: '0.1.0',
@@ -19,30 +12,34 @@ const ENV: Bindings = {
   JWT_SECRET: 'test-secret',
 }
 
+type StubResponse = { ok: boolean; body?: unknown }
 type Stub = {
-  readonly login?: { ok: boolean; body?: unknown }
-  readonly team?: { ok: boolean; body?: unknown }
+  readonly login?: StubResponse
+  readonly team?: StubResponse
+}
+
+const buildResponse = (
+  s: StubResponse | undefined,
+  okStatus: number,
+  failStatus: number
+): Response => {
+  const body = s?.body === undefined ? null : JSON.stringify(s.body)
+  return new Response(body, { status: s?.ok ? okStatus : failStatus })
+}
+
+const routeStub = (stub: Stub, url: string): Response => {
+  if (url === 'https://api.github.com/user') {
+    return buildResponse(stub.login, 200, 401)
+  }
+  return url.startsWith('https://api.github.com/orgs/')
+    ? buildResponse(stub.team, 200, 404)
+    : new Response('unexpected', { status: 500 })
 }
 
 const stubFetch = (stub: Stub) => {
-  vi.stubGlobal('fetch', async (input: RequestInfo) => {
-    const url = typeof input === 'string' ? input : input.url
-    if (url === 'https://api.github.com/user') {
-      const s = stub.login
-      return new Response(
-        s?.body === undefined ? null : JSON.stringify(s.body),
-        { status: s?.ok ? 200 : 401 }
-      )
-    }
-    if (url.startsWith('https://api.github.com/orgs/')) {
-      const s = stub.team
-      return new Response(
-        s?.body === undefined ? null : JSON.stringify(s.body),
-        { status: s?.ok ? 200 : 404 }
-      )
-    }
-    return new Response('unexpected', { status: 500 })
-  })
+  vi.stubGlobal('fetch', async (input: RequestInfo) =>
+    routeStub(stub, typeof input === 'string' ? input : input.url)
+  )
 }
 
 beforeEach(() => {
@@ -127,9 +124,7 @@ describe('POST /auth/session', () => {
     expect(res.headers.get('access-control-allow-origin')).toBe(
       'https://admin.comprom.org'
     )
-    expect(res.headers.get('access-control-allow-credentials')).toBe(
-      'true'
-    )
+    expect(res.headers.get('access-control-allow-credentials')).toBe('true')
   })
 })
 
@@ -141,9 +136,7 @@ describe('OPTIONS preflight', () => {
     })
     const res = await createApp().fetch(req, ENV)
     expect(res.status).toBe(204)
-    expect(res.headers.get('access-control-allow-credentials')).toBe(
-      'true'
-    )
+    expect(res.headers.get('access-control-allow-credentials')).toBe('true')
   })
 
   it('does not emit CORS headers for an unknown origin', async () => {

--- a/services/auth-worker/src/session-handler.ts
+++ b/services/auth-worker/src/session-handler.ts
@@ -1,43 +1,17 @@
 import type { Context, Hono } from 'hono'
 import type { WorkerCtx } from './bindings'
-import { buildSessionCookie } from './cookie'
 import { fetchUserLogin, isActiveTeamMember } from './gh-user'
-import { signSessionJwt } from './jwt/sign'
-import { JWT_TTL_SECONDS } from './jwt/types'
+import { mintSessionResponse } from './session-mint'
 
 const BEARER = 'Bearer '
 
 const readBearerToken = (header: string | undefined): string | undefined =>
-  header !== undefined && header.startsWith(BEARER)
-    ? header.slice(BEARER.length)
-    : undefined
+  header?.startsWith(BEARER) ? header.slice(BEARER.length) : undefined
 
-/**
- * Mint a session cookie for a verified GitHub admin.
- *
- * Flow:
- *   1. Read `Authorization: Bearer <gh_token>`.
- *   2. Resolve the GH login from the token.
- *   3. Verify the login is an active member of the configured admin
- *      team.
- *   4. Sign an HS256 session JWT and ship it back both in the
- *      response body (so the SPA can read `{login, teams, expires}`
- *      for UI) and as an HttpOnly cookie scoped to `.comprom.org`.
- *
- * Failure modes:
- *   - missing/empty bearer → 401
- *   - GH refuses the token → 401
- *   - login is not an active member of the admin team → 403
- * @param c Hono context with worker bindings.
- * @returns JSON response with the session payload, plus Set-Cookie.
- */
-const handleSession = async (
-  c: Context<WorkerCtx>
-): Promise<Response> => {
-  const ghToken = readBearerToken(c.req.header('authorization'))
-  if (ghToken === undefined) {
-    return c.json({ error: 'authorization header required' }, 401)
-  }
+const checkAdmin = async (
+  c: Context<WorkerCtx>,
+  ghToken: string
+): Promise<Response | { login: string }> => {
   const login = await fetchUserLogin(ghToken)
   if (login === undefined) {
     return c.json({ error: 'github token rejected' }, 401)
@@ -48,35 +22,30 @@ const handleSession = async (
     login,
     token: ghToken,
   })
-  if (!active) {
-    return c.json({ error: 'not a member of admin team' }, 403)
-  }
-  const teams = [c.env.GITHUB_ADMIN_TEAM]
-  const jwt = await signSessionJwt({
-    login,
-    teams,
-    secret: c.env.JWT_SECRET,
-  })
-  const cookie = buildSessionCookie(jwt, {
-    domain: c.env.COOKIE_DOMAIN,
-    maxAgeSeconds: JWT_TTL_SECONDS,
-  })
-  const now = Math.floor(Date.now() / 1000)
-  return c.json(
-    {
-      login,
-      teams,
-      expires: now + JWT_TTL_SECONDS,
-    },
-    200,
-    { 'Set-Cookie': cookie }
-  )
+  return active
+    ? { login }
+    : c.json({ error: 'not a member of admin team' }, 403)
 }
 
 /**
- * Wire `POST /auth/session`. The route is the only public entry
- * point that takes a raw GH token — every other call goes through
- * the cookie.
+ * `POST /auth/session` — exchanges a GitHub OAuth token for a
+ * parent-domain SSO cookie. Failure modes are mapped to 401 (bad
+ * bearer / GH refused) and 403 (login not in the admin team).
+ * @param c Hono context with worker bindings.
+ * @returns JSON `{login,teams,expires}` + `Set-Cookie` on success.
+ */
+const handleSession = async (c: Context<WorkerCtx>): Promise<Response> => {
+  const ghToken = readBearerToken(c.req.header('authorization'))
+  if (ghToken === undefined) {
+    return c.json({ error: 'authorization header required' }, 401)
+  }
+  const checked = await checkAdmin(c, ghToken)
+  return 'login' in checked ? mintSessionResponse(c, checked.login) : checked
+}
+
+/**
+ * Wire `POST /auth/session` — the only public entry point that
+ * accepts a raw GH token; every other call goes through the cookie.
  * @param app Hono app to extend.
  * @returns Same app for chaining.
  */

--- a/services/auth-worker/src/session-mint.ts
+++ b/services/auth-worker/src/session-mint.ts
@@ -1,0 +1,32 @@
+import type { Context } from 'hono'
+import type { WorkerCtx } from './bindings'
+import { buildSessionCookie } from './cookie'
+import { signSessionJwt } from './jwt/sign'
+import { JWT_TTL_SECONDS } from './jwt/types'
+
+/**
+ * Sign a session JWT for `login`, wrap it in a parent-domain cookie,
+ * and return the JSON response the SPA needs to render UI. Pulled out
+ * of the route handler so the auth/session decision tree stays linear
+ * and under the per-function line cap.
+ * @param c Hono context with worker bindings.
+ * @param login Verified GitHub login (subject of the JWT).
+ * @returns 200 JSON response with `Set-Cookie: comprom_session=…`.
+ */
+export const mintSessionResponse = async (
+  c: Context<WorkerCtx>,
+  login: string
+): Promise<Response> => {
+  const teams = [c.env.GITHUB_ADMIN_TEAM]
+  const jwt = await signSessionJwt({
+    login,
+    teams,
+    secret: c.env.JWT_SECRET,
+  })
+  const cookie = buildSessionCookie(jwt, {
+    domain: c.env.COOKIE_DOMAIN,
+    maxAgeSeconds: JWT_TTL_SECONDS,
+  })
+  const expires = Math.floor(Date.now() / 1000) + JWT_TTL_SECONDS
+  return c.json({ login, teams, expires }, 200, { 'Set-Cookie': cookie })
+}

--- a/services/comms-worker/src/app.ts
+++ b/services/comms-worker/src/app.ts
@@ -34,10 +34,7 @@ export const createApp = (opts: CreateAppOptions = {}): Hono<WorkerCtx> => {
   const app = new Hono<WorkerCtx>()
   app.use('*', cors())
   registerHealthRoute(app)
-  app.use(
-    '/api/*',
-    requireSession({ verifier: opts.sessionVerifier })
-  )
+  app.use('/api/*', requireSession({ verifier: opts.sessionVerifier }))
   mountSubscriberRoutes(app, c =>
     createRepo({ db: (c.env as Bindings).DB, now: nowIso })
   )

--- a/services/comms-worker/src/auth/claims-guard.ts
+++ b/services/comms-worker/src/auth/claims-guard.ts
@@ -1,0 +1,28 @@
+import type { SessionClaims } from './session-types'
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const isStringArray = (x: unknown): x is readonly string[] =>
+  Array.isArray(x) && x.every(item => typeof item === 'string')
+
+/**
+ * Structural type guard for the decoded SSO JWT payload. Used after
+ * `JSON.parse` to fail fast without sprinkling `as` assertions over
+ * the verify path. Mirrors `auth-worker/src/jwt/claims-guard.ts` —
+ * the two MUST agree on shape.
+ * @param value Result of `JSON.parse`.
+ * @returns True iff value matches the `SessionClaims` shape.
+ */
+export const isSessionClaims = (value: unknown): value is SessionClaims => {
+  if (!isObject(value)) return false
+  return (
+    typeof value['sub'] === 'string' &&
+    typeof value['login'] === 'string' &&
+    isStringArray(value['teams']) &&
+    typeof value['iat'] === 'number' &&
+    typeof value['exp'] === 'number' &&
+    typeof value['aud'] === 'string' &&
+    typeof value['iss'] === 'string'
+  )
+}

--- a/services/comms-worker/src/auth/session-verify.ts
+++ b/services/comms-worker/src/auth/session-verify.ts
@@ -1,42 +1,14 @@
 import { base64urlDecode } from './base64url'
-import { importHs256Key } from './hmac-key'
-import {
-  JWT_AUDIENCE,
-  JWT_ISSUER,
-  type SessionClaims,
-} from './session-types'
+import { isSessionClaims } from './claims-guard'
+import { JWT_AUDIENCE, JWT_ISSUER, type SessionClaims } from './session-types'
+import { checkSignature } from './signature'
 
-const isObject = (x: unknown): x is Record<string, unknown> =>
-  x !== null && typeof x === 'object'
-
-const isStringArray = (x: unknown): x is readonly string[] =>
-  Array.isArray(x) && x.every(item => typeof item === 'string')
-
-const isSessionClaims = (value: unknown): value is SessionClaims => {
-  if (!isObject(value)) return false
-  return (
-    typeof value['sub'] === 'string' &&
-    typeof value['login'] === 'string' &&
-    isStringArray(value['teams']) &&
-    typeof value['iat'] === 'number' &&
-    typeof value['exp'] === 'number' &&
-    typeof value['aud'] === 'string' &&
-    typeof value['iss'] === 'string'
-  )
-}
-
-const checkSignature = async (
-  data: string,
-  signature: string,
-  secret: string
-): Promise<boolean> => {
-  const key = await importHs256Key(secret)
-  return globalThis.crypto.subtle.verify(
-    'HMAC',
-    key,
-    base64urlDecode(signature),
-    new TextEncoder().encode(data)
-  )
+const decodeBody = (body: string | undefined): unknown => {
+  try {
+    return JSON.parse(new TextDecoder().decode(base64urlDecode(body ?? '')))
+  } catch {
+    return undefined
+  }
 }
 
 /** Optional clock injection for tests. */
@@ -66,13 +38,7 @@ export const verifySessionJwt = async (
     () => false
   )
   if (!validSig) return undefined
-  const decoded = ((): unknown => {
-    try {
-      return JSON.parse(new TextDecoder().decode(base64urlDecode(body ?? '')))
-    } catch {
-      return undefined
-    }
-  })()
+  const decoded = decodeBody(body)
   if (!isSessionClaims(decoded)) return undefined
   const nowSec = Math.floor((opts.now ?? (() => Date.now()))() / 1000)
   return decoded.aud === JWT_AUDIENCE &&

--- a/services/comms-worker/src/auth/signature.ts
+++ b/services/comms-worker/src/auth/signature.ts
@@ -1,0 +1,25 @@
+import { base64urlDecode } from './base64url'
+import { importHs256Key } from './hmac-key'
+
+/**
+ * Verify the HMAC-SHA256 signature attached to `data`. Kept narrow
+ * so the verify path stays linear — the only cryptography in the
+ * comms-worker auth surface.
+ * @param data Unsigned `<head>.<body>` portion of the JWT.
+ * @param signature Base64url-encoded signature segment.
+ * @param secret HS256 secret (shared with auth-worker).
+ * @returns True iff the signature matches.
+ */
+export const checkSignature = async (
+  data: string,
+  signature: string,
+  secret: string
+): Promise<boolean> => {
+  const key = await importHs256Key(secret)
+  return globalThis.crypto.subtle.verify(
+    'HMAC',
+    key,
+    base64urlDecode(signature),
+    new TextEncoder().encode(data)
+  )
+}

--- a/services/comms-worker/src/middleware/cors.ts
+++ b/services/comms-worker/src/middleware/cors.ts
@@ -14,8 +14,7 @@ const ALLOW_METHODS = 'GET, POST, PUT, DELETE, OPTIONS'
  * @returns Hono middleware handler.
  */
 export const cors =
-  (): MiddlewareHandler<{ Bindings: CorsEnv }> =>
-  async (c, next) => {
+  (): MiddlewareHandler<{ Bindings: CorsEnv }> => async (c, next) => {
     const origin = c.req.header('origin')
     const allow = origin === c.env.ALLOWED_ORIGIN ? origin : undefined
     const setHeaders = (res: Response): Response => {

--- a/services/comms-worker/src/middleware/require-session.test.ts
+++ b/services/comms-worker/src/middleware/require-session.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest'
 import { SESSION_COOKIE } from '../auth/session-cookie'
 import type { SessionClaims } from '../auth/session-types'
 import {
-  requireSession,
   type RequireSessionEnv,
   type RequireSessionVariables,
+  requireSession,
 } from './require-session'
 
 const ENV: RequireSessionEnv = {
@@ -13,7 +13,9 @@ const ENV: RequireSessionEnv = {
   REQUIRED_TEAM: 'admins',
 }
 
-const buildApp = (verifier: (t: string) => Promise<SessionClaims | undefined>) => {
+const buildApp = (
+  verifier: (t: string) => Promise<SessionClaims | undefined>
+) => {
   const app = new Hono<{
     Bindings: RequireSessionEnv
     Variables: RequireSessionVariables
@@ -84,10 +86,7 @@ describe('requireSession middleware', () => {
       seen = t
       return validClaims
     })
-    await app.fetch(
-      req(`foo=bar; ${SESSION_COOKIE}=THE_TOKEN; baz=qux`),
-      ENV
-    )
+    await app.fetch(req(`foo=bar; ${SESSION_COOKIE}=THE_TOKEN; baz=qux`), ENV)
     expect(seen).toBe('THE_TOKEN')
   })
 })

--- a/services/log-collector/src/auth-middleware.ts
+++ b/services/log-collector/src/auth-middleware.ts
@@ -16,9 +16,7 @@ const PUBLIC_PATHS = new Set<string>(['/health', '/auth/exchange'])
 
 const tokenFrom = (header: string | undefined): string | undefined => {
   const prefix = 'Bearer '
-  return header !== undefined && header.startsWith(prefix)
-    ? header.slice(prefix.length)
-    : undefined
+  return header?.startsWith(prefix) ? header.slice(prefix.length) : undefined
 }
 
 /**

--- a/src/composables/useAuth/mint-session.ts
+++ b/src/composables/useAuth/mint-session.ts
@@ -40,7 +40,12 @@ export const mintSession = async (
     credentials: 'include',
     headers: { Authorization: `Bearer ${ghToken}` },
   })
-  if (!res.ok) return undefined
+  return res.ok ? readPayload(res) : undefined
+}
+
+const readPayload = async (
+  res: Response
+): Promise<SessionPayload | undefined> => {
   const body: unknown = await res.json().catch(() => undefined)
   return isSessionPayload(body) ? body : undefined
 }

--- a/src/config/auth-session.ts
+++ b/src/config/auth-session.ts
@@ -1,8 +1,6 @@
 const envBase = (): string => {
   const v = import.meta.env.VITE_AUTH_BASE
-  return typeof v === 'string' && v.length > 0
-    ? v.replace(/\/$/, '')
-    : ''
+  return typeof v === 'string' && v.length > 0 ? v.replace(/\/$/, '') : ''
 }
 
 const defaultBase = (): string =>


### PR DESCRIPTION
## Summary

- Post-merge polish so `bun run build` (validate → biome ci → sonarjs → eslint jsdoc → typecheck) is clean.
- Extracted JWT claim-guard + signature helpers into separate files so verify/sign/session-verify stay under the 50-line file / 25-line function caps.
- Split auth-worker session handler into checkAdmin + mintSessionResponse.
- biome.json: auth-worker index.ts added to noDefaultExport override; ++ added to file include excludes.
- log-collector auth-middleware.ts: useOptionalChain fix biome ci caught (pre-existing, not SSO-related).
- mint-session.ts: extracted readPayload helper to satisfy the no-`if` rule.

## Test plan

- [x] +[0m[36mChecked 1451 files in 835[0m[0m[2m[36mms[0m[0m[36m.[0m[0m[36m No fixes applied.[0m
Found 0 warnings and 0 errors.
Finished in 8.0s on 1423 files with 160 rules using 16 threads.
Checking 238 Vue files...
✅ All Vue templates pass depth check
[36mvite v8.0.8 [32mbuilding client environment for production...[36m[39m
[2K
transforming...✓ 2080 modules transformed.
rendering chunks...
computing gzip size...
dist/client/index.html                                        1.90 kB │ gzip:     0.65 kB
dist/client/.vite/manifest.json                              10.22 kB │ gzip:     1.38 kB
dist/client/assets/mupdf-wasm-b0pRsPEa.wasm               9,991.58 kB │ gzip: 4,642.68 kB
dist/client/assets/style-SeFbuaHl.css                        95.08 kB │ gzip:    15.97 kB
dist/client/assets/_plugin-vue_export-helper-B67ILkmu.js      0.08 kB │ gzip:     0.09 kB
dist/client/assets/__vite-browser-external-_GVFLBrh.js        0.10 kB │ gzip:     0.11 kB
dist/client/assets/extract-string-Btn_HzA-.js                 0.12 kB │ gzip:     0.12 kB
dist/client/assets/file-to-base64-BYx5_e8W.js                 0.15 kB │ gzip:     0.14 kB
dist/client/assets/decode-response-jVexxRPc.js                0.29 kB │ gzip:     0.23 kB
dist/client/assets/usePermissions-DQOXqewe.js                 0.43 kB │ gzip:     0.29 kB
dist/client/assets/extract-pdf-cover-viPlnah2.js              0.75 kB │ gzip:     0.48 kB
dist/client/assets/mupdf-BmyGrTZp.js                          0.85 kB │ gzip:     0.47 kB
dist/client/assets/content-fetch-BV1CV5ft.js                  0.94 kB │ gzip:     0.56 kB
dist/client/assets/labels-Cnod8Ejc.js                         1.12 kB │ gzip:     0.56 kB
dist/client/assets/AuthCallbackView-CSstlChN.js               1.13 kB │ gzip:     0.71 kB
dist/client/assets/conflicts-inl0GUiH.js                      1.17 kB │ gzip:     0.63 kB
dist/client/assets/rolldown-runtime-Bhmf7a9N.js               1.20 kB │ gzip:     0.66 kB
dist/client/assets/content-BWOuCa-k.js                        1.24 kB │ gzip:     0.71 kB
dist/client/assets/DeploySteps-BEPPgO8m.js                    1.96 kB │ gzip:     1.04 kB
dist/client/assets/VisualMergeView-By-rpage.js                3.17 kB │ gzip:     1.48 kB
dist/client/assets/labels-DqjBKQwF.js                         3.70 kB │ gzip:     1.50 kB
dist/client/assets/available-languages-CDzbZrhi.js            4.36 kB │ gzip:     1.87 kB
dist/client/assets/TicketDetailView-ChDxdaMU.js               4.36 kB │ gzip:     2.00 kB
dist/client/assets/ConflictsView-DRqH2a-o.js                  4.64 kB │ gzip:     1.71 kB
dist/client/assets/DeployDetailView-DHeV3vE8.js               7.10 kB │ gzip:     3.11 kB
dist/client/assets/auth-guard-CV6wkPlb.js                     7.79 kB │ gzip:     3.45 kB
dist/client/assets/CommsView-Cl9q7BwE.js                     16.26 kB │ gzip:     5.57 kB
dist/client/assets/ContentView-Cb4Ga7Nh.js                   18.18 kB │ gzip:     6.21 kB
dist/client/assets/TicketsView-CDb7fKZu.js                   18.52 kB │ gzip:     6.32 kB
dist/client/assets/AppLayout-DUhWNscT.js                     21.49 kB │ gzip:     8.12 kB
dist/client/assets/SettingsView-BqSnpmFA.js                  29.54 kB │ gzip:     8.34 kB
dist/client/assets/vue-vendor-Df_2wPy1.js                    33.17 kB │ gzip:    12.95 kB
dist/client/assets/index-2m-1Anm6.js                         34.10 kB │ gzip:    11.63 kB
dist/client/assets/marked-B10qeLxf.js                        43.45 kB │ gzip:    13.27 kB
dist/client/assets/ContentEditView-DP_sWE_t.js               67.18 kB │ gzip:    21.25 kB
dist/client/assets/vendor-CQviBtxH.js                       981.05 kB │ gzip:   278.95 kB

[32m✓ built in 2.23s[39m
[36mvite v8.0.8 [32mbuilding client environment for production...[36m[39m
[2K
transforming...✓ 974 modules transformed.
rendering chunks...
computing gzip size...
dist/client/sw.js  645.35 kB │ gzip: 201.78 kB

[32m✓ built in 538ms[39m
OK sw.js is browser-safe (644108 bytes)+ clean (validate + client + sw)
- [x] Workers tests 218/218
- [x] +
 ⛅️ wrangler 4.98.0
───────────────────+ — admin-website db58df42 (first prod build with mintSession wired)
- [x] Smoke against admin.comprom.org → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)