### PR TITLE
fix(comms): retry-and-mint on 401 from lists.comprom.org

### DIFF
--- a/src/stores/comms-api.ts
+++ b/src/stores/comms-api.ts
@@ -8,16 +8,14 @@ import {
   SubscriberSchema,
   SubscribersListSchema,
 } from '@/validation/schemas/subscriber'
-import { commsUrl, ensureOk, jsonHeaders } from './comms-http'
+import { commsFetch, ensureOk, jsonHeaders } from './comms-http'
 
 /**
  * GET /api/subscribers — list every subscriber row, regardless of status.
  * @returns Parsed list payload.
  */
 export const apiListSubscribers = async (): Promise<SubscribersList> => {
-  const res = await fetch(commsUrl('/api/subscribers'), {
-    credentials: 'include',
-  })
+  const res = await commsFetch('/api/subscribers')
   return decodeResponse(SubscribersListSchema)(res)
 }
 
@@ -31,9 +29,8 @@ export const apiAddSubscriber = async (
   email: string,
   langs: ReadonlyArray<Lang>
 ): Promise<Subscriber> => {
-  const res = await fetch(commsUrl('/api/subscribers'), {
+  const res = await commsFetch('/api/subscribers', {
     method: 'POST',
-    credentials: 'include',
     headers: jsonHeaders(),
     body: JSON.stringify({ email, langs }),
   })
@@ -50,9 +47,8 @@ export const apiUpdateLangs = async (
   id: number,
   langs: ReadonlyArray<Lang>
 ): Promise<Subscriber> => {
-  const res = await fetch(commsUrl(`/api/subscribers/${id}`), {
+  const res = await commsFetch(`/api/subscribers/${id}`, {
     method: 'PATCH',
-    credentials: 'include',
     headers: jsonHeaders(),
     body: JSON.stringify({ langs }),
   })
@@ -66,10 +62,7 @@ export const apiUpdateLangs = async (
  */
 export const apiRemoveSubscriber = async (id: number): Promise<void> => {
   ensureOk(
-    await fetch(commsUrl(`/api/subscribers/${id}`), {
-      method: 'DELETE',
-      credentials: 'include',
-    }),
+    await commsFetch(`/api/subscribers/${id}`, { method: 'DELETE' }),
     'Delete'
   )
 }

--- a/src/stores/comms-http.ts
+++ b/src/stores/comms-http.ts
@@ -1,3 +1,5 @@
+import { mintSession } from '@/composables/useAuth/mint-session'
+import { loadToken } from '@/composables/useAuth/token-storage'
 import { getCommsBase } from '@/config/comms'
 
 /**
@@ -14,6 +16,49 @@ export const commsUrl = (path: string): string => `${getCommsBase()}${path}`
 export const jsonHeaders = (): HeadersInit => ({
   'Content-Type': 'application/json',
 })
+
+const send = (url: string, init: RequestInit): Promise<Response> =>
+  fetch(url, { ...init, credentials: 'include' })
+
+const retryWithMint = async (
+  url: string,
+  init: RequestInit,
+  token: string,
+  first: Response
+): Promise<Response> => {
+  const minted = await mintSession(token)
+  return minted === undefined ? first : await send(url, init)
+}
+
+const maybeRetry = async (
+  url: string,
+  init: RequestInit,
+  first: Response
+): Promise<Response> => {
+  const token = loadToken()
+  return token === undefined
+    ? first
+    : await retryWithMint(url, init, token, first)
+}
+
+/**
+ * Fetch helper for `comms-worker` calls. Sends credentials with
+ * every request and, on a single 401, re-mints the SSO session
+ * (cookie may be missing or 24h-expired) and retries once. Any
+ * other status — including a second 401 — is returned to the
+ * caller as-is.
+ * @param path Path on `lists.comprom.org` (beginning with `/`).
+ * @param init Standard fetch init; `credentials` is forced to include.
+ * @returns Final response, possibly after a single retry.
+ */
+export const commsFetch = async (
+  path: string,
+  init: RequestInit = {}
+): Promise<Response> => {
+  const url = commsUrl(path)
+  const first = await send(url, init)
+  return first.status === 401 ? await maybeRetry(url, init, first) : first
+}
 
 /**
  * Pass-through that throws when the response status is non-2xx.

--- a/src/stores/runs-api.ts
+++ b/src/stores/runs-api.ts
@@ -1,7 +1,7 @@
 import { decodeResponse } from '@/validation/decode-response'
 import type { RunLogList } from '@/validation/schemas/run-log'
 import { RunLogListSchema } from '@/validation/schemas/run-log'
-import { commsUrl } from './comms-http'
+import { commsFetch } from './comms-http'
 
 /**
  * GET /api/runs — return the most-recent send_log rows joined with
@@ -11,6 +11,6 @@ import { commsUrl } from './comms-http'
  */
 export const apiListRuns = async (limit?: number): Promise<RunLogList> => {
   const path = limit === undefined ? '/api/runs' : `/api/runs?limit=${limit}`
-  const res = await fetch(commsUrl(path), { credentials: 'include' })
+  const res = await commsFetch(path)
   return decodeResponse(RunLogListSchema)(res)
 }

--- a/src/stores/schedule-api.ts
+++ b/src/stores/schedule-api.ts
@@ -4,16 +4,14 @@ import type {
   ScheduleWithNext,
 } from '@/validation/schemas/schedule'
 import { ScheduleWithNextSchema } from '@/validation/schemas/schedule'
-import { commsUrl, jsonHeaders } from './comms-http'
+import { commsFetch, jsonHeaders } from './comms-http'
 
 /**
  * GET /api/schedule — return the saved schedule with computed `nextRunAt`.
  * @returns Parsed schedule payload.
  */
 export const apiGetSchedule = async (): Promise<ScheduleWithNext> => {
-  const res = await fetch(commsUrl('/api/schedule'), {
-    credentials: 'include',
-  })
+  const res = await commsFetch('/api/schedule')
   return decodeResponse(ScheduleWithNextSchema)(res)
 }
 
@@ -26,9 +24,8 @@ export const apiGetSchedule = async (): Promise<ScheduleWithNext> => {
 export const apiPutSchedule = async (
   schedule: Schedule
 ): Promise<ScheduleWithNext> => {
-  const res = await fetch(commsUrl('/api/schedule'), {
+  const res = await commsFetch('/api/schedule', {
     method: 'PUT',
-    credentials: 'include',
     headers: jsonHeaders(),
     body: JSON.stringify(schedule),
   })


### PR DESCRIPTION
Adds `commsFetch()` wrapper that handles two real failure modes:

1. Race on first load: the SPA used to fire `mintSession()` fire-and-forget, so the first call to `lists.comprom.org/api/*` could reach the worker before the cookie roundtrip finished — page showed `unauthorized`.
2. 24h expiry: the SSO cookie has Max-Age=86400 and every later API call silently 401s without a refresh path.

On the first 401, `commsFetch` pulls the gh_token from localStorage, re-mints the session cookie via `auth.comprom.org/auth/session`, and retries the original request once. Any second 401 (gh_token gone, caller not an org owner) is returned through to the existing error surface.

Deployed: admin-website f74db5c4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)