### PR TITLE
fix(e2e): 30s anchor budget in visitSettled for cold SW boots on CI

### DIFF
--- a/e2e/helpers/visit-settled.ts
+++ b/e2e/helpers/visit-settled.ts
@@ -43,5 +43,11 @@ export const visitSettled = async (
     const reg = sw ? await sw.getRegistration() : undefined
     return !sw || sw.controller !== null || Boolean(reg?.active)
   })
-  await expectVisible(page, page.locator(`[data-testid="${stableTestId}"]`))
+  // First-visit budget: a cold SW boot (register + activate + mock
+  // clone) under 4-worker CPU contention legitimately exceeds the
+  // toolkit's 10 s default ceiling on CI. Still event-driven — the
+  // wait resolves the instant the anchor renders.
+  await expectVisible(page, page.locator(`[data-testid="${stableTestId}"]`), {
+    maxMs: 30_000,
+  })
 }


### PR DESCRIPTION
## Summary
First CI run of the 4-worker suite tripped the toolkit's 10s `maxMs` in `visitSettled` (tracing/offline-gate beforeEach): a cold SW boot under CPU contention exceeds 10s, which the old `networkidle` wait absorbed silently with its 30s navigation cap. Explicit 30s budget on the stable-anchor wait — still event-driven, resolves the instant the anchor renders.

## Test plan
- [x] tracing + settings suites locally at 4 workers: 26/26
- [ ] master deploy green ~4.5m

🤖 Generated with [Claude Code](https://claude.com/claude-code)