### PR TITLE
fix(e2e): raise the toolkit wait ceiling on CI via E2E_MAX_WAIT_MS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,9 +99,14 @@ jobs:
         run: bunx playwright install --with-deps chromium
         timeout-minutes: 8
 
+      # E2E_MAX_WAIT_MS: the toolkit's wait ceiling is a safety net;
+      # on 4 shared vCPUs cold SW boots legitimately exceed the 10s
+      # local default. Healthy waits still resolve in milliseconds.
       - name: Running E2E tests
         run: bunx playwright test --project=chromium --reporter=line
         timeout-minutes: 20
+        env:
+          E2E_MAX_WAIT_MS: '30000'
 
       # Playwright's webServer runs `bun run build:e2e` which overwrites
       # dist/ with a VITE_MOCK_AUTH=true bundle AND leaves a


### PR DESCRIPTION
## Summary
Master deploys at 4 workers tripped the toolkit's 10s `maxMs` safety net on random tail tests (cold SW boot under shared-vCPU contention). The net is now env-tunable (e2e-toolkit#4, submodule bumped); the deploy workflow sets `E2E_MAX_WAIT_MS=30000`. Healthy waits still resolve in milliseconds; local runs keep the strict 10s.

## Test plan
- [ ] master deploy green end-to-end at the new ~4–4.5m pace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)