### PR TITLE
feat(archive): file viewer — lightbox, navigation, fullscreen (iterations 2-4)

### DIFF
--- a/e2e/content/archive-download.spec.ts
+++ b/e2e/content/archive-download.spec.ts
@@ -15,10 +15,10 @@ test.describe('Archive — download', () => {
 
     const thumbs = am.getAssetThumbnails()
     await expect(thumbs.first()).toBeVisible({ timeout: 15000 })
-    expect(await thumbs.count()).toBe(2)
+    expect(await thumbs.count()).toBe(3)
 
     // Every file — image and non-image alike — offers a download.
-    expect(await am.getDownloadAssetBtns().count()).toBe(2)
+    expect(await am.getDownloadAssetBtns().count()).toBe(3)
   })
 
   test('download control names each file accessibly', async ({ page }) => {

--- a/e2e/content/archive-viewer.spec.ts
+++ b/e2e/content/archive-viewer.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { AssetManagerPage } from '../pages/AssetManagerPage'
+
+const ARCHIVE_SLUG = 'founding-documents'
+const IMAGE_A = 'flag.svg' // first image (index 0)
+const IMAGE_B = 'manifesto-poster.svg' // second image (index 1)
+const DOC_FILE = 'notes.txt' // non-image (index 2)
+
+const open = async (page: import('@playwright/test').Page, name: string) => {
+  const am = new AssetManagerPage(page)
+  await am.navigateToEdit('archive', ARCHIVE_SLUG)
+  await am.expectPanelVisible()
+  await expect(am.getAssetThumbnails().first()).toBeVisible({
+    timeout: 15000,
+  })
+  await am.getViewBtnFor(name).click()
+  await expect(page.getByTestId('file-viewer')).toBeVisible()
+  return am
+}
+
+test.describe('Archive — viewer', () => {
+  test('view control appears only on image files', async ({ page }) => {
+    const am = new AssetManagerPage(page)
+    await am.navigateToEdit('archive', ARCHIVE_SLUG)
+    await am.expectPanelVisible()
+    await expect(am.getAssetThumbnails().first()).toBeVisible({
+      timeout: 15000,
+    })
+    // Two images get a view button; the .txt does not.
+    expect(await am.getViewAssetBtns().count()).toBe(2)
+    await expect(am.getViewBtnFor(DOC_FILE)).toHaveCount(0)
+  })
+
+  test('opens an image, closes on Escape and on the close button', async ({
+    page,
+  }) => {
+    await open(page, IMAGE_B)
+    await expect(page.getByTestId('file-viewer-image')).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('file-viewer')).toBeHidden()
+
+    await open(page, IMAGE_B)
+    await page.getByTestId('file-viewer-close').click()
+    await expect(page.getByTestId('file-viewer')).toBeHidden()
+  })
+
+  test('navigates with buttons and arrows, bounded at the ends', async ({
+    page,
+  }) => {
+    await open(page, IMAGE_A) // index 0
+    await expect(page.getByTestId('file-viewer-prev')).toBeDisabled()
+    await expect(page.getByTestId('file-viewer-next')).toBeEnabled()
+
+    // 0 -> 1 (image) -> 2 (the .txt, unsupported)
+    await page.getByTestId('file-viewer-next').click()
+    await expect(page.getByTestId('file-viewer-image')).toBeVisible()
+    await page.getByTestId('file-viewer-next').click()
+    await expect(page.getByTestId('file-viewer-unsupported')).toBeVisible()
+    await expect(page.getByTestId('file-viewer-next')).toBeDisabled()
+
+    // ArrowLeft returns to an image
+    await page.keyboard.press('ArrowLeft')
+    await expect(page.getByTestId('file-viewer-image')).toBeVisible()
+  })
+
+  test('announces position in a live region', async ({ page }) => {
+    await open(page, IMAGE_A)
+    await expect(page.getByTestId('file-viewer-status')).toContainText(
+      'File 1 of 3'
+    )
+    await page.getByTestId('file-viewer-next').click()
+    await expect(page.getByTestId('file-viewer-status')).toContainText(
+      'File 2 of 3'
+    )
+  })
+
+  test('unsupported file downloads under its name from the viewer', async ({
+    page,
+  }) => {
+    await open(page, IMAGE_B) // index 1
+    await page.getByTestId('file-viewer-next').click() // -> notes.txt
+    await expect(page.getByTestId('file-viewer-unsupported')).toBeVisible()
+
+    const started = page.waitForEvent('download')
+    await page.getByTestId('file-viewer-download').click()
+    const download = await started
+    expect(download.suggestedFilename()).toBe(DOC_FILE)
+  })
+
+  test('advances on a left-swipe', async ({ page }) => {
+    await open(page, IMAGE_A) // index 0
+    await expect(page.getByTestId('file-viewer-status')).toContainText(
+      'File 1 of 3'
+    )
+    // Pointer events with explicit clientX — device-independent (mouse
+    // emulation differs on touch contexts); start right, release left.
+    const image = page.getByTestId('file-viewer-image')
+    await image.dispatchEvent('pointerdown', { clientX: 300, clientY: 200 })
+    await image.dispatchEvent('pointerup', { clientX: 90, clientY: 200 })
+    await expect(page.getByTestId('file-viewer-status')).toContainText(
+      'File 2 of 3'
+    )
+  })
+
+  test('exposes an operable fullscreen control', async ({ page }) => {
+    await open(page, IMAGE_A)
+    const fs = page.getByTestId('file-viewer-fullscreen')
+    await expect(fs).toHaveAttribute('aria-label', 'Enter fullscreen')
+    // Clicking must not tear the viewer down (fullscreen itself is
+    // environment-dependent in headless runs).
+    await fs.click()
+    await expect(page.getByTestId('file-viewer')).toBeVisible()
+  })
+})

--- a/e2e/pages/AssetManagerPage.ts
+++ b/e2e/pages/AssetManagerPage.ts
@@ -76,6 +76,15 @@ export class AssetManagerPage {
     return this.page.locator('[data-testid="asset-download-btn"]')
   }
 
+  getViewAssetBtns(): Locator {
+    return this.page.locator('[data-testid="asset-view-btn"]')
+  }
+
+  /** The view button inside a specific thumbnail by file name */
+  getViewBtnFor(name: string): Locator {
+    return this.getThumbByName(name).locator('[data-testid="asset-view-btn"]')
+  }
+
   /** Wait for cover image section to be visible */
   async expectCoverVisible(): Promise<void> {
     await expect(this.getCoverImage()).toBeVisible({

--- a/src/components/AssetManager/AssetActions.vue
+++ b/src/components/AssetManager/AssetActions.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import DownloadIcon from './DownloadIcon.vue'
-import {
-  ASSET_COVER_ID,
-  ASSET_DELETE_ID,
-  ASSET_DOWNLOAD_ID,
-} from './test-ids'
+import AssetDownloadButton from './AssetDownloadButton.vue'
+import AssetViewButton from './AssetViewButton.vue'
+import { ASSET_COVER_ID, ASSET_DELETE_ID } from './test-ids'
 
 defineProps<{
   readonly showCover: boolean
+  readonly showView: boolean
   readonly name: string
 }>()
 
@@ -15,20 +13,18 @@ defineEmits<{
   'set-cover': []
   delete: []
   download: []
+  view: []
 }>()
 </script>
 
 <template>
   <menu class="actions">
-    <button
-      type="button"
-      class="icon-btn"
-      :data-testid="ASSET_DOWNLOAD_ID"
-      :aria-label="`Download ${name}`"
-      @click="$emit('download')"
-    >
-      <DownloadIcon />
-    </button>
+    <AssetViewButton
+      v-if="showView"
+      :name="name"
+      @view="$emit('view')"
+    />
+    <AssetDownloadButton :name="name" @download="$emit('download')" />
     <button
       v-if="showCover"
       type="button"
@@ -52,6 +48,7 @@ defineEmits<{
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   gap: 0.375rem;
   list-style: none;
   padding: 0;
@@ -75,19 +72,5 @@ button:hover {
 button:focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-}
-
-.icon-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 28px;
-  min-height: 28px;
-  padding: 0.25rem;
-  color: var(--color-text-secondary);
-}
-
-.icon-btn:hover {
-  color: var(--color-accent);
 }
 </style>

--- a/src/components/AssetManager/AssetDownloadButton.vue
+++ b/src/components/AssetManager/AssetDownloadButton.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import DownloadIcon from './DownloadIcon.vue'
+import { ASSET_DOWNLOAD_ID } from './test-ids'
+
+defineProps<{
+  readonly name: string
+}>()
+
+defineEmits<{
+  download: []
+}>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="icon-btn"
+    :data-testid="ASSET_DOWNLOAD_ID"
+    :aria-label="`Download ${name}`"
+    @click="$emit('download')"
+  >
+    <DownloadIcon />
+  </button>
+</template>
+
+<style scoped>
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-background);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background: var(--color-background-soft);
+  color: var(--color-accent);
+}
+
+.icon-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/AssetManager/AssetGrid.vue
+++ b/src/components/AssetManager/AssetGrid.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import type { DownloadableAsset } from '@/composables/useAssets/download-asset'
+import {
+  assetToDownloadable,
+  type DownloadableAsset,
+} from '@/composables/useAssets/download-asset'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 import AssetThumbnail from './AssetThumbnail.vue'
 
@@ -11,30 +14,24 @@ const emit = defineEmits<{
   'set-cover': [name: string]
   'delete-asset': [path: string]
   'download-asset': [asset: DownloadableAsset]
+  'view-asset': [index: number]
 }>()
 
-// A committed asset is fetched fresh through the SW; a pending one is
-// only in memory, so hand its blob URL straight to the downloader.
-const toDownloadable = (asset: AssetDisplay): DownloadableAsset => ({
-  path: asset.path,
-  name: asset.name,
-  blobUrl: asset.status === 'committed' ? undefined : asset.thumbnailUrl,
-})
-
 const onDownload = (asset: AssetDisplay): void => {
-  emit('download-asset', toDownloadable(asset))
+  emit('download-asset', assetToDownloadable(asset))
 }
 </script>
 
 <template>
   <ul class="asset-grid">
     <AssetThumbnail
-      v-for="asset in assets"
+      v-for="(asset, i) in assets"
       :key="asset.path"
       v-bind="asset"
       @set-cover="$emit('set-cover', asset.name)"
       @delete="$emit('delete-asset', asset.path)"
       @download="onDownload(asset)"
+      @view="$emit('view-asset', i)"
     />
   </ul>
 </template>

--- a/src/components/AssetManager/AssetPanel.vue
+++ b/src/components/AssetManager/AssetPanel.vue
@@ -14,6 +14,7 @@ defineEmits<{
   'delete-asset': [path: string]
   'upload-asset': [file: File]
   'download-asset': [asset: DownloadableAsset]
+  'view-asset': [index: number]
 }>()
 </script>
 
@@ -26,6 +27,7 @@ defineEmits<{
       @set-cover="$emit('set-cover', $event)"
       @delete-asset="$emit('delete-asset', $event)"
       @download-asset="$emit('download-asset', $event)"
+      @view-asset="$emit('view-asset', $event)"
     />
     <p v-else class="empty">No assets yet</p>
   </section>

--- a/src/components/AssetManager/AssetThumbnail.vue
+++ b/src/components/AssetManager/AssetThumbnail.vue
@@ -15,6 +15,7 @@ defineEmits<{
   'set-cover': []
   delete: []
   download: []
+  view: []
 }>()
 
 const isImage = () => props.mimeType.startsWith('image/')
@@ -58,10 +59,12 @@ const isVisual = () => isImage() || isVideo()
     <AssetActions
       v-if="status !== 'pending-delete'"
       :show-cover="isVisual() && !isCover"
+      :show-view="isImage() && Boolean(thumbnailUrl)"
       :name="name"
       @set-cover="$emit('set-cover')"
       @delete="$emit('delete')"
       @download="$emit('download')"
+      @view="$emit('view')"
     />
   </li>
 </template>

--- a/src/components/AssetManager/AssetViewButton.vue
+++ b/src/components/AssetManager/AssetViewButton.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import ViewIcon from '../FileViewer/icons/ViewIcon.vue'
+import { ASSET_VIEW_ID } from './test-ids'
+
+defineProps<{
+  readonly name: string
+}>()
+
+defineEmits<{
+  view: []
+}>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="icon-btn"
+    :data-testid="ASSET_VIEW_ID"
+    :aria-label="`Open ${name} in viewer`"
+    @click="$emit('view')"
+  >
+    <ViewIcon />
+  </button>
+</template>
+
+<style scoped>
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 0.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-background);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background: var(--color-background-soft);
+  color: var(--color-accent);
+}
+
+.icon-btn:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/AssetManager/test-ids.ts
+++ b/src/components/AssetManager/test-ids.ts
@@ -27,3 +27,6 @@ export const ASSET_DELETE_ID = 'asset-delete-btn'
 
 /** Download asset button */
 export const ASSET_DOWNLOAD_ID = 'asset-download-btn'
+
+/** Open asset in the file viewer button */
+export const ASSET_VIEW_ID = 'asset-view-btn'

--- a/src/components/FileViewer/CloseButton.vue
+++ b/src/components/FileViewer/CloseButton.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import CloseIcon from './icons/CloseIcon.vue'
+import { VIEWER_CLOSE_ID } from './test-ids'
+
+defineEmits<{
+  close: []
+}>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="viewer-icon-btn"
+    :data-testid="VIEWER_CLOSE_ID"
+    aria-label="Close viewer"
+    @click="$emit('close')"
+  >
+    <CloseIcon />
+  </button>
+</template>
+
+<style scoped>
+.viewer-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: rgb(0 0 0 / 35%);
+  color: #fff;
+  cursor: pointer;
+}
+
+.viewer-icon-btn:hover {
+  background: rgb(0 0 0 / 55%);
+}
+
+.viewer-icon-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/FileViewer/FileViewer.vue
+++ b/src/components/FileViewer/FileViewer.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import { fireAndForward } from '@/utils/fire-and-forward'
+import FileViewerStage from './FileViewerStage.vue'
+import FileViewerToolbar from './FileViewerToolbar.vue'
+import NavButton from './NavButton.vue'
+import { VIEWER_ID, VIEWER_STATUS_ID } from './test-ids'
+import type { ViewerFile } from './types'
+import { moveIndex, swipeStep } from './viewer-nav'
+
+const SWIPE_THRESHOLD_PX = 50
+
+const props = defineProps<{
+  readonly files: readonly ViewerFile[]
+  readonly index: number
+}>()
+
+const emit = defineEmits<{
+  close: []
+  'update:index': [index: number]
+  download: [index: number]
+}>()
+
+const dialog = useTemplateRef<HTMLDialogElement>('dialog')
+const isFullscreen = ref(false)
+
+const total = computed(() => props.files.length)
+const current = computed((): ViewerFile | undefined => props.files[props.index])
+const position = computed(() => `${props.index + 1} / ${total.value}`)
+const statusText = computed(() =>
+  current.value
+    ? `File ${props.index + 1} of ${total.value}: ${current.value.name}`
+    : ''
+)
+const atStart = computed(() => props.index <= 0)
+const atEnd = computed(() => props.index >= total.value - 1)
+
+const move = (step: number): void => {
+  emit('update:index', moveIndex(props.index, step, total.value))
+}
+
+const onSwipe = (deltaX: number): void => {
+  const step = swipeStep(deltaX, SWIPE_THRESHOLD_PX)
+  if (step !== 0) move(step)
+}
+
+const syncFullscreen = (): void => {
+  isFullscreen.value = document.fullscreenElement === dialog.value
+}
+
+const exitFullscreen = (): void => {
+  if (document.fullscreenElement) fireAndForward(document.exitFullscreen())
+}
+
+const toggleFullscreen = (): void => {
+  const el = dialog.value
+  if (isFullscreen.value || !el) exitFullscreen()
+  else fireAndForward(el.requestFullscreen())
+}
+
+const onKeydown = (e: KeyboardEvent): void => {
+  if (e.key === 'ArrowRight') move(1)
+  else if (e.key === 'ArrowLeft') move(-1)
+  else if (e.key === 'Escape') {
+    e.preventDefault()
+    if (isFullscreen.value) exitFullscreen()
+    else emit('close')
+  }
+}
+
+const onBackdrop = (e: MouseEvent): void => {
+  if (e.target === dialog.value) emit('close')
+}
+
+onMounted(() => {
+  dialog.value?.showModal()
+  // Keydown on document, not the dialog: when a nav button disables at
+  // an end it loses focus, and a dialog-scoped listener would then miss
+  // the arrow keys. The viewer is the only thing up while mounted.
+  document.addEventListener('keydown', onKeydown)
+  document.addEventListener('fullscreenchange', syncFullscreen)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown)
+  document.removeEventListener('fullscreenchange', syncFullscreen)
+  exitFullscreen()
+})
+</script>
+
+<template>
+  <dialog
+    ref="dialog"
+    :data-testid="VIEWER_ID"
+    class="viewer"
+    @cancel.prevent
+    @click="onBackdrop"
+  >
+    <FileViewerToolbar
+      :position="position"
+      :fullscreen="isFullscreen"
+      @close="$emit('close')"
+      @toggle-fullscreen="toggleFullscreen"
+    />
+    <NavButton
+      direction="prev"
+      :disabled="atStart"
+      @move="move(-1)"
+    />
+    <NavButton
+      direction="next"
+      :disabled="atEnd"
+      @move="move(1)"
+    />
+    <FileViewerStage
+      v-if="current"
+      :file="current"
+      @download="$emit('download', index)"
+      @swipe="onSwipe"
+    />
+    <p
+      :data-testid="VIEWER_STATUS_ID"
+      class="sr-only"
+      aria-live="polite"
+    >
+      {{ statusText }}
+    </p>
+  </dialog>
+</template>
+
+<style scoped>
+.viewer {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: rgb(0 0 0 / 88%);
+  overflow: hidden;
+}
+
+.viewer::backdrop {
+  background: rgb(0 0 0 / 88%);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+</style>

--- a/src/components/FileViewer/FileViewerStage.vue
+++ b/src/components/FileViewer/FileViewerStage.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import FileViewerUnsupported from './FileViewerUnsupported.vue'
+import { VIEWER_IMAGE_ID } from './test-ids'
+import type { ViewerFile } from './types'
+import { isViewable } from './viewer-nav'
+
+const props = defineProps<{
+  readonly file: ViewerFile
+}>()
+
+const emit = defineEmits<{
+  download: []
+  swipe: [deltaX: number]
+}>()
+
+const viewable = (): boolean => isViewable(props.file.mimeType) && !!props.file.url
+
+let startX = 0
+
+const onPointerDown = (e: PointerEvent): void => {
+  startX = e.clientX
+}
+
+const onPointerUp = (e: PointerEvent): void => {
+  emit('swipe', e.clientX - startX)
+}
+</script>
+
+<template>
+  <div
+    class="stage"
+    @pointerdown="onPointerDown"
+    @pointerup="onPointerUp"
+  >
+    <img
+      v-if="viewable()"
+      :key="file.url"
+      :data-testid="VIEWER_IMAGE_ID"
+      :src="file.url"
+      alt=""
+      :aria-label="file.name"
+      decoding="async"
+      draggable="false"
+    />
+    <FileViewerUnsupported
+      v-else
+      :name="file.name"
+      @download="$emit('download')"
+    />
+  </div>
+</template>
+
+<style scoped>
+.stage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  touch-action: pan-y;
+  user-select: none;
+}
+
+img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  -webkit-user-drag: none;
+}
+</style>

--- a/src/components/FileViewer/FileViewerToolbar.vue
+++ b/src/components/FileViewer/FileViewerToolbar.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import CloseButton from './CloseButton.vue'
+import FullscreenButton from './FullscreenButton.vue'
+
+defineProps<{
+  readonly position: string
+  readonly fullscreen: boolean
+}>()
+
+defineEmits<{
+  close: []
+  'toggle-fullscreen': []
+}>()
+</script>
+
+<template>
+  <div class="toolbar">
+    <span class="position">{{ position }}</span>
+    <FullscreenButton
+      :active="fullscreen"
+      @toggle="$emit('toggle-fullscreen')"
+    />
+    <CloseButton @close="$emit('close')" />
+  </div>
+</template>
+
+<style scoped>
+.toolbar {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: clamp(0.5rem, 2vw, 1rem);
+}
+
+.position {
+  margin-inline-end: auto;
+  padding: 0.25rem 0.625rem;
+  border-radius: var(--radius-sm);
+  background: rgb(0 0 0 / 35%);
+  color: #fff;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/src/components/FileViewer/FileViewerUnsupported.vue
+++ b/src/components/FileViewer/FileViewerUnsupported.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import { VIEWER_UNSUPPORTED_ID } from './test-ids'
+import ViewerDownloadButton from './ViewerDownloadButton.vue'
+
+defineProps<{
+  readonly name: string
+}>()
+
+defineEmits<{
+  download: []
+}>()
+</script>
+
+<template>
+  <div :data-testid="VIEWER_UNSUPPORTED_ID" class="unsupported">
+    <span class="pictogram" aria-hidden="true">📄</span>
+    <span class="filename">{{ name }}</span>
+    <ViewerDownloadButton :name="name" @download="$emit('download')" />
+  </div>
+</template>
+
+<style scoped>
+.unsupported {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem;
+  color: #fff;
+  text-align: center;
+}
+
+.pictogram {
+  font-size: 4rem;
+  line-height: 1;
+}
+
+.filename {
+  font-size: 1rem;
+  word-break: break-all;
+  max-width: 80vw;
+}
+</style>

--- a/src/components/FileViewer/FullscreenButton.vue
+++ b/src/components/FileViewer/FullscreenButton.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import FullscreenExitIcon from './icons/FullscreenExitIcon.vue'
+import FullscreenIcon from './icons/FullscreenIcon.vue'
+import { VIEWER_FULLSCREEN_ID } from './test-ids'
+
+defineProps<{
+  readonly active: boolean
+}>()
+
+defineEmits<{
+  toggle: []
+}>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="viewer-icon-btn"
+    :data-testid="VIEWER_FULLSCREEN_ID"
+    :aria-label="active ? 'Exit fullscreen' : 'Enter fullscreen'"
+    :aria-pressed="active"
+    @click="$emit('toggle')"
+  >
+    <FullscreenExitIcon v-if="active" />
+    <FullscreenIcon v-else />
+  </button>
+</template>
+
+<style scoped>
+.viewer-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0.5rem;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: rgb(0 0 0 / 35%);
+  color: #fff;
+  cursor: pointer;
+}
+
+.viewer-icon-btn:hover {
+  background: rgb(0 0 0 / 55%);
+}
+
+.viewer-icon-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/FileViewer/NavButton.vue
+++ b/src/components/FileViewer/NavButton.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import ChevronLeftIcon from './icons/ChevronLeftIcon.vue'
+import ChevronRightIcon from './icons/ChevronRightIcon.vue'
+import { VIEWER_NEXT_ID, VIEWER_PREV_ID } from './test-ids'
+
+const props = defineProps<{
+  readonly direction: 'prev' | 'next'
+  readonly disabled: boolean
+}>()
+
+defineEmits<{
+  move: []
+}>()
+
+const isPrev = props.direction === 'prev'
+</script>
+
+<template>
+  <button
+    type="button"
+    class="nav-btn"
+    :class="direction"
+    :data-testid="isPrev ? VIEWER_PREV_ID : VIEWER_NEXT_ID"
+    :aria-label="isPrev ? 'Previous file' : 'Next file'"
+    :disabled="disabled"
+    @click="$emit('move')"
+  >
+    <ChevronLeftIcon v-if="isPrev" />
+    <ChevronRightIcon v-else />
+  </button>
+</template>
+
+<style scoped>
+.nav-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border: none;
+  border-radius: 50%;
+  background: rgb(0 0 0 / 35%);
+  color: #fff;
+  cursor: pointer;
+}
+
+.nav-btn.prev {
+  inset-inline-start: clamp(0.5rem, 2vw, 1.5rem);
+}
+
+.nav-btn.next {
+  inset-inline-end: clamp(0.5rem, 2vw, 1.5rem);
+}
+
+.nav-btn:hover:not(:disabled) {
+  background: rgb(0 0 0 / 55%);
+}
+
+.nav-btn:disabled {
+  opacity: 35%;
+  cursor: default;
+}
+
+.nav-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/FileViewer/ViewerDownloadButton.vue
+++ b/src/components/FileViewer/ViewerDownloadButton.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import DownloadIcon from '../AssetManager/DownloadIcon.vue'
+import { VIEWER_DOWNLOAD_ID } from './test-ids'
+
+defineProps<{
+  readonly name: string
+}>()
+
+defineEmits<{
+  download: []
+}>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="download-btn"
+    :data-testid="VIEWER_DOWNLOAD_ID"
+    :aria-label="`Download ${name}`"
+    @click="$emit('download')"
+  >
+    <DownloadIcon />
+    <span>Download</span>
+  </button>
+</template>
+
+<style scoped>
+.download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-height: 44px;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-accent);
+  color: #fff;
+  cursor: pointer;
+}
+
+.download-btn:hover {
+  background: var(--color-accent-hover);
+}
+
+.download-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/FileViewer/icons/ChevronLeftIcon.vue
+++ b/src/components/FileViewer/icons/ChevronLeftIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M15 5l-7 7 7 7"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</template>

--- a/src/components/FileViewer/icons/ChevronRightIcon.vue
+++ b/src/components/FileViewer/icons/ChevronRightIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M9 5l7 7-7 7"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</template>

--- a/src/components/FileViewer/icons/CloseIcon.vue
+++ b/src/components/FileViewer/icons/CloseIcon.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M5 5l10 10M15 5L5 15"
+      stroke="currentColor"
+      stroke-width="1.6"
+      stroke-linecap="round"
+    />
+  </svg>
+</template>

--- a/src/components/FileViewer/icons/FullscreenExitIcon.vue
+++ b/src/components/FileViewer/icons/FullscreenExitIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M6 2v4H2M12 2v4h4M6 16v-4H2M12 16v-4h4"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</template>

--- a/src/components/FileViewer/icons/FullscreenIcon.vue
+++ b/src/components/FileViewer/icons/FullscreenIcon.vue
@@ -1,0 +1,17 @@
+<template>
+  <svg
+    width="18"
+    height="18"
+    viewBox="0 0 18 18"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M2 6V2h4M16 6V2h-4M2 12v4h4M16 12v4h-4"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</template>

--- a/src/components/FileViewer/icons/ViewIcon.vue
+++ b/src/components/FileViewer/icons/ViewIcon.vue
@@ -1,0 +1,18 @@
+<template>
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M1 8s2.5-4.5 7-4.5S15 8 15 8s-2.5 4.5-7 4.5S1 8 1 8Z"
+      stroke="currentColor"
+      stroke-width="1.3"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <circle cx="8" cy="8" r="1.8" stroke="currentColor" stroke-width="1.3" />
+  </svg>
+</template>

--- a/src/components/FileViewer/test-ids.ts
+++ b/src/components/FileViewer/test-ids.ts
@@ -1,0 +1,26 @@
+/** Viewer dialog root */
+export const VIEWER_ID = 'file-viewer'
+
+/** Currently displayed image */
+export const VIEWER_IMAGE_ID = 'file-viewer-image'
+
+/** Unsupported-type fallback panel */
+export const VIEWER_UNSUPPORTED_ID = 'file-viewer-unsupported'
+
+/** Close viewer button */
+export const VIEWER_CLOSE_ID = 'file-viewer-close'
+
+/** Previous file button */
+export const VIEWER_PREV_ID = 'file-viewer-prev'
+
+/** Next file button */
+export const VIEWER_NEXT_ID = 'file-viewer-next'
+
+/** Fullscreen toggle button */
+export const VIEWER_FULLSCREEN_ID = 'file-viewer-fullscreen'
+
+/** Download current file button (in the unsupported panel) */
+export const VIEWER_DOWNLOAD_ID = 'file-viewer-download'
+
+/** Polite live region announcing position */
+export const VIEWER_STATUS_ID = 'file-viewer-status'

--- a/src/components/FileViewer/types.ts
+++ b/src/components/FileViewer/types.ts
@@ -1,0 +1,11 @@
+/**
+ * One file the viewer can page through. Display-only: the viewer never
+ * fetches — the host supplies `url` (an image URL, or empty when the
+ * type is not viewable, which triggers the pictogram + download panel).
+ */
+export interface ViewerFile {
+  readonly name: string
+  readonly mimeType: string
+  /** Display URL for images; empty string when nothing to show. */
+  readonly url: string
+}

--- a/src/components/FileViewer/viewer-nav.test.ts
+++ b/src/components/FileViewer/viewer-nav.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { clampIndex, isViewable, moveIndex, swipeStep } from './viewer-nav'
+
+describe('isViewable', () => {
+  it('accepts image types', () => {
+    expect(isViewable('image/png')).toBe(true)
+    expect(isViewable('image/svg+xml')).toBe(true)
+  })
+
+  it('rejects non-image types', () => {
+    expect(isViewable('application/zip')).toBe(false)
+    expect(isViewable('text/plain')).toBe(false)
+    expect(isViewable('')).toBe(false)
+  })
+})
+
+describe('clampIndex', () => {
+  it('keeps an in-range index', () => {
+    expect(clampIndex(2, 5)).toBe(2)
+  })
+
+  it('clamps below and above the range', () => {
+    expect(clampIndex(-3, 5)).toBe(0)
+    expect(clampIndex(9, 5)).toBe(4)
+  })
+
+  it('returns 0 for an empty list', () => {
+    expect(clampIndex(3, 0)).toBe(0)
+  })
+})
+
+describe('moveIndex', () => {
+  it('advances and retreats within bounds', () => {
+    expect(moveIndex(1, 1, 4)).toBe(2)
+    expect(moveIndex(2, -1, 4)).toBe(1)
+  })
+
+  it('does not wrap past the ends', () => {
+    expect(moveIndex(0, -1, 4)).toBe(0)
+    expect(moveIndex(3, 1, 4)).toBe(3)
+  })
+})
+
+describe('swipeStep', () => {
+  it('advances on a left-swipe past threshold', () => {
+    expect(swipeStep(-60, 50)).toBe(1)
+  })
+
+  it('retreats on a right-swipe past threshold', () => {
+    expect(swipeStep(70, 50)).toBe(-1)
+  })
+
+  it('ignores deltas within the threshold', () => {
+    expect(swipeStep(-20, 50)).toBe(0)
+    expect(swipeStep(30, 50)).toBe(0)
+  })
+})

--- a/src/components/FileViewer/viewer-nav.ts
+++ b/src/components/FileViewer/viewer-nav.ts
@@ -1,0 +1,45 @@
+/**
+ * Whether the viewer can render this file inline. Iteration-2 scope is
+ * raster + vector images; everything else falls back to the
+ * pictogram + download panel.
+ * @param mimeType - File MIME type
+ * @returns True when the viewer displays the file directly
+ */
+export const isViewable = (mimeType: string): boolean =>
+  mimeType.startsWith('image/')
+
+/**
+ * Clamp an index into the valid range of a list (no wrap).
+ * @param index - Desired index
+ * @param length - List length
+ * @returns Index within [0, length - 1], or 0 for an empty list
+ */
+export const clampIndex = (index: number, length: number): number =>
+  length === 0 ? 0 : Math.max(0, Math.min(index, length - 1))
+
+/**
+ * Move from `index` by `step`, clamped to the list (ends do not wrap).
+ * @param index - Current index
+ * @param step - Signed step (e.g. -1 previous, +1 next)
+ * @param length - List length
+ * @returns New clamped index
+ */
+export const moveIndex = (
+  index: number,
+  step: number,
+  length: number
+): number => clampIndex(index + step, length)
+
+/**
+ * Translate a horizontal pointer delta into a navigation step. A
+ * left-swipe (negative delta) advances; a right-swipe retreats. Deltas
+ * within the threshold do not navigate.
+ * @param deltaX - Pointer displacement (end minus start), px
+ * @param threshold - Minimum absolute displacement to count, px
+ * @returns +1 next, -1 previous, 0 none
+ */
+export const swipeStep = (deltaX: number, threshold: number): number => {
+  if (deltaX <= -threshold) return 1
+  if (deltaX >= threshold) return -1
+  return 0
+}

--- a/src/composables/useAssets/download-asset.ts
+++ b/src/composables/useAssets/download-asset.ts
@@ -1,4 +1,5 @@
 import { resolveAssetUrl } from './resolve-asset-url'
+import type { AssetDisplay } from './types'
 
 /** Minimal asset reference sufficient to download a file. */
 export interface DownloadableAsset {
@@ -7,6 +8,21 @@ export interface DownloadableAsset {
   /** In-memory blob URL for a not-yet-committed (pending) asset. */
   readonly blobUrl?: string
 }
+
+/**
+ * Map a display asset to a downloadable reference: a committed asset is
+ * fetched fresh through the SW, a pending one is only in memory so its
+ * blob URL is handed straight to the downloader.
+ * @param asset - Display asset
+ * @returns Downloadable reference
+ */
+export const assetToDownloadable = (
+  asset: AssetDisplay
+): DownloadableAsset => ({
+  path: asset.path,
+  name: asset.name,
+  blobUrl: asset.status === 'committed' ? undefined : asset.thumbnailUrl,
+})
 
 /**
  * Resolve the URL to download an asset from: the in-memory blob URL for

--- a/src/composables/useFileViewer/useFileViewer.test.ts
+++ b/src/composables/useFileViewer/useFileViewer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AssetDisplay } from '@/composables/useAssets/types'
+import { useFileViewer } from './useFileViewer'
+
+const asset = (over: Partial<AssetDisplay>): AssetDisplay => ({
+  name: 'a.png',
+  path: 'archive/x/assets/a.png',
+  mimeType: 'image/png',
+  thumbnailUrl: 'blob:a',
+  status: 'committed',
+  isCover: false,
+  ...over,
+})
+
+describe('useFileViewer', () => {
+  it('maps assets to viewer files (name, mime, url)', () => {
+    const v = useFileViewer(
+      () => [asset({}), asset({ name: 'b.txt', mimeType: 'text/plain' })],
+      () => undefined
+    )
+    expect(v.files.value).toEqual([
+      { name: 'a.png', mimeType: 'image/png', url: 'blob:a' },
+      { name: 'b.txt', mimeType: 'text/plain', url: 'blob:a' },
+    ])
+  })
+
+  it('opens at an index and closes', () => {
+    const v = useFileViewer(
+      () => [asset({})],
+      () => undefined
+    )
+    expect(v.open.value).toBe(false)
+    v.openAt(3)
+    expect(v.open.value).toBe(true)
+    expect(v.index.value).toBe(3)
+    v.close()
+    expect(v.open.value).toBe(false)
+  })
+
+  it('routes a download for the asset at an index', () => {
+    const sink = vi.fn()
+    const v = useFileViewer(
+      () => [asset({ name: 'one.png' }), asset({ name: 'two.zip' })],
+      sink
+    )
+    v.downloadAt(1)
+    expect(sink).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'two.zip' })
+    )
+  })
+
+  it('ignores a download for an out-of-range index', () => {
+    const sink = vi.fn()
+    const v = useFileViewer(() => [asset({})], sink)
+    v.downloadAt(5)
+    expect(sink).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/useFileViewer/useFileViewer.ts
+++ b/src/composables/useFileViewer/useFileViewer.ts
@@ -1,0 +1,52 @@
+import { computed, ref } from 'vue'
+import type { ViewerFile } from '@/components/FileViewer/types'
+import {
+  assetToDownloadable,
+  type DownloadableAsset,
+} from '@/composables/useAssets/download-asset'
+import type { AssetDisplay } from '@/composables/useAssets/types'
+
+/**
+ * Drive the file viewer over a live list of display assets: open at an
+ * index, page through, and download the current file. The viewer
+ * component itself stays display-only; this glue maps assets to
+ * {@link ViewerFile} and routes downloads back to the asset layer.
+ * @param assets - Accessor for the current display assets
+ * @param download - Sink that performs the actual download
+ * @returns Reactive viewer state + actions
+ */
+export const useFileViewer = (
+  assets: () => readonly AssetDisplay[],
+  download: (asset: DownloadableAsset) => void
+) => {
+  const open = ref(false)
+  const index = ref(0)
+
+  const files = computed<readonly ViewerFile[]>(() =>
+    assets().map(a => ({
+      name: a.name,
+      mimeType: a.mimeType,
+      url: a.thumbnailUrl,
+    }))
+  )
+
+  const openAt = (at: number): void => {
+    index.value = at
+    open.value = true
+  }
+
+  const close = (): void => {
+    open.value = false
+  }
+
+  const setIndex = (at: number): void => {
+    index.value = at
+  }
+
+  const downloadAt = (at: number): void => {
+    const asset = assets()[at]
+    if (asset) download(assetToDownloadable(asset))
+  }
+
+  return { open, index, files, openAt, close, setIndex, downloadAt }
+}

--- a/src/sw/mock/archive/founding-documents.ts
+++ b/src/sw/mock/archive/founding-documents.ts
@@ -6,6 +6,12 @@ const POSTER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 280
     font-family="serif" font-size="18">Manifesto</text>
 </svg>`
 
+const FLAG_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 280 200">
+  <rect width="280" height="200" fill="#b91c1c"/>
+  <text x="140" y="110" text-anchor="middle" fill="#fde68a"
+    font-family="serif" font-size="20">Flag</text>
+</svg>`
+
 const README_TXT = `Founding documents of the collective.
 Scans and source files are kept here for the archive.`
 
@@ -25,6 +31,7 @@ lang: en
 
 The originals and working files of our founding texts.`,
   },
+  { path: `${BASE}/flag.svg`, content: FLAG_SVG },
   { path: `${BASE}/manifesto-poster.svg`, content: POSTER_SVG },
   { path: `${BASE}/notes.txt`, content: README_TXT },
 ]

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -5,7 +5,9 @@ import AssetPanel from '@/components/AssetManager/AssetPanel.vue'
 import CoverImage from '@/components/AssetManager/CoverImage.vue'
 import ErrorMessage from '@/components/common/ErrorMessage.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
+import FileViewer from '@/components/FileViewer/FileViewer.vue'
 import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue'
+import { useFileViewer } from '@/composables/useFileViewer/useFileViewer'
 import ContentEditMain from './ContentEditView/ContentEditMain.vue'
 import ContentPreview from './ContentEditView/ContentPreview.vue'
 import EditBreadcrumb from './ContentEditView/EditBreadcrumb.vue'
@@ -38,6 +40,20 @@ const title = computed(() =>
 )
 const isRenameable = computed(
   () => p.contentType.value !== 'pages' && p.contentType.value !== 'common'
+)
+const {
+  open: viewerOpen,
+  index: viewerIndex,
+  files: viewerFiles,
+  openAt: openViewer,
+  close: closeViewer,
+  setIndex: setViewerIndex,
+  downloadAt: downloadViewerFile,
+} = useFileViewer(
+  () => (p.hasAssets.value ? p.assets.allAssets.value : []),
+  asset => {
+    void p.ah.onDownloadAsset(asset)
+  }
 )
 </script>
 
@@ -101,6 +117,15 @@ const isRenameable = computed(
       @delete-asset="p.ah.onDeleteAsset"
       @upload-asset="p.ah.onUploadAsset"
       @download-asset="p.ah.onDownloadAsset"
+      @view-asset="openViewer"
+    />
+    <FileViewer
+      v-if="viewerOpen"
+      :files="viewerFiles"
+      :index="viewerIndex"
+      @close="closeViewer"
+      @update:index="setViewerIndex"
+      @download="downloadViewerFile"
     />
     <PublishConfirmDialog
       :show="flow.showDialog.value"


### PR DESCRIPTION
## Archive — iterations 2–4: image viewer (lightbox, navigation, fullscreen)

Builds the **FileViewer** on top of iteration 1. A view control on image
thumbnails opens an accessible lightbox; from there you page through every
file in the archive item.

### Iteration 2 — viewer
- Native `<dialog>` modal (`showModal`) — built-in focus trap + focus
  restoration; backdrop dimmer; `aria-modal`.
- Images render fit-to-viewport (`object-fit: contain`, `decoding=async`).
- Unsupported types render a pictogram + filename + download instead of a
  broken image.
- View control (`asset-view-btn`) shows only on images, named
  `Open <file> in viewer`.

### Iteration 3 — navigation
- Prev/next buttons (disabled at the ends, no wrap), **ArrowLeft/ArrowRight**,
  and **swipe** (pointer delta past a 50px threshold).
- Keydown is bound on `document` (not the dialog): a nav button that disables
  at an end loses focus, and a dialog-scoped listener would then drop the
  arrow keys.
- Polite `aria-live` region announces "File N of M".
- Navigating onto a non-image shows its pictogram + download (no broken image).

### Iteration 4 — fullscreen
- Fullscreen toggle via the Fullscreen API on the dialog, graceful fallback
  (the modal already fills the viewport). Escape exits fullscreen first, then
  closes on the next press.

### Architecture / house rules
- Every control is a dedicated child component (icon rendered *inside* the
  button) to satisfy the **max-depth-2** Vue template rule. This also **fixes
  the depth-3 `AssetActions`** shipped in iteration 1 — `realmode` CI does not
  run `lint:vue-depth`, so it slipped; `bun run lint:vue-depth` is green now.
- The viewer is **display-only** (takes `files` + `index`, emits
  `close`/`update:index`/`download`) so iteration 5 can mount the same core as
  a public island. Pure nav helpers (`isViewable`, `clampIndex`, `moveIndex`,
  `swipeStep`) are unit-tested.

### Verification
- Unit: viewer-nav (10) + useFileViewer (4) + download (4); **full suite
  1022/1022**.
- E2E `archive-viewer` + `archive-download`: **22/22 on chromium +
  mobile-chromium** (open/close/Escape, button + arrow + swipe nav, end bounds,
  unsupported mid-stream, live region, real download event, fullscreen control).
- `vue-tsc` clean; `lint:vue-depth` green; biome clean on all changed files.
- Screenshot proof captured at 1280px and 390px (centered image, counter,
  side chevrons, fullscreen/close; mobile uses 48px circular nav targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
