### PR TITLE
fix(nav): show role-gated entries while role unknown; restore CI deploy

### DIFF
--- a/e2e/content/section-switching.spec.ts
+++ b/e2e/content/section-switching.spec.ts
@@ -56,7 +56,10 @@ test.describe('Content Section Switching', () => {
       .locator('[data-testid="content-item"]')
       .count()
 
-    await click(page, page.locator('a[href="/content/positions"]'))
+    await click(
+      page,
+      page.getByTestId('app-nav').locator('a[href="/content/positions"]')
+    )
     await waitForCondition(page, async () =>
       page.url().includes('/content/positions')
     )
@@ -71,7 +74,10 @@ test.describe('Content Section Switching', () => {
     await visit(page, '/content/positions')
     await waitForContentReady(page)
 
-    await click(page, page.locator('a[href="/content/pages"]'))
+    await click(
+      page,
+      page.getByTestId('app-nav').locator('a[href="/content/pages"]')
+    )
     await waitForCondition(page, async () =>
       page.url().includes('/content/pages')
     )

--- a/e2e/github-content/list-content.spec.ts
+++ b/e2e/github-content/list-content.spec.ts
@@ -43,7 +43,16 @@ test.describe('GitHub Content - List', () => {
   })
 
   test('should navigate between content types', async ({ page }) => {
-    await click(page, page.locator('a[href="/content/pages"]'))
+    /*
+     * Scope to the desktop content-nav: with the role-gating fix
+     * landing in PR #271, role-gated links now also render in the
+     * mobile-menu surface, so a bare `a[href]` selector matches
+     * twice and trips strict mode.
+     */
+    await click(
+      page,
+      page.getByTestId('app-nav').locator('a[href="/content/pages"]')
+    )
     await waitForCondition(page, async () =>
       page.url().includes('/content/pages')
     )

--- a/playwright.config.constants.ts
+++ b/playwright.config.constants.ts
@@ -12,3 +12,11 @@ export const MOBILE_TEST_PATTERN = '**/mobile/**'
  * leaks into a fast-mode run.
  */
 export const THROTTLED_TEST_PATTERN = '**/throttled/**'
+
+/**
+ * The comms walkthrough recording is a long-running scripted scene
+ * (5 min budget, 350 ms slowMo) intended for `playwright.config.walkthrough.ts`,
+ * not the regular CI suite. Excluding it from the default config keeps
+ * it out of the 30 s default timeout sweep.
+ */
+export const WALKTHROUGH_TEST_PATTERN = '**/comms-walkthrough/**'

--- a/playwright.config.projects.ts
+++ b/playwright.config.projects.ts
@@ -4,6 +4,7 @@ import {
   LIGHTHOUSE_TEST_PATTERN,
   MOBILE_TEST_PATTERN,
   THROTTLED_TEST_PATTERN,
+  WALKTHROUGH_TEST_PATTERN,
 } from './playwright.config.constants'
 import { lighthouseProjects } from './playwright.config.lighthouse'
 import { throttledCritical } from './playwright.config.throttled'
@@ -14,6 +15,7 @@ const desktopIgnore = [
   LIGHTHOUSE_TEST_PATTERN,
   MOBILE_TEST_PATTERN,
   THROTTLED_TEST_PATTERN,
+  WALKTHROUGH_TEST_PATTERN,
 ]
 
 /**

--- a/src/components/AppNav.vue
+++ b/src/components/AppNav.vue
@@ -8,7 +8,7 @@ const auth = useAuthStore()
 </script>
 
 <template>
-  <nav class="app-nav">
+  <nav class="app-nav" data-testid="app-nav">
     <RouterLink
       to="/"
       :class="{ active: route.path === '/' }"

--- a/src/components/ContentNav/nav-by-role.ts
+++ b/src/components/ContentNav/nav-by-role.ts
@@ -38,8 +38,14 @@ const ORDER: Record<Role, number> = {
   admin: 2,
 }
 
+// Role-gated entries pass when the entry has no minRole, OR when the
+// resolved role meets the bar, OR when the role is still unknown
+// (mock auth, role-fetch in flight, or transient SW error). Hiding
+// chrome before the role probe completes flickers the nav and breaks
+// any caller that depends on the link existing — mirror the
+// permissive default already in `usePermissions.canCreate`.
 const passesRole = (entry: NavEntry, role: Role | undefined): boolean =>
-  !entry.minRole || (!!role && ORDER[role] >= ORDER[entry.minRole])
+  !entry.minRole || !role || ORDER[role] >= ORDER[entry.minRole]
 
 // Owner-only entries pass when the visitor is a known owner OR the
 // owner check is still unknown (empty `roles` = mint hasn't returned

--- a/src/components/MobileMenu/visible-items.ts
+++ b/src/components/MobileMenu/visible-items.ts
@@ -8,8 +8,12 @@ const ORDER: Record<Role, number> = {
   admin: 2,
 }
 
+// Role-gated items pass when the item has no minRole, OR when the
+// resolved role meets the bar, OR when the role is still unknown
+// (mock auth, role-fetch in flight, or transient SW error). Mirror
+// the permissive default in `nav-by-role.ts` + `usePermissions`.
 const passesRole = (item: NavItem, role: Role | undefined): boolean =>
-  !item.minRole || (!!role && ORDER[role] >= ORDER[item.minRole])
+  !item.minRole || !role || ORDER[role] >= ORDER[item.minRole]
 
 // Owner-only entries pass when the visitor is a known owner OR the
 // owner check is still unknown (empty `roles` = mint hasn't returned


### PR DESCRIPTION
## Summary

Three regressions tied together — admin master deploys have been red since PR #256 (parent-domain cookie auth) because the E2E suite clicks nav links that the app silently stopped rendering for the mock-OAuth \`test-user\`.

1. **\`nav-by-role\` + \`visible-items\`**: when the role probe hasn't returned yet, the previous behaviour was *show all role-gated entries*. The docstring still says so, but the rewrite from PR #259 flipped it to *hide everything with a \`minRole\`*. \`usePermissions.canCreate\` keeps the permissive default; nav must match, or the link a test wants to click never mounts.
2. **Strict-mode collisions**: once nav renders, both desktop and mobile-menu surfaces match \`a[href=\"/content/...\"]\`. Adds \`data-testid=\"app-nav\"\` to the desktop nav and scopes the affected tests through it. (\`ContentNav.vue\` carries a \`content-nav\` testid but is dead code — no caller imports it.)
3. **Walkthrough leak**: the comms walkthrough recording (5 min scripted scene, 350 ms slowMo) was being swept into the default Playwright config and timing out at 30 s. Added to the desktop ignore list under \`WALKTHROUGH_TEST_PATTERN\`; the dedicated \`playwright.config.walkthrough.ts\` still picks it up.

## Test plan

- [x] Previously-failing suite locally: \`MOCK_OAUTH=true npx playwright test --project=chromium e2e/content/content-switch-verify e2e/content/section-switching e2e/settings/languages e2e/github-content/list-content e2e/content/language-filtering\` → 35/35 pass.
- [x] Full chromium suite locally: 269 passed, 2 skipped (was 10 failed in CI).
- [ ] Admin master deploy CI goes green after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)