### PR TITLE
chore(ci): bump actions to node24 majors, dependabot ecosystems, TS 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: npm
+  # The repo's lockfile is bun.lock — the `bun` ecosystem (GA since
+  # Feb 2025) updates package.json AND the lockfile together; the old
+  # `npm` entry could not write bun.lock.
+  - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
@@ -11,3 +14,16 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  # e2e-toolkit submodule — keeps the pinned SHA moving with upstream.
+  - package-ecosystem: gitsubmodule
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 2

--- a/.github/workflows/deploy-comms-worker.yml
+++ b/.github/workflows/deploy-comms-worker.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cloning git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/deploy-log-collector.yml
+++ b/.github/workflows/deploy-log-collector.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cloning git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       VITE_GITHUB_CLIENT_ID_DEVELOP: ${{ vars.VITE_GITHUB_CLIENT_ID_DEVELOP }}
     steps:
       - name: Cloning git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # e2e-toolkit lives in a separate repo and is wired in as a
           # submodule. Without this, e2e tsconfig path mapping points
@@ -57,12 +57,13 @@ jobs:
 
       # Wrangler 4 (used by `bunx wrangler dev` below) requires Node 22+.
       # setup-bun ships bundled Node, but `bunx wrangler` resolves against
-      # whatever node is on $PATH. Pin Node 22 so the wrangler CLI doesn't
-      # refuse to start with "requires at least Node.js v22".
-      - name: Installing Node 22
-        uses: actions/setup-node@v4
+      # whatever node is on $PATH. Pin Node 24 (current LTS, matches the
+      # runner's action runtime) so the wrangler CLI doesn't refuse to
+      # start with "requires at least Node.js v22".
+      - name: Installing Node 24
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Installing tools and dependencies
         uses: oven-sh/setup-bun@v2
@@ -144,7 +145,7 @@ jobs:
             e2e-prod/prod-bundle-smoke.pw.ts --reporter=line
 
       - name: Deploying to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -22,7 +22,7 @@ jobs:
       MOCK_OAUTH: 'false'
       VITE_MOCK_AUTH: 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/.github/workflows/realmode-e2e.yml
+++ b/.github/workflows/realmode-e2e.yml
@@ -23,7 +23,7 @@ jobs:
       SANDBOX_BRANCH: main
       SANDBOX_BASELINE_TAG: baseline
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
 

--- a/bun.lock
+++ b/bun.lock
@@ -64,7 +64,7 @@
         "stylelint-config-recommended-vue": "^1.6.1",
         "stylelint-config-standard": "^40.0.0",
         "tsx": "^4.21.0",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "unified": "^11.0.5",
         "unplugin-auto-import": "^21.0.0",
         "unplugin-vue-components": "^31.0.0",
@@ -1881,7 +1881,7 @@
 
     "typed-query-selector": ["typed-query-selector@2.12.1", "", {}, "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "ua-parser-js": ["ua-parser-js@1.0.41", "", { "bin": "script/cli.js" }, "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug=="],
 
@@ -2090,6 +2090,8 @@
     "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "eslint-plugin-sonarjs/ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
+
+    "eslint-plugin-sonarjs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "stylelint-config-recommended-vue": "^1.6.1",
     "stylelint-config-standard": "^40.0.0",
     "tsx": "^4.21.0",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "unified": "^11.0.5",
     "unplugin-auto-import": "^21.0.0",
     "unplugin-vue-components": "^31.0.0",


### PR DESCRIPTION
## Summary
- `actions/checkout` v4→v6, `actions/setup-node` v4→v6 (pin Node 24), `cloudflare/wrangler-action` v3→v4 in all workflows — v4-era actions run on Node 20, which GitHub force-migrates to Node 24 on **June 16, 2026**.
- Dependabot: `npm` → `bun` ecosystem (lockfile is `bun.lock`; npm flavour can't update it), added `github-actions` and `gitsubmodule` ecosystems.
- TypeScript `~5.9.3` → `~6.0.3` (latest stable). TS 7 / tsgo is still beta and vue-tsc has no native backend yet.

## Test plan
- [x] `bun run type-check` (vue-tsc --build) clean on TS 6.0.3
- [x] `bun run test:unit --run` — 958/958
- [x] tsgo 7.0.0-dev checks `tsconfig.sw.json` clean (informational)
- [ ] CI deploy pipeline green on the bumped actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)