### PR TITLE
fix(security): close June 2026 audit findings (3 critical, 4 high, 7 medium)

### DIFF
--- a/.github/workflows/cf-probe.yml
+++ b/.github/workflows/cf-probe.yml
@@ -8,6 +8,11 @@ on:
 # to be a manual triage tool — run it when something is off in production
 # and look at the run logs.
 
+# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
+# nothing here needs repo write access via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   probe:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-comms-worker.yml
+++ b/.github/workflows/deploy-comms-worker.yml
@@ -12,17 +12,22 @@ concurrency:
   group: deploy-comms-worker-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
+# nothing here needs repo write access via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Cloning git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - name: Install root dependencies (provides hono, wrangler, cron-parser)
         run: bun install --frozen-lockfile

--- a/.github/workflows/deploy-log-collector.yml
+++ b/.github/workflows/deploy-log-collector.yml
@@ -11,17 +11,22 @@ concurrency:
   group: deploy-log-collector-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
+# nothing here needs repo write access via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Cloning git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - name: Install root dependencies (provides hono, wrangler)
         run: bun install --frozen-lockfile

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,11 @@ concurrency:
   group: deploy-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
+# nothing here needs repo write access via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -31,7 +36,7 @@ jobs:
       VITE_GITHUB_CLIENT_ID_DEVELOP: ${{ vars.VITE_GITHUB_CLIENT_ID_DEVELOP }}
     steps:
       - name: Cloning git repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # e2e-toolkit lives in a separate repo and is wired in as a
           # submodule. Without this, e2e tsconfig path mapping points
@@ -61,12 +66,12 @@ jobs:
       # runner's action runtime) so the wrangler CLI doesn't refuse to
       # start with "requires at least Node.js v22".
       - name: Installing Node 24
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 
       - name: Installing tools and dependencies
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install --frozen-lockfile
 
       - name: Running unit tests
@@ -145,7 +150,7 @@ jobs:
             e2e-prod/prod-bundle-smoke.pw.ts --reporter=line
 
       - name: Deploying to Cloudflare Workers
-        uses: cloudflare/wrangler-action@v4
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/e2e-integration.yml
+++ b/.github/workflows/e2e-integration.yml
@@ -11,6 +11,11 @@ on:
 # Intentionally kept separate from the deploy gate so a hiccup in the
 # real content repo doesn't block unrelated shipping work.
 
+# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
+# nothing here needs repo write access via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -22,11 +27,11 @@ jobs:
       MOCK_OAUTH: 'false'
       VITE_MOCK_AUTH: 'false'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install --frozen-lockfile
 
       - run: bunx playwright install --with-deps chromium

--- a/.github/workflows/oauth-probe.yml
+++ b/.github/workflows/oauth-probe.yml
@@ -26,6 +26,11 @@ on:
 # out of sync with the GitHub App's registered callback URLs, the deploy
 # is noisy (but not blocking — this is an observability workflow).
 
+# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
+# nothing here needs repo write access via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   probe:
     runs-on: ubuntu-latest

--- a/.github/workflows/realmode-e2e.yml
+++ b/.github/workflows/realmode-e2e.yml
@@ -13,33 +13,48 @@ concurrency:
   group: realmode-e2e
   cancel-in-progress: false
 
+# Least-privilege GITHUB_TOKEN - deploys use dedicated secrets,
+# nothing here needs repo write access via the ambient token.
+permissions:
+  contents: read
+
 jobs:
   realmode:
     runs-on: ubuntu-latest
+    # Deny the sandbox PAT to fork PRs: GitHub already withholds
+    # secrets from fork-PR runs, but this guard keeps the job from
+    # running attacker-edited test code next to the secret even if
+    # repo settings ever loosen.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     env:
-      GITHUB_E2E_KEY: ${{ secrets.GH_E2E_PAT }}
       SANDBOX_OWNER: communist-prometheus
       SANDBOX_REPO: admin-e2e-sandbox
       SANDBOX_BRANCH: main
       SANDBOX_BASELINE_TAG: baseline
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       - run: bun install --frozen-lockfile
       - run: bunx playwright install --with-deps chromium
 
       - name: Reset sandbox to baseline
+        env:
+          GITHUB_E2E_KEY: ${{ secrets.GH_E2E_PAT }}
         run: bun run sandbox:reset
 
       - name: Run real-mode suite
+        env:
+          GITHUB_E2E_KEY: ${{ secrets.GH_E2E_PAT }}
         run: bun run test:e2e:realmode
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-realmode-report
           path: |

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@isomorphic-git/lightning-fs": "^4.6.2",
         "@types/turndown": "^5.0.6",
+        "dompurify": "^3.4.9",
         "github-slugger": "^2.0.0",
         "hono": "^4.12.8",
         "isomorphic-git": "^1.37.2",
@@ -577,6 +578,8 @@
 
     "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/turndown": ["@types/turndown@5.0.6", "", {}, "sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -916,6 +919,8 @@
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
 
     "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "dompurify": ["dompurify@3.4.9", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ=="],
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 

--- a/documentation/security/audit-2026-06-11.md
+++ b/documentation/security/audit-2026-06-11.md
@@ -1,0 +1,206 @@
+# Security Audit — June 11, 2026
+
+Scope: `admin-website` (SPA + CF Worker + SW git BFF), its service
+workers (`auth-worker`, `comms-worker`, `log-collector`), the
+`public-website` repo, and the CI/CD pipelines of both. Three
+parallel reviews: server-side API surface, client auth + Service
+Worker layer, CI/supply chain.
+
+Every finding below marked **fixed** shipped in the same PR as this
+document, with unit tests. Residual risks are listed at the end.
+
+## Summary
+
+| # | Finding | Severity | Status |
+|---|---------|----------|--------|
+| 1 | CORS proxy was an open relay (SSRF + credential forwarding) | Critical | Fixed |
+| 2 | Stored XSS in markdown preview via unsanitized `v-html` | Critical | Fixed |
+| 3 | SW RBAC mutations executed without a role check | Critical | Fixed |
+| 4 | OAuth flow lacked `state` (login CSRF) | High | Fixed |
+| 5 | Callback posted the token with `postMessage('*')` | High | Fixed |
+| 6 | token-handler exchanged codes for any client, relayed params | High | Fixed |
+| 7 | log-collector minted JWTs for any GitHub user | High | Fixed |
+| 8 | No `permissions:` blocks; actions pinned by mutable tags | High | Fixed |
+| 9 | `GH_E2E_PAT` exposed at job level on `pull_request` | High | Fixed |
+| 10 | `/unsubscribe` mutated state on GET | Medium | Fixed |
+| 11 | Action-history leaked URLs with query strings to a public repo | Medium | Fixed |
+| 12 | JS-readable `gh_token` cookie survived migration | Medium | Fixed |
+| 13 | `.dev.vars` tracked in public-website git | Medium | Fixed |
+| 14 | Dual lockfiles (`package-lock.json` + `bun.lock`) | Medium | Fixed |
+| 15 | `bun-version: latest` in worker deploy jobs | Medium | Fixed |
+| 16 | `fetch-content.ts` built shell strings from env values | Low | Fixed |
+| 17 | No rate limiting on unauthenticated endpoints | Medium | Open |
+| 18 | Token scope breadth + IDB persistence | Medium | Open |
+| 19 | Shared `JWT_SECRET` across all workers | Medium | Open |
+| 20 | No SAST / secret-scan / dependency-audit in CI | Medium | Open |
+| 21 | Missing security headers (CSP, HSTS, nosniff) | Low | Open |
+| 22 | Public `tickets` repo carries action-history attachments | Low | Open |
+
+## Fixed findings
+
+### 1. CORS proxy open relay (Critical)
+
+`src/api/cors-proxy.ts` built `https://${path}` from the request
+path with no host allowlist, reflected any `Origin`, and forwarded
+every inbound header — including `Authorization` and `Cookie` — to
+the attacker-chosen host. `admin.comprom.org/api/cors/evil.tld/x`
+proxied to `https://evil.tld/x` with credentials attached. The
+standalone Worker this code replaced had a host pin and an origin
+allowlist; the in-app port had lost both.
+
+Fix: `src/api/cors-allow.ts` pins targets to
+`github.com/<owner>/<repo>/(info/refs|git-upload-pack|git-receive-pack)`
+(the only endpoints isomorphic-git needs), allowlists the admin app
+origins (prod, develop, localhost), and the proxy strips the
+`Cookie` header before forwarding. Tests: `src/api/cors-proxy.test.ts`.
+
+### 2. Stored XSS in markdown preview (Critical)
+
+`MarkdownPreview.vue` rendered `marked` output through `v-html`
+with no sanitizer in the project. Content is written by
+editor-role users; a crafted `<img onerror=…>` in a post executed
+in the session of whoever previewed it — with the GitHub token
+(scopes incl. `admin:org`) readable from localStorage. Editor →
+org-admin escalation in one click.
+
+Fix: `sanitize-html.ts` runs DOMPurify over the rendered HTML
+(default config + `blob:` URI allowance for asset previews) before
+`v-html`. Tests cover script/onerror/javascript:/iframe/data:
+vectors and legitimate content (blob previews, footnote anchors,
+media tags): `sanitize-html.test.ts`.
+
+### 3. Ungated SW RBAC mutations (Critical)
+
+`POST /api/github/org-role`, `POST /api/github/org-invite` and the
+invite revoke ran with the SW's stored admin token without checking
+the caller's role — unlike the roles-config handlers, which gate on
+admin. Any same-origin script (e.g. the XSS in finding 2) could
+promote an arbitrary account.
+
+Fix: `src/sw/rbac/require-admin.ts` — the same `resolveRole` gate
+the roles-config handlers use, applied to all three handlers.
+Tests: `require-admin.test.ts`.
+
+### 4–5. OAuth `state` + targeted postMessage (High)
+
+PKCE protects against code interception but not login CSRF: without
+`state`, an attacker could complete the callback with their own
+code and log the victim into the attacker's account. The callback
+also posted the token to its opener with targetOrigin `'*'` — any
+window that opened the callback URL would receive the credential.
+
+Fix: `buildAuthorizeUrl` now generates a crypto-random `state`
+(stored alongside the verifier, single-use), and
+`completeCallback` rejects mismatches. `notifyOpener` posts only to
+the explicit `TRUSTED_ORIGINS` set (`trusted-origins.ts`, shared
+with the receiving-side check). Tests: `authorize-url.test.ts`.
+
+### 6. token-handler as an exchange oracle (High)
+
+The handler forwarded the raw request body (only overwriting
+`client_secret`) and returned GitHub's response verbatim. Fix:
+`client_id` is pinned per environment via wrangler `vars` and
+mismatches are rejected; only `code`/`redirect_uri`/`code_verifier`
+are forwarded; only the documented token-response fields are
+returned. Tests: `token-handler.test.ts`.
+
+### 7. log-collector JWT minting (High)
+
+`POST /auth/exchange` signed a collector JWT for any GitHub user
+who completed OAuth — no org check (the auth-worker equivalent has
+one). Anyone could write spans/logs into the observability store.
+Fix: active-org-membership gate (`gh-org.ts`) before signing;
+GitHub failures now map to 400 instead of unhandled 500s. Tests:
+`exchange-handler.test.ts`.
+
+### 8–9. CI hardening (High)
+
+No workflow declared `permissions:`, so every job ran with the
+default `GITHUB_TOKEN` grant; all third-party actions were pinned
+to mutable tags; `GH_E2E_PAT` sat in job-level env on a
+`pull_request` trigger. Fix: `permissions: contents: read` in every
+workflow of both repos, all actions pinned to full commit SHAs
+(dependabot's `github-actions` ecosystem keeps them moving), bun
+pinned to 1.3.9, and the sandbox PAT moved to step-level env behind
+a same-repo guard.
+
+### 10. Unsubscribe GET mutation (Medium)
+
+`GET /unsubscribe?t=…` flipped the subscriber to `unsubscribed` —
+mail-client prefetchers and AV link scanners follow GETs, silently
+unsubscribing recipients. Fix: GET only verifies and renders a
+localized confirm form (7 languages); the flip happens exclusively
+on POST (both RFC-8058 one-click and the form land there).
+`verifyLookup` in `handler.ts` is the side-effect-free path.
+
+### 11. Action-history privacy (Medium)
+
+The 60-minute action-history JSON attached to tickets (a public
+repo) carried full URLs and SPA routes — query strings can hold
+OAuth codes, unsubscribe tokens, `state` values. Fix: `stripQuery`
+removes everything after `?`/`#` from navigation routes and
+network-error URLs at the redaction boundary (`redact-helpers.ts`).
+
+### 12. Cookie migration (Medium)
+
+The JS-readable `gh_token` cookie fallback was read into
+localStorage but never deleted, leaving a second exfiltration
+target. Fix: `deleteCookie` expires it (host + parent domain) right
+after the one-time migration. Tests: `token-storage.test.ts`.
+
+### 13–16. public-website supply chain (Medium/Low)
+
+`.dev.vars` was tracked (placeholder values, but the file wrangler
+loads real secrets from — a commit landmine); now
+`.dev.vars.example` + gitignored. `package-lock.json` removed —
+`bun.lock` is the single dependency truth. `fetch-content.ts` now
+uses `execFileSync` argv arrays instead of shell strings.
+
+## Verified clean
+
+- JWT crypto in all workers: HS256, signature verified before
+  decode, `aud`/`iss`/`exp` enforced, constant-time comparisons,
+  no `alg:none` path.
+- All D1 access parameterized — no SQL injection.
+- No live secrets in either working tree; `.env` ignored;
+  submodule SHA-pinned over HTTPS; no `pull_request_target`; no
+  install scripts in dependencies.
+- Session cookie: `HttpOnly; Secure; SameSite=Lax`.
+- Unsubscribe token + Resend webhook: HMAC with timestamp window
+  and constant-time compare.
+- SW debug panel renders only `entry.msg`, never `entry.data`;
+  no token is ever logged.
+- Content-repo → CI code execution: no path found (no MDX, js-yaml
+  v4 safe schema, fixed write roots, host-pinned favicon fetches).
+
+## Open items (residual risk)
+
+1. **Rate limiting (17)** — `/api/oauth/token`, `/api/cors/*`,
+   `auth-worker /auth/session`, `comms-worker /unsubscribe` have no
+   throttling; log-collector's limiter is per-isolate only. Add
+   Cloudflare WAF rate rules for `admin.comprom.org/api/*`,
+   `auth.comprom.org`, `lists.comprom.org` — dashboard work, not
+   repo work.
+2. **Token scope + persistence (18)** — the SPA token carries
+   `admin:org` and is persisted into the IDB-backed SW config.
+   Direction: drop `admin:org` from the SPA scope set and route
+   org-admin operations through the SSO-cookie-gated auth-worker;
+   stop persisting the raw token (re-supply on SW_INIT).
+3. **Shared JWT_SECRET (19)** — audiences differ (`comprom-sso` vs
+   `log-collector`), so cross-replay is blocked, but one leaked
+   secret still forges everything. Move to per-audience secrets.
+4. **Security automation (20)** — add CodeQL + gitleaks + osv-scanner
+   workflow; enable GitHub secret scanning + push protection.
+5. **Security headers (21)** — CSP (`script-src 'self'`), HSTS,
+   `nosniff`, `frame-ancestors 'none'` on worker responses. A strict
+   CSP would have blunted finding 2 independently.
+6. **Tickets repo visibility (22)** — `communist-prometheus/tickets`
+   is public; even redacted action-history doesn't belong in public
+   attachments. Recommend flipping the repo to private (verify the
+   attachment raw-URL flow for org members afterwards).
+7. **Branch protection** — verify in GitHub settings: required
+   status checks on `master`/`develop`, restricted direct pushes,
+   restricted fork-PR workflow approval. The `content:`
+   commit-message prefix that skips the public-website e2e gate is
+   a deliberate bypass; branch protection should make the e2e check
+   required so the bypass can't ship a broken deploy.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "@isomorphic-git/lightning-fs": "^4.6.2",
     "@types/turndown": "^5.0.6",
+    "dompurify": "^3.4.9",
     "github-slugger": "^2.0.0",
     "hono": "^4.12.8",
     "isomorphic-git": "^1.37.2",

--- a/services/comms-worker/src/unsubscribe/confirmation.ts
+++ b/services/comms-worker/src/unsubscribe/confirmation.ts
@@ -1,40 +1,43 @@
 import { htmlEscape } from '../digest/escape'
 import type { Lang } from '../subscribers/types'
-import { CONFIRMATION_STYLE } from './confirmation-style'
-import {
-  CONFIRMATION,
-  type ConfirmationChrome,
-  RE_SUBSCRIBE_MAILTO,
-} from './i18n'
+import { CONFIRMATION, RE_SUBSCRIBE_MAILTO } from './i18n'
+import { renderPage } from './render-page'
 
-const renderPage = (
-  lang: Lang,
-  c: ConfirmationChrome,
-  heading: string,
-  body: string
-): string =>
-  [
-    '<!DOCTYPE html>',
-    `<html lang="${lang}"><head>`,
-    '<meta charset="utf-8" />',
-    '<meta name="viewport" content="width=device-width,initial-scale=1" />',
-    `<title>${htmlEscape(c.title)}</title>`,
-    CONFIRMATION_STYLE,
-    '</head><body><main><article class="card">',
-    `<h1>${htmlEscape(heading)}</h1>`,
-    `<p>${htmlEscape(body)}</p>`,
-    `<a class="cta" href="${RE_SUBSCRIBE_MAILTO}">${htmlEscape(c.reSubscribeLabel)}</a>`,
-    '</article></main></body></html>',
-  ].join('')
+const reSubscribeCta = (label: string): string =>
+  `<a class="cta" href="${RE_SUBSCRIBE_MAILTO}">${htmlEscape(label)}</a>`
 
 /**
- * Render the success confirmation page shown after a token validates.
+ * Render the confirm page for a valid GET. The flip itself happens
+ * only when the visitor submits this POST form — a GET must stay
+ * side-effect free so link prefetchers cannot unsubscribe people.
+ * @param lang Lang code chosen from Accept-Language.
+ * @param token Verified raw token, re-embedded as the form target.
+ * @returns Full HTML document body.
+ */
+export const renderConfirmPage = (lang: Lang, token: string): string => {
+  const c = CONFIRMATION[lang]
+  const action = `/unsubscribe?t=${encodeURIComponent(token)}`
+  const form =
+    `<form method="post" action="${htmlEscape(action)}">` +
+    `<button class="cta" type="submit">${htmlEscape(c.confirmButton)}</button>` +
+    '</form>'
+  return renderPage(lang, c, c.confirmHeading, c.confirmBody, form)
+}
+
+/**
+ * Render the success confirmation page shown after the flip.
  * @param lang Lang code chosen from Accept-Language by the route handler.
  * @returns Full HTML document body.
  */
 export const renderUnsubscribedPage = (lang: Lang): string => {
   const c = CONFIRMATION[lang]
-  return renderPage(lang, c, c.unsubscribedHeading, c.unsubscribedBody)
+  return renderPage(
+    lang,
+    c,
+    c.unsubscribedHeading,
+    c.unsubscribedBody,
+    reSubscribeCta(c.reSubscribeLabel)
+  )
 }
 
 /**
@@ -44,5 +47,11 @@ export const renderUnsubscribedPage = (lang: Lang): string => {
  */
 export const renderExpiredPage = (lang: Lang): string => {
   const c = CONFIRMATION[lang]
-  return renderPage(lang, c, c.expiredHeading, c.expiredBody)
+  return renderPage(
+    lang,
+    c,
+    c.expiredHeading,
+    c.expiredBody,
+    reSubscribeCta(c.reSubscribeLabel)
+  )
 }

--- a/services/comms-worker/src/unsubscribe/handler.ts
+++ b/services/comms-worker/src/unsubscribe/handler.ts
@@ -7,6 +7,36 @@ export type UnsubscribeOutcome =
   | { readonly kind: 'already' }
   | { readonly kind: 'invalid' }
 
+/** Outcomes of the side-effect-free GET verification. */
+export type VerifyOutcome =
+  | { readonly kind: 'valid' }
+  | { readonly kind: 'already' }
+  | { readonly kind: 'invalid' }
+
+/**
+ * Verify the token and look the subscriber up WITHOUT mutating —
+ * GET must stay side-effect free, otherwise mail-client link
+ * prefetchers and AV URL scanners silently unsubscribe recipients.
+ * The flip happens only on POST (RFC 8058 one-click, or the confirm
+ * form the GET renders).
+ * @param repo Subscriber repo bound to the current request's D1.
+ * @param secret Shared UNSUBSCRIBE_SECRET used to verify the token.
+ * @param token Raw `t` query parameter, possibly undefined.
+ * @returns Discriminated outcome consumed by the GET renderer.
+ */
+export const verifyLookup = async (
+  repo: SubscriberRepo,
+  secret: string,
+  token: string | undefined
+): Promise<VerifyOutcome> => {
+  if (token === undefined || token === '') return { kind: 'invalid' }
+  const verified = await verifyUnsubscribeToken(token, secret)
+  if (verified === undefined) return { kind: 'invalid' }
+  const found = await repo.findById(verified.id)
+  if (found === undefined) return { kind: 'invalid' }
+  return found.status === 'active' ? { kind: 'valid' } : { kind: 'already' }
+}
+
 /**
  * Verify the token, look up the subscriber, and (only when active)
  * flip status to `unsubscribed`. Already-unsubscribed rows return

--- a/services/comms-worker/src/unsubscribe/i18n-cyrillic.ts
+++ b/services/comms-worker/src/unsubscribe/i18n-cyrillic.ts
@@ -3,6 +3,10 @@ import type { ConfirmationChrome } from './i18n-types'
 /** Russian confirmation chrome (ru). */
 export const CONF_RU: ConfirmationChrome = {
   title: 'Отписка — Коммунистический Прометей',
+  confirmHeading: 'Подтвердите отписку',
+  confirmBody:
+    'Нажмите кнопку ниже, чтобы перестать получать рассылку на этот адрес.',
+  confirmButton: 'Отписаться',
   unsubscribedHeading: 'Вы отписаны',
   unsubscribedBody:
     'Вы больше не будете получать рассылку Коммунистического Прометея на этот адрес.',
@@ -15,6 +19,10 @@ export const CONF_RU: ConfirmationChrome = {
 /** Ukrainian confirmation chrome (uk). */
 export const CONF_UK: ConfirmationChrome = {
   title: 'Скасовано — Комуністичний Прометей',
+  confirmHeading: 'Підтвердьте відписку',
+  confirmBody:
+    'Натисніть кнопку нижче, щоб припинити отримувати розсилку на цю адресу.',
+  confirmButton: 'Відписатися',
   unsubscribedHeading: 'Ви відписалися',
   unsubscribedBody:
     'Ви більше не отримуватимете розсилку Комуністичного Прометея на цю адресу.',
@@ -27,6 +35,10 @@ export const CONF_UK: ConfirmationChrome = {
 /** Belarusian confirmation chrome (bl). */
 export const CONF_BL: ConfirmationChrome = {
   title: 'Адпіска — Камуністычны Праметэй',
+  confirmHeading: 'Пацвердзіце адпіску',
+  confirmBody:
+    'Націсніце кнопку ніжэй, каб перастаць атрымліваць рассылку на гэты адрас.',
+  confirmButton: 'Адпісацца',
   unsubscribedHeading: 'Вы адпісаныя',
   unsubscribedBody:
     'Вы больш не атрымаеце рассылку Камуністычнага Праметэя на гэты адрас.',

--- a/services/comms-worker/src/unsubscribe/i18n-latin-more.ts
+++ b/services/comms-worker/src/unsubscribe/i18n-latin-more.ts
@@ -1,0 +1,33 @@
+import type { ConfirmationChrome } from './i18n-types'
+
+/** Spanish confirmation chrome (es). */
+export const CONF_ES: ConfirmationChrome = {
+  title: 'Cancelado — Prometeo Comunista',
+  confirmHeading: 'Confirma la cancelación',
+  confirmBody:
+    'Pulsa el botón de abajo para dejar de recibir el boletín en esta dirección.',
+  confirmButton: 'Cancelar suscripción',
+  unsubscribedHeading: 'Te has dado de baja',
+  unsubscribedBody:
+    'Ya no recibirás el boletín de Prometeo Comunista en esta dirección.',
+  reSubscribeLabel: 'Volver a suscribirse por correo',
+  expiredHeading: 'Este enlace ha caducado',
+  expiredBody:
+    'El enlace de cancelación ya no es válido. Si todavía deseas cancelarte, contáctanos.',
+}
+
+/** Polish confirmation chrome (pl). */
+export const CONF_PL: ConfirmationChrome = {
+  title: 'Wypisano — Komunistyczny Prometeusz',
+  confirmHeading: 'Potwierdź wypisanie',
+  confirmBody:
+    'Kliknij poniższy przycisk, aby przestać otrzymywać newsletter pod tym adresem.',
+  confirmButton: 'Wypisz się',
+  unsubscribedHeading: 'Zostałeś wypisany',
+  unsubscribedBody:
+    'Nie będziesz już otrzymywać newslettera Komunistycznego Prometeusza pod tym adresem.',
+  reSubscribeLabel: 'Zapisz się ponownie przez e-mail',
+  expiredHeading: 'Ten link wygasł',
+  expiredBody:
+    'Link do wypisania się jest już nieważny. Jeśli nadal chcesz się wypisać, skontaktuj się z nami.',
+}

--- a/services/comms-worker/src/unsubscribe/i18n-latin.ts
+++ b/services/comms-worker/src/unsubscribe/i18n-latin.ts
@@ -3,6 +3,10 @@ import type { ConfirmationChrome } from './i18n-types'
 /** English confirmation chrome (en). */
 export const CONF_EN: ConfirmationChrome = {
   title: 'Unsubscribed — Communist Prometheus',
+  confirmHeading: 'Confirm unsubscribe',
+  confirmBody:
+    'Click the button below to stop receiving the newsletter at this address.',
+  confirmButton: 'Unsubscribe',
   unsubscribedHeading: 'You have been unsubscribed',
   unsubscribedBody:
     'You will no longer receive the Communist Prometheus newsletter at this address.',
@@ -15,6 +19,10 @@ export const CONF_EN: ConfirmationChrome = {
 /** Italian confirmation chrome (it). */
 export const CONF_IT: ConfirmationChrome = {
   title: 'Disiscritto — Prometeo Comunista',
+  confirmHeading: 'Conferma la disiscrizione',
+  confirmBody:
+    'Premi il pulsante qui sotto per non ricevere più la newsletter a questo indirizzo.',
+  confirmButton: 'Disiscriviti',
   unsubscribedHeading: 'Sei stato disiscritto',
   unsubscribedBody:
     'Non riceverai più la newsletter di Prometeo Comunista a questo indirizzo.',
@@ -24,26 +32,4 @@ export const CONF_IT: ConfirmationChrome = {
     'Il link di disiscrizione non è più valido. Se vuoi ancora disiscriverti, contattaci.',
 }
 
-/** Spanish confirmation chrome (es). */
-export const CONF_ES: ConfirmationChrome = {
-  title: 'Cancelado — Prometeo Comunista',
-  unsubscribedHeading: 'Te has dado de baja',
-  unsubscribedBody:
-    'Ya no recibirás el boletín de Prometeo Comunista en esta dirección.',
-  reSubscribeLabel: 'Volver a suscribirse por correo',
-  expiredHeading: 'Este enlace ha caducado',
-  expiredBody:
-    'El enlace de cancelación ya no es válido. Si todavía deseas cancelarte, contáctanos.',
-}
-
-/** Polish confirmation chrome (pl). */
-export const CONF_PL: ConfirmationChrome = {
-  title: 'Wypisano — Komunistyczny Prometeusz',
-  unsubscribedHeading: 'Zostałeś wypisany',
-  unsubscribedBody:
-    'Nie będziesz już otrzymywać newslettera Komunistycznego Prometeusza pod tym adresem.',
-  reSubscribeLabel: 'Zapisz się ponownie przez e-mail',
-  expiredHeading: 'Ten link wygasł',
-  expiredBody:
-    'Link do wypisania się jest już nieważny. Jeśli nadal chcesz się wypisać, skontaktuj się z nami.',
-}
+export { CONF_ES, CONF_PL } from './i18n-latin-more'

--- a/services/comms-worker/src/unsubscribe/i18n-types.ts
+++ b/services/comms-worker/src/unsubscribe/i18n-types.ts
@@ -1,6 +1,9 @@
 /** Localised chrome strings for the public unsubscribe surface. */
 export type ConfirmationChrome = {
   readonly title: string
+  readonly confirmHeading: string
+  readonly confirmBody: string
+  readonly confirmButton: string
   readonly unsubscribedHeading: string
   readonly unsubscribedBody: string
   readonly reSubscribeLabel: string

--- a/services/comms-worker/src/unsubscribe/render-page.ts
+++ b/services/comms-worker/src/unsubscribe/render-page.ts
@@ -1,0 +1,35 @@
+import { htmlEscape } from '../digest/escape'
+import type { Lang } from '../subscribers/types'
+import { CONFIRMATION_STYLE } from './confirmation-style'
+import type { ConfirmationChrome } from './i18n'
+
+/**
+ * Shared HTML chrome for every public unsubscribe page.
+ * @param lang Document language.
+ * @param c Localised chrome strings (used for the title).
+ * @param heading Card heading (escaped here).
+ * @param body Card paragraph (escaped here).
+ * @param footer Pre-rendered, ALREADY-ESCAPED footer block (CTA link
+ * or confirm form) — callers own its escaping.
+ * @returns Full HTML document string.
+ */
+export const renderPage = (
+  lang: Lang,
+  c: ConfirmationChrome,
+  heading: string,
+  body: string,
+  footer: string
+): string =>
+  [
+    '<!DOCTYPE html>',
+    `<html lang="${lang}"><head>`,
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width,initial-scale=1" />',
+    `<title>${htmlEscape(c.title)}</title>`,
+    CONFIRMATION_STYLE,
+    '</head><body><main><article class="card">',
+    `<h1>${htmlEscape(heading)}</h1>`,
+    `<p>${htmlEscape(body)}</p>`,
+    footer,
+    '</article></main></body></html>',
+  ].join('')

--- a/services/comms-worker/src/unsubscribe/route-helpers.ts
+++ b/services/comms-worker/src/unsubscribe/route-helpers.ts
@@ -1,0 +1,35 @@
+import type { Context } from 'hono'
+import { createRepo, type SubscriberRepo } from '../subscribers/repo'
+import type { UnsubscribeEnv } from './runtime-env'
+
+const HTML_HEADERS = {
+  'Content-Type': 'text/html; charset=utf-8',
+}
+
+/** Repo + secret pair bound to the current request. */
+export type RouteDeps = {
+  readonly repo: SubscriberRepo
+  readonly secret: string
+}
+
+/**
+ * Build the subscriber repo + secret for the current request's D1.
+ * @param c Hono context carrying UnsubscribeEnv bindings.
+ * @returns Request-scoped repo and the shared unsubscribe secret.
+ */
+export const repoOf = (c: Context): RouteDeps => {
+  const env = c.env as UnsubscribeEnv
+  return {
+    repo: createRepo({ db: env.DB, now: () => new Date().toISOString() }),
+    secret: env.UNSUBSCRIBE_SECRET,
+  }
+}
+
+/**
+ * Wrap a rendered page into an HTML response.
+ * @param body Full HTML document.
+ * @param status HTTP status code.
+ * @returns Response with the html content type.
+ */
+export const html = (body: string, status: number): Response =>
+  new Response(body, { status, headers: HTML_HEADERS })

--- a/services/comms-worker/src/unsubscribe/routes.test.ts
+++ b/services/comms-worker/src/unsubscribe/routes.test.ts
@@ -68,7 +68,7 @@ describe('GET /unsubscribe', () => {
     expect(await res.text()).toContain('expired')
   })
 
-  it('flips status to unsubscribed + stamps unsubscribed_at on a valid GET', async () => {
+  it('does NOT mutate on a valid GET — renders the confirm form instead', async () => {
     const id = await seedActive('a@b.c')
     const token = await signUnsubscribeToken(id, SECRET)
     const res = await app.fetch(
@@ -76,13 +76,15 @@ describe('GET /unsubscribe', () => {
       bindEnv()
     )
     expect(res.status).toBe(200)
-    expect(await res.text()).toContain('unsubscribed')
+    const body = await res.text()
+    expect(body).toContain('<form method="post"')
+    expect(body).toContain('type="submit"')
     const after = await subs.findById(id)
-    expect(after?.status).toBe('unsubscribed')
-    expect(after?.unsubscribedAt).toBeDefined()
+    expect(after?.status).toBe('active')
+    expect(after?.unsubscribedAt).toBeUndefined()
   })
 
-  it('is idempotent for an already-unsubscribed row (200, no state churn)', async () => {
+  it('shows the already-done page for an unsubscribed row (200, no churn)', async () => {
     const id = await seedActive('a@b.c')
     await subs.setStatus(id, 'unsubscribed')
     const before = (await subs.findById(id))?.unsubscribedAt
@@ -92,12 +94,13 @@ describe('GET /unsubscribe', () => {
       bindEnv()
     )
     expect(res.status).toBe(200)
+    expect(await res.text()).not.toContain('<form')
     const after = await subs.findById(id)
     expect(after?.status).toBe('unsubscribed')
     expect(after?.unsubscribedAt).toBe(before)
   })
 
-  it('honours Accept-Language for the rendered confirmation', async () => {
+  it('honours Accept-Language for the rendered confirm page', async () => {
     const id = await seedActive('a@b.c')
     const token = await signUnsubscribeToken(id, SECRET)
     const res = await app.fetch(
@@ -108,7 +111,20 @@ describe('GET /unsubscribe', () => {
     )
     const body = await res.text()
     expect(body).toMatch(/<html lang="ru">/)
-    expect(body).toContain('Вы отписаны')
+    expect(body).toContain('Подтвердите отписку')
+  })
+
+  it('form submit (POST) after the GET performs the flip', async () => {
+    const id = await seedActive('a@b.c')
+    const token = await signUnsubscribeToken(id, SECRET)
+    await app.fetch(new Request(`http://x/unsubscribe?t=${token}`), bindEnv())
+    const res = await app.fetch(
+      new Request(`http://x/unsubscribe?t=${token}`, { method: 'POST' }),
+      bindEnv()
+    )
+    expect(res.status).toBe(200)
+    const after = await subs.findById(id)
+    expect(after?.status).toBe('unsubscribed')
   })
 })
 

--- a/services/comms-worker/src/unsubscribe/routes.ts
+++ b/services/comms-worker/src/unsubscribe/routes.ts
@@ -1,59 +1,52 @@
 import type { Context, Hono } from 'hono'
 import { logEvent } from '../log/structured'
-import { createRepo } from '../subscribers/repo'
 import { pickLang } from './accept-language'
-import { renderExpiredPage, renderUnsubscribedPage } from './confirmation'
-import { verifyAndFlip } from './handler'
+import {
+  renderConfirmPage,
+  renderExpiredPage,
+  renderUnsubscribedPage,
+} from './confirmation'
+import { verifyAndFlip, verifyLookup } from './handler'
+import { html, repoOf } from './route-helpers'
 import type { UnsubscribeEnv } from './runtime-env'
 
 export type { UnsubscribeEnv } from './runtime-env'
 
 type App = Hono<{ Bindings: UnsubscribeEnv }>
 
-const HTML_HEADERS = {
-  'Content-Type': 'text/html; charset=utf-8',
-}
-
-const runVerify = (c: Context) => {
-  const env = c.env as UnsubscribeEnv
-  const repo = createRepo({
-    db: env.DB,
-    now: () => new Date().toISOString(),
-  })
-  return verifyAndFlip(repo, env.UNSUBSCRIBE_SECRET, c.req.query('t'))
-}
-
-const logOutcome = (method: 'GET' | 'POST', kind: string): void => {
-  const evt =
-    kind === 'invalid' ? 'unsubscribe.rejected' : 'unsubscribe.applied'
-  logEvent(evt, { method, kind })
-}
-
+/*
+ * GET is side-effect free: it only verifies the token and renders
+ * either the confirm form (valid), the already-done page, or the
+ * expired page. Mail-client prefetchers and AV link scanners follow
+ * GETs — flipping state here silently unsubscribed recipients.
+ */
 const handleGet = async (c: Context): Promise<Response> => {
   const lang = pickLang(c.req.header('Accept-Language'))
-  const outcome = await runVerify(c)
-  logOutcome('GET', outcome.kind)
-  return outcome.kind === 'invalid'
-    ? new Response(renderExpiredPage(lang), {
-        status: 404,
-        headers: HTML_HEADERS,
-      })
-    : new Response(renderUnsubscribedPage(lang), {
-        status: 200,
-        headers: HTML_HEADERS,
-      })
+  const { repo, secret } = repoOf(c)
+  const token = c.req.query('t')
+  const outcome = await verifyLookup(repo, secret, token)
+  logEvent('unsubscribe.viewed', { method: 'GET', kind: outcome.kind })
+  if (outcome.kind === 'invalid') return html(renderExpiredPage(lang), 404)
+  return outcome.kind === 'already'
+    ? html(renderUnsubscribedPage(lang), 200)
+    : html(renderConfirmPage(lang, token ?? ''), 200)
 }
 
 const handlePost = async (c: Context): Promise<Response> => {
-  const outcome = await runVerify(c)
-  logOutcome('POST', outcome.kind)
+  const { repo, secret } = repoOf(c)
+  const outcome = await verifyAndFlip(repo, secret, c.req.query('t'))
+  const evt =
+    outcome.kind === 'invalid'
+      ? 'unsubscribe.rejected'
+      : 'unsubscribe.applied'
+  logEvent(evt, { method: 'POST', kind: outcome.kind })
   return outcome.kind === 'invalid' ? c.body(null, 404) : c.body(null, 200)
 }
 
 /**
- * Mount the public unsubscribe surface: GET renders an HTML
- * confirmation in the visitor's preferred language, POST honours
- * the RFC-8058 one-click contract with a 200 empty body.
+ * Mount the public unsubscribe surface: GET verifies and renders a
+ * confirm form (no mutation), POST performs the flip — both the
+ * RFC-8058 one-click contract and the form submit land here.
  * @param app Hono app instance (no session middleware on this prefix).
  * @returns The same app for chaining.
  */

--- a/services/log-collector/src/exchange-handler.test.ts
+++ b/services/log-collector/src/exchange-handler.test.ts
@@ -1,0 +1,89 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  type ExchangeBindings,
+  registerExchangeRoute,
+} from './exchange-handler'
+
+const ENV: ExchangeBindings = {
+  JWT_SECRET: 'test-secret-test-secret-test-secret!',
+  GH_CLIENT_ID: 'id',
+  GH_CLIENT_SECRET: 'secret',
+  GITHUB_ORG: 'communist-prometheus',
+}
+
+const app = registerExchangeRoute(new Hono<{ Bindings: ExchangeBindings }>())
+
+const fetchMock = vi.fn()
+
+const jsonResponse = (body: object): Response =>
+  new Response(JSON.stringify(body), { status: 200 })
+
+const githubHappyPath = (membershipState: string | undefined): void => {
+  fetchMock.mockImplementation((url: string) => {
+    if (url.includes('login/oauth'))
+      return Promise.resolve(jsonResponse({ access_token: 'gho_x' }))
+    if (url.endsWith('/user'))
+      return Promise.resolve(jsonResponse({ login: 'mallory' }))
+    if (url.includes('/memberships/'))
+      return membershipState === undefined
+        ? Promise.resolve(new Response('not found', { status: 404 }))
+        : Promise.resolve(
+            jsonResponse({ state: membershipState, role: 'member' })
+          )
+    return Promise.reject(new Error(`unexpected url ${url}`))
+  })
+}
+
+const exchange = (): Promise<Response> =>
+  app.request(
+    '/auth/exchange',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'abc' }),
+    },
+    ENV
+  )
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  fetchMock.mockReset()
+})
+
+describe('/auth/exchange org gate', () => {
+  it('rejects a non-member with 403 and mints no JWT', async () => {
+    githubHappyPath(undefined)
+    const res = await exchange()
+    expect(res.status).toBe(403)
+    const body: Record<string, unknown> = await res.json()
+    expect(body.token).toBeUndefined()
+  })
+
+  it('rejects a pending (not yet active) member', async () => {
+    githubHappyPath('pending')
+    const res = await exchange()
+    expect(res.status).toBe(403)
+  })
+
+  it('mints a JWT for an active member', async () => {
+    githubHappyPath('active')
+    const res = await exchange()
+    expect(res.status).toBe(200)
+    const body: Record<string, unknown> = await res.json()
+    expect(typeof body.token).toBe('string')
+    expect(body.login).toBe('mallory')
+  })
+
+  it('maps a failed GitHub exchange to 400, not 500', async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ error: 'bad_code' }))
+    const res = await exchange()
+    expect(res.status).toBe(400)
+    const body: Record<string, unknown> = await res.json()
+    expect(body.error).toBe('oauth_failed')
+  })
+})

--- a/services/log-collector/src/exchange-handler.ts
+++ b/services/log-collector/src/exchange-handler.ts
@@ -1,5 +1,5 @@
 import type { Context, Hono } from 'hono'
-import { exchangeCodeForToken, fetchUserLogin } from './gh-user'
+import { exchangeCodeForToken, fetchUserLogin, isOrgMember } from './gh-user'
 import { signJwt } from './jwt'
 
 /** Bindings the exchange handler reads from the worker env. */
@@ -7,7 +7,10 @@ export type ExchangeBindings = {
   readonly JWT_SECRET: string
   readonly GH_CLIENT_ID: string
   readonly GH_CLIENT_SECRET: string
+  readonly GITHUB_ORG: string
 }
+
+type Ctx = Context<{ Bindings: ExchangeBindings }>
 
 const isObject = (x: unknown): x is Record<string, unknown> =>
   x !== null && typeof x === 'object'
@@ -17,34 +20,36 @@ const codeFrom = (body: unknown): string | undefined => {
   return typeof code === 'string' ? code : undefined
 }
 
-const handle = async (
-  c: Context<{ Bindings: ExchangeBindings }>
-): Promise<Response> => {
+const handle = async (c: Ctx): Promise<Response> => {
   const body: unknown = await c.req.json().catch(() => undefined)
   const code = codeFrom(body)
-  return code === undefined
-    ? c.json({ error: 'code required' }, 400)
-    : runExchange(c, code)
+  if (code === undefined) return c.json({ error: 'code required' }, 400)
+  // GitHub failures (bad/expired code, API hiccup) must map to a
+  // client error, not an unhandled 500 leaking upstream messages.
+  return runExchange(c, code).catch(() =>
+    c.json({ error: 'oauth_failed' }, 400)
+  )
 }
 
-const runExchange = async (
-  c: Context<{ Bindings: ExchangeBindings }>,
-  code: string
-): Promise<Response> => {
+const runExchange = async (c: Ctx, code: string): Promise<Response> => {
   const token = await exchangeCodeForToken(
     code,
     c.env.GH_CLIENT_ID,
     c.env.GH_CLIENT_SECRET
   )
   const login = await fetchUserLogin(token)
+  // Org gate: a collector JWT is a write credential for the
+  // observability store — only active org members may mint one.
+  if (!(await isOrgMember(c.env.GITHUB_ORG, login, token)))
+    return c.json({ error: 'not an org member' }, 403)
   const jwt = await signJwt(login, c.env.JWT_SECRET)
   return c.json({ token: jwt, login })
 }
 
 /**
  * Wire the `POST /auth/exchange` route. Accepts `{ code }`,
- * exchanges with GitHub, fetches the login, and returns a signed
- * collector JWT.
+ * exchanges with GitHub, verifies org membership, and returns a
+ * signed collector JWT.
  * @param app Hono app to extend.
  * @returns Same app for chaining.
  */

--- a/services/log-collector/src/gh-org.ts
+++ b/services/log-collector/src/gh-org.ts
@@ -1,0 +1,30 @@
+const isObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object'
+
+/**
+ * Check that a login is an ACTIVE member of the org. Gate for
+ * `/auth/exchange` — without it any GitHub user who completes the
+ * OAuth flow would receive a valid collector JWT and could write
+ * arbitrary spans/logs into the observability store.
+ * @param org GitHub org login.
+ * @param login User login to check.
+ * @param token The user's own access token (may read own membership).
+ * @returns true when the user's membership state is `active`.
+ */
+export const isOrgMember = async (
+  org: string,
+  login: string,
+  token: string
+): Promise<boolean> => {
+  const url = `https://api.github.com/orgs/${org}/memberships/${login}`
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'User-Agent': 'log-collector',
+    },
+  })
+  if (!res.ok) return false
+  const body: unknown = await res.json().catch(() => undefined)
+  return isObject(body) && body['state'] === 'active'
+}

--- a/services/log-collector/src/gh-user.ts
+++ b/services/log-collector/src/gh-user.ts
@@ -58,3 +58,5 @@ export const fetchUserLogin = async (token: string): Promise<string> => {
     ? login
     : Promise.reject(new Error('Could not read GitHub user login'))
 }
+
+export { isOrgMember } from './gh-org'

--- a/services/log-collector/wrangler.jsonc
+++ b/services/log-collector/wrangler.jsonc
@@ -8,6 +8,9 @@
   // - ANALYTICS_DATASET — Workers Analytics Engine dataset for spans
   // - D1 — D1 database for trace metadata index
   "vars": {
-    "VERSION": "0.1.0"
+    "VERSION": "0.1.0",
+    // Org whose ACTIVE members may mint a collector JWT via
+    // /auth/exchange — see exchange-handler.ts.
+    "GITHUB_ORG": "communist-prometheus"
   }
 }

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -4,9 +4,13 @@ import { tokenHandler } from './token-handler'
 
 /**
  * Env bindings available on CF Workers and in Vite dev.
+ * GITHUB_CLIENT_ID is a public value pinned per environment in
+ * wrangler.jsonc — the token handler rejects exchanges for any
+ * other client. Optional so local dev without vars keeps working.
  */
 export interface Env {
   readonly GITHUB_CLIENT_SECRET: string
+  readonly GITHUB_CLIENT_ID?: string
 }
 
 /**

--- a/src/api/cors-allow.ts
+++ b/src/api/cors-allow.ts
@@ -1,0 +1,36 @@
+const ALLOWED_ORIGINS: ReadonlySet<string> = new Set([
+  'https://admin.comprom.org',
+  'https://dev-admin.comprom.org',
+])
+
+const LOCAL_ORIGIN = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/
+
+/**
+ * Decide whether a browser Origin may use the CORS proxy. Only the
+ * admin app origins (prod, develop, local dev/e2e) are allowed —
+ * reflecting arbitrary origins would make the proxy usable from any
+ * website in a visitor's browser.
+ * @param origin - Value of the Origin request header
+ * @returns true when the origin belongs to the admin app
+ */
+export const isAllowedOrigin = (origin: string): boolean =>
+  ALLOWED_ORIGINS.has(origin) || LOCAL_ORIGIN.test(origin)
+
+/*
+ * isomorphic-git only ever needs the git smart-HTTP endpoints on
+ * github.com: ref discovery + upload-pack (clone/pull) +
+ * receive-pack (push). Anything else through the proxy would turn it
+ * into an SSRF relay that forwards Authorization headers to
+ * arbitrary hosts.
+ */
+const GIT_SMART_HTTP =
+  /^github\.com\/[\w.-]+\/[\w.-]+\/(info\/refs|git-upload-pack|git-receive-pack)$/
+
+/**
+ * Validate the proxied target path. Pins the proxy to GitHub's git
+ * smart-HTTP endpoints — host allowlist and path restriction in one.
+ * @param path - Target path after the /api/cors/ prefix
+ * @returns true when the path is a github.com git smart-HTTP endpoint
+ */
+export const isAllowedTarget = (path: string): boolean =>
+  GIT_SMART_HTTP.test(path)

--- a/src/api/cors-proxy.test.ts
+++ b/src/api/cors-proxy.test.ts
@@ -1,0 +1,99 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { corsProxy } from './cors-proxy'
+
+const APP_ORIGIN = 'https://admin.comprom.org'
+const GIT_PATH = '/api/cors/github.com/owner/repo/info/refs'
+
+const app = new Hono().all('/api/cors/*', corsProxy)
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+  fetchMock.mockResolvedValue(new Response('ok', { status: 200 }))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  fetchMock.mockReset()
+})
+
+describe('corsProxy origin gate', () => {
+  it('rejects a foreign origin without proxying', async () => {
+    const res = await app.request(GIT_PATH, {
+      headers: { Origin: 'https://evil.example' },
+    })
+    expect(res.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('answers preflight for the app origin', async () => {
+    const res = await app.request(GIT_PATH, {
+      method: 'OPTIONS',
+      headers: { Origin: APP_ORIGIN },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(APP_ORIGIN)
+  })
+
+  it('allows localhost dev origins', async () => {
+    const res = await app.request(GIT_PATH, {
+      headers: { Origin: 'http://localhost:5173' },
+    })
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('corsProxy target gate', () => {
+  it('rejects non-github hosts without proxying', async () => {
+    const res = await app.request('/api/cors/evil.example/x', {
+      headers: { Origin: APP_ORIGIN },
+    })
+    expect(res.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects github paths outside git smart-HTTP', async () => {
+    const res = await app.request(
+      '/api/cors/github.com/owner/repo/contents/secrets',
+      { headers: { Origin: APP_ORIGIN } }
+    )
+    expect(res.status).toBe(403)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('proxies git ref discovery with the query intact', async () => {
+    await app.request(`${GIT_PATH}?service=git-upload-pack`, {
+      headers: { Origin: APP_ORIGIN },
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://github.com/owner/repo/info/refs?service=git-upload-pack',
+      expect.objectContaining({ method: 'GET' })
+    )
+  })
+})
+
+describe('corsProxy header hygiene', () => {
+  it('forwards Authorization but strips Cookie', async () => {
+    await app.request(GIT_PATH, {
+      headers: {
+        Origin: APP_ORIGIN,
+        Authorization: 'Basic dXNlcjp0b2tlbg==',
+        Cookie: 'comprom_session=secret',
+      },
+    })
+    const call = fetchMock.mock.calls[0]
+    if (!call) throw new Error('fetch was not called')
+    const headers = call[1].headers
+    expect(headers.get('authorization')).toBe('Basic dXNlcjp0b2tlbg==')
+    expect(headers.get('cookie')).toBeNull()
+  })
+
+  it('reflects only the validated origin on the response', async () => {
+    const res = await app.request(GIT_PATH, {
+      headers: { Origin: APP_ORIGIN },
+    })
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(APP_ORIGIN)
+  })
+})

--- a/src/api/cors-proxy.ts
+++ b/src/api/cors-proxy.ts
@@ -1,4 +1,5 @@
 import type { Context } from 'hono'
+import { isAllowedOrigin, isAllowedTarget } from './cors-allow'
 
 const CORS_HEADERS: Record<string, string> = {
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
@@ -13,31 +14,38 @@ const addCors = (res: Response, origin: string): Response => {
   return out
 }
 
-/**
- * CORS proxy for isomorphic-git push/pull to GitHub.
- * Proxies /api/cors/github.com/* → https://github.com/*
- * @param c - Hono context
- * @returns Proxied response with CORS headers
- */
-export const corsProxy = async (c: Context): Promise<Response> => {
-  const origin = c.req.header('Origin') ?? '*'
-  if (c.req.method === 'OPTIONS')
-    return addCors(new Response(undefined, { status: 204 }), origin)
-  const path = c.req.path.replace('/api/cors/', '')
+const forbidden = (reason: string): Response =>
+  new Response(reason, { status: 403 })
+
+const forward = async (c: Context, path: string): Promise<Response> => {
   const url = new URL(c.req.url)
-  const target = url.search
-    ? `https://${path}${url.search}`
-    : `https://${path}`
+  const target = `https://${path}${url.search}`
   const headers = new Headers(c.req.raw.headers)
   headers.delete('host')
+  // The proxy must never relay the admin session cookie to GitHub.
+  headers.delete('cookie')
   const body =
     c.req.method === 'GET' || c.req.method === 'HEAD'
       ? undefined
       : await c.req.arrayBuffer()
-  const resp = await fetch(target, {
-    method: c.req.method,
-    headers,
-    body,
-  })
-  return addCors(resp, origin)
+  return fetch(target, { method: c.req.method, headers, body })
+}
+
+/**
+ * CORS proxy for isomorphic-git push/pull to GitHub. Locked down to
+ * the admin app origins and to github.com git smart-HTTP paths —
+ * see cors-allow.ts for why both gates exist.
+ * @param c - Hono context
+ * @returns Proxied response with CORS headers
+ */
+export const corsProxy = async (c: Context): Promise<Response> => {
+  const origin = c.req.header('Origin')
+  if (origin !== undefined && !isAllowedOrigin(origin))
+    return forbidden('Origin not allowed')
+  if (c.req.method === 'OPTIONS')
+    return addCors(new Response(undefined, { status: 204 }), origin ?? '*')
+  const path = c.req.path.replace('/api/cors/', '')
+  if (!isAllowedTarget(path)) return forbidden('Target not allowed')
+  const resp = await forward(c, path)
+  return origin === undefined ? resp : addCors(resp, origin)
 }

--- a/src/api/token-fields.ts
+++ b/src/api/token-fields.ts
@@ -1,0 +1,40 @@
+/** Only the PKCE exchange fields — nothing else passes through. */
+export const FORWARDED: readonly string[] = [
+  'code',
+  'redirect_uri',
+  'code_verifier',
+]
+
+/** Only the documented token-response fields reach the browser. */
+export const RETURNED: readonly string[] = [
+  'access_token',
+  'token_type',
+  'scope',
+  'error',
+  'error_description',
+]
+
+/**
+ * Collect the present string values for the given keys.
+ * @param source - Lookup returning a value or undefined
+ * @param keys - Keys to pick
+ * @returns Object with only the defined entries
+ */
+export const pickFields = (
+  source: (k: string) => string | undefined,
+  keys: readonly string[]
+): Record<string, string> =>
+  Object.fromEntries(
+    keys.flatMap(k => {
+      const v = source(k)
+      return v === undefined ? [] : [[k, v]]
+    })
+  )
+
+/**
+ * Narrow an unknown JSON value to a string-keyed record.
+ * @param v - Parsed JSON of unknown shape
+ * @returns Record view, empty when v is not an object
+ */
+export const toRecord = (v: unknown): Record<string, unknown> =>
+  typeof v === 'object' && v !== null ? { ...v } : {}

--- a/src/api/token-handler.test.ts
+++ b/src/api/token-handler.test.ts
@@ -1,0 +1,97 @@
+import { Hono } from 'hono'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Env } from './app'
+import { tokenHandler } from './token-handler'
+
+const CLIENT_ID = 'Ov23test'
+
+const app = new Hono<{ Bindings: Env }>().post(
+  '/api/oauth/token',
+  tokenHandler
+)
+
+const fetchMock = vi.fn()
+
+const post = (
+  fields: Record<string, string>,
+  env: Partial<Env> = {}
+): Promise<Response> =>
+  Promise.resolve(
+    app.request(
+      '/api/oauth/token',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams(fields).toString(),
+      },
+      { GITHUB_CLIENT_SECRET: 's3cret', GITHUB_CLIENT_ID: CLIENT_ID, ...env }
+    )
+  )
+
+beforeEach(() => {
+  fetchMock.mockResolvedValue(
+    new Response(
+      JSON.stringify({
+        access_token: 'gho_abc',
+        token_type: 'bearer',
+        scope: 'repo',
+        internal_field: 'leak-me',
+      }),
+      { status: 200 }
+    )
+  )
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  fetchMock.mockReset()
+})
+
+describe('tokenHandler client pinning', () => {
+  it('rejects a foreign client_id without contacting GitHub', async () => {
+    const res = await post({ client_id: 'other-app', code: 'c' })
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing code', async () => {
+    const res = await post({ client_id: CLIENT_ID })
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('exchanges a valid request and injects the secret', async () => {
+    const res = await post({
+      client_id: CLIENT_ID,
+      code: 'c',
+      code_verifier: 'v',
+    })
+    expect(res.status).toBe(200)
+    const sent = String(fetchMock.mock.calls[0]?.[1]?.body)
+    expect(sent).toContain('client_secret=s3cret')
+    expect(sent).toContain('code_verifier=v')
+  })
+
+  it('drops unknown inbound params instead of relaying them', async () => {
+    await post({ client_id: CLIENT_ID, code: 'c', evil: 'param' })
+    const sent = String(fetchMock.mock.calls[0]?.[1]?.body)
+    expect(sent).not.toContain('evil')
+  })
+})
+
+describe('tokenHandler response filtering', () => {
+  it('returns only documented fields', async () => {
+    const res = await post({ client_id: CLIENT_ID, code: 'c' })
+    const body: Record<string, unknown> = await res.json()
+    expect(body.access_token).toBe('gho_abc')
+    expect(body.internal_field).toBeUndefined()
+  })
+
+  it('survives a non-JSON GitHub response', async () => {
+    fetchMock.mockResolvedValue(new Response('plain', { status: 502 }))
+    const res = await post({ client_id: CLIENT_ID, code: 'c' })
+    expect(res.status).toBe(502)
+    expect(await res.json()).toEqual({})
+  })
+})

--- a/src/api/token-handler.ts
+++ b/src/api/token-handler.ts
@@ -1,32 +1,17 @@
 import type { Context } from 'hono'
 import type { Env } from './app'
+import { FORWARDED, pickFields, RETURNED, toRecord } from './token-fields'
 
 const TOKEN_URL = 'https://github.com/login/oauth/access_token'
 
-/**
- * Exchange OAuth code for access token via GitHub.
- * Injects GITHUB_CLIENT_SECRET from env bindings.
- * @param c - Hono context
- * @returns JSON response with token or error
- */
-export const tokenHandler = async (
-  c: Context<{ Bindings: Env }>
-): Promise<Response> => {
-  const secret = c.env.GITHUB_CLIENT_SECRET
-  if (!secret) {
-    return c.json(
-      {
-        error: 'server_config',
-        error_description: 'GITHUB_CLIENT_SECRET not configured',
-      },
-      500
-    )
-  }
+const json = (payload: unknown, status: number): Response =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
 
-  const body = new URLSearchParams(await c.req.text())
-  body.set('client_secret', secret)
-
-  const gh = await fetch(TOKEN_URL, {
+const exchange = async (body: URLSearchParams): Promise<Response> =>
+  fetch(TOKEN_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -35,5 +20,35 @@ export const tokenHandler = async (
     body: body.toString(),
   })
 
-  return c.json(await gh.json(), gh.status as 200)
+/**
+ * Exchange OAuth code for access token via GitHub. Injects
+ * GITHUB_CLIENT_SECRET from env bindings; pins client_id to the
+ * configured app and forwards/returns only known-safe fields so the
+ * endpoint cannot relay arbitrary parameters or response data.
+ * @param c - Hono context
+ * @returns JSON response with token or error
+ */
+export const tokenHandler = async (
+  c: Context<{ Bindings: Env }>
+): Promise<Response> => {
+  const secret = c.env.GITHUB_CLIENT_SECRET
+  if (!secret) return json({ error: 'server_config' }, 500)
+  const inbound = new URLSearchParams(await c.req.text())
+  const expected = c.env.GITHUB_CLIENT_ID
+  const clientId = inbound.get('client_id') ?? ''
+  if (expected && clientId !== expected)
+    return json({ error: 'invalid_client' }, 400)
+  if (!inbound.get('code')) return json({ error: 'invalid_request' }, 400)
+  const body = new URLSearchParams({
+    ...pickFields(k => inbound.get(k) ?? undefined, FORWARDED),
+    client_id: clientId,
+    client_secret: secret,
+  })
+  const gh = await exchange(body)
+  const record = toRecord(await gh.json().catch(() => ({})))
+  const safe = pickFields(k => {
+    const v = record[k]
+    return typeof v === 'string' ? v : undefined
+  }, RETURNED)
+  return json(safe, gh.status)
 }

--- a/src/components/MarkdownEditor/MarkdownPreview.vue
+++ b/src/components/MarkdownEditor/MarkdownPreview.vue
@@ -3,6 +3,7 @@ import { Marked } from 'marked'
 import markedFootnote from 'marked-footnote'
 import { computed } from 'vue'
 import { createAssetExtension } from './create-asset-renderer'
+import { sanitizeHtml } from './sanitize-html'
 
 const props = defineProps<{
   readonly content: string
@@ -23,7 +24,8 @@ const html = computed(() => {
   if (props.assetUrlMap && props.assetUrlMap.size > 0) {
     m.use(createAssetExtension(props.assetUrlMap))
   }
-  return m.parse(props.content, { async: false })
+  // Sanitize before v-html — see sanitize-html.ts for the threat.
+  return sanitizeHtml(m.parse(props.content, { async: false }))
 })
 </script>
 

--- a/src/components/MarkdownEditor/sanitize-html.test.ts
+++ b/src/components/MarkdownEditor/sanitize-html.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { sanitizeHtml } from './sanitize-html'
+
+describe('sanitizeHtml XSS vectors', () => {
+  it('strips script tags', () => {
+    const out = sanitizeHtml('<p>hi</p><script>steal()</script>')
+    expect(out).toBe('<p>hi</p>')
+  })
+
+  it('strips event handlers from img', () => {
+    const out = sanitizeHtml('<img src="x" onerror="steal()">')
+    expect(out).not.toContain('onerror')
+    expect(out).toContain('<img')
+  })
+
+  it('strips javascript: hrefs', () => {
+    const out = sanitizeHtml('<a href="javascript:steal()">x</a>')
+    expect(out).not.toContain('javascript:')
+  })
+
+  it('strips iframes', () => {
+    const out = sanitizeHtml('<iframe src="https://evil.example"></iframe>')
+    expect(out).not.toContain('iframe')
+  })
+
+  it('strips data: URLs in src', () => {
+    const out = sanitizeHtml(
+      '<img src="data:text/html,<script>steal()</script>">'
+    )
+    expect(out).not.toContain('data:')
+  })
+})
+
+describe('sanitizeHtml legitimate content', () => {
+  it('keeps blob: asset previews', () => {
+    const out = sanitizeHtml('<img src="blob:http://localhost/abc" alt="a">')
+    expect(out).toContain('blob:http://localhost/abc')
+  })
+
+  it('keeps relative asset paths', () => {
+    const out = sanitizeHtml('<img src="./assets/pic.png" alt="a">')
+    expect(out).toContain('./assets/pic.png')
+  })
+
+  it('keeps footnote ids and anchors', () => {
+    const html =
+      '<sup><a href="#user-content-fn-1" id="user-content-fnref-1">1</a></sup>'
+    const out = sanitizeHtml(html)
+    expect(out).toContain('#user-content-fn-1')
+    expect(out).toContain('id="user-content-fnref-1"')
+  })
+
+  it('keeps media elements used by the asset renderer', () => {
+    const html =
+      '<video controls><source src="./assets/clip.mp4" type="video/mp4"></video>'
+    const out = sanitizeHtml(html)
+    expect(out).toContain('<video')
+    expect(out).toContain('<source')
+  })
+
+  it('keeps https links and images', () => {
+    const out = sanitizeHtml(
+      '<a href="https://comprom.org">x</a><img src="https://comprom.org/a.png">'
+    )
+    expect(out).toContain('https://comprom.org')
+  })
+})

--- a/src/components/MarkdownEditor/sanitize-html.ts
+++ b/src/components/MarkdownEditor/sanitize-html.ts
@@ -1,0 +1,22 @@
+import DOMPurify from 'dompurify'
+
+/*
+ * marked does NOT sanitize its output. Content comes from the shared
+ * content repo, which editor-role users can write to — without
+ * sanitization a crafted post becomes stored XSS running in a
+ * chief-editor's or admin's session via v-html in MarkdownPreview
+ * (and localStorage holds the GitHub token). The URI regexp is the
+ * DOMPurify default plus `blob:` so resolved asset previews keep
+ * working; relative ./assets/ paths and #footnote anchors pass via
+ * the non-alpha branch.
+ */
+const URI_ALLOW =
+  /^(?:(?:(?:f|ht)tps?|mailto|tel|blob|callto|sms|cid|xmpp):|[^a-z]|[a-z+.-]+(?:[^a-z+.\-:]|$))/i
+
+/**
+ * Sanitize rendered markdown HTML before it reaches v-html.
+ * @param html - HTML produced by marked
+ * @returns Sanitized HTML safe for v-html injection
+ */
+export const sanitizeHtml = (html: string): string =>
+  DOMPurify.sanitize(html, { ALLOWED_URI_REGEXP: URI_ALLOW })

--- a/src/composables/useAuth/complete-callback.ts
+++ b/src/composables/useAuth/complete-callback.ts
@@ -1,0 +1,48 @@
+import { extractString } from '@/validation/extract-string'
+import { exchangeCodeForToken } from './exchange-token'
+import { mintSession } from './mint-session'
+import { loadAndClearState, loadAndClearVerifier } from './pkce-storage'
+import { saveToken } from './token-storage'
+
+type QueryValue = string | null | undefined | (string | null)[]
+
+const fail = (message: string): never => {
+  throw new Error(message)
+}
+
+const requireStateMatch = (
+  state: string | undefined,
+  expected: string | undefined
+): string =>
+  expected !== undefined && state === expected
+    ? expected
+    : fail('State mismatch — restart the sign-in flow')
+
+/**
+ * Validate the OAuth callback query and complete the PKCE exchange.
+ * Enforces the `state` round trip (login-CSRF gate: the callback
+ * must carry the value saved by the SAME browser session that
+ * started the flow), persists the token, and fire-and-forgets the
+ * parent-domain SSO cookie mint.
+ * @param codeRaw - route.query.code as received
+ * @param stateRaw - route.query.state as received
+ * @returns The GitHub access token
+ * @throws Error with a user-facing message on any validation failure
+ */
+export const completeCallback = async (
+  codeRaw: QueryValue,
+  stateRaw: QueryValue
+): Promise<string> => {
+  const code = extractString(codeRaw) ?? fail('Missing code or verifier')
+  const verifier =
+    loadAndClearVerifier() ?? fail('Missing code or verifier')
+  requireStateMatch(extractString(stateRaw), loadAndClearState())
+  const token = await exchangeCodeForToken(code, verifier)
+  saveToken(token)
+  // Mint the parent-domain SSO cookie so subsequent calls to
+  // *.comprom.org workers carry auth automatically. Fire-and-forget
+  // — if the user is not yet on the admins team, the SPA still
+  // loads but cookie-gated workers will 401 until membership lands.
+  void mintSession(token)
+  return token
+}

--- a/src/composables/useAuth/cookie-token.ts
+++ b/src/composables/useAuth/cookie-token.ts
@@ -10,3 +10,18 @@ export const readCookie = (name: string): string | undefined =>
     ?.split('=')
     .slice(1)
     .join('=') || undefined
+
+/**
+ * Expire a named cookie on the current host and the parent domain.
+ * A JS-readable credential cookie must not outlive its one-time
+ * migration into localStorage — it is an XSS-exfiltration target.
+ * @param name - Cookie name to delete
+ */
+export const deleteCookie = (name: string): void => {
+  const stale = `${name}=; max-age=0; path=/`
+  const host = globalThis.location?.hostname ?? ''
+  const parent = host.split('.').slice(-2).join('.')
+  const variants =
+    parent && parent !== host ? [stale, `${stale}; domain=.${parent}`] : [stale]
+  for (const v of variants) document.cookie = v
+}

--- a/src/composables/useAuth/pkce-storage.ts
+++ b/src/composables/useAuth/pkce-storage.ts
@@ -1,4 +1,11 @@
 const VERIFIER_KEY = 'pkce_verifier'
+const STATE_KEY = 'oauth_state'
+
+const loadAndClear = (key: string): string | undefined => {
+  const v = localStorage.getItem(key) ?? undefined
+  localStorage.removeItem(key)
+  return v
+}
 
 /**
  * Save PKCE verifier to localStorage.
@@ -14,8 +21,23 @@ export const saveVerifier = (verifier: string): void => {
  * Load and remove PKCE verifier from localStorage.
  * @returns Verifier string or undefined
  */
-export const loadAndClearVerifier = (): string | undefined => {
-  const v = localStorage.getItem(VERIFIER_KEY) ?? undefined
-  localStorage.removeItem(VERIFIER_KEY)
-  return v
+export const loadAndClearVerifier = (): string | undefined =>
+  loadAndClear(VERIFIER_KEY)
+
+/**
+ * Save the OAuth `state` value for the in-flight authorize round
+ * trip. PKCE protects against code interception but not against
+ * login CSRF — `state` binds the callback to the session that
+ * initiated the flow.
+ * @param state - Random state value sent to the authorize endpoint
+ */
+export const saveState = (state: string): void => {
+  localStorage.setItem(STATE_KEY, state)
 }
+
+/**
+ * Load and remove the saved OAuth `state`.
+ * @returns State string or undefined
+ */
+export const loadAndClearState = (): string | undefined =>
+  loadAndClear(STATE_KEY)

--- a/src/composables/useAuth/token-storage.test.ts
+++ b/src/composables/useAuth/token-storage.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { loadToken } from './token-storage'
+
+const setCookie = (value: string): void => {
+  document.cookie = `gh_token=${value}; path=/`
+}
+
+describe('loadToken cookie migration', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    document.cookie = 'gh_token=; max-age=0; path=/'
+    localStorage.clear()
+  })
+
+  it('prefers the localStorage copy', () => {
+    localStorage.setItem('gh_token', 'from-storage')
+    setCookie('from-cookie')
+    expect(loadToken()).toBe('from-storage')
+  })
+
+  it('migrates the cookie into localStorage', () => {
+    setCookie('from-cookie')
+    expect(loadToken()).toBe('from-cookie')
+    expect(localStorage.getItem('gh_token')).toBe('from-cookie')
+  })
+
+  it('expires the cookie after migration', () => {
+    setCookie('from-cookie')
+    loadToken()
+    expect(document.cookie).not.toContain('gh_token=from-cookie')
+  })
+
+  it('returns undefined when neither store has a token', () => {
+    expect(loadToken()).toBeUndefined()
+  })
+})

--- a/src/composables/useAuth/token-storage.ts
+++ b/src/composables/useAuth/token-storage.ts
@@ -1,4 +1,4 @@
-import { readCookie } from './cookie-token'
+import { deleteCookie, readCookie } from './cookie-token'
 import { clearProfile } from './profile-cache'
 
 const TOKEN_KEY = 'gh_token'
@@ -13,7 +13,9 @@ export const saveToken = (token: string): void => {
 
 /**
  * Load GitHub token from localStorage or cookie fallback.
- * When found in cookie, persists to localStorage.
+ * When found in cookie, persists to localStorage and expires the
+ * cookie — the JS-readable copy must not linger as a second
+ * exfiltration target after the one-time migration.
  * @returns Token string or undefined
  */
 export const loadToken = (): string | undefined => {
@@ -21,7 +23,10 @@ export const loadToken = (): string | undefined => {
   if (stored) return stored
 
   const fromCookie = readCookie(TOKEN_KEY)
-  if (fromCookie) saveToken(fromCookie)
+  if (fromCookie) {
+    saveToken(fromCookie)
+    deleteCookie(TOKEN_KEY)
+  }
   return fromCookie
 }
 

--- a/src/composables/useOAuthPopup/authorize-url.test.ts
+++ b/src/composables/useOAuthPopup/authorize-url.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  loadAndClearState,
+  loadAndClearVerifier,
+} from '../useAuth/pkce-storage'
+import { buildAuthorizeUrl } from './authorize-url'
+
+describe('buildAuthorizeUrl', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('includes a state parameter and persists it for the callback', async () => {
+    const url = new URL(await buildAuthorizeUrl())
+    const state = url.searchParams.get('state')
+    expect(state).toBeTruthy()
+    expect(loadAndClearState()).toBe(state)
+  })
+
+  it('generates a fresh state per flow', async () => {
+    const first = new URL(await buildAuthorizeUrl()).searchParams.get('state')
+    const second = new URL(await buildAuthorizeUrl()).searchParams.get(
+      'state'
+    )
+    expect(first).not.toBe(second)
+  })
+
+  it('keeps the PKCE pair intact alongside state', async () => {
+    const url = new URL(await buildAuthorizeUrl())
+    expect(url.searchParams.get('code_challenge')).toBeTruthy()
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256')
+    expect(loadAndClearVerifier()).toBeTruthy()
+  })
+
+  it('state is single-use', async () => {
+    await buildAuthorizeUrl()
+    loadAndClearState()
+    expect(loadAndClearState()).toBeUndefined()
+  })
+})

--- a/src/composables/useOAuthPopup/authorize-url.ts
+++ b/src/composables/useOAuthPopup/authorize-url.ts
@@ -1,24 +1,30 @@
 import { getAuthConfig } from '@/config/auth'
 import { generateCodeChallenge, generateCodeVerifier } from '../useAuth/pkce'
-import { saveVerifier } from '../useAuth/pkce-storage'
+import { saveState, saveVerifier } from '../useAuth/pkce-storage'
 
 const GITHUB_AUTHORIZE = 'https://github.com/login/oauth/authorize'
 
 /**
- * Build GitHub PKCE authorize URL and save verifier.
+ * Build GitHub PKCE authorize URL and save verifier + state.
+ * `state` reuses the verifier generator (32 crypto-random bytes,
+ * base64url) and is validated in AuthCallbackView — login-CSRF
+ * protection that PKCE alone does not provide.
  * @returns Popup URL string
  */
 export const buildAuthorizeUrl = async (): Promise<string> => {
   const { clientId, redirectUri, scopes } = getAuthConfig()
   const verifier = generateCodeVerifier()
   const challenge = await generateCodeChallenge(verifier)
+  const state = generateCodeVerifier()
   saveVerifier(verifier)
+  saveState(state)
   const params = new URLSearchParams({
     client_id: clientId,
     redirect_uri: redirectUri,
     scope: scopes,
     code_challenge: challenge,
     code_challenge_method: 'S256',
+    state,
   })
   return `${GITHUB_AUTHORIZE}?${params}`
 }

--- a/src/composables/useOAuthPopup/handlers.ts
+++ b/src/composables/useOAuthPopup/handlers.ts
@@ -4,28 +4,7 @@ import { saveToken } from '@/composables/useAuth/token-storage'
 import type { User } from '@/types/user'
 import { decodeOrUndefined } from '@/validation/decode'
 import { OAuthMessageSchema } from '@/validation/schemas/oauth-message'
-
-/**
- * Origins allowed to deliver OAuth success messages to the admin.
- *
- * When the OAuth popup's redirect_uri points to one of these hostnames,
- * the callback page runs there (cross-origin from the opener) and uses
- * `postMessage(..., '*')` to deliver the token. We gate trust on the
- * receiving side: any message whose `event.origin` is NOT in this list
- * is silently dropped.
- *
- * The opener's own origin is always trusted (same-origin popup case).
- */
-const TRUSTED_ORIGINS: readonly string[] = [
-  'https://admin.comprom.org',
-  'https://admin-website.igor-ganov.workers.dev',
-  'http://localhost:5173',
-  'http://localhost:4173',
-]
-
-const isTrustedOrigin = (origin: string): boolean =>
-  typeof globalThis.location !== 'undefined' &&
-  (origin === globalThis.location.origin || TRUSTED_ORIGINS.includes(origin))
+import { isTrustedOrigin } from './trusted-origins'
 
 /**
  * Handle received token: save and fetch user profile.

--- a/src/composables/useOAuthPopup/trusted-origins.ts
+++ b/src/composables/useOAuthPopup/trusted-origins.ts
@@ -1,0 +1,27 @@
+/**
+ * Origins allowed to exchange OAuth success messages with the admin.
+ *
+ * Used on BOTH sides of the popup handshake:
+ * - the opener drops any message whose `event.origin` is not listed
+ *   (see handlers.ts);
+ * - the callback popup posts the token only TO these origins —
+ *   never `'*'`, so a malicious opener that spawned the callback
+ *   URL itself can not receive the credential.
+ */
+export const TRUSTED_ORIGINS: readonly string[] = [
+  'https://admin.comprom.org',
+  'https://dev-admin.comprom.org',
+  'https://admin-website.igor-ganov.workers.dev',
+  'http://localhost:5173',
+  'http://localhost:4173',
+]
+
+/**
+ * Check whether an origin participates in the OAuth handshake.
+ * The current origin is always trusted (same-origin popup case).
+ * @param origin - Origin to check (e.g. event.origin)
+ * @returns true when the origin is the app itself or allowlisted
+ */
+export const isTrustedOrigin = (origin: string): boolean =>
+  typeof globalThis.location !== 'undefined' &&
+  (origin === globalThis.location.origin || TRUSTED_ORIGINS.includes(origin))

--- a/src/features/action-history/redact-helpers.ts
+++ b/src/features/action-history/redact-helpers.ts
@@ -1,0 +1,23 @@
+import { MAX_TEXT_LENGTH } from './config'
+
+/**
+ * Truncate a free-text field to the PII budget.
+ * @param s - Raw string
+ * @param max - Maximum length to keep
+ * @returns Same string or a truncated copy ending with an ellipsis
+ */
+export const truncate = (s: string, max = MAX_TEXT_LENGTH): string =>
+  s.length <= max ? s : `${s.slice(0, max)}…`
+
+/**
+ * Drop everything after `?` / `#`. Query strings and fragments are
+ * where credentials travel (`?code=`, `?t=<unsubscribe token>`,
+ * OAuth `state`…) — and the history JSON is attached to tickets in
+ * a PUBLIC repo. Origin + path stay for diagnostics.
+ * @param raw - URL or SPA route string
+ * @returns The string without query string and fragment
+ */
+export const stripQuery = (raw: string): string => {
+  const cut = raw.search(/[?#]/)
+  return cut === -1 ? raw : raw.slice(0, cut)
+}

--- a/src/features/action-history/redact.test.ts
+++ b/src/features/action-history/redact.test.ts
@@ -37,13 +37,35 @@ describe('redactEntry', () => {
     expect(JSON.stringify(out)).not.toMatch(/content/i)
   })
 
-  it('passes navigation entries through unchanged', () => {
+  it('keeps plain navigation paths intact', () => {
     const entry: Omit<NavigationEntry, 'id' | 'ts'> = {
       kind: 'navigation',
       from: '/a',
       to: '/b',
     }
     expect(redactEntry(entry)).toEqual(entry)
+  })
+
+  it('strips query strings from navigation routes', () => {
+    const entry: Omit<NavigationEntry, 'id' | 'ts'> = {
+      kind: 'navigation',
+      from: '/auth/callback?code=gho_secret&state=abc',
+      to: '/editor#token=leak',
+    }
+    const out = redactEntry(entry) as Omit<NavigationEntry, 'id' | 'ts'>
+    expect(out.from).toBe('/auth/callback')
+    expect(out.to).toBe('/editor')
+  })
+
+  it('strips query strings from network-error urls', () => {
+    const entry: RecordableEntry = {
+      kind: 'network-error',
+      url: 'https://lists.comprom.org/unsubscribe?t=42.signature',
+      status: 500,
+      reason: 'boom',
+    }
+    const out = redactEntry(entry) as { url: string }
+    expect(out.url).toBe('https://lists.comprom.org/unsubscribe')
   })
 })
 

--- a/src/features/action-history/redact.ts
+++ b/src/features/action-history/redact.ts
@@ -1,14 +1,12 @@
-import { MAX_TEXT_LENGTH } from './config'
+import { stripQuery, truncate } from './redact-helpers'
 import type {
   ActionEntry,
+  NavigationEntry,
   NetworkErrorEntry,
   RecordableEntry,
   SaveEntry,
   SwErrorEntry,
 } from './types'
-
-const truncate = (s: string, max = MAX_TEXT_LENGTH): string =>
-  s.length <= max ? s : `${s.slice(0, max)}…`
 
 const redactSave = (e: Omit<SaveEntry, 'id' | 'ts'>): typeof e => ({
   ...e,
@@ -23,7 +21,14 @@ const redactSw = (e: Omit<SwErrorEntry, 'id' | 'ts'>): typeof e => ({
 
 const redactNet = (e: Omit<NetworkErrorEntry, 'id' | 'ts'>): typeof e => ({
   ...e,
+  url: stripQuery(e.url),
   reason: truncate(e.reason),
+})
+
+const redactNav = (e: Omit<NavigationEntry, 'id' | 'ts'>): typeof e => ({
+  ...e,
+  from: stripQuery(e.from),
+  to: stripQuery(e.to),
 })
 
 /**
@@ -43,7 +48,7 @@ export const redactEntry = (entry: RecordableEntry): RecordableEntry => {
     'sw-error': () => redactSw(entry as Omit<SwErrorEntry, 'id' | 'ts'>),
     'network-error': () =>
       redactNet(entry as Omit<NetworkErrorEntry, 'id' | 'ts'>),
-    navigation: () => entry,
+    navigation: () => redactNav(entry as Omit<NavigationEntry, 'id' | 'ts'>),
     stage: () => entry,
     auth: () => entry,
   } as const

--- a/src/sw/rbac/handle-invite.ts
+++ b/src/sw/rbac/handle-invite.ts
@@ -3,6 +3,7 @@ import { errorResponse, jsonResponse } from '../handlers/shared/json-response'
 import { workerState } from '../state/state'
 import type { InviteBody } from './invite-build'
 import { runInviteFromBody } from './invite-post'
+import { requireAdmin } from './require-admin'
 
 const MOCK_OK = { id: 1, role: 'direct_member', email: 'mock@example.com' }
 
@@ -21,11 +22,12 @@ export const handleInvite = async (request: Request): Promise<Response> =>
     Match.orElse(async cfg =>
       __MOCK_MODE__ || cfg.mock
         ? jsonResponse(MOCK_OK)
-        : runInviteFromBody(
+        : (requireAdmin() ??
+          runInviteFromBody(
             cfg.owner,
             cfg.token,
             (await request.json()) as Partial<InviteBody>
-          )
+          ))
     )
   )
 

--- a/src/sw/rbac/handle-revoke-invite.ts
+++ b/src/sw/rbac/handle-revoke-invite.ts
@@ -2,6 +2,7 @@ import { Match } from 'effect'
 import { errorResponse, jsonResponse } from '../handlers/shared/json-response'
 import { workerState } from '../state/state'
 import { API, ghHeaders } from './github-api'
+import { requireAdmin } from './require-admin'
 
 const remote = async (
   owner: string,
@@ -32,6 +33,6 @@ export const handleRevokeInvite = async (id: string): Promise<Response> =>
     Match.orElse(async cfg =>
       __MOCK_MODE__ || cfg.mock
         ? jsonResponse({ success: true })
-        : remote(cfg.owner, cfg.token, id)
+        : (requireAdmin() ?? remote(cfg.owner, cfg.token, id))
     )
   )

--- a/src/sw/rbac/handle-set-role.ts
+++ b/src/sw/rbac/handle-set-role.ts
@@ -2,6 +2,7 @@ import { Match, Option } from 'effect'
 import { errorResponse, jsonResponse } from '../handlers/shared/json-response'
 import { workerState } from '../state/state'
 import { applyRole, type SetRoleBody } from './org-role-ops'
+import { requireAdmin } from './require-admin'
 
 const validate = (body: Partial<SetRoleBody>): Option.Option<SetRoleBody> =>
   body.login && body.role
@@ -43,10 +44,11 @@ export const handleSetRole = async (request: Request): Promise<Response> =>
     Match.orElse(async c =>
       __MOCK_MODE__ || c.mock
         ? jsonResponse({ success: true })
-        : handleBody(
+        : (requireAdmin() ??
+          handleBody(
             c.owner,
             c.token,
             (await request.json()) as Partial<SetRoleBody>
-          )
+          ))
     )
   )

--- a/src/sw/rbac/require-admin.test.ts
+++ b/src/sw/rbac/require-admin.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SWGitConfig } from '../protocol'
+import { workerState } from '../state/state'
+import { handleInvite } from './handle-invite'
+import { handleRevokeInvite } from './handle-revoke-invite'
+import { handleSetRole } from './handle-set-role'
+import { setOrgAdmins } from './org-admin-cache'
+import { requireAdmin } from './require-admin'
+
+vi.mock('./org-role-ops', () => ({
+  applyRole: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('./invite-post', () => ({
+  runInviteFromBody: vi.fn().mockResolvedValue(new Response('{}')),
+}))
+// resolve-role transitively imports lightning-fs, which touches
+// indexedDB at module scope — absent under jsdom.
+vi.mock('../git/io/read-file', () => ({
+  readRepoFile: vi.fn().mockRejectedValue(new Error('no fs in tests')),
+}))
+
+const config = (username: string): SWGitConfig => ({
+  owner: 'communist-prometheus',
+  repo: 'public-website-content',
+  branch: 'develop',
+  contentPath: '',
+  corsProxy: '/api/cors',
+  token: 'tok',
+  username,
+})
+
+const asUser = (username: string): void => {
+  workerState.config = config(username)
+}
+
+const request = (body: object): Request =>
+  new Request('http://sw.local/api/github/org-role', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+
+afterEach(() => {
+  workerState.config = undefined
+  setOrgAdmins([])
+})
+
+describe('requireAdmin', () => {
+  it('rejects when SW has no config', () => {
+    expect(requireAdmin()?.status).toBe(403)
+  })
+
+  it('rejects a non-admin user', () => {
+    asUser('eve')
+    expect(requireAdmin()?.status).toBe(403)
+  })
+
+  it('passes an org admin through', () => {
+    asUser('alice')
+    setOrgAdmins(['alice'])
+    expect(requireAdmin()).toBeUndefined()
+  })
+})
+
+describe('privileged RBAC handlers reject non-admins', () => {
+  it('handleSetRole returns 403 for a non-admin', async () => {
+    asUser('eve')
+    const res = await handleSetRole(request({ login: 'eve', role: 'admin' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('handleInvite returns 403 for a non-admin', async () => {
+    asUser('eve')
+    const res = await handleInvite(
+      request({ login: 'accomplice', role: 'admin' })
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('handleRevokeInvite returns 403 for a non-admin', async () => {
+    asUser('eve')
+    const res = await handleRevokeInvite('42')
+    expect(res.status).toBe(403)
+  })
+
+  it('handleSetRole proceeds for an admin', async () => {
+    asUser('alice')
+    setOrgAdmins(['alice'])
+    const res = await handleSetRole(request({ login: 'bob', role: 'editor' }))
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/sw/rbac/require-admin.ts
+++ b/src/sw/rbac/require-admin.ts
@@ -1,0 +1,23 @@
+import { errorResponse } from '../handlers/shared/json-response'
+import { workerState } from '../state/state'
+import { resolveRole } from './resolve-role'
+
+/*
+ * Defense-in-depth gate for privileged RBAC mutations (set-role,
+ * invite, revoke). The SW holds the logged-in user's token and would
+ * otherwise act as a confused deputy: any same-origin script (e.g.
+ * via an XSS foothold) could POST /api/github/org-role and promote
+ * an arbitrary account. UI-level gating is not a security boundary —
+ * this is the same check handle-roles-config.ts already performs.
+ */
+
+/**
+ * Require the current SW user to hold the admin role.
+ * @returns 403 Response when the user is not an admin, undefined
+ * when the request may proceed
+ */
+export const requireAdmin = (): Response | undefined => {
+  const username = workerState.config?.username
+  const role = username ? resolveRole(username) : undefined
+  return role === 'admin' ? undefined : errorResponse('Admin only', 403)
+}

--- a/src/views/AuthCallbackView.vue
+++ b/src/views/AuthCallbackView.vue
@@ -1,14 +1,11 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { exchangeCodeForToken } from '@/composables/useAuth/exchange-token'
+import { completeCallback } from '@/composables/useAuth/complete-callback'
 import { fetchGitHubUser } from '@/composables/useAuth/fetch-github-user'
-import { mintSession } from '@/composables/useAuth/mint-session'
-import { loadAndClearVerifier } from '@/composables/useAuth/pkce-storage'
-import { saveToken } from '@/composables/useAuth/token-storage'
+import { TRUSTED_ORIGINS } from '@/composables/useOAuthPopup/trusted-origins'
 import { loadRedirect } from '@/router/auth-guard'
 import { useAuthStore } from '@/stores/auth'
-import { extractString } from '@/validation/extract-string'
 
 const router = useRouter()
 const route = useRoute()
@@ -18,54 +15,33 @@ const status = ref('Completing authentication…')
 /**
  * Post token to opener window and close popup.
  *
- * Uses `'*'` as targetOrigin so the token delivers across origins — the
- * popup may run at a different origin (e.g. workers.dev) than the opener
- * (e.g. admin.comprom.org) when VITE_OAUTH_REDIRECT_URI is set to a
- * centralized callback URL. The opener validates the sender origin via
- * the TRUSTED_ORIGINS allowlist in useOAuthPopup/handlers.ts, so the
- * wildcard target is safe — only admin hostnames we control can produce
- * a message that the opener will accept.
+ * Never posts with `'*'` — a wildcard would hand the token to ANY
+ * window that opened this callback URL, including an attacker's
+ * page. Instead the message is posted once per trusted origin (plus
+ * our own, for the same-origin popup case): postMessage silently
+ * drops deliveries whose targetOrigin does not match the opener, so
+ * exactly one copy arrives and only if the opener is one of ours.
  * @param token - GitHub access token
  */
 const notifyOpener = (token: string) => {
-  globalThis.opener?.postMessage(
-    { type: 'github-oauth-success', token },
-    '*'
-  )
+  const msg = { type: 'github-oauth-success', token }
+  const targets = new Set([...TRUSTED_ORIGINS, globalThis.location.origin])
+  for (const target of targets) globalThis.opener?.postMessage(msg, target)
   globalThis.close()
 }
 
 onMounted(async () => {
   try {
-    const code = extractString(route.query.code)
-    const verifier = loadAndClearVerifier()
-
-    if (!code || !verifier) {
-      status.value = 'Missing code or verifier'
-      return
-    }
-
-    const token = await exchangeCodeForToken(code, verifier)
-    saveToken(token)
-    // Mint the parent-domain SSO cookie so subsequent calls to
-    // *.comprom.org workers (lists.*, future ones) carry auth via
-    // the cookie automatically. Fire-and-forget — if the user is
-    // not yet on the `admins` team, the SPA still loads (token-only
-    // GitHub calls keep working) but cookie-gated workers will 401
-    // until membership is granted.
-    void mintSession(token)
-
+    const token = await completeCallback(route.query.code, route.query.state)
     if (globalThis.opener) {
       notifyOpener(token)
       return
     }
-
     const user = await fetchGitHubUser(token)
     authStore.setUser(user)
     router.push(loadRedirect() ?? '/')
   } catch (e) {
-    status.value =
-      e instanceof Error ? e.message : 'Auth failed'
+    status.value = e instanceof Error ? e.message : 'Auth failed'
   }
 })
 </script>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -9,6 +9,11 @@
   },
   // The OAuth token exchange handler reads the GitHub App client
   // secret. Set with: wrangler secret put GITHUB_CLIENT_SECRET
+  // GITHUB_CLIENT_ID is public (it ships in the SPA bundle) — pinned
+  // here so the token handler only exchanges codes for OUR app.
+  "vars": {
+    "GITHUB_CLIENT_ID": "Ov23libphIePjZydDlke"
+  },
   "env": {
     // Develop environment — deploys from the `develop` branch into a
     // separate CF Worker (admin-website-develop) bound to
@@ -19,7 +24,10 @@
       "name": "admin-website-develop",
       "routes": [
         { "pattern": "dev-admin.comprom.org", "custom_domain": true }
-      ]
+      ],
+      "vars": {
+        "GITHUB_CLIENT_ID": "Ov23liXRu1WNCvOCce7s"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Closes the fixable findings from the June 2026 security audit (full report in `documentation/security/audit-2026-06-11.md`).

**Critical**
- CORS proxy was an open relay: now pinned to github.com git smart-HTTP paths, origin-allowlisted, `Cookie` stripped (`src/api/cors-allow.ts`).
- Stored XSS in markdown preview: DOMPurify sanitizes marked output before `v-html` (editor-written content could steal admin tokens).
- SW RBAC mutations (org-role / org-invite / revoke) now gated on `requireAdmin()` — were executing with the stored admin token for any same-origin caller.

**High**
- OAuth: `state` parameter (login-CSRF), targeted `postMessage` instead of `'*'`, gh_token cookie expired after migration.
- token-handler: client_id pinned per env (wrangler vars), field allowlists both directions.
- log-collector `/auth/exchange`: org-membership gate before minting collector JWTs.
- CI: `permissions: contents: read` everywhere, SHA-pinned actions, step-scoped `GH_E2E_PAT` with fork guard, pinned bun.

**Medium**
- `/unsubscribe`: GET side-effect free (renders confirm form, 7 locales), flip on POST only.
- action-history: query strings stripped before public-repo attachment.

## Tests
- 37 new unit tests across cors-proxy, sanitize-html, require-admin, authorize-url, token-storage, token-handler, exchange-handler, unsubscribe routes, redact.
- Full suite: 1004/1004. vue-tsc, biome, oxlint, jsdoc lint all green.

## Deploy notes
- `wrangler.jsonc` gains `GITHUB_CLIENT_ID` vars (public values) for prod + develop.
- log-collector gains `GITHUB_ORG` var; redeploy it after merge (`deploy-log-collector` workflow).
- comms-worker unsubscribe UX change: email link now shows a confirm button instead of unsubscribing instantly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)