### PR TITLE
fix(ci): worker deploys referenced a nonexistent secret

### DIFF
--- a/.github/workflows/deploy-comms-worker.yml
+++ b/.github/workflows/deploy-comms-worker.yml
@@ -45,11 +45,13 @@ jobs:
             npx wrangler d1 execute comms-prod --remote --file "$f"
           done
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.VITE_CF_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy to Cloudflare Workers
         run: |
           cd services/comms-worker
           npx wrangler deploy
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.VITE_CF_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/deploy-log-collector.yml
+++ b/.github/workflows/deploy-log-collector.yml
@@ -39,4 +39,5 @@ jobs:
           cd services/log-collector
           npx wrangler deploy
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.VITE_CF_API_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
`deploy-comms-worker.yml` / `deploy-log-collector.yml` referenced `secrets.VITE_CF_API_TOKEN`, which is not defined in this repo (`gh secret list`: only `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `GH_E2E_PAT`). Both deploys have failed on every trigger since at least June 7. Switched to the real secret + added `CLOUDFLARE_ACCOUNT_ID`.

This also closes the audit finding about the `VITE_`-prefixed deploy-token name (`VITE_` is reserved for browser-bundled values).

## Test plan
- [ ] After merge, `Deploy comms-worker` and `Deploy log-collector` runs go green (this PR touches their workflow files, so both trigger on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)