### PR TITLE
fix(e2e): gate post-login navigation on SW control

### DIFF
--- a/e2e/auth/popup-login.spec.ts
+++ b/e2e/auth/popup-login.spec.ts
@@ -6,6 +6,7 @@ import {
   visit,
 } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 test.use({ storageState: { cookies: [], origins: [] } })
 
@@ -23,6 +24,11 @@ test.describe('Login Flow', () => {
       page.getByRole('button', { name: /test user/i })
     )
 
+    // The first authenticated load registers the SW; activation
+    // claims the client and aborts an in-flight goto
+    // (net::ERR_ABORTED). Gate on the lifecycle before navigating —
+    // event-driven, no sleep.
+    await waitForSWControl(page)
     await visit(page, '/content/blog')
     await waitForContentReady(page)
 

--- a/e2e/helpers/visit-settled.ts
+++ b/e2e/helpers/visit-settled.ts
@@ -18,6 +18,23 @@ import { expectVisible, visit } from '@prometheus/e2e-toolkit'
  */
 
 /**
+ * Wait until the SW lifecycle has settled for the current document.
+ * Use after any action that (re)registers the SW — e.g. the first
+ * authenticated load — and BEFORE the next navigation: activation
+ * claims clients and aborts an in-flight goto (net::ERR_ABORTED).
+ * WebKit in Playwright never exposes `controller`, so an active
+ * registration counts as the same lifecycle gate there.
+ * @param page Playwright page.
+ */
+export const waitForSWControl = async (page: Page): Promise<void> => {
+  await page.waitForFunction(async () => {
+    const sw = navigator.serviceWorker
+    const reg = sw ? await sw.getRegistration() : undefined
+    return !sw || sw.controller !== null || Boolean(reg?.active)
+  })
+}
+
+/**
  * Navigate to `url`, wait for the SW to control the page, then
  * assert `stableTestId` is visible. The stable test-id is required —
  * it is the post-activate DOM anchor that proves the
@@ -36,13 +53,7 @@ export const visitSettled = async (
   stableTestId: string
 ): Promise<void> => {
   await visit(page, url)
-  // WebKit in Playwright never exposes `controller` — an active
-  // registration is the same lifecycle gate there.
-  await page.waitForFunction(async () => {
-    const sw = navigator.serviceWorker
-    const reg = sw ? await sw.getRegistration() : undefined
-    return !sw || sw.controller !== null || Boolean(reg?.active)
-  })
+  await waitForSWControl(page)
   // First-visit budget: a cold SW boot (register + activate + mock
   // clone) under 4-worker CPU contention legitimately exceeds the
   // toolkit's 10 s default ceiling on CI. Still event-driven — the


### PR DESCRIPTION
## Summary
CI hit `net::ERR_ABORTED` on `visit('/content/blog')` right after the mock login: the first authenticated load registers the SW, whose activation claims the client and aborts the in-flight navigation. `waitForSWControl` (extracted from `visit-settled`) now gates the navigation — event-driven, resolves instantly when the SW is already controlling.

## Test plan
- [x] auth + tracing + settings suites at 4 workers: 34/34 locally
- [ ] master deploy green

🤖 Generated with [Claude Code](https://claude.com/claude-code)