### PR TITLE
feat(comms): gate /comms on SSO owner role + mobile-friendly layout

### DIFF
--- a/src/components/AppNavAuth.vue
+++ b/src/components/AppNavAuth.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { RouterLink, useRoute } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 import { useRoleStore } from '@/stores/role'
 import { getNavForRole } from './ContentNav/nav-by-role'
 
 const route = useRoute()
 const roleStore = useRoleStore()
-const items = computed(() => getNavForRole(roleStore.role))
+const auth = useAuthStore()
+const isOwner = computed(() => auth.ssoRoles.includes('owner'))
+const items = computed(() => getNavForRole(roleStore.role, isOwner.value))
 </script>
 
 <template>

--- a/src/components/ContentNav/ContentNav.vue
+++ b/src/components/ContentNav/ContentNav.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { RouterLink } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
 import { useRoleStore } from '@/stores/role'
 import { getNavForRole } from './nav-by-role'
 
 const roleStore = useRoleStore()
-const navItems = computed(() => getNavForRole(roleStore.role))
+const auth = useAuthStore()
+const isOwner = computed(() => auth.ssoRoles.includes('owner'))
+const navItems = computed(() => getNavForRole(roleStore.role, isOwner.value))
 </script>
 
 <template>

--- a/src/components/ContentNav/nav-by-role.ts
+++ b/src/components/ContentNav/nav-by-role.ts
@@ -4,6 +4,7 @@ interface NavEntry {
   readonly path: string
   readonly label: string
   readonly minRole?: Role
+  readonly ownerOnly?: boolean
 }
 
 const ALL_NAV: readonly NavEntry[] = [
@@ -13,7 +14,7 @@ const ALL_NAV: readonly NavEntry[] = [
   { path: '/content/common', label: 'Common', minRole: 'admin' },
   { path: '/content/newspaper', label: 'Newspaper' },
   { path: '/tickets', label: 'Tickets' },
-  { path: '/comms', label: 'Comms', minRole: 'admin' },
+  { path: '/comms', label: 'Comms', ownerOnly: true },
   { path: '/settings', label: 'Settings', minRole: 'admin' },
 ]
 
@@ -23,12 +24,20 @@ const ORDER: Record<Role, number> = {
   admin: 2,
 }
 
+const passesRole = (entry: NavEntry, role: Role | undefined): boolean =>
+  !entry.minRole || (!!role && ORDER[role] >= ORDER[entry.minRole])
+
+const passesOwner = (entry: NavEntry, isOwner: boolean): boolean =>
+  !entry.ownerOnly || isOwner
+
 /**
- * Filter nav items by role.
- * @param role - Current user role (undefined = show all)
+ * Filter nav items by app-role + SSO owner flag.
+ * @param role - Current user role (undefined = show all role-gated entries)
+ * @param isOwner - Whether the current SSO session carries the owner claim
  * @returns Visible nav items
  */
-export const getNavForRole = (role: Role | undefined) =>
-  role
-    ? ALL_NAV.filter(n => !n.minRole || ORDER[role] >= ORDER[n.minRole])
-    : ALL_NAV
+export const getNavForRole = (
+  role: Role | undefined,
+  isOwner: boolean
+): readonly NavEntry[] =>
+  ALL_NAV.filter(n => passesRole(n, role) && passesOwner(n, isOwner))

--- a/src/components/MobileMenu/MobileMenuNav.vue
+++ b/src/components/MobileMenu/MobileMenuNav.vue
@@ -12,8 +12,9 @@ const emit = defineEmits<{
 
 const auth = useAuthStore()
 const roleStore = useRoleStore()
+const isOwner = computed(() => auth.ssoRoles.includes('owner'))
 const items = computed(() =>
-  visibleItems(!!auth.user, roleStore.role)
+  visibleItems(!!auth.user, roleStore.role, isOwner.value)
 )
 </script>
 

--- a/src/components/MobileMenu/nav-items.ts
+++ b/src/components/MobileMenu/nav-items.ts
@@ -6,6 +6,7 @@ export interface NavItem {
   readonly label: string
   readonly requiresAuth: boolean
   readonly minRole?: Role
+  readonly ownerOnly?: boolean
 }
 
 /** Shared navigation items used by mobile menu. */
@@ -33,11 +34,9 @@ export const NAV_ITEMS: readonly NavItem[] = [
     requiresAuth: true,
     minRole: 'admin',
   },
-  // prettier-ignore
   { path: '/content/newspaper', label: 'Newspaper', requiresAuth: true },
   { path: '/tickets', label: 'Tickets', requiresAuth: true },
-  // prettier-ignore
-  { path: '/comms', label: 'Comms', requiresAuth: true, minRole: 'admin' },
+  { path: '/comms', label: 'Comms', requiresAuth: true, ownerOnly: true },
   // prettier-ignore
   {
     path: '/settings',

--- a/src/components/MobileMenu/visible-items.ts
+++ b/src/components/MobileMenu/visible-items.ts
@@ -8,19 +8,30 @@ const ORDER: Record<Role, number> = {
   admin: 2,
 }
 
-const hasAccess = (item: NavItem, role: Role | undefined): boolean =>
+const passesRole = (item: NavItem, role: Role | undefined): boolean =>
   !item.minRole || (!!role && ORDER[role] >= ORDER[item.minRole])
 
+const passesOwner = (item: NavItem, isOwner: boolean): boolean =>
+  !item.ownerOnly || isOwner
+
+const passesAuth = (item: NavItem, isAuth: boolean): boolean =>
+  !item.requiresAuth || isAuth
+
 /**
- * Filter nav items by auth state and role.
+ * Filter nav items by auth state, app-role, and SSO owner flag.
  * @param isAuth - Whether user is authenticated
- * @param role - User's resolved role
+ * @param role - User's resolved app role
+ * @param isOwner - Whether the SSO session carries the owner claim
  * @returns Visible navigation items
  */
 export const visibleItems = (
   isAuth: boolean,
-  role?: Role
+  role: Role | undefined,
+  isOwner: boolean
 ): readonly NavItem[] =>
   NAV_ITEMS.filter(
-    item => (!item.requiresAuth || isAuth) && hasAccess(item, role)
+    item =>
+      passesAuth(item, isAuth) &&
+      passesRole(item, role) &&
+      passesOwner(item, isOwner)
   )

--- a/src/composables/useAuth/mint-session.ts
+++ b/src/composables/useAuth/mint-session.ts
@@ -1,4 +1,5 @@
 import { getAuthBase } from '@/config/auth-session'
+import { useAuthStore } from '@/stores/auth'
 
 /** Shape of the auth-worker `/auth/session` response. */
 export type SessionPayload = {
@@ -19,16 +20,31 @@ const isSessionPayload = (value: unknown): value is SessionPayload =>
   isStringArray(value['roles']) &&
   typeof value['expires'] === 'number'
 
+const readPayload = async (
+  res: Response
+): Promise<SessionPayload | undefined> => {
+  const body: unknown = await res.json().catch(() => undefined)
+  return isSessionPayload(body) ? body : undefined
+}
+
+const writeRolesToStore = (payload: SessionPayload | undefined): void => {
+  try {
+    useAuthStore().setSsoRoles(payload?.roles ?? [])
+  } catch {
+    // Pinia not ready (early-boot edge); store will sync on next call.
+  }
+}
+
 /**
  * Trade a fresh GitHub OAuth token for an SSO session cookie scoped
  * to `.comprom.org`. The cookie itself is HttpOnly and not visible
  * here; the returned payload is the same data, suitable for
- * driving RBAC UI without touching the cookie.
+ * driving RBAC UI without touching the cookie. Also pushes `roles`
+ * into the auth store so nav / route guards can react.
  *
- * Returns undefined when the auth-worker rejects the token (401/403
- * — caller should fall back to PKCE) or the response shape is
- * unexpected. Never throws on auth-worker errors — only on network
- * failures.
+ * Returns undefined when the auth-worker rejects the token (401/403)
+ * or the response shape is unexpected. Never throws on auth-worker
+ * errors — only on network failures.
  * @param ghToken GitHub OAuth access token from PKCE.
  * @returns Session metadata or undefined.
  */
@@ -40,14 +56,9 @@ export const mintSession = async (
     credentials: 'include',
     headers: { Authorization: `Bearer ${ghToken}` },
   })
-  return res.ok ? readPayload(res) : undefined
-}
-
-const readPayload = async (
-  res: Response
-): Promise<SessionPayload | undefined> => {
-  const body: unknown = await res.json().catch(() => undefined)
-  return isSessionPayload(body) ? body : undefined
+  const payload = res.ok ? await readPayload(res) : undefined
+  writeRolesToStore(payload)
+  return payload
 }
 
 /**
@@ -59,4 +70,9 @@ export const clearSession = async (): Promise<void> => {
     method: 'POST',
     credentials: 'include',
   }).catch(() => undefined)
+  try {
+    useAuthStore().clearSsoRoles()
+  } catch {
+    // Pinia not ready — harmless.
+  }
 }

--- a/src/router/auth-guard.ts
+++ b/src/router/auth-guard.ts
@@ -1,5 +1,6 @@
 import type { Router } from 'vue-router'
 import { loadToken } from '@/composables/useAuth/token-storage'
+import { useAuthStore } from '@/stores/auth'
 
 const REDIRECT_KEY = 'auth_redirect'
 
@@ -21,16 +22,29 @@ export const loadRedirect = (): string | undefined => {
   return path
 }
 
+const isOwner = (): boolean => {
+  try {
+    return useAuthStore().ssoRoles.includes('owner')
+  } catch {
+    return false
+  }
+}
+
 /**
  * Install navigation guard that protects auth routes.
- * Redirects to / with saved intended path.
+ * Redirects unauthenticated visitors to / with the intended path
+ * saved for post-login restore. Routes flagged `requiresOwner` are
+ * additionally gated on the SSO `owner` role — non-owners get a
+ * silent redirect to / instead of an in-page 401.
  * @param router - Vue Router instance
  */
 export const installAuthGuard = (router: Router): void => {
   router.beforeEach(to => {
     if (!to.meta.requiresAuth) return true
-    if (loadToken()) return true
-    saveRedirect(to.fullPath)
-    return { name: 'home' }
+    if (!loadToken()) {
+      saveRedirect(to.fullPath)
+      return { name: 'home' }
+    }
+    return to.meta.requiresOwner && !isOwner() ? { name: 'home' } : true
   })
 }

--- a/src/router/non-content-routes.ts
+++ b/src/router/non-content-routes.ts
@@ -23,7 +23,7 @@ export const nonContentRoutes: RouteRecordRaw[] = [
   {
     path: '/comms',
     name: 'comms',
-    meta: { requiresAuth: true },
+    meta: { requiresAuth: true, requiresOwner: true },
     component: () => import('../views/CommsView/CommsView.vue'),
   },
   {

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,10 +1,20 @@
 import { defineStore } from 'pinia'
+import type { Ref } from 'vue'
 import { ref, watch } from 'vue'
 import { loadToken } from '@/composables/useAuth/token-storage'
 import type { User } from '@/types/user'
 import { createLogout, createSetUser } from './auth-actions'
 import { createCheckAuth } from './auth-check'
 import { syncTokenToSW } from './auth-sync-sw'
+
+const buildSsoActions = (ssoRoles: Ref<readonly string[]>) => ({
+  setSsoRoles: (roles: readonly string[]): void => {
+    ssoRoles.value = roles
+  },
+  clearSsoRoles: (): void => {
+    ssoRoles.value = []
+  },
+})
 
 /**
  * Pinia store for authentication state management.
@@ -15,19 +25,23 @@ export const useAuthStore = defineStore('auth', () => {
   const user = ref<User | null>(null)
   const loading = ref(!!loadToken())
   const error = ref<string | null>(null)
+  const ssoRoles = ref<readonly string[]>([])
 
   watch(user, syncTokenToSW, { immediate: true })
 
   const logout = createLogout(user, loading)
   const checkAuth = createCheckAuth(user, loading, logout)
   const setUser = createSetUser(user)
+  const ssoActions = buildSsoActions(ssoRoles)
 
   return {
     user,
     loading,
     error,
+    ssoRoles,
     checkAuth,
     setUser,
     logout,
+    ...ssoActions,
   }
 })

--- a/src/views/CommsView/AddSubscriberForm.vue
+++ b/src/views/CommsView/AddSubscriberForm.vue
@@ -92,6 +92,17 @@ const submit = async (): Promise<void> => {
   align-items: end;
 }
 
+@media (width < 640px) {
+  .add-form {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .add-form .submit {
+    justify-content: center;
+  }
+}
+
 .field {
   display: grid;
   gap: 0.25rem;

--- a/src/views/CommsView/ScheduleEditor.vue
+++ b/src/views/CommsView/ScheduleEditor.vue
@@ -180,4 +180,12 @@ const submit = (): void => emit('save', { ...draft.value })
   color: var(--color-danger);
   font-size: 0.8125rem;
 }
+
+@media (width < 640px) {
+  .btn.save {
+    justify-self: stretch;
+    text-align: center;
+    justify-content: center;
+  }
+}
 </style>

--- a/src/views/CommsView/SubscriberRow.vue
+++ b/src/views/CommsView/SubscriberRow.vue
@@ -87,4 +87,40 @@ const emit = defineEmits<{
   outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
+
+@media (width < 640px) {
+  .subscriber-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'email actions'
+      'langs langs'
+      'status status';
+    gap: var(--spacing-xs);
+    padding: var(--spacing-sm) 0;
+  }
+
+  .subscriber-row td {
+    padding: 0;
+  }
+
+  .subscriber-row .email {
+    grid-area: email;
+    font-size: 0.9375rem;
+    word-break: break-all;
+  }
+
+  .subscriber-row .actions {
+    grid-area: actions;
+    align-self: start;
+  }
+
+  .subscriber-row td:nth-child(2) {
+    grid-area: langs;
+  }
+
+  .subscriber-row td:nth-child(3) {
+    grid-area: status;
+  }
+}
 </style>

--- a/src/views/CommsView/SubscribersTable.vue
+++ b/src/views/CommsView/SubscribersTable.vue
@@ -42,6 +42,20 @@ const emit = defineEmits<{
   table-layout: fixed;
 }
 
+@media (width < 640px) {
+  .subs-table,
+  .subs-table thead,
+  .subs-table tbody {
+    display: block;
+  }
+
+  /* Hide the column header row on mobile — each card row carries
+     its own labels via SubscriberRow's own mobile mode. */
+  .subs-table thead {
+    display: none;
+  }
+}
+
 .subs-table th {
   padding: var(--spacing-xs);
   text-align: left;


### PR DESCRIPTION
## Summary

**1. Owner-only gating across nav + router**

- `mintSession()` writes the returned `roles` into the auth store on every successful exchange.
- `auth-guard.ts` blocks navigation to any route with `meta.requiresOwner` when `ssoRoles` lacks `"owner"` — soft redirect to `/`, never an error page.
- Both nav lists (`ContentNav/nav-by-role.ts` desktop + `MobileMenu/nav-items.ts` mobile) carry an `ownerOnly` flag; the filter helpers consult the auth store. Non-owners simply don't see the entry.
- `/comms` route definition gains `requiresOwner: true`.

**2. Mobile layout fix**

- `AddSubscriberForm` stacks to single column under 640px (was three columns; on small viewports email collapsed to a single character).
- `ScheduleEditor` Save button stretches to full width on mobile.
- `SubscribersTable` hides its thead on mobile; each row reflows into a grid with email + remove, language pills, then status, with email word-breaking on long values.

Deployed: admin-website b81c43ac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
