### PR TITLE
feat(sso): gate on GitHub org Owner role instead of team membership

### DIFF
--- a/docs/architecture/sso.md
+++ b/docs/architecture/sso.md
@@ -94,13 +94,20 @@ reads it. Issuance is centralised; verification is per-worker.
 {
   "sub":   "undeadliner",                   // github login
   "login": "undeadliner",                   // alias of sub for handler ergonomics
-  "teams": ["admins"],                      // memberships in communist-prometheus org
+  "roles": ["owner"],                       // authorisation tier
   "iat":   1780827572,                      // seconds
   "exp":   1780913972,                      // iat + 24h
   "aud":   "comprom-sso",                   // pinned audience string
   "iss":   "auth.comprom.org"               // pinned issuer
 }
 ```
+
+`roles` is the only authorisation claim consumers gate on. Today
+the only tier issued is `"owner"` — the auth-worker only mints a
+session when the GitHub user is an **org owner** of
+`communist-prometheus` (in GH API terms: `role: "admin"` on the
+org membership endpoint). Future tiers (`editor`, `viewer`) extend
+the same array without breaking the shape.
 
 - **alg:** HS256
 - **secret:** `JWT_SECRET` env var, the SAME on `auth-worker`,
@@ -128,23 +135,25 @@ The SPA still gets the JWT body in the JSON response so it can read
 `{ login, teams, expires }` and render UI. The signed token itself
 lives only in the cookie.
 
-## 6. GitHub team check
+## 6. GitHub org-owner check
 
-Source of truth = GitHub org `communist-prometheus` team `admins`.
+Source of truth = GitHub org `communist-prometheus`, "owner" role.
 
-- create team (one-time): `gh api orgs/communist-prometheus/teams -X POST -f name=admins -f description='Admin surface allowlist' -f privacy=closed`
-- seed: `gh api orgs/communist-prometheus/teams/admins/memberships/{login} -X PUT`
 - check (auth-worker, per request):
-  `GET /orgs/communist-prometheus/teams/admins/memberships/{login}` →
-  body `state` must be `"active"` (not `"pending"`). Non-200 ⇒ not a
-  member.
+  `GET /orgs/communist-prometheus/memberships/{login}` →
+  - `state` must be `"active"` (not `"pending"`)
+  - `role` must be `"admin"` (GitHub's wire term for what the UI
+    calls an **Owner**)
+  - non-200 ⇒ not a member
 
-The team check is the only GitHub call we make per session; cache the
-verified login → team list pair in a worker-isolate Map for 5 min so
-repeated SPA-issued `/auth/session` calls don't hammer GH.
+The owner check is the only GitHub call we make per session;
+worker-isolate caching is optional but a Map keyed on the GH token
+hash for 5 min would amortise repeated SPA-issued `/auth/session`
+calls without introducing staleness windows that matter.
 
-The org name is locked into the auth-worker as a `vars.GITHUB_ORG`
-binding — single source.
+The org name is pinned in the auth-worker as `vars.GITHUB_ORG`
+— single source. Adding/removing org owners happens entirely in
+the GitHub org Members page; the worker has nothing to provision.
 
 ## 7. CORS
 

--- a/services/auth-worker/src/bindings.ts
+++ b/services/auth-worker/src/bindings.ts
@@ -8,7 +8,6 @@ import type { SessionClaims } from './jwt/types'
 export type Bindings = {
   readonly VERSION: string
   readonly GITHUB_ORG: string
-  readonly GITHUB_ADMIN_TEAM: string
   readonly ALLOWED_ORIGIN: string
   readonly COOKIE_DOMAIN: string
   readonly JWT_SECRET: string

--- a/services/auth-worker/src/gh-user.ts
+++ b/services/auth-worker/src/gh-user.ts
@@ -27,27 +27,29 @@ export const fetchUserLogin = async (
   return typeof login === 'string' ? login : undefined
 }
 
-export type TeamCheckInput = {
+export type OrgRoleCheckInput = {
   readonly org: string
-  readonly team: string
   readonly login: string
   readonly token: string
 }
 
 /**
- * Check whether `login` is an **active** member of the given org
- * team. GitHub returns 200 + `state: "active"` for full members,
- * 200 + `state: "pending"` for pending invitations (which we treat
- * as not-yet-a-member), and 404 for everyone else.
- * @param input Team coordinates + the OAuth token to authenticate the call.
- * @returns True only when state is `"active"`.
+ * Check whether `login` is an org **owner** (GitHub calls this
+ * `role: "admin"` on the membership endpoint). GitHub returns
+ * 200 + `state: "active"` + `role: "admin"` for owners,
+ * `role: "member"` for regular members, `state: "pending"` for
+ * unaccepted invitations, and 404 for non-members.
+ * @param input Org coordinates + the OAuth token to authenticate.
+ * @returns True only when state is `"active"` AND role is `"admin"`.
  */
-export const isActiveTeamMember = async (
-  input: TeamCheckInput
+export const isOrgOwner = async (
+  input: OrgRoleCheckInput
 ): Promise<boolean> => {
-  const url = `https://api.github.com/orgs/${input.org}/teams/${input.team}/memberships/${input.login}`
+  const url = `https://api.github.com/orgs/${input.org}/memberships/${input.login}`
   const res = await fetch(url, { headers: GH_HEADERS(input.token) })
   if (!res.ok) return false
   const body: unknown = await res.json().catch(() => undefined)
-  return isObject(body) && body['state'] === 'active'
+  return (
+    isObject(body) && body['state'] === 'active' && body['role'] === 'admin'
+  )
 }

--- a/services/auth-worker/src/jwt/claims-guard.ts
+++ b/services/auth-worker/src/jwt/claims-guard.ts
@@ -18,7 +18,7 @@ export const isSessionClaims = (value: unknown): value is SessionClaims => {
   return (
     typeof value['sub'] === 'string' &&
     typeof value['login'] === 'string' &&
-    isStringArray(value['teams']) &&
+    isStringArray(value['roles']) &&
     typeof value['iat'] === 'number' &&
     typeof value['exp'] === 'number' &&
     typeof value['aud'] === 'string' &&

--- a/services/auth-worker/src/jwt/jwt-roundtrip.test.ts
+++ b/services/auth-worker/src/jwt/jwt-roundtrip.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { signSessionJwt } from './sign'
-import { JWT_AUDIENCE, JWT_ISSUER } from './types'
+import { JWT_AUDIENCE, JWT_ISSUER, ROLE_OWNER } from './types'
 import { verifySessionJwt } from './verify'
 
 const SECRET = 'test-secret-do-not-reuse'
@@ -11,14 +11,14 @@ describe('jwt roundtrip', () => {
   it('signs + verifies a valid token', async () => {
     const tok = await signSessionJwt({
       login: 'undeadliner',
-      teams: ['admins'],
+      roles: [ROLE_OWNER],
       secret: SECRET,
       now,
     })
     const claims = await verifySessionJwt(tok, { secret: SECRET, now })
     expect(claims?.login).toBe('undeadliner')
     expect(claims?.sub).toBe('undeadliner')
-    expect(claims?.teams).toEqual(['admins'])
+    expect(claims?.roles).toEqual([ROLE_OWNER])
     expect(claims?.aud).toBe(JWT_AUDIENCE)
     expect(claims?.iss).toBe(JWT_ISSUER)
   })
@@ -26,7 +26,7 @@ describe('jwt roundtrip', () => {
   it('rejects a tampered body', async () => {
     const tok = await signSessionJwt({
       login: 'a',
-      teams: ['admins'],
+      roles: [ROLE_OWNER],
       secret: SECRET,
       now,
     })
@@ -39,7 +39,7 @@ describe('jwt roundtrip', () => {
   it('rejects a token signed with a different secret', async () => {
     const tok = await signSessionJwt({
       login: 'a',
-      teams: ['admins'],
+      roles: [ROLE_OWNER],
       secret: 'wrong',
       now,
     })
@@ -50,7 +50,7 @@ describe('jwt roundtrip', () => {
   it('rejects an expired token', async () => {
     const tok = await signSessionJwt({
       login: 'a',
-      teams: ['admins'],
+      roles: [ROLE_OWNER],
       secret: SECRET,
       now,
       ttlSeconds: 10,
@@ -76,14 +76,14 @@ describe('jwt roundtrip', () => {
     expect(claims).toBeUndefined()
   })
 
-  it('preserves multi-team membership in the claims', async () => {
+  it('preserves multi-role membership in the claims', async () => {
     const tok = await signSessionJwt({
       login: 'a',
-      teams: ['admins', 'editors'],
+      roles: [ROLE_OWNER, 'editor'],
       secret: SECRET,
       now,
     })
     const claims = await verifySessionJwt(tok, { secret: SECRET, now })
-    expect(claims?.teams).toEqual(['admins', 'editors'])
+    expect(claims?.roles).toEqual([ROLE_OWNER, 'editor'])
   })
 })

--- a/services/auth-worker/src/jwt/sign.ts
+++ b/services/auth-worker/src/jwt/sign.ts
@@ -13,7 +13,7 @@ const HEADER: JwtHeader = { alg: 'HS256', typ: 'JWT' }
 /** Inputs the signer needs from the caller — everything else is computed. */
 export type SignSessionInput = {
   readonly login: string
-  readonly teams: readonly string[]
+  readonly roles: readonly string[]
   readonly secret: string
   readonly now?: () => number
   readonly ttlSeconds?: number
@@ -26,7 +26,7 @@ const buildPayload = (input: SignSessionInput): SessionClaims => {
   return {
     sub: input.login,
     login: input.login,
-    teams: input.teams,
+    roles: input.roles,
     iat: nowSec,
     exp: nowSec + ttl,
     aud: JWT_AUDIENCE,
@@ -37,7 +37,7 @@ const buildPayload = (input: SignSessionInput): SessionClaims => {
 /**
  * Sign an SSO session JWT (HS256). `iat`/`exp` come from the
  * injected clock; `aud`/`iss` are pinned by the protocol.
- * @param input Login, teams, secret, optional clock + ttl.
+ * @param input Login, roles, secret, optional clock + ttl.
  * @returns Signed JWT in compact serialisation form.
  */
 export const signSessionJwt = async (

--- a/services/auth-worker/src/jwt/types.ts
+++ b/services/auth-worker/src/jwt/types.ts
@@ -7,17 +7,20 @@ export const JWT_ISSUER = 'auth.comprom.org'
 /** Default token lifetime in seconds (24 hours). */
 export const JWT_TTL_SECONDS = 86_400
 
+/** Single tier today; the claim is plural so future tiers slot in. */
+export const ROLE_OWNER = 'owner'
+
 /**
  * Decoded SSO JWT payload. `sub` and `login` are intentional
  * duplicates: `sub` is the RFC 7519 standard slot, `login` is what
- * downstream handlers care about. `teams` is the source-of-truth
+ * downstream handlers care about. `roles` is the source-of-truth
  * authorisation claim — every consumer should gate on it, not on
  * `login`.
  */
 export type SessionClaims = {
   readonly sub: string
   readonly login: string
-  readonly teams: readonly string[]
+  readonly roles: readonly string[]
   readonly iat: number
   readonly exp: number
   readonly aud: string

--- a/services/auth-worker/src/session-handler.test.ts
+++ b/services/auth-worker/src/session-handler.test.ts
@@ -6,7 +6,6 @@ import { SESSION_COOKIE } from './cookie'
 const ENV: Bindings = {
   VERSION: '0.1.0',
   GITHUB_ORG: 'communist-prometheus',
-  GITHUB_ADMIN_TEAM: 'admins',
   ALLOWED_ORIGIN: 'https://admin.comprom.org',
   COOKIE_DOMAIN: '.comprom.org',
   JWT_SECRET: 'test-secret',
@@ -15,7 +14,7 @@ const ENV: Bindings = {
 type StubResponse = { ok: boolean; body?: unknown }
 type Stub = {
   readonly login?: StubResponse
-  readonly team?: StubResponse
+  readonly membership?: StubResponse
 }
 
 const buildResponse = (
@@ -32,7 +31,7 @@ const routeStub = (stub: Stub, url: string): Response => {
     return buildResponse(stub.login, 200, 401)
   }
   return url.startsWith('https://api.github.com/orgs/')
-    ? buildResponse(stub.team, 200, 404)
+    ? buildResponse(stub.membership, 200, 404)
     : new Response('unexpected', { status: 500 })
 }
 
@@ -62,10 +61,10 @@ const post = (token?: string): Request => {
 }
 
 describe('POST /auth/session', () => {
-  it('mints a cookie + body for an active admin team member', async () => {
+  it('mints a cookie + body for an org owner', async () => {
     stubFetch({
       login: { ok: true, body: { login: 'undeadliner' } },
-      team: { ok: true, body: { state: 'active' } },
+      membership: { ok: true, body: { state: 'active', role: 'admin' } },
     })
     const res = await createApp().fetch(post('ghp_OK'), ENV)
     expect(res.status).toBe(200)
@@ -76,11 +75,11 @@ describe('POST /auth/session', () => {
     expect(setCookie).toContain('Secure')
     const body = (await res.json()) as {
       login: string
-      teams: string[]
+      roles: string[]
       expires: number
     }
     expect(body.login).toBe('undeadliner')
-    expect(body.teams).toEqual(['admins'])
+    expect(body.roles).toEqual(['owner'])
     expect(body.expires).toBeGreaterThan(0)
   })
 
@@ -97,19 +96,28 @@ describe('POST /auth/session', () => {
     expect(res.status).toBe(401)
   })
 
-  it('returns 403 when the login is not an admin team member', async () => {
+  it('returns 403 when the login is not in the org at all', async () => {
     stubFetch({
       login: { ok: true, body: { login: 'outsider' } },
-      team: { ok: false },
+      membership: { ok: false },
     })
     const res = await createApp().fetch(post('ghp_OK'), ENV)
     expect(res.status).toBe(403)
   })
 
-  it('returns 403 for a pending (not yet accepted) team invitation', async () => {
+  it('returns 403 when the login is a regular member (not owner)', async () => {
+    stubFetch({
+      login: { ok: true, body: { login: 'plain-member' } },
+      membership: { ok: true, body: { state: 'active', role: 'member' } },
+    })
+    const res = await createApp().fetch(post('ghp_OK'), ENV)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 when the membership is pending (invitation not accepted)', async () => {
     stubFetch({
       login: { ok: true, body: { login: 'pendinguser' } },
-      team: { ok: true, body: { state: 'pending' } },
+      membership: { ok: true, body: { state: 'pending', role: 'admin' } },
     })
     const res = await createApp().fetch(post('ghp_OK'), ENV)
     expect(res.status).toBe(403)
@@ -118,7 +126,7 @@ describe('POST /auth/session', () => {
   it('echoes the allowed origin in CORS headers', async () => {
     stubFetch({
       login: { ok: true, body: { login: 'undeadliner' } },
-      team: { ok: true, body: { state: 'active' } },
+      membership: { ok: true, body: { state: 'active', role: 'admin' } },
     })
     const res = await createApp().fetch(post('ghp_OK'), ENV)
     expect(res.headers.get('access-control-allow-origin')).toBe(

--- a/services/auth-worker/src/session-handler.ts
+++ b/services/auth-worker/src/session-handler.ts
@@ -1,6 +1,6 @@
 import type { Context, Hono } from 'hono'
 import type { WorkerCtx } from './bindings'
-import { fetchUserLogin, isActiveTeamMember } from './gh-user'
+import { fetchUserLogin, isOrgOwner } from './gh-user'
 import { mintSessionResponse } from './session-mint'
 
 const BEARER = 'Bearer '
@@ -8,7 +8,7 @@ const BEARER = 'Bearer '
 const readBearerToken = (header: string | undefined): string | undefined =>
   header?.startsWith(BEARER) ? header.slice(BEARER.length) : undefined
 
-const checkAdmin = async (
+const checkOwner = async (
   c: Context<WorkerCtx>,
   ghToken: string
 ): Promise<Response | { login: string }> => {
@@ -16,30 +16,27 @@ const checkAdmin = async (
   if (login === undefined) {
     return c.json({ error: 'github token rejected' }, 401)
   }
-  const active = await isActiveTeamMember({
+  const owner = await isOrgOwner({
     org: c.env.GITHUB_ORG,
-    team: c.env.GITHUB_ADMIN_TEAM,
     login,
     token: ghToken,
   })
-  return active
-    ? { login }
-    : c.json({ error: 'not a member of admin team' }, 403)
+  return owner ? { login } : c.json({ error: 'not an org owner' }, 403)
 }
 
 /**
  * `POST /auth/session` — exchanges a GitHub OAuth token for a
- * parent-domain SSO cookie. Failure modes are mapped to 401 (bad
- * bearer / GH refused) and 403 (login not in the admin team).
+ * parent-domain SSO cookie. Failure modes map to 401 (missing /
+ * rejected GH token) and 403 (login is not an active org owner).
  * @param c Hono context with worker bindings.
- * @returns JSON `{login,teams,expires}` + `Set-Cookie` on success.
+ * @returns JSON `{login,roles,expires}` + `Set-Cookie` on success.
  */
 const handleSession = async (c: Context<WorkerCtx>): Promise<Response> => {
   const ghToken = readBearerToken(c.req.header('authorization'))
   if (ghToken === undefined) {
     return c.json({ error: 'authorization header required' }, 401)
   }
-  const checked = await checkAdmin(c, ghToken)
+  const checked = await checkOwner(c, ghToken)
   return 'login' in checked ? mintSessionResponse(c, checked.login) : checked
 }
 

--- a/services/auth-worker/src/session-mint.ts
+++ b/services/auth-worker/src/session-mint.ts
@@ -2,13 +2,13 @@ import type { Context } from 'hono'
 import type { WorkerCtx } from './bindings'
 import { buildSessionCookie } from './cookie'
 import { signSessionJwt } from './jwt/sign'
-import { JWT_TTL_SECONDS } from './jwt/types'
+import { JWT_TTL_SECONDS, ROLE_OWNER } from './jwt/types'
 
 /**
  * Sign a session JWT for `login`, wrap it in a parent-domain cookie,
- * and return the JSON response the SPA needs to render UI. Pulled out
- * of the route handler so the auth/session decision tree stays linear
- * and under the per-function line cap.
+ * and return the JSON response the SPA needs to render UI. Every
+ * issued session is owner-tier today; future tiers add entries to
+ * `roles` without changing the shape.
  * @param c Hono context with worker bindings.
  * @param login Verified GitHub login (subject of the JWT).
  * @returns 200 JSON response with `Set-Cookie: comprom_session=…`.
@@ -17,10 +17,10 @@ export const mintSessionResponse = async (
   c: Context<WorkerCtx>,
   login: string
 ): Promise<Response> => {
-  const teams = [c.env.GITHUB_ADMIN_TEAM]
+  const roles = [ROLE_OWNER]
   const jwt = await signSessionJwt({
     login,
-    teams,
+    roles,
     secret: c.env.JWT_SECRET,
   })
   const cookie = buildSessionCookie(jwt, {
@@ -28,5 +28,5 @@ export const mintSessionResponse = async (
     maxAgeSeconds: JWT_TTL_SECONDS,
   })
   const expires = Math.floor(Date.now() / 1000) + JWT_TTL_SECONDS
-  return c.json({ login, teams, expires }, 200, { 'Set-Cookie': cookie })
+  return c.json({ login, roles, expires }, 200, { 'Set-Cookie': cookie })
 }

--- a/services/auth-worker/wrangler.jsonc
+++ b/services/auth-worker/wrangler.jsonc
@@ -9,9 +9,8 @@
   // Secrets (wrangler secret put):
   // - JWT_SECRET — HS256 secret shared with every *.comprom.org worker
   "vars": {
-    "VERSION": "0.1.0",
+    "VERSION": "0.2.0",
     "GITHUB_ORG": "communist-prometheus",
-    "GITHUB_ADMIN_TEAM": "admins",
     "ALLOWED_ORIGIN": "https://admin.comprom.org",
     "COOKIE_DOMAIN": ".comprom.org"
   },

--- a/services/comms-worker/README.md
+++ b/services/comms-worker/README.md
@@ -35,23 +35,20 @@ saved `settings.schedule` and decides per-tick whether to dispatch
 
 ## One-time provisioning
 
-### GitHub team — source of truth for "who is an admin"
+### GitHub org owners — source of truth for "who can edit comms"
 
-The `auth-worker` SSO check requires active membership in this team;
-adding / removing admins in future is a single `gh` call.
+The `auth-worker` SSO check accepts only **org owners** of
+`communist-prometheus` (GitHub UI label; in the API it's
+`role: "admin"` on the org membership endpoint). Adding or removing
+a person is a GitHub-org-page operation — no worker config touch.
 
 ```bash
-# Create the team (private/closed visibility) — already done.
-gh api orgs/communist-prometheus/teams \
-  -X POST -f name=admins \
-  -f description='Admin surface allowlist' \
-  -f privacy=closed
+# Verify the current owners list.
+gh api 'orgs/communist-prometheus/members?role=admin' --jq '.[].login'
 
-# Seed.
-gh api orgs/communist-prometheus/teams/admins/memberships/undeadliner -X PUT
-
-# Verify.
-gh api orgs/communist-prometheus/teams/admins/members --jq '.[].login'
+# Promote someone (requires existing-owner perms on the org).
+gh api 'orgs/communist-prometheus/memberships/<login>' -X PUT \
+  -f role=admin
 ```
 
 ### SSO (`auth.comprom.org`)

--- a/services/comms-worker/docs/editor-user-guide.md
+++ b/services/comms-worker/docs/editor-user-guide.md
@@ -14,18 +14,17 @@ newsletter admin surface at `admin.comprom.org/comms`.
 
 ## 1. Access requirements
 
-Before the first login the org admin must have added your GitHub
-login to the `communist-prometheus/admins` team:
+Before the first login an existing org owner must have promoted
+your GitHub login to **Owner** in `communist-prometheus` (Settings
+→ Members → role: Owner). Owners are the only role that the auth
+worker accepts; regular members get a 403 from `lists.comprom.org`
+even after PKCE.
 
-```bash
-gh api orgs/communist-prometheus/teams/admins/memberships/<login> -X PUT
-```
-
-Once that's done, opening `admin.comprom.org/comms` triggers the
-standard PKCE GitHub OAuth flow. After the token is in localStorage
-the SPA also mints a `comprom_session` cookie scoped to
-`.comprom.org` via `auth.comprom.org/auth/session`; that cookie is
-then shared with `lists.comprom.org` automatically. See
+Once you are an owner, opening `admin.comprom.org/comms` triggers
+the standard PKCE GitHub OAuth flow. After the token lands in
+localStorage the SPA also mints a `comprom_session` cookie scoped
+to `.comprom.org` via `auth.comprom.org/auth/session`; that cookie
+is then shared with `lists.comprom.org` automatically. See
 [`docs/architecture/sso.md`](../../../docs/architecture/sso.md) for
 the full flow.
 

--- a/services/comms-worker/src/auth/claims-guard.ts
+++ b/services/comms-worker/src/auth/claims-guard.ts
@@ -19,7 +19,7 @@ export const isSessionClaims = (value: unknown): value is SessionClaims => {
   return (
     typeof value['sub'] === 'string' &&
     typeof value['login'] === 'string' &&
-    isStringArray(value['teams']) &&
+    isStringArray(value['roles']) &&
     typeof value['iat'] === 'number' &&
     typeof value['exp'] === 'number' &&
     typeof value['aud'] === 'string' &&

--- a/services/comms-worker/src/auth/session-types.ts
+++ b/services/comms-worker/src/auth/session-types.ts
@@ -13,11 +13,14 @@ export const JWT_AUDIENCE = 'comprom-sso'
 /** Issuer claim. Pinned, never per-deploy. */
 export const JWT_ISSUER = 'auth.comprom.org'
 
+/** Owner-tier role; the only tier today. */
+export const ROLE_OWNER = 'owner'
+
 /** Decoded SSO session claims. */
 export type SessionClaims = {
   readonly sub: string
   readonly login: string
-  readonly teams: readonly string[]
+  readonly roles: readonly string[]
   readonly iat: number
   readonly exp: number
   readonly aud: string

--- a/services/comms-worker/src/dispatch/force-route.test.ts
+++ b/services/comms-worker/src/dispatch/force-route.test.ts
@@ -9,14 +9,14 @@ import type { DispatchEnv } from './runtime-env'
 const claims: SessionClaims = {
   sub: 'undeadliner',
   login: 'undeadliner',
-  teams: ['admins'],
+  roles: ['owner'],
   iat: 1,
   exp: 9_999_999_999,
   aud: 'comprom-sso',
   iss: 'auth.comprom.org',
 }
 
-type SessionEnv = { JWT_SECRET: string; REQUIRED_TEAM: string }
+type SessionEnv = { JWT_SECRET: string }
 
 let env: DispatchEnv
 let dispatcher: ReturnType<typeof vi.fn>
@@ -46,7 +46,6 @@ beforeEach(() => {
     RESEND_API_KEY: 'rk_test',
     UNSUBSCRIBE_SECRET: 'shhh',
     JWT_SECRET: 'unused-in-tests',
-    REQUIRED_TEAM: 'admins',
   } as DispatchEnv & SessionEnv
 })
 

--- a/services/comms-worker/src/dispatch/full-flow.test.ts
+++ b/services/comms-worker/src/dispatch/full-flow.test.ts
@@ -9,7 +9,7 @@ import { signWebhookHeader } from '../webhooks/svix'
 const CLAIMS: SessionClaims = {
   sub: 'undeadliner',
   login: 'undeadliner',
-  teams: ['admins'],
+  roles: ['owner'],
   iat: 1,
   exp: 9_999_999_999,
   aud: 'comprom-sso',
@@ -63,7 +63,6 @@ const env = (): Bindings =>
   ({
     DB: db,
     JWT_SECRET: 'unused-in-tests',
-    REQUIRED_TEAM: 'admins',
     ALLOWED_ORIGIN: 'https://admin.test',
     RESEND_API_KEY: 'rk_test',
     UNSUBSCRIBE_SECRET: 'shhh-1234567890abcdef',

--- a/services/comms-worker/src/middleware/require-session.test.ts
+++ b/services/comms-worker/src/middleware/require-session.test.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import { describe, expect, it } from 'vitest'
 import { SESSION_COOKIE } from '../auth/session-cookie'
-import type { SessionClaims } from '../auth/session-types'
+import { ROLE_OWNER, type SessionClaims } from '../auth/session-types'
 import {
   type RequireSessionEnv,
   type RequireSessionVariables,
@@ -10,7 +10,6 @@ import {
 
 const ENV: RequireSessionEnv = {
   JWT_SECRET: 'unused-in-tests',
-  REQUIRED_TEAM: 'admins',
 }
 
 const buildApp = (
@@ -30,7 +29,7 @@ const buildApp = (
 const validClaims: SessionClaims = {
   sub: 'undeadliner',
   login: 'undeadliner',
-  teams: ['admins'],
+  roles: [ROLE_OWNER],
   iat: 1_780_000_000,
   exp: 1_780_086_400,
   aud: 'comprom-sso',
@@ -62,16 +61,16 @@ describe('requireSession middleware', () => {
     expect(res.status).toBe(401)
   })
 
-  it('returns 403 when the verified claims lack the required team', async () => {
+  it('returns 403 when the verified claims lack the owner role', async () => {
     const app = buildApp(async () => ({
       ...validClaims,
-      teams: ['editors'],
+      roles: ['editor'],
     }))
     const res = await app.fetch(req(`${SESSION_COOKIE}=OK`), ENV)
     expect(res.status).toBe(403)
   })
 
-  it('allows the request when the team is present and exposes claims on c.var', async () => {
+  it('allows the request when owner is present and exposes claims on c.var', async () => {
     const app = buildApp(async () => validClaims)
     const res = await app.fetch(req(`${SESSION_COOKIE}=OK`), ENV)
     expect(res.status).toBe(200)

--- a/services/comms-worker/src/middleware/require-session.ts
+++ b/services/comms-worker/src/middleware/require-session.ts
@@ -1,13 +1,10 @@
 import type { MiddlewareHandler } from 'hono'
 import { readSessionCookie } from '../auth/session-cookie'
-import type { SessionClaims } from '../auth/session-types'
+import { ROLE_OWNER, type SessionClaims } from '../auth/session-types'
 import { verifySessionJwt } from '../auth/session-verify'
 
 /** Bindings the middleware reads from the worker env. */
-export type RequireSessionEnv = {
-  readonly JWT_SECRET: string
-  readonly REQUIRED_TEAM: string
-}
+export type RequireSessionEnv = { readonly JWT_SECRET: string }
 
 /** Variables the middleware writes onto the Hono context. */
 export type RequireSessionVariables = { readonly session: SessionClaims }
@@ -25,11 +22,11 @@ const defaultVerifier =
     verifySessionJwt(token, { secret: env.JWT_SECRET })
 
 /**
- * Hono middleware enforcing a valid SSO session cookie on every
+ * Hono middleware enforcing a valid owner SSO session on every
  * wrapped route. The token comes from the `comprom_session` cookie
- * set by auth-worker; team gating is by membership in the configured
- * `REQUIRED_TEAM`. Failures return 401 (missing/invalid token) or
- * 403 (valid token but team missing). On success the decoded claims
+ * set by auth-worker; authorisation is gated on `roles` including
+ * `owner`. Failures return 401 (missing/invalid token) or 403
+ * (valid token but not an owner). On success the decoded claims
  * are attached to `c.var.session`.
  * @param opts Optional verifier override for tests.
  * @returns Hono middleware.
@@ -52,7 +49,7 @@ export const requireSession =
     if (claims === undefined) {
       return c.json({ error: 'unauthorized' }, 401)
     }
-    if (!claims.teams.includes(c.env.REQUIRED_TEAM)) {
+    if (!claims.roles.includes(ROLE_OWNER)) {
       return c.json({ error: 'forbidden' }, 403)
     }
     c.set('session', claims)

--- a/services/comms-worker/src/schedule/routes.test.ts
+++ b/services/comms-worker/src/schedule/routes.test.ts
@@ -9,14 +9,14 @@ import { mountScheduleRoutes } from './routes'
 const claims: SessionClaims = {
   sub: 'undeadliner',
   login: 'undeadliner',
-  teams: ['admins'],
+  roles: ['owner'],
   iat: 1,
   exp: 9_999_999_999,
   aud: 'comprom-sso',
   iss: 'auth.comprom.org',
 }
 
-const env = { JWT_SECRET: 'unused-in-tests', REQUIRED_TEAM: 'admins' }
+const env = { JWT_SECRET: 'unused-in-tests' }
 const FROZEN = new Date('2026-06-01T00:00:00.000Z')
 
 const build = () => {

--- a/services/comms-worker/src/send-log/route.test.ts
+++ b/services/comms-worker/src/send-log/route.test.ts
@@ -11,14 +11,14 @@ import { mountRunsRoute } from './route'
 const claims: SessionClaims = {
   sub: 'undeadliner',
   login: 'undeadliner',
-  teams: ['admins'],
+  roles: ['owner'],
   iat: 1,
   exp: 9_999_999_999,
   aud: 'comprom-sso',
   iss: 'auth.comprom.org',
 }
 
-const env = { JWT_SECRET: 'unused-in-tests', REQUIRED_TEAM: 'admins' }
+const env = { JWT_SECRET: 'unused-in-tests' }
 
 let db: D1Database
 let subs: SubscriberRepo

--- a/services/comms-worker/src/subscribers/routes.test.ts
+++ b/services/comms-worker/src/subscribers/routes.test.ts
@@ -10,14 +10,14 @@ import type { Subscriber } from './types'
 const claims: SessionClaims = {
   sub: 'undeadliner',
   login: 'undeadliner',
-  teams: ['admins'],
+  roles: ['owner'],
   iat: 1,
   exp: 9_999_999_999,
   aud: 'comprom-sso',
   iss: 'auth.comprom.org',
 }
 
-const env = { JWT_SECRET: 'unused-in-tests', REQUIRED_TEAM: 'admins' }
+const env = { JWT_SECRET: 'unused-in-tests' }
 
 const build = () => {
   const repo = createRepo({

--- a/services/comms-worker/wrangler.jsonc
+++ b/services/comms-worker/wrangler.jsonc
@@ -18,10 +18,9 @@
   // - RESEND_WEBHOOK_SECRET    — Svix-style webhook signature verification
   // - UNSUBSCRIBE_SECRET       — HMAC secret for unsubscribe tokens
   "vars": {
-    "VERSION": "0.1.0",
+    "VERSION": "0.2.0",
     "ADMIN_HOSTNAME": "admin.comprom.org",
-    "ALLOWED_ORIGIN": "https://admin.comprom.org",
-    "REQUIRED_TEAM": "admins"
+    "ALLOWED_ORIGIN": "https://admin.comprom.org"
   },
   "d1_databases": [
     {

--- a/src/composables/useAuth/mint-session.ts
+++ b/src/composables/useAuth/mint-session.ts
@@ -3,7 +3,7 @@ import { getAuthBase } from '@/config/auth-session'
 /** Shape of the auth-worker `/auth/session` response. */
 export type SessionPayload = {
   readonly login: string
-  readonly teams: ReadonlyArray<string>
+  readonly roles: ReadonlyArray<string>
   readonly expires: number
 }
 
@@ -16,7 +16,7 @@ const isStringArray = (x: unknown): x is ReadonlyArray<string> =>
 const isSessionPayload = (value: unknown): value is SessionPayload =>
   isObject(value) &&
   typeof value['login'] === 'string' &&
-  isStringArray(value['teams']) &&
+  isStringArray(value['roles']) &&
   typeof value['expires'] === 'number'
 
 /**


### PR DESCRIPTION
## Summary

- Replaces the team-membership check with a direct check against the GitHub org Owner role. Adding/removing access is now a GitHub org Settings → Members operation; no team to provision or rotate.
- JWT claim renamed `teams: ["admins"]` → `roles: ["owner"]`. `ROLE_OWNER` constant exported from both workers' claim modules so consumers gate on it, not a string literal.
- auth-worker's `gh-user.ts` swaps `isActiveTeamMember` for `isOrgOwner` (org membership endpoint with `role:"admin"` check — GH's wire term for "Owner"). `GITHUB_ADMIN_TEAM` env var removed.
- comms-worker's `requireSession` middleware drops env-driven `REQUIRED_TEAM` for hardcoded `ROLE_OWNER`. Future tiers slot into the same array.
- SPA `mint-session.ts` reads `roles`. Both wrangler.jsonc files bump VERSION 0.1.0 → 0.2.0.
- Docs rewritten (sso.md §4/§6, comms-worker README, editor-user-guide).

## Test plan

- [x] auth-worker 25/25 (added explicit "regular member → 403" case)
- [x] comms-worker 194/194
- [x] Full `bun run build` (validate + client + sw) clean
- [x] Deployed: auth-worker a01b1e8f, comms-worker 08cf4ad3, admin-website 775bb582
- [x] End-to-end smoke against prod: `POST auth.comprom.org/auth/session` with owner PAT → 200 + `Set-Cookie`, `GET lists.comprom.org/api/subscribers` with cookie → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)
