### PR TITLE
fix(ci): pin Node back to 22, timeout the Playwright install step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,13 +62,15 @@ jobs:
 
       # Wrangler 4 (used by `bunx wrangler dev` below) requires Node 22+.
       # setup-bun ships bundled Node, but `bunx wrangler` resolves against
-      # whatever node is on $PATH. Pin Node 24 (current LTS, matches the
-      # runner's action runtime) so the wrangler CLI doesn't refuse to
-      # start with "requires at least Node.js v22".
-      - name: Installing Node 24
+      # whatever node is on $PATH. Pin Node 22: with Node 24 on PATH the
+      # `bunx playwright install --with-deps` step hung indefinitely on
+      # two consecutive master deploys (2026-06-11) — realmode-e2e, which
+      # never installs Node, kept passing with the same command. 22 is
+      # the known-good pin that satisfies wrangler.
+      - name: Installing Node 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '24'
+          node-version: '22'
 
       - name: Installing tools and dependencies
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -80,8 +82,11 @@ jobs:
       - name: Building application (validate + type-check + lint + build)
         run: bun run build
 
+      # timeout-minutes: a hung apt/download here previously held the
+      # run for 1h+ — fail fast instead so the queue stays honest.
       - name: Installing Playwright browsers
         run: bunx playwright install --with-deps chromium
+        timeout-minutes: 8
 
       - name: Running E2E tests
         run: bunx playwright test --project=chromium --reporter=line


### PR DESCRIPTION
## Summary
Two consecutive master deploys hung 1h+ on `Installing Playwright browsers`. Correlation: the hang appeared exactly after the Node 22→24 bump in deploy.yml; `realmode-e2e.yml` runs the identical `bunx playwright install --with-deps chromium` all evening without setup-node and passes. Wrangler 4 needs only Node 22+, so:
- pin `node-version: '22'` back (known-good),
- `timeout-minutes: 8` on the install step so any future hang fails fast.

## Test plan
- [ ] Master deploy completes in its usual ~9-10 min end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)