### PR TITLE
fix(lint): suppress noDocumentCookie on intentional legacy-cookie path

### DIFF
--- a/src/composables/useAuth/complete-callback.ts
+++ b/src/composables/useAuth/complete-callback.ts
@@ -34,8 +34,7 @@ export const completeCallback = async (
   stateRaw: QueryValue
 ): Promise<string> => {
   const code = extractString(codeRaw) ?? fail('Missing code or verifier')
-  const verifier =
-    loadAndClearVerifier() ?? fail('Missing code or verifier')
+  const verifier = loadAndClearVerifier() ?? fail('Missing code or verifier')
   requireStateMatch(extractString(stateRaw), loadAndClearState())
   const token = await exchangeCodeForToken(code, verifier)
   saveToken(token)

--- a/src/composables/useAuth/cookie-token.ts
+++ b/src/composables/useAuth/cookie-token.ts
@@ -22,6 +22,11 @@ export const deleteCookie = (name: string): void => {
   const host = globalThis.location?.hostname ?? ''
   const parent = host.split('.').slice(-2).join('.')
   const variants =
-    parent && parent !== host ? [stale, `${stale}; domain=.${parent}`] : [stale]
-  for (const v of variants) document.cookie = v
+    parent && parent !== host
+      ? [stale, `${stale}; domain=.${parent}`]
+      : [stale]
+  for (const v of variants) {
+    // biome-ignore lint/suspicious/noDocumentCookie: Cookie Store API is async and absent in Firefox/jsdom; this synchronous one-shot expiry is intentional.
+    document.cookie = v
+  }
 }

--- a/src/composables/useAuth/token-storage.test.ts
+++ b/src/composables/useAuth/token-storage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { loadToken } from './token-storage'
 
 const setCookie = (value: string): void => {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom has no Cookie Store API; tests drive the legacy cookie path on purpose.
   document.cookie = `gh_token=${value}; path=/`
 }
 
@@ -11,6 +12,7 @@ describe('loadToken cookie migration', () => {
   })
 
   afterEach(() => {
+    // biome-ignore lint/suspicious/noDocumentCookie: see setCookie above.
     document.cookie = 'gh_token=; max-age=0; path=/'
     localStorage.clear()
   })


### PR DESCRIPTION
## Summary
`biome ci` (deploy pipeline) errors on `noDocumentCookie` warnings introduced by the security PR's cookie-expiry fix. The Cookie Store API alternative is async and missing in Firefox/jsdom, so the synchronous `document.cookie` writes are intentional — suppressed with biome-ignore comments. Plus formatting drift in two files.

## Test plan
- [x] `biome ci src services` clean locally
- [x] token-storage tests 4/4
- [ ] master deploy green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)