### PR TITLE
feat(archive): Archive section with per-file download (iteration 1/5)

### DIFF
--- a/e2e/content/archive-download.spec.ts
+++ b/e2e/content/archive-download.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { AssetManagerPage } from '../pages/AssetManagerPage'
+
+const ARCHIVE_SLUG = 'founding-documents'
+const IMAGE_FILE = 'manifesto-poster.svg'
+const DOC_FILE = 'notes.txt'
+
+test.describe('Archive — download', () => {
+  test('lists archive files with a download control each', async ({
+    page,
+  }) => {
+    const am = new AssetManagerPage(page)
+    await am.navigateToEdit('archive', ARCHIVE_SLUG)
+    await am.expectPanelVisible()
+
+    const thumbs = am.getAssetThumbnails()
+    await expect(thumbs.first()).toBeVisible({ timeout: 15000 })
+    expect(await thumbs.count()).toBe(2)
+
+    // Every file — image and non-image alike — offers a download.
+    expect(await am.getDownloadAssetBtns().count()).toBe(2)
+  })
+
+  test('download control names each file accessibly', async ({ page }) => {
+    const am = new AssetManagerPage(page)
+    await am.navigateToEdit('archive', ARCHIVE_SLUG)
+    await am.expectPanelVisible()
+    await expect(am.getAssetThumbnails().first()).toBeVisible({
+      timeout: 15000,
+    })
+
+    await expect(
+      page.getByRole('button', { name: `Download ${IMAGE_FILE}` })
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: `Download ${DOC_FILE}` })
+    ).toBeVisible()
+  })
+
+  test('non-image file shows a pictogram yet still downloads', async ({
+    page,
+  }) => {
+    const am = new AssetManagerPage(page)
+    await am.navigateToEdit('archive', ARCHIVE_SLUG)
+    await am.expectPanelVisible()
+
+    const doc = am.getThumbByName(DOC_FILE)
+    await expect(doc).toBeVisible({ timeout: 15000 })
+    await expect(doc.locator('.file-icon')).toBeVisible()
+    await expect(
+      doc.locator('[data-testid="asset-download-btn"]')
+    ).toBeVisible()
+  })
+
+  test('activating download saves the file under its name', async ({
+    page,
+  }) => {
+    const am = new AssetManagerPage(page)
+    await am.navigateToEdit('archive', ARCHIVE_SLUG)
+    await am.expectPanelVisible()
+    await expect(am.getAssetThumbnails().first()).toBeVisible({
+      timeout: 15000,
+    })
+
+    const started = page.waitForEvent('download')
+    await page.getByRole('button', { name: `Download ${DOC_FILE}` }).click()
+    const download = await started
+    expect(download.suggestedFilename()).toBe(DOC_FILE)
+  })
+})

--- a/e2e/pages/AssetManagerPage.ts
+++ b/e2e/pages/AssetManagerPage.ts
@@ -9,7 +9,12 @@ export class AssetManagerPage {
 
   /** Navigate to a blog post edit page and wait for editor */
   async navigateToBlog(slug: string): Promise<void> {
-    await this.page.goto(`/content/blog/edit/${slug}`, {
+    await this.navigateToEdit('blog', slug)
+  }
+
+  /** Navigate to any content item's edit page and wait for the editor */
+  async navigateToEdit(type: string, slug: string): Promise<void> {
+    await this.page.goto(`/content/${type}/edit/${slug}`, {
       waitUntil: 'domcontentloaded',
     })
     await expect(this.getEditorBody()).toBeVisible({
@@ -65,6 +70,10 @@ export class AssetManagerPage {
 
   getDeleteAssetBtns(): Locator {
     return this.page.locator('[data-testid="asset-delete-btn"]')
+  }
+
+  getDownloadAssetBtns(): Locator {
+    return this.page.locator('[data-testid="asset-download-btn"]')
   }
 
   /** Wait for cover image section to be visible */

--- a/specs/archive/design.md
+++ b/specs/archive/design.md
@@ -1,0 +1,148 @@
+# Archive — Design
+
+> **Status:** DRAFT — phase 2 of three. Resolves the open decisions from
+> requirements.md §9 and specifies the implementation per iteration.
+>
+> _Pause for review before tasks.md._
+
+## 1. Resolved decisions
+
+1. **Data model — archive item = nested content type.** An archive item is a
+   folder `archive/{slug}/` with `index.{lang}.md` (frontmatter only matters;
+   body optional) plus `assets/`. This makes it a peer of blog/positions and
+   flows through every existing section-agnostic mechanism (content store,
+   list, create dialog, edit view, AssetManager, publish, delete, SW handlers)
+   with only registration boilerplate.
+
+2. **Frontmatter shape.** `title` (required), `description` (optional),
+   `published` (checkbox), `publishDate` (date). No `category` in v1. A future
+   per-file caption/order manifest is deferred; iteration order = directory
+   listing order until a manifest is needed.
+
+3. **Viewer framework.** The viewer is a self-contained Vue 3 component in the
+   admin (iterations 2–4). For the public widget (iteration 5) we add
+   `@astrojs/vue` to public-website and mount the **same** viewer core as an
+   Astro island (`client:visible`), feeding it plain props (image URLs +
+   metadata) so it has no admin/SW coupling. The viewer core therefore takes
+   data, never fetches it.
+
+4. **Role gate.** Editor-visible (no `minRole`), matching blog.
+
+5. **Public exposure timing.** Public listing/detail pages land in iteration 5
+   alongside the widget (the widget links to them). Iterations 1–4 are
+   admin-only; this matches the user's sequencing (manage + view first, expose
+   publicly last).
+
+## 2. Iteration 1 — Section, upload, download
+
+### 2.1 Registration (the section boilerplate)
+
+`archive` is added to every enumeration point:
+
+| File | Change |
+|---|---|
+| `src/types/content-type.ts` | `'archive'` in the union, `CONTENT_TYPE_VALUES`, `NESTED_TYPES` |
+| `src/router/content-routes.ts` | `'archive'` in `CONTENT_SECTIONS` |
+| `src/components/ContentNav/nav-by-role.ts` | `{ path: '/content/archive', label: 'Archive' }` |
+| `src/config/content-paths.ts` | `'archive'` in the local `NESTED_TYPES` set |
+| `src/sw/handlers/content/base.ts` | `'archive'` in the SW `NESTED_TYPES` set |
+| `src/components/MarkdownEditor/fields-archive.ts` (new) | field list |
+| `src/components/MarkdownEditor/frontmatter-fields.ts` | map `archive → archiveFields` |
+| `src/components/MarkdownEditor/field-definitions.ts` | re-export `archiveFields` |
+| `src/sw/mock/archive/*`, `src/sw/mock/archive-entries.ts`, `all-entries.ts` | mock fixtures incl. a non-image file |
+
+`hasAssets`/`hasCover` derive from `NESTED_TYPES` already
+(`page-computeds.ts`), so the AssetManager appears for archive automatically.
+
+### 2.2 Download control
+
+The download action is added to the shared AssetManager (benefits every
+section, satisfies R1.4–R1.6 for archive):
+
+- **`src/components/AssetManager/icons/DownloadIcon.vue`** (new) — inline SVG,
+  `aria-hidden`, `currentColor`, 24×24 viewBox, ~18px rendered, matching the
+  existing icon convention.
+- **`src/composables/useAssets/download-asset.ts`** (new) — pure helper:
+  ```
+  downloadAsset({ path, name, blobUrl }):
+    url = blobUrl ?? await resolveAssetUrl(path)   // pending vs committed
+    anchor = <a href=url download=name>; click(); remove()
+  ```
+  Reuses `resolveAssetUrl` (SW fetch → cached blob URL). No new SW protocol.
+- **`AssetActions.vue`** — add a download icon-button (`type=button`,
+  `aria-label="Download <name>"`, `data-testid=ASSET_DOWNLOAD_ID`) emitting
+  `download`. `AssetThumbnail.vue` forwards it with `{ path, name, blobUrl }`;
+  the parent (`useAssetHandlers`) calls `downloadAsset`.
+- **`test-ids.ts`** — `ASSET_DOWNLOAD_ID = 'asset-download'`.
+
+The control shows for every non-deleted asset (committed and pending-add);
+pending uses the in-memory `blobUrl`, committed resolves via SW.
+
+### 2.3 Accessibility & mobile
+
+Icon-button: ≥44px hit area (padding), `:focus-visible` accent outline,
+visible on `@media (hover: none)` like the existing actions. Accessible name
+includes the filename to stay unique and avoid the `view/save/new` collisions.
+
+## 3. Iteration 2 — Viewer
+
+- **`src/components/FileViewer/FileViewer.vue`** — `<dialog>`-based modal
+  (native focus trap + Escape), `aria-modal`, `role=dialog`, `::backdrop`
+  dimmer, `--z-modal`. Props: `files: ViewerFile[]`, `index`, emits
+  `close`/`update:index`. A `ViewerFile` is `{ name, mimeType, url(s) }` — the
+  component never fetches.
+- **Supported-type check** = `mimeType` starts with `image/`. Unsupported →
+  `FileViewerUnsupported.vue` (pictogram by type + filename + download).
+- **Image rendering** = responsive `<picture>`/`<img>` fit to viewport
+  (`max-width/height: 100%`, `object-fit: contain`), `decoding=async`.
+- Reduced-motion: open/close transition collapses to ~0ms.
+- AssetThumbnail gains a view icon-button (image types only) → ContentEditView
+  owns viewer open-state + current index.
+
+## 4. Iteration 3 — Navigation
+
+- Prev/next icon-buttons (`ChevronLeftIcon`/`ChevronRightIcon`), disabled at
+  ends. Keyboard: ArrowLeft/ArrowRight on the dialog. Touch: `pointerdown/up`
+  delta past ~50px threshold (no library).
+- Lazy strategy: current `loading=eager`, immediate neighbors prefetched, rest
+  `loading=lazy`; `<picture>` with `width/height` for intrinsic sizing.
+- Polite `aria-live` region announces "file N of M".
+
+## 5. Iteration 4 — Fullscreen
+
+- Fullscreen toggle uses `requestFullscreen()` on the dialog container with a
+  graceful no-op fallback (modal already fills the viewport). State tracked via
+  `fullscreenchange`. Escape semantics: exit fullscreen first, then close.
+
+## 6. Iteration 5 — Embed widget
+
+- **Admin:** `archive` reference field added to `fields-blog.ts` /
+  `fields-positions.ts` via a new `archive-ref` field type backed by an
+  `ArchivePicker.vue` (lists archive items from the content store). Persists
+  `archive: <slug>` in frontmatter.
+- **Content schema:** `blog`/`positions` collections gain optional `archive`
+  slug; new `archive` collection (`title`, `description?`, `published?`,
+  `publishDate?`, `lang`).
+- **public-website:**
+  - `@astrojs/vue` integration; mount the viewer core as `client:visible`.
+  - `ArchiveWidget.astro` slotted before `SuggestChangesLink` in blog/position
+    pages; first image via existing `BlogPicture` presets, rest lazy.
+  - `archive` listing (`/[lang]/archive/`) + detail (`/[lang]/archive/[slug]`)
+    pages, mirroring blog; `DownloadLink`-style controls per file.
+  - `src/integrations/archive-files/` build hook copying
+    `archive/{slug}/assets/*` → `dist/archive/{slug}/assets/*` (model:
+    `newspaper-pdfs`), reading sizes at build time.
+  - i18n labels (`archiveTitle`, `openViewer`, `downloadFile`, …) + a feature
+    flag in `settings/features.json`.
+
+## 7. Testing strategy
+
+- **Unit:** `download-asset` (picks blobUrl vs resolveAssetUrl, sets `download`
+  attr); path resolver for `archive`; viewer supported/unsupported branch;
+  navigation bounds; schema validation (public).
+- **E2E (admin):** create archive item → upload an image + a non-image →
+  assert both download controls present with correct accessible names →
+  (it2+) open viewer, navigate, fullscreen.
+- **E2E (public, it5):** build renders a referencing article with the widget;
+  widget opens viewer; archive page lists downloads.
+- Full stable pass, zero retries, mobile-viewport screenshot of viewer/widget.

--- a/specs/archive/requirements.md
+++ b/specs/archive/requirements.md
@@ -1,0 +1,140 @@
+# Archive — Requirements
+
+> **Status:** DRAFT — phase 1 of three (requirements → design → tasks).
+>
+> _Pause for review at the end of this file before moving to design.md._
+
+## 1. Overview
+
+Add an **Archive** content section to the platform: a place where editors
+upload arbitrary files (images, archives, documents, datasets) grouped into
+named **archive items** (albums), and where those files can be downloaded,
+previewed, and — eventually — embedded into articles and positions through a
+gallery widget.
+
+The work is split into five sequential **iterations**, each shippable and
+green on its own. The first delivers management + download; later ones layer a
+viewer, navigation, fullscreen, and an article-embed widget.
+
+This spec spans three deployable units, but not every iteration touches all of
+them:
+
+1. **admin-website** — a new nested content section `archive`, reusing the
+   existing content store / create dialog / AssetManager; the file viewer
+   (lightbox) lives here too.
+2. **public-website-content** — archive items stored as
+   `archive/{slug}/index.{lang}.md` + `archive/{slug}/assets/*`, mirroring the
+   blog/positions layout.
+3. **public-website** — an `archive` content collection, listing + detail
+   pages, a build-time asset-copy integration, and the article/position embed
+   widget.
+
+Out of scope across all iterations: file editing/transformation (crop, rotate,
+re-encode) beyond what upload already does; video/audio playback inside the
+viewer (they keep the existing inline `<video>/<audio>` controls); access
+control on individual files beyond the section's role gate; archive-to-archive
+linking.
+
+## 2. Glossary
+
+| Term | Meaning |
+|---|---|
+| **Archive item** | One album: a folder `archive/{slug}/` with a localized `index.{lang}.md` (title, description, metadata) and an `assets/` directory of files |
+| **File** | One asset under an archive item's `assets/` — any uploaded binary |
+| **Viewer** | The lightbox overlay that previews a file; images render full-bleed, unsupported types render a type pictogram + download |
+| **Widget** | The embedded mini-viewer placed at the foot of an article/position, expandable to fullscreen or linkable to the archive page |
+| **Supported type** | A file the viewer renders inline (iteration 2 scope: raster + SVG images). Everything else is an *unsupported type* |
+
+## 3. Iteration 1 — Section, upload, download
+
+> **As** an editor,
+> **I want** an Archive section where I can create archive items and upload any
+> kind of file into them, each file offering a one-click download,
+> **so that** I can manage a library of downloadable material.
+
+#### Acceptance criteria (EARS)
+
+- **R1.1** WHEN an authenticated editor opens `/content/archive` THE SYSTEM SHALL render the archive items list using the same list/grid chrome as the other content sections.
+- **R1.2** WHEN the editor creates an archive item via the create dialog with a valid slug + title THE SYSTEM SHALL stage `archive/{slug}/index.{lang}.md` with the title/description frontmatter and route to its edit page.
+- **R1.3** WHILE editing an archive item THE SYSTEM SHALL present the AssetManager so the editor can upload one or more files of any allowed type into `archive/{slug}/assets/`.
+- **R1.4** WHERE a file is present in an archive item (committed or pending) THE SYSTEM SHALL render a download control bearing a download pictogram and an accessible name of the form "Download <filename>".
+- **R1.5** WHEN the editor activates a file's download control THE SYSTEM SHALL trigger a browser download of that exact file under its original filename, without navigating away.
+- **R1.6** WHERE a file is not an inline-previewable image THE SYSTEM SHALL still render the download control (download is the universal action in iteration 1).
+- **R1.7** THE SYSTEM SHALL register `archive` as a nested content type everywhere a section is enumerated (type union, routing, navigation, path resolver, service-worker handler, mock fixtures) so listing/create/edit/publish/delete all work with no section-specific branches.
+- **R1.8** THE archive navigation entry SHALL respect the same role model as the other sections; absent a stricter decision it is editor-visible.
+
+## 4. Iteration 2 — Image viewer
+
+> **As** a viewer of an archive item,
+> **I want** to open a file in a viewer,
+> **so that** I can see images large without downloading them, and still get a
+> clear download path for files the viewer can't render.
+
+#### Acceptance criteria (EARS)
+
+- **R2.1** WHERE a file is a supported image type THE SYSTEM SHALL render a view control bearing a view pictogram with the accessible name "Open <filename> in viewer".
+- **R2.2** WHEN the view control is activated THE SYSTEM SHALL open the viewer as a modal overlay showing the image fit to the viewport, with the page behind it inert.
+- **R2.3** WHEN the viewer opens THE SYSTEM SHALL move focus into the viewer, trap focus within it, and restore focus to the invoking control on close.
+- **R2.4** WHEN the user presses Escape OR activates the close control THE SYSTEM SHALL close the viewer.
+- **R2.5** WHERE the opened file is an unsupported type THE SYSTEM SHALL render the file-type pictogram, the filename, and a download control inside the viewer instead of attempting to display it.
+- **R2.6** THE viewer SHALL load the displayed image at a resolution appropriate to the viewport (no multi-megabyte original forced into a thumbnail), honoring `prefers-reduced-motion` for its open/close transition.
+
+## 5. Iteration 3 — Navigation
+
+> **As** a viewer with the viewer open,
+> **I want** to move to the previous/next file,
+> **so that** I can browse the whole archive item without reopening.
+
+#### Acceptance criteria (EARS)
+
+- **R3.1** WHILE the viewer is open THE SYSTEM SHALL expose previous/next controls with accessible names "Previous file" / "Next file", disabled at the respective ends (no wrap, unless design later opts into wrap).
+- **R3.2** WHILE the viewer is open THE SYSTEM SHALL advance on ArrowRight and retreat on ArrowLeft.
+- **R3.3** WHILE the viewer is open on a touch device THE SYSTEM SHALL advance on left-swipe and retreat on right-swipe past a sensible threshold.
+- **R3.4** WHEN navigating to an unsupported-type file THE SYSTEM SHALL show its pictogram + download per R2.5 rather than a broken image.
+- **R3.5** WHILE navigating THE SYSTEM SHALL lazy-load non-current images (current eager, neighbors prefetched, far images deferred) using a responsive `<picture>` with intrinsic sizing to avoid layout shift.
+- **R3.6** THE SYSTEM SHALL announce the current position ("file N of M") to assistive technology on each change via a polite live region.
+
+## 6. Iteration 4 — Fullscreen
+
+> **As** a viewer,
+> **I want** to take the viewer fullscreen,
+> **so that** I can see images at maximum size.
+
+#### Acceptance criteria (EARS)
+
+- **R4.1** WHILE the viewer is open THE SYSTEM SHALL expose a fullscreen toggle ("Enter fullscreen" / "Exit fullscreen").
+- **R4.2** WHEN fullscreen is requested THE SYSTEM SHALL use the Fullscreen API on the viewer container, falling back gracefully (the modal already covers the viewport) where the API is unavailable or rejected.
+- **R4.3** WHILE fullscreen THE SYSTEM SHALL keep all navigation, the live region, and the close/exit controls operable.
+- **R4.4** WHEN the user exits fullscreen (control, Escape, or browser UI) THE SYSTEM SHALL return to the windowed modal without closing the viewer, and a subsequent Escape SHALL close the modal.
+
+## 7. Iteration 5 — Article / position embed widget
+
+> **As** an editor authoring an article or position,
+> **I want** to attach an existing archive item to it,
+> **so that** readers see a gallery widget at the foot of the piece that they
+> can expand or follow to the archive page.
+
+#### Acceptance criteria (EARS)
+
+- **R5.1** WHILE editing a blog article or position THE SYSTEM SHALL offer an archive picker that lists existing archive items by title (a selection interface, not free-text path entry).
+- **R5.2** WHEN the editor selects an archive item THE SYSTEM SHALL persist its slug into the piece's frontmatter as an `archive` reference.
+- **R5.3** WHERE a published piece references an archive item THE public-website SHALL render a widget at the foot of the article/position showing a mini version of the viewer (first image prominent, the rest as thumbnails).
+- **R5.4** WHEN a reader activates the widget THE SYSTEM SHALL open the full viewer (iterations 2–4) over the page.
+- **R5.5** THE widget SHALL provide a link to the standalone archive page for that item.
+- **R5.6** THE widget SHALL lazy-load every image past the first with responsive `<picture>` + intrinsic sizing, and SHALL be fully keyboard- and screen-reader-operable.
+- **R5.7** WHERE the referenced archive item does not exist or is unpublished THE public build SHALL omit the widget rather than fail.
+
+## 8. Cross-cutting requirements (all iterations)
+
+- **R8.1 — Design fidelity.** Every surface SHALL use the existing design tokens, card/grid/dialog primitives, and icon conventions; no new color or spacing values outside the token set.
+- **R8.2 — Accessibility.** All controls SHALL be reachable and operable by keyboard, carry non-colliding accessible names (avoid bare "view"/"save"/"new"/"create"/"delete" per the repo's test-locator hygiene), expose state via ARIA, respect `prefers-reduced-motion`, and meet AA contrast.
+- **R8.3 — Mobile.** Every surface SHALL be usable at a 360px viewport: touch targets ≥44px, swipe where specified, no horizontal scroll; the viewer and widget SHALL be verified at a mobile viewport with a screenshot.
+- **R8.4 — Performance.** Images beyond the first visible one SHALL be lazy-loaded; the viewer and widget SHALL use responsive `<picture>` with width-appropriate sources and intrinsic dimensions to prevent layout shift and oversized downloads.
+- **R8.5 — Quality gate.** Each iteration SHALL ship with unit + E2E coverage, pass build/lint/type-check, and survive a full stable E2E pass (zero retries) before merge.
+
+## 9. Open decisions (resolve in design.md)
+
+1. **Viewer framework reuse across repos.** The viewer is Vue in the admin; the public widget runs in Astro. Decide: shared Vue island (requires `@astrojs/vue` on public-website) vs. a framework-light viewer core consumed by both.
+2. **Archive item frontmatter shape.** Minimum is `title` + optional `description`; decide whether to add `category`, `published`, `publishDate` for parity with blog, and an optional per-file caption/order manifest.
+3. **Role gate.** Editor-visible (like blog) vs. chief-editor (like positions). Default: editor-visible.
+4. **Public exposure timing.** The public archive listing/detail pages are required by iteration 5 (the widget links to them). Decide whether to bring them forward to accompany the viewer or keep them at iteration 5.

--- a/specs/archive/tasks.md
+++ b/specs/archive/tasks.md
@@ -1,0 +1,81 @@
+# Archive — Tasks
+
+> **Status:** DRAFT — phase 3 of three. Traces every task to a requirement.
+> Iterations ship independently; each must be green before the next.
+
+## Iteration 1 — Section, upload, download (this PR)
+
+- [ ] **T1.1** Register `archive` in the type union / values / `NESTED_TYPES`
+      (`content-type.ts`). _(R1.7)_
+- [ ] **T1.2** Add `archive` to `CONTENT_SECTIONS` routing. _(R1.7)_
+- [ ] **T1.3** Add the archive nav entry, editor-visible. _(R1.1, R1.8)_
+- [ ] **T1.4** Add `archive` to `content-paths.ts` and SW `content/base.ts`
+      `NESTED_TYPES`. _(R1.7)_
+- [ ] **T1.5** `fields-archive.ts` (title, description, published, publishDate)
+      + register in `frontmatter-fields.ts` + `field-definitions.ts`. _(R1.2)_
+- [ ] **T1.6** Mock fixtures: an archive item with one image + one non-image
+      file; wire into `all-entries.ts`. _(R1.1, R1.3, E2E)_
+- [ ] **T1.7** `DownloadIcon.vue`. _(R1.4)_
+- [ ] **T1.8** `download-asset.ts` helper + unit test. _(R1.5)_
+- [ ] **T1.9** Download icon-button in `AssetActions.vue`, forwarded through
+      `AssetThumbnail.vue`, handled in `useAssetHandlers`; `ASSET_DOWNLOAD_ID`
+      test-id. _(R1.4–R1.6, R8.2)_
+- [ ] **T1.10** E2E: create archive item, upload image + non-image, assert
+      both download controls + accessible names. _(R1.1–R1.6, R8.5)_
+- [ ] **T1.11** Verify build / lint / type-check / unit / full stable E2E;
+      MCP-browser smoke at desktop + 360px. _(R8.3, R8.5)_
+
+## Iteration 2 — Viewer
+
+- [ ] **T2.1** `FileViewer.vue` (`<dialog>`, focus trap, Escape, backdrop).
+      _(R2.2–R2.4)_
+- [ ] **T2.2** `FileViewerUnsupported.vue` (pictogram + name + download).
+      _(R2.5)_
+- [ ] **T2.3** `ViewIcon.vue` + view button on image thumbnails; open-state in
+      ContentEditView. _(R2.1)_
+- [ ] **T2.4** Viewport-fit image render, `decoding=async`, reduced-motion.
+      _(R2.6)_
+- [ ] **T2.5** Unit (supported/unsupported branch) + E2E (open/close/Escape) +
+      mobile screenshot. _(R8.3, R8.5)_
+
+## Iteration 3 — Navigation
+
+- [ ] **T3.1** `ChevronLeftIcon`/`ChevronRightIcon` + prev/next buttons,
+      end-disabled. _(R3.1)_
+- [ ] **T3.2** Arrow-key handlers on the dialog. _(R3.2)_
+- [ ] **T3.3** Pointer swipe with threshold. _(R3.3)_
+- [ ] **T3.4** Lazy/prefetch strategy + responsive `<picture>` intrinsic
+      sizing. _(R3.5)_
+- [ ] **T3.5** Polite live region "file N of M". _(R3.6)_
+- [ ] **T3.6** E2E (click/arrow/swipe nav, bounds, unsupported mid-stream).
+      _(R3.4, R8.5)_
+
+## Iteration 4 — Fullscreen
+
+- [ ] **T4.1** Fullscreen toggle + `requestFullscreen` w/ fallback. _(R4.1,
+      R4.2)_
+- [ ] **T4.2** Keep controls/live-region operable; Escape precedence. _(R4.3,
+      R4.4)_
+- [ ] **T4.3** E2E (enter/exit, Escape precedence). _(R8.5)_
+
+## Iteration 5 — Embed widget
+
+- [ ] **T5.1** `archive-ref` field type + `ArchivePicker.vue`; add to
+      blog/positions fields. _(R5.1, R5.2)_
+- [ ] **T5.2** Content schema: `archive` collection + optional `archive` slug
+      on blog/positions. _(R5.2, R5.3)_
+- [ ] **T5.3** public-website `@astrojs/vue`; viewer core as island. _(R5.4)_
+- [ ] **T5.4** `ArchiveWidget.astro` in blog/position pages; first image
+      prominent, rest lazy. _(R5.3, R5.6)_
+- [ ] **T5.5** Archive listing + detail pages; per-file download. _(R5.5)_
+- [ ] **T5.6** `archive-files` build integration (copy assets, read sizes).
+      _(R5.3, R5.5)_
+- [ ] **T5.7** i18n labels + feature flag. _(R8.1)_
+- [ ] **T5.8** Missing/unpublished reference omits widget. _(R5.7)_
+- [ ] **T5.9** E2E (widget renders, opens viewer, archive link) + mobile
+      screenshot. _(R5.6, R8.3, R8.5)_
+
+## Traceability
+
+Every requirement R1.*–R5.*, R8.* maps to at least one task above. R8.1/R8.2/
+R8.4 are satisfied within each surface's task rather than as standalone items.

--- a/src/components/AssetManager/AssetActions.vue
+++ b/src/components/AssetManager/AssetActions.vue
@@ -1,18 +1,34 @@
 <script setup lang="ts">
-import { ASSET_COVER_ID, ASSET_DELETE_ID } from './test-ids'
+import DownloadIcon from './DownloadIcon.vue'
+import {
+  ASSET_COVER_ID,
+  ASSET_DELETE_ID,
+  ASSET_DOWNLOAD_ID,
+} from './test-ids'
 
 defineProps<{
   readonly showCover: boolean
+  readonly name: string
 }>()
 
 defineEmits<{
   'set-cover': []
   delete: []
+  download: []
 }>()
 </script>
 
 <template>
   <menu class="actions">
+    <button
+      type="button"
+      class="icon-btn"
+      :data-testid="ASSET_DOWNLOAD_ID"
+      :aria-label="`Download ${name}`"
+      @click="$emit('download')"
+    >
+      <DownloadIcon />
+    </button>
     <button
       v-if="showCover"
       type="button"
@@ -34,6 +50,7 @@ defineEmits<{
 <style scoped>
 .actions {
   display: flex;
+  align-items: center;
   justify-content: center;
   gap: 0.375rem;
   list-style: none;
@@ -53,5 +70,24 @@ button {
 
 button:hover {
   background: var(--color-background-soft);
+}
+
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 0.25rem;
+  color: var(--color-text-secondary);
+}
+
+.icon-btn:hover {
+  color: var(--color-accent);
 }
 </style>

--- a/src/components/AssetManager/AssetGrid.vue
+++ b/src/components/AssetManager/AssetGrid.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DownloadableAsset } from '@/composables/useAssets/download-asset'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import AssetThumbnail from './AssetThumbnail.vue'
 
@@ -6,10 +7,23 @@ defineProps<{
   readonly assets: readonly AssetDisplay[]
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   'set-cover': [name: string]
   'delete-asset': [path: string]
+  'download-asset': [asset: DownloadableAsset]
 }>()
+
+// A committed asset is fetched fresh through the SW; a pending one is
+// only in memory, so hand its blob URL straight to the downloader.
+const toDownloadable = (asset: AssetDisplay): DownloadableAsset => ({
+  path: asset.path,
+  name: asset.name,
+  blobUrl: asset.status === 'committed' ? undefined : asset.thumbnailUrl,
+})
+
+const onDownload = (asset: AssetDisplay): void => {
+  emit('download-asset', toDownloadable(asset))
+}
 </script>
 
 <template>
@@ -20,6 +34,7 @@ defineEmits<{
       v-bind="asset"
       @set-cover="$emit('set-cover', asset.name)"
       @delete="$emit('delete-asset', asset.path)"
+      @download="onDownload(asset)"
     />
   </ul>
 </template>

--- a/src/components/AssetManager/AssetPanel.vue
+++ b/src/components/AssetManager/AssetPanel.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { DownloadableAsset } from '@/composables/useAssets/download-asset'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import AssetGrid from './AssetGrid.vue'
 import AssetPanelHeader from './AssetPanelHeader.vue'
@@ -12,6 +13,7 @@ defineEmits<{
   'set-cover': [name: string]
   'delete-asset': [path: string]
   'upload-asset': [file: File]
+  'download-asset': [asset: DownloadableAsset]
 }>()
 </script>
 
@@ -23,6 +25,7 @@ defineEmits<{
       :assets="assets"
       @set-cover="$emit('set-cover', $event)"
       @delete-asset="$emit('delete-asset', $event)"
+      @download-asset="$emit('download-asset', $event)"
     />
     <p v-else class="empty">No assets yet</p>
   </section>

--- a/src/components/AssetManager/AssetThumbnail.vue
+++ b/src/components/AssetManager/AssetThumbnail.vue
@@ -14,6 +14,7 @@ const props = defineProps<{
 defineEmits<{
   'set-cover': []
   delete: []
+  download: []
 }>()
 
 const isImage = () => props.mimeType.startsWith('image/')
@@ -57,8 +58,10 @@ const isVisual = () => isImage() || isVideo()
     <AssetActions
       v-if="status !== 'pending-delete'"
       :show-cover="isVisual() && !isCover"
+      :name="name"
       @set-cover="$emit('set-cover')"
       @delete="$emit('delete')"
+      @download="$emit('download')"
     />
   </li>
 </template>

--- a/src/components/AssetManager/DownloadIcon.vue
+++ b/src/components/AssetManager/DownloadIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M8 2v8m0 0L5 7m3 3 3-3M3 13h10"
+      stroke="currentColor"
+      stroke-width="1.3"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</template>

--- a/src/components/AssetManager/test-ids.ts
+++ b/src/components/AssetManager/test-ids.ts
@@ -24,3 +24,6 @@ export const ASSET_COVER_ID = 'asset-set-cover-btn'
 
 /** Delete asset button */
 export const ASSET_DELETE_ID = 'asset-delete-btn'
+
+/** Download asset button */
+export const ASSET_DOWNLOAD_ID = 'asset-download-btn'

--- a/src/components/ContentNav/nav-by-role.ts
+++ b/src/components/ContentNav/nav-by-role.ts
@@ -16,6 +16,7 @@ const ALL_NAV: readonly NavEntry[] = [
   { path: '/content/pages', label: 'Pages', minRole: 'admin' },
   { path: '/content/common', label: 'Common', minRole: 'admin' },
   { path: '/content/newspaper', label: 'Newspaper' },
+  { path: '/content/archive', label: 'Archive' },
   { path: '/tickets', label: 'Tickets' },
   {
     path: '/comms',

--- a/src/components/MarkdownEditor/field-definitions.ts
+++ b/src/components/MarkdownEditor/field-definitions.ts
@@ -1,3 +1,4 @@
+export { archiveFields } from './fields-archive'
 export { blogFields } from './fields-blog'
 export {
   commonFieldsBySlug,

--- a/src/components/MarkdownEditor/fields-archive.ts
+++ b/src/components/MarkdownEditor/fields-archive.ts
@@ -1,0 +1,24 @@
+import type { FieldDefinition } from './frontmatter-fields'
+
+/**
+ * Frontmatter fields for an archive item. An archive item is a named
+ * album whose real payload is the files in its `assets/` folder; the
+ * body markdown is optional. Title is required for listings; the
+ * description gives the album a short preface. Publish state mirrors
+ * the other sections so archives flow through the same gate.
+ */
+export const archiveFields: readonly FieldDefinition[] = [
+  {
+    key: 'title',
+    label: 'Title',
+    type: 'text',
+    required: true,
+  },
+  {
+    key: 'description',
+    label: 'Description',
+    type: 'textarea',
+  },
+  { key: 'published', label: 'Published', type: 'checkbox' },
+  { key: 'publishDate', label: 'Publish Date', type: 'date' },
+]

--- a/src/components/MarkdownEditor/frontmatter-fields.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.ts
@@ -1,6 +1,7 @@
 import { Match, pipe } from 'effect'
 import type { ContentType } from '@/types/content'
 import {
+  archiveFields,
   basePageFields,
   blogFields,
   commonFieldsBySlug,
@@ -21,6 +22,7 @@ const fieldsByContentType: Readonly<
   pages: basePageFields,
   common: labelsFields,
   newspaper: newspaperFields,
+  archive: archiveFields,
 }
 
 const fieldsForType = (type: ContentType): readonly FieldDefinition[] =>

--- a/src/composables/useAssets/download-asset.test.ts
+++ b/src/composables/useAssets/download-asset.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  downloadAsset,
+  resolveDownloadUrl,
+  triggerDownload,
+} from './download-asset'
+
+vi.mock('./resolve-asset-url', () => ({
+  resolveAssetUrl: vi.fn(async (path: string) => `blob:resolved/${path}`),
+}))
+
+const { resolveAssetUrl } = await import('./resolve-asset-url')
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('resolveDownloadUrl', () => {
+  it('uses the in-memory blob URL for a pending asset', async () => {
+    const url = await resolveDownloadUrl({
+      path: 'archive/x/assets/a.png',
+      name: 'a.png',
+      blobUrl: 'blob:pending/a',
+    })
+    expect(url).toBe('blob:pending/a')
+    expect(resolveAssetUrl).not.toHaveBeenCalled()
+  })
+
+  it('fetches a committed asset through the SW resolver', async () => {
+    const url = await resolveDownloadUrl({
+      path: 'archive/x/assets/b.txt',
+      name: 'b.txt',
+    })
+    expect(url).toBe('blob:resolved/archive/x/assets/b.txt')
+    expect(resolveAssetUrl).toHaveBeenCalledWith('archive/x/assets/b.txt')
+  })
+})
+
+describe('triggerDownload', () => {
+  it('anchors the URL with the download filename and clicks once', () => {
+    const click = vi.fn()
+    const anchor = { click, remove: vi.fn() } as unknown as HTMLAnchorElement
+    const create = vi.spyOn(document, 'createElement').mockReturnValue(anchor)
+    const append = vi
+      .spyOn(document.body, 'append')
+      .mockImplementation(() => undefined)
+
+    triggerDownload('blob:url/x', 'report.pdf')
+
+    expect(create).toHaveBeenCalledWith('a')
+    expect(anchor.href).toBe('blob:url/x')
+    expect(anchor.download).toBe('report.pdf')
+    expect(append).toHaveBeenCalledWith(anchor)
+    expect(click).toHaveBeenCalledOnce()
+
+    create.mockRestore()
+    append.mockRestore()
+  })
+})
+
+describe('downloadAsset', () => {
+  it('resolves then triggers a download under the original name', async () => {
+    const click = vi.fn()
+    const anchor = { click, remove: vi.fn() } as unknown as HTMLAnchorElement
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor)
+    vi.spyOn(document.body, 'append').mockImplementation(() => undefined)
+
+    await downloadAsset({
+      path: 'archive/x/assets/c.zip',
+      name: 'c.zip',
+    })
+
+    expect(anchor.href).toBe('blob:resolved/archive/x/assets/c.zip')
+    expect(anchor.download).toBe('c.zip')
+    expect(click).toHaveBeenCalledOnce()
+  })
+})

--- a/src/composables/useAssets/download-asset.ts
+++ b/src/composables/useAssets/download-asset.ts
@@ -1,0 +1,47 @@
+import { resolveAssetUrl } from './resolve-asset-url'
+
+/** Minimal asset reference sufficient to download a file. */
+export interface DownloadableAsset {
+  readonly path: string
+  readonly name: string
+  /** In-memory blob URL for a not-yet-committed (pending) asset. */
+  readonly blobUrl?: string
+}
+
+/**
+ * Resolve the URL to download an asset from: the in-memory blob URL for
+ * a pending asset, otherwise the committed file fetched through the SW.
+ * @param asset - Asset reference
+ * @returns Object URL to download from
+ */
+export const resolveDownloadUrl = (
+  asset: DownloadableAsset
+): Promise<string> =>
+  asset.blobUrl ? Promise.resolve(asset.blobUrl) : resolveAssetUrl(asset.path)
+
+/**
+ * Trigger a browser download of `url` saved under `filename`, without
+ * navigating the current document.
+ * @param url - Object or remote URL
+ * @param filename - Suggested download filename
+ */
+export const triggerDownload = (url: string, filename: string): void => {
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  anchor.rel = 'noopener'
+  document.body.append(anchor)
+  anchor.click()
+  anchor.remove()
+}
+
+/**
+ * Download an asset file under its original name.
+ * @param asset - Asset reference (pending or committed)
+ */
+export const downloadAsset = async (
+  asset: DownloadableAsset
+): Promise<void> => {
+  const url = await resolveDownloadUrl(asset)
+  triggerDownload(url, asset.name)
+}

--- a/src/config/content-paths.ts
+++ b/src/config/content-paths.ts
@@ -6,6 +6,7 @@ const NESTED_TYPES = new Set([
   'pages',
   'common',
   'newspaper',
+  'archive',
 ])
 
 /**

--- a/src/router/content-routes.ts
+++ b/src/router/content-routes.ts
@@ -8,6 +8,7 @@ const CONTENT_SECTIONS: readonly ContentType[] = [
   'pages',
   'common',
   'newspaper',
+  'archive',
 ]
 
 const contentView = () => import('../views/ContentView.vue')

--- a/src/sw/handlers/content/base.ts
+++ b/src/sw/handlers/content/base.ts
@@ -7,6 +7,7 @@ export const NESTED_TYPES = new Set([
   'pages',
   'common',
   'newspaper',
+  'archive',
 ])
 
 /**

--- a/src/sw/mock/all-entries.ts
+++ b/src/sw/mock/all-entries.ts
@@ -1,3 +1,4 @@
+import { archiveEntries } from './archive-entries'
 import { blogEntries } from './blog-entries'
 import { pageEntries } from './page-entries'
 import { positionEntries } from './position-entries'
@@ -30,10 +31,11 @@ export interface MockEntry {
   readonly content: string
 }
 
-/** All mock entries combined (blog + pages + positions + settings) */
+/** All mock entries combined (blog + pages + positions + archive + settings) */
 export const allMockEntries: readonly MockEntry[] = [
   ...blogEntries,
   ...pageEntries,
   ...positionEntries,
+  ...archiveEntries,
   ...settingsEntries,
 ]

--- a/src/sw/mock/archive-entries.ts
+++ b/src/sw/mock/archive-entries.ts
@@ -1,0 +1,4 @@
+import { foundingDocumentsEntries } from './archive/founding-documents'
+
+/** All mock archive entries combined. */
+export const archiveEntries = [...foundingDocumentsEntries]

--- a/src/sw/mock/archive/founding-documents.ts
+++ b/src/sw/mock/archive/founding-documents.ts
@@ -1,0 +1,30 @@
+import type { MockEntry } from '../all-entries'
+
+const POSTER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 280">
+  <rect width="200" height="280" fill="#7f1d1d"/>
+  <text x="100" y="150" text-anchor="middle" fill="#fde68a"
+    font-family="serif" font-size="18">Manifesto</text>
+</svg>`
+
+const README_TXT = `Founding documents of the collective.
+Scans and source files are kept here for the archive.`
+
+const BASE = 'archive/founding-documents/assets'
+
+/** Mock entries for the "founding-documents" archive item. */
+export const foundingDocumentsEntries: readonly MockEntry[] = [
+  {
+    path: 'archive/founding-documents/index.en.md',
+    content: `---
+title: Founding Documents
+description: Scans and source files behind the collective's manifesto.
+published: true
+publishDate: 2026-05-01
+lang: en
+---
+
+The originals and working files of our founding texts.`,
+  },
+  { path: `${BASE}/manifesto-poster.svg`, content: POSTER_SVG },
+  { path: `${BASE}/notes.txt`, content: README_TXT },
+]

--- a/src/types/content-type.ts
+++ b/src/types/content-type.ts
@@ -7,6 +7,7 @@ export type ContentType =
   | 'pages'
   | 'common'
   | 'newspaper'
+  | 'archive'
 
 /** All valid content type values */
 const CONTENT_TYPE_VALUES: readonly string[] = [
@@ -15,6 +16,7 @@ const CONTENT_TYPE_VALUES: readonly string[] = [
   'pages',
   'common',
   'newspaper',
+  'archive',
 ]
 
 /**
@@ -35,4 +37,5 @@ export const NESTED_TYPES: ReadonlySet<ContentType> = new Set([
   'pages',
   'common',
   'newspaper',
+  'archive',
 ])

--- a/src/validation/schemas/frontmatter-archive.ts
+++ b/src/validation/schemas/frontmatter-archive.ts
@@ -1,0 +1,17 @@
+import { Schema } from 'effect'
+
+/**
+ * Shape a committed archive-item frontmatter must have before it hits
+ * git. An archive item is an album whose payload is its `assets/`
+ * files; the frontmatter only carries listing metadata. Mirrors the
+ * public-website archiveCollection.
+ */
+export const ArchiveFrontmatterSchema = Schema.Struct({
+  title: Schema.String.pipe(Schema.nonEmptyString()),
+  description: Schema.optional(Schema.String),
+  lang: Schema.String.pipe(Schema.nonEmptyString()),
+  published: Schema.optional(Schema.Boolean),
+  publishDate: Schema.optional(
+    Schema.Union(Schema.String, Schema.DateFromSelf)
+  ),
+})

--- a/src/validation/schemas/frontmatter.ts
+++ b/src/validation/schemas/frontmatter.ts
@@ -1,5 +1,6 @@
 import { Either, Schema } from 'effect'
 import type { ContentType } from '@/types/content'
+import { ArchiveFrontmatterSchema } from './frontmatter-archive'
 import { BlogFrontmatterSchema } from './frontmatter-blog'
 import { NewspaperFrontmatterSchema } from './frontmatter-newspaper'
 import { PagesFrontmatterSchema } from './frontmatter-pages'
@@ -30,5 +31,6 @@ export const validateFrontmatter = (
   if (type === 'positions') return run(PositionsFrontmatterSchema, value)
   if (type === 'newspaper') return run(NewspaperFrontmatterSchema, value)
   if (type === 'pages') return run(PagesFrontmatterSchema, value)
+  if (type === 'archive') return run(ArchiveFrontmatterSchema, value)
   return Either.right(undefined)
 }

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -100,6 +100,7 @@ const isRenameable = computed(
       @set-cover="p.ah.onSetCover"
       @delete-asset="p.ah.onDeleteAsset"
       @upload-asset="p.ah.onUploadAsset"
+      @download-asset="p.ah.onDownloadAsset"
     />
     <PublishConfirmDialog
       :show="flow.showDialog.value"

--- a/src/views/ContentEditView/asset-handlers.ts
+++ b/src/views/ContentEditView/asset-handlers.ts
@@ -1,3 +1,7 @@
+import {
+  type DownloadableAsset,
+  downloadAsset,
+} from '@/composables/useAssets/download-asset'
 import type { useAssets } from '@/composables/useAssets/useAssets'
 import { createUploadHandlers } from './asset-upload-handlers'
 
@@ -34,5 +38,13 @@ export const createAssetHandlers = (assets: Assets) => ({
    */
   onSetCover: (name: string): void => {
     assets.setCover(name)
+  },
+
+  /**
+   * Handle download of an asset under its original filename.
+   * @param asset - Asset reference (pending or committed)
+   */
+  onDownloadAsset: async (asset: DownloadableAsset): Promise<void> => {
+    await downloadAsset(asset)
   },
 })


### PR DESCRIPTION
## Archive — iteration 1 of 5: section, upload, download

Introduces an **Archive** content section. An archive item is an album —
`archive/{slug}/index.{lang}.md` (title/description/publish metadata) plus an
`assets/` folder of files — a peer of blog/positions, so it flows through the
existing content store, create dialog, edit view, AssetManager, publish and
delete with **no section-specific branches**. Every file (image or not) now
offers a one-click **download** under its original name.

This is the first of five planned iterations. Full spec (requirements with
EARS, design, tasks) lands in `specs/archive/`:

1. **(this PR)** section + upload + per-file download
2. image viewer (lightbox; unsupported types → pictogram + download)
3. viewer navigation (click / arrows / swipe)
4. fullscreen viewer
5. article/position embed widget + public archive pages

### What's in this PR
- **Section registration** (`archive` added to the type union, routing, nav,
  path resolver, SW nested-types, fields, frontmatter validation schema, mock
  fixtures). `hasAssets` already derives from `NESTED_TYPES`, so the
  AssetManager appears for archive automatically.
- **Download control** in the shared AssetManager: `DownloadIcon`, a
  `download-asset` helper (pending → in-memory blob URL, committed → SW fetch),
  an icon-button with accessible name `Download <filename>`, wired
  thumbnail → grid → panel → edit view. Benefits every section, not just
  archive.
- **Tests**: `download-asset` unit (4); `archive-download` E2E (4 — lists files
  with a download each, accessible names, non-image pictogram + download, and a
  real `download` event with the correct `suggestedFilename`).

### Verification
- `download-asset` unit green; **full unit suite 1008/1008**.
- E2E `archive-download` green on **chromium + mobile-chromium** (8/8, incl. the
  real download event on touch).
- Existing asset specs **15/15** — no regression from the shared download button.
- `vue-tsc` clean; biome clean on all changed files.
- Manual browser check at 1280px and 390px: grid reflows, SVG renders, `.txt`
  shows the file pictogram, download control present.

### Scope notes
- Iteration 1 is **admin-only** by design (the user's sequencing: manage + view
  first, expose publicly at iteration 5). No content-repo / public-website
  changes here; real archive items are authored post-merge, the public archive
  pages + widget arrive with iteration 5.
- The archive nav entry is editor-visible (like blog); revisit in design §1 if a
  stricter gate is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
