### PR TITLE
fix(ci): comms D1 migrations via idempotent migrations-apply

### DIFF
--- a/.github/workflows/deploy-comms-worker.yml
+++ b/.github/workflows/deploy-comms-worker.yml
@@ -38,12 +38,14 @@ jobs:
       - name: Audit EARS coverage
         run: bun scripts/comms-spec-coverage.ts
 
+      # `migrations apply` tracks state in the d1_migrations table and
+      # only runs pending files — the previous `d1 execute` loop re-ran
+      # every migration on every deploy and died on "table already
+      # exists" (and would have duplicated seed rows had it not).
       - name: Apply D1 migrations to prod
         run: |
           cd services/comms-worker
-          for f in migrations/*.sql; do
-            npx wrangler d1 execute comms-prod --remote --file "$f"
-          done
+          npx wrangler d1 migrations apply comms-prod --remote
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- Replace the `d1 execute` loop (re-ran every migration each deploy → "table already exists") with `wrangler d1 migrations apply comms-prod --remote`.
- `d1_migrations` bookkeeping for the two already-applied files was bootstrapped in prod out-of-band (verified: both rows present).
- Repo secret `CLOUDFLARE_API_TOKEN` was re-minted with Workers Scripts/KV/Queues/Observability Write + **D1 Write** + Account Settings Read + zone Workers Routes Write — the old token lacked D1 permissions.

## Test plan
- [ ] `Deploy comms-worker` run on master goes green end-to-end (migrations no-op + deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)