### PR TITLE
feat(comms): force-dispatch button with two-step confirmation

### DIFF
--- a/scripts/check-vue-template-depth/config.ts
+++ b/scripts/check-vue-template-depth/config.ts
@@ -26,6 +26,7 @@ export const config: Config = {
     'src/views/CommsView/ScheduleEditor.vue',
     'src/views/CommsView/CommsView.vue',
     'src/views/CommsView/CommsSection.vue',
+    'src/views/CommsView/ForceDispatchPanel.vue',
   ],
 } as const
 

--- a/services/comms-worker/src/dispatch/force-route.test.ts
+++ b/services/comms-worker/src/dispatch/force-route.test.ts
@@ -60,30 +60,27 @@ describe('POST /api/dispatch — auth gating', () => {
   })
 })
 
-describe('POST /api/dispatch — BYPASS_SCHEDULE gating', () => {
-  it('returns 404 when BYPASS_SCHEDULE is unset (default prod posture)', async () => {
+describe('POST /api/dispatch — ?force=1 opt-in', () => {
+  it('returns 404 when ?force is missing', async () => {
+    const res = await build().fetch(reqWithAccess('/api/dispatch'), env)
+    expect(res.status).toBe(404)
+    expect(dispatcher).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when ?force is something other than 1', async () => {
     const res = await build().fetch(
-      reqWithAccess('/api/dispatch?force=1'),
+      reqWithAccess('/api/dispatch?force=0'),
       env
     )
     expect(res.status).toBe(404)
     expect(dispatcher).not.toHaveBeenCalled()
   })
 
-  it('returns 404 when BYPASS_SCHEDULE is set but ?force is missing', async () => {
-    const res = await build().fetch(reqWithAccess('/api/dispatch'), {
-      ...env,
-      BYPASS_SCHEDULE: '1',
-    })
-    expect(res.status).toBe(404)
-    expect(dispatcher).not.toHaveBeenCalled()
-  })
-
   it('runs dispatch with current wall-clock and returns 202 on force=1', async () => {
-    const res = await build().fetch(reqWithAccess('/api/dispatch?force=1'), {
-      ...env,
-      BYPASS_SCHEDULE: '1',
-    })
+    const res = await build().fetch(
+      reqWithAccess('/api/dispatch?force=1'),
+      env
+    )
     expect(res.status).toBe(202)
     expect(dispatcher).toHaveBeenCalledOnce()
     const body = (await res.json()) as { sent: number; failed: number }

--- a/services/comms-worker/src/dispatch/force-route.ts
+++ b/services/comms-worker/src/dispatch/force-route.ts
@@ -15,22 +15,23 @@ export type ForceDispatcher = (
 const defaultDispatcher: ForceDispatcher = (env, tickAt) =>
   runDispatch(buildRuntimeDeps(env, tickAt))
 
-const isGated = (c: Context): boolean =>
-  (c.env as DispatchEnv).BYPASS_SCHEDULE === '1' &&
-  c.req.query('force') === '1'
+const isOptedIn = (c: Context): boolean => c.req.query('force') === '1'
 
 const buildHandler =
   (dispatcher: ForceDispatcher) =>
   async (c: Context): Promise<Response> => {
-    if (!isGated(c)) return c.json({ error: 'not_found' }, 404)
+    if (!isOptedIn(c)) return c.json({ error: 'not_found' }, 404)
     const summary = await dispatcher(c.env as DispatchEnv, new Date())
     return c.json(summary, 202)
   }
 
 /**
- * Mount `POST /api/dispatch` — a session-gated manual tick
- * trigger guarded by `BYPASS_SCHEDULE=1` + `?force=1`. Exists in
- * prod (where `BYPASS_SCHEDULE` is unset) but always 404s there.
+ * Mount `POST /api/dispatch?force=1` — owner-only manual tick
+ * trigger. The route is gated by the session middleware
+ * (owner-only) and by the `?force=1` query string so an accidental
+ * GET or omitted query returns 404 instead of firing. Always
+ * leaves `settings.schedule` untouched; the saved cron continues
+ * to fire on its own cadence after a manual tick.
  * @param app Hono app, already wrapped with `requireSession`.
  * @param opts Optional dispatcher seam for unit tests.
  * @returns The same app for chaining.

--- a/services/comms-worker/src/dispatch/full-flow.test.ts
+++ b/services/comms-worker/src/dispatch/full-flow.test.ts
@@ -67,7 +67,6 @@ const env = (): Bindings =>
     RESEND_API_KEY: 'rk_test',
     UNSUBSCRIBE_SECRET: 'shhh-1234567890abcdef',
     RESEND_WEBHOOK_SECRET: SVIX_SECRET,
-    BYPASS_SCHEDULE: '1',
     VERSION: '0.0.0-test',
     ADMIN_HOSTNAME: 'admin.test',
   }) as Bindings

--- a/services/comms-worker/src/dispatch/runtime-env.ts
+++ b/services/comms-worker/src/dispatch/runtime-env.ts
@@ -7,7 +7,6 @@ export type DispatchEnv = {
   readonly UNSUBSCRIBE_SECRET: string
   readonly FROM_ADDRESS?: string
   readonly PUBLIC_BASE_URL?: string
-  readonly BYPASS_SCHEDULE?: string
 }
 
 /** Default sender displayed in the From header. */

--- a/src/stores/dispatch-api.ts
+++ b/src/stores/dispatch-api.ts
@@ -1,0 +1,41 @@
+import { commsFetch, ensureOk } from './comms-http'
+
+/** Shape of the `/api/dispatch?force=1` worker response. */
+export type ForceDispatchResult = {
+  readonly sent: number
+  readonly failed: number
+  readonly skipped: number
+  readonly durationMs: number
+}
+
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+const isForceDispatchResult = (
+  value: unknown
+): value is ForceDispatchResult =>
+  isObject(value) &&
+  typeof value['sent'] === 'number' &&
+  typeof value['failed'] === 'number' &&
+  typeof value['skipped'] === 'number' &&
+  typeof value['durationMs'] === 'number'
+
+/**
+ * POST /api/dispatch?force=1 — owner-only manual tick. Sends the
+ * current digest to every active subscriber immediately. The cron
+ * schedule is NOT modified; the next scheduled tick fires on its
+ * own cadence. Throws on non-2xx, and on a malformed response body.
+ * @returns Summary `{sent, failed, skipped, durationMs}`.
+ */
+export const apiForceDispatch = async (): Promise<ForceDispatchResult> => {
+  const res = ensureOk(
+    await commsFetch('/api/dispatch?force=1', { method: 'POST' }),
+    'Force dispatch'
+  )
+  const body: unknown = await res.json().catch(() => undefined)
+  return isForceDispatchResult(body)
+    ? body
+    : (() => {
+        throw new Error('Force dispatch: malformed response')
+      })()
+}

--- a/src/views/CommsView/CommsView.vue
+++ b/src/views/CommsView/CommsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onMounted, ref } from 'vue'
+import { computed, nextTick, onMounted, ref } from 'vue'
 import type { Lang } from '@/stores/comms'
 import { useCommsStore } from '@/stores/comms'
 import { useRunsStore } from '@/stores/runs'
@@ -7,6 +7,7 @@ import type { Schedule } from '@/stores/schedule'
 import { useScheduleStore } from '@/stores/schedule'
 import AddSubscriberForm from './AddSubscriberForm.vue'
 import CommsSection from './CommsSection.vue'
+import ForceDispatchPanel from './ForceDispatchPanel.vue'
 import RunHistory from './RunHistory.vue'
 import ScheduleEditor from './ScheduleEditor.vue'
 import SubscribersTable from './SubscribersTable.vue'
@@ -14,6 +15,10 @@ import SubscribersTable from './SubscribersTable.vue'
 const store = useCommsStore()
 const schedule = useScheduleStore()
 const runs = useRunsStore()
+
+const activeCount = computed(
+  () => store.subscribers.filter(s => s.status === 'active').length
+)
 
 const showRuns = ref(false)
 
@@ -40,6 +45,10 @@ const onRemove = (id: number): void => {
 
 const onScheduleSave = (next: Schedule): void => {
   void schedule.save(next)
+}
+
+const onDispatched = (): void => {
+  void runs.load()
 }
 </script>
 
@@ -86,6 +95,15 @@ const onScheduleSave = (next: Schedule): void => {
         >
           Loading…
         </p>
+      </CommsSection>
+      <CommsSection
+        title="Test dispatch"
+        lead="Owner-only — fires the dispatch loop immediately for testing. Does not modify the saved schedule."
+      >
+        <ForceDispatchPanel
+          :active-count="activeCount"
+          @dispatched="onDispatched"
+        />
       </CommsSection>
       <CommsSection
         title="Run history"

--- a/src/views/CommsView/ForceDispatchPanel.vue
+++ b/src/views/CommsView/ForceDispatchPanel.vue
@@ -1,0 +1,297 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  apiForceDispatch,
+  type ForceDispatchResult,
+} from '@/stores/dispatch-api'
+
+const props = defineProps<{
+  readonly activeCount: number
+}>()
+
+const emit = defineEmits<{
+  dispatched: []
+}>()
+
+type Phase = 'idle' | 'confirm' | 'sending' | 'done' | 'error'
+
+const phase = ref<Phase>('idle')
+const result = ref<ForceDispatchResult | undefined>(undefined)
+const error = ref<string | undefined>(undefined)
+
+const ask = (): void => {
+  phase.value = 'confirm'
+}
+
+const cancel = (): void => {
+  phase.value = 'idle'
+}
+
+const confirm = async (): Promise<void> => {
+  phase.value = 'sending'
+  error.value = undefined
+  try {
+    result.value = await apiForceDispatch()
+    phase.value = 'done'
+    emit('dispatched')
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Dispatch failed'
+    phase.value = 'error'
+  }
+}
+
+const reset = (): void => {
+  phase.value = 'idle'
+  result.value = undefined
+  error.value = undefined
+}
+</script>
+
+<template>
+  <div
+    class="force-dispatch"
+    data-testid="force-dispatch-panel"
+    aria-labelledby="force-dispatch-title"
+  >
+    <p id="force-dispatch-title" class="lead">
+      Trigger an immediate send to every active subscriber. The
+      saved schedule is <strong>not</strong> changed — the next
+      cron tick still fires at its regular time.
+    </p>
+
+    <button
+      v-if="phase === 'idle'"
+      type="button"
+      class="btn btn-trigger"
+      data-testid="force-dispatch-start"
+      :disabled="activeCount === 0"
+      @click="ask"
+    >
+      Send test dispatch now
+    </button>
+
+    <div
+      v-else-if="phase === 'confirm'"
+      class="confirm"
+      role="alertdialog"
+      aria-labelledby="force-confirm-warning"
+    >
+      <p id="force-confirm-warning" class="warning">
+        ⚠ This sends the current digest to
+        <strong>{{ activeCount }}</strong>
+        active subscriber<span v-if="activeCount !== 1">s</span>
+        right now and writes a row per recipient to the run log.
+      </p>
+      <div class="confirm-actions">
+        <button
+          type="button"
+          class="btn btn-cancel"
+          data-testid="force-dispatch-cancel"
+          @click="cancel"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="btn btn-confirm"
+          data-testid="force-dispatch-confirm"
+          @click="confirm"
+        >
+          Yes, send now
+        </button>
+      </div>
+    </div>
+
+    <p
+      v-else-if="phase === 'sending'"
+      class="status"
+      role="status"
+      data-testid="force-dispatch-sending"
+    >
+      Dispatching…
+    </p>
+
+    <div
+      v-else-if="phase === 'done' && result"
+      class="result"
+      role="status"
+      data-testid="force-dispatch-result"
+    >
+      <p>
+        <strong>Sent {{ result.sent }}</strong> ·
+        failed {{ result.failed }} ·
+        skipped {{ result.skipped }} ·
+        {{ result.durationMs }}ms.
+      </p>
+      <button
+        type="button"
+        class="btn btn-ghost"
+        data-testid="force-dispatch-reset"
+        @click="reset"
+      >
+        Reset
+      </button>
+    </div>
+
+    <div
+      v-else-if="phase === 'error'"
+      class="error"
+      role="alert"
+      data-testid="force-dispatch-error"
+    >
+      <p>{{ error }}</p>
+      <button
+        type="button"
+        class="btn btn-ghost"
+        data-testid="force-dispatch-error-reset"
+        @click="reset"
+      >
+        Reset
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.force-dispatch {
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.lead {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.btn {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-sm);
+  font: 600 0.95rem/1 var(--font-sans);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+  border: 1px solid transparent;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.btn:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
+.btn-trigger {
+  justify-self: start;
+  background: var(--color-warning);
+  color: var(--color-background);
+  border-color: var(--color-warning);
+}
+
+.btn-trigger:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.confirm {
+  border: 1px solid var(--color-warning);
+  background: var(--color-danger-subtle);
+  padding: var(--spacing-sm);
+  border-radius: var(--radius-sm);
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.warning {
+  margin: 0;
+  color: var(--color-text-primary);
+  font-size: 0.9375rem;
+  line-height: 1.4;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+.btn-cancel {
+  background: transparent;
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+
+.btn-cancel:hover {
+  border-color: var(--color-text-secondary);
+}
+
+.btn-confirm {
+  background: var(--color-danger);
+  color: var(--color-background);
+  border-color: var(--color-danger);
+}
+
+.btn-confirm:hover {
+  filter: brightness(1.08);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-color: var(--color-border);
+  padding: 0.4rem 0.85rem;
+  font-size: 0.8125rem;
+  justify-self: start;
+}
+
+.btn-ghost:hover {
+  border-color: var(--color-text-secondary);
+}
+
+.status {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.result {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.result p {
+  margin: 0;
+  color: var(--color-success);
+  font-size: 0.9375rem;
+}
+
+.error {
+  display: grid;
+  gap: var(--spacing-xs);
+}
+
+.error p {
+  margin: 0;
+  color: var(--color-danger);
+  font-size: 0.9375rem;
+}
+
+@media (width < 640px) {
+  .btn-trigger,
+  .btn-cancel,
+  .btn-confirm {
+    justify-self: stretch;
+    width: 100%;
+  }
+
+  .confirm-actions {
+    flex-direction: column;
+  }
+}
+</style>


### PR DESCRIPTION
## Summary

- Adds an owner-only "Test dispatch" section to `/comms` with a two-step confirmation flow. Triggers an immediate dispatch tick for testing while leaving the saved cron schedule untouched.
- Worker drops the `BYPASS_SCHEDULE` env flag on `POST /api/dispatch?force=1`. Session middleware (owner-only) + the explicit `?force=1` query string are the two gates that remain. `BYPASS_SCHEDULE` is removed from `DispatchEnv` and the related test cases were rewritten around the cleaner `?force` boundary.
- New `dispatch-api.ts` posts through the existing `commsFetch` so a stale cookie just silently re-mints.
- `ForceDispatchPanel.vue` has five visual states (idle, confirm, sending, done, error) and is mobile-friendly (buttons stretch under 640px).
- `CommsView` listens on `@dispatched` and reloads `runs.load()` so the run history reflects the new rows immediately.

## Verification

- Worker test suite — 194/194 (added `?force=0` boundary case)
- Built + deployed: comms-worker `a523f57d`, admin-website `eeb29723`.
- Real-Chromium end-to-end via chrome-devtools MCP:
  - `/comms` renders with new "Test dispatch" section in document order
  - Click trigger → alertdialog appears: "⚠ This sends the current digest to **2** active subscribers right now and writes a row per recipient to the run log." with Cancel + Yes, send now
  - (Confirm button NOT clicked — would spam real subscribers; the request path is identical to the `?force=1` branch covered by worker unit tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
