### PR TITLE
feat(comms-worker): include the newspaper in the digest

### DIFF
--- a/services/comms-worker/src/digest/html-newspaper-current.ts
+++ b/services/comms-worker/src/digest/html-newspaper-current.ts
@@ -1,0 +1,34 @@
+import { htmlEscape } from './escape'
+import type { StampedArticle } from './html-shared'
+import type { DigestChrome } from './i18n-types'
+
+const line = (label: string, [issue, url]: StampedArticle): string =>
+  [
+    '<div style="margin:6px 0;font-size:14px">',
+    `<span class="muted" style="color:#888">${htmlEscape(label)}: </span>`,
+    `<a href="${url}" class="footer-link" `,
+    'style="color:#ee6f57;text-decoration:none;font-weight:600">',
+    htmlEscape(issue.title),
+    '</a>',
+    '</div>',
+  ].join('')
+
+/**
+ * Already-announced latest issue rendered at the FOOT of the card as
+ * a subtle "current issue" line, linking to its page.
+ * @param chrome Localised strings.
+ * @param issues Stamped (issue + UTM url) pairs predating the cutoff.
+ * @returns HTML, or '' when there are none.
+ */
+export const renderCurrentIssues = (
+  chrome: DigestChrome,
+  issues: ReadonlyArray<StampedArticle>
+): string =>
+  issues.length === 0
+    ? ''
+    : [
+        '<div class="divider" style="margin:20px 0 0;padding-top:14px;',
+        'border-top:1px solid #eee">',
+        issues.map(i => line(chrome.currentIssueLabel, i)).join(''),
+        '</div>',
+      ].join('')

--- a/services/comms-worker/src/digest/html-newspaper.ts
+++ b/services/comms-worker/src/digest/html-newspaper.ts
@@ -1,0 +1,31 @@
+import { htmlEscape } from './escape'
+import type { StampedArticle } from './html-shared'
+import type { DigestChrome } from './i18n-types'
+
+const banner = (label: string, [issue, url]: StampedArticle): string =>
+  [
+    '<div style="margin:4px 0 18px;padding:12px 16px;',
+    'background:#fff3f0;border-left:3px solid #ee6f57;border-radius:6px">',
+    '<div class="muted" style="font-size:12px;text-transform:uppercase;',
+    'letter-spacing:0.08em;color:#888">',
+    htmlEscape(label),
+    '</div>',
+    `<a href="${url}" class="item-title" style="display:block;`,
+    'color:#ee6f57;text-decoration:none;font-size:17px;font-weight:700;',
+    'line-height:1.3;margin-top:2px">',
+    htmlEscape(issue.title),
+    '</a>',
+    '</div>',
+  ].join('')
+
+/**
+ * New-issue announcements rendered at the TOP of the card: a flagged
+ * banner per freshly-published issue, linking to its page.
+ * @param chrome Localised strings.
+ * @param issues Stamped (issue + UTM url) pairs published since cutoff.
+ * @returns HTML, or '' when there are none.
+ */
+export const renderAnnouncements = (
+  chrome: DigestChrome,
+  issues: ReadonlyArray<StampedArticle>
+): string => issues.map(i => banner(chrome.newIssueLabel, i)).join('')

--- a/services/comms-worker/src/digest/html-shared.ts
+++ b/services/comms-worker/src/digest/html-shared.ts
@@ -9,5 +9,11 @@ export type LangGroups = ReadonlyArray<
   readonly [Lang, ReadonlyArray<StampedArticle>]
 >
 
+/** Stamped newspaper issues split into top announcements + foot current. */
+export type StampedNewspapers = {
+  readonly announcements: ReadonlyArray<StampedArticle>
+  readonly current: ReadonlyArray<StampedArticle>
+}
+
 /** Light-card background applied inline so non-style-aware clients keep working. */
 export const CARD_STYLE = 'background:#fff;color:#222'

--- a/services/comms-worker/src/digest/html.ts
+++ b/services/comms-worker/src/digest/html.ts
@@ -1,13 +1,24 @@
 import { renderFooter, renderHead, renderHeader } from './html-chrome'
 import { renderGroups } from './html-groups'
-import { CARD_STYLE, type LangGroups } from './html-shared'
+import { renderAnnouncements } from './html-newspaper'
+import { renderCurrentIssues } from './html-newspaper-current'
+import {
+  CARD_STYLE,
+  type LangGroups,
+  type StampedNewspapers,
+} from './html-shared'
 import type { DigestChrome } from './i18n-types'
 
-export type { LangGroups, StampedArticle } from './html-shared'
+export type {
+  LangGroups,
+  StampedArticle,
+  StampedNewspapers,
+} from './html-shared'
 
 const renderBody = (
   chrome: DigestChrome,
   groups: LangGroups,
+  newspapers: StampedNewspapers,
   unsubscribeUrl: string
 ): string =>
   [
@@ -16,7 +27,9 @@ const renderBody = (
     'style="max-width:640px;margin:0 auto;background:#fff;color:#222">',
     renderHeader(chrome),
     `<tr><td class="card" style="padding:8px 28px 24px;${CARD_STYLE}">`,
+    renderAnnouncements(chrome, newspapers.announcements),
     renderGroups(groups),
+    renderCurrentIssues(chrome, newspapers.current),
     '</td></tr>',
     renderFooter(chrome, unsubscribeUrl),
     '</table>',
@@ -31,12 +44,14 @@ const renderBody = (
  * `@media (prefers-color-scheme: dark)` override block.
  * @param chrome Localised strings for the recipient.
  * @param groups Articles grouped by language, recipient-order.
+ * @param newspapers Stamped newspaper issues (top announcements + foot current).
  * @param unsubscribeUrl Per-recipient unsubscribe URL.
  * @returns Complete HTML string.
  */
 export const renderHtml = (
   chrome: DigestChrome,
   groups: LangGroups,
+  newspapers: StampedNewspapers,
   unsubscribeUrl: string
 ): string =>
   [
@@ -45,6 +60,6 @@ export const renderHtml = (
     renderHead(),
     '<body style="margin:0;padding:24px 12px;background:#f6f6f6;color:#222;',
     'font-family:system-ui,Segoe UI,Roboto,sans-serif;line-height:1.4">',
-    renderBody(chrome, groups, unsubscribeUrl),
+    renderBody(chrome, groups, newspapers, unsubscribeUrl),
     '</body></html>',
   ].join('')

--- a/services/comms-worker/src/digest/i18n-cyrillic.ts
+++ b/services/comms-worker/src/digest/i18n-cyrillic.ts
@@ -3,8 +3,12 @@ import type { DigestChrome } from './i18n-types'
 /** Russian digest chrome (ru). */
 export const CHROME_RU: DigestChrome = {
   subject: n => `Коммунистический Прометей — ${n} новых статей`,
+  newIssueSubject: title =>
+    `Коммунистический Прометей — новый выпуск: ${title}`,
   intro: 'С момента последнего дайджеста:',
   readLabel: 'Читать',
+  newIssueLabel: 'Новый выпуск',
+  currentIssueLabel: 'Текущий выпуск',
   unsubscribeLabel: 'Отписаться',
   unsubscribeNote:
     'Если вы больше не хотите получать эти письма, перейдите по ссылке выше.',
@@ -13,8 +17,11 @@ export const CHROME_RU: DigestChrome = {
 /** Ukrainian digest chrome (uk). */
 export const CHROME_UK: DigestChrome = {
   subject: n => `Комуністичний Прометей — ${n} нових статей`,
+  newIssueSubject: title => `Комуністичний Прометей — новий випуск: ${title}`,
   intro: 'З моменту попереднього випуску:',
   readLabel: 'Читати',
+  newIssueLabel: 'Новий випуск',
+  currentIssueLabel: 'Поточний випуск',
   unsubscribeLabel: 'Відписатися',
   unsubscribeNote:
     'Якщо ви більше не хочете отримувати ці листи, перейдіть за посиланням вище.',
@@ -23,8 +30,11 @@ export const CHROME_UK: DigestChrome = {
 /** Belarusian digest chrome (bl). */
 export const CHROME_BL: DigestChrome = {
   subject: n => `Камуністычны Праметэй — ${n} новых артыкулаў`,
+  newIssueSubject: title => `Камуністычны Праметэй — новы нумар: ${title}`,
   intro: 'З моманту папярэдняга выпуску:',
   readLabel: 'Чытаць',
+  newIssueLabel: 'Новы нумар',
+  currentIssueLabel: 'Бягучы нумар',
   unsubscribeLabel: 'Адпісацца',
   unsubscribeNote:
     'Калі вы больш не хочаце атрымліваць гэтыя лісты, перайдзіце па спасылцы вышэй.',

--- a/services/comms-worker/src/digest/i18n-latin.ts
+++ b/services/comms-worker/src/digest/i18n-latin.ts
@@ -4,8 +4,11 @@ import type { DigestChrome } from './i18n-types'
 export const CHROME_EN: DigestChrome = {
   subject: n =>
     `Communist Prometheus — ${n} new article${n === 1 ? '' : 's'}`,
+  newIssueSubject: title => `Communist Prometheus — new issue: ${title}`,
   intro: 'Since your last digest:',
   readLabel: 'Read',
+  newIssueLabel: 'New issue',
+  currentIssueLabel: 'Current issue',
   unsubscribeLabel: 'Unsubscribe',
   unsubscribeNote:
     'If you no longer wish to receive these digests, click the link above.',
@@ -14,8 +17,11 @@ export const CHROME_EN: DigestChrome = {
 /** Italian digest chrome (it). */
 export const CHROME_IT: DigestChrome = {
   subject: n => `Prometeo Comunista — ${n} nuovi articoli`,
+  newIssueSubject: title => `Prometeo Comunista — nuovo numero: ${title}`,
   intro: 'Dal tuo ultimo digest:',
   readLabel: 'Leggi',
+  newIssueLabel: 'Nuovo numero',
+  currentIssueLabel: 'Numero attuale',
   unsubscribeLabel: 'Disiscriviti',
   unsubscribeNote:
     'Se non vuoi più ricevere questi digest, clicca il link qui sopra.',
@@ -24,8 +30,11 @@ export const CHROME_IT: DigestChrome = {
 /** Spanish digest chrome (es). */
 export const CHROME_ES: DigestChrome = {
   subject: n => `Prometeo Comunista — ${n} nuevos artículos`,
+  newIssueSubject: title => `Prometeo Comunista — nuevo número: ${title}`,
   intro: 'Desde tu último digest:',
   readLabel: 'Leer',
+  newIssueLabel: 'Nuevo número',
+  currentIssueLabel: 'Número actual',
   unsubscribeLabel: 'Cancelar suscripción',
   unsubscribeNote:
     'Si ya no quieres recibir estos digests, haz clic en el enlace superior.',
@@ -34,8 +43,11 @@ export const CHROME_ES: DigestChrome = {
 /** Polish digest chrome (pl). */
 export const CHROME_PL: DigestChrome = {
   subject: n => `Komunistyczny Prometeusz — ${n} nowych artykułów`,
+  newIssueSubject: title => `Komunistyczny Prometeusz — nowy numer: ${title}`,
   intro: 'Od ostatniego skrótu:',
   readLabel: 'Czytaj',
+  newIssueLabel: 'Nowy numer',
+  currentIssueLabel: 'Bieżący numer',
   unsubscribeLabel: 'Wypisz się',
   unsubscribeNote:
     'Jeśli nie chcesz już otrzymywać tych wiadomości, kliknij link powyżej.',

--- a/services/comms-worker/src/digest/i18n-types.ts
+++ b/services/comms-worker/src/digest/i18n-types.ts
@@ -1,8 +1,14 @@
 /** Localised chrome strings used by the digest renderer. */
 export type DigestChrome = {
   readonly subject: (n: number) => string
+  /** Subject when there are no new articles but a new issue is out. */
+  readonly newIssueSubject: (title: string) => string
   readonly intro: string
   readonly readLabel: string
+  /** Banner above a freshly-published newspaper issue. */
+  readonly newIssueLabel: string
+  /** Label for the already-announced latest issue, shown at the foot. */
+  readonly currentIssueLabel: string
   readonly unsubscribeLabel: string
   readonly unsubscribeNote: string
 }

--- a/services/comms-worker/src/digest/render-helpers.ts
+++ b/services/comms-worker/src/digest/render-helpers.ts
@@ -1,0 +1,83 @@
+import type { NewspaperSelection } from '../newspaper/classify'
+import type { Article } from '../rss/types'
+import type { Lang } from '../subscribers/types'
+import type { LangGroups, StampedArticle, StampedNewspapers } from './html'
+import { CHROME } from './i18n'
+import type { DigestChrome } from './i18n-types'
+import { appendUtm } from './utm'
+
+/** Empty selection used when a render has no newspaper issues. */
+export const EMPTY_NEWSPAPERS: NewspaperSelection = {
+  announcements: [],
+  current: [],
+}
+
+/**
+ * Pair an article with its UTM-stamped link for the campaign.
+ * @param a Article to stamp.
+ * @param campaign ISO-week campaign tag.
+ * @returns Article + tagged URL tuple.
+ */
+export const stampedFor = (a: Article, campaign: string): StampedArticle =>
+  [a, appendUtm(a.link, campaign)] as const
+
+/**
+ * Group articles by language in the recipient's preferred order,
+ * dropping languages with no items.
+ * @param langs Recipient languages, in order.
+ * @param articles Articles to group.
+ * @param campaign ISO-week campaign tag.
+ * @returns Non-empty per-language stamped groups.
+ */
+export const groupByLang = (
+  langs: ReadonlyArray<Lang>,
+  articles: ReadonlyArray<Article>,
+  campaign: string
+): LangGroups =>
+  langs
+    .map(lang => {
+      const items = articles
+        .filter(a => a.lang === lang)
+        .map(a => stampedFor(a, campaign))
+      return [lang, items] as const
+    })
+    .filter(([, items]) => items.length > 0)
+
+/**
+ * Pick the chrome dictionary for the subscriber's primary language.
+ * @param langs Recipient languages, in order.
+ * @returns Localised chrome strings.
+ */
+export const chromeFor = (langs: ReadonlyArray<Lang>): DigestChrome =>
+  CHROME[langs[0] ?? 'en']
+
+/**
+ * UTM-stamp both arms of a newspaper selection for the campaign.
+ * @param selection Announcements + current issues.
+ * @param campaign ISO-week campaign tag.
+ * @returns Stamped announcements + current pairs.
+ */
+export const stampNewspapers = (
+  selection: NewspaperSelection,
+  campaign: string
+): StampedNewspapers => ({
+  announcements: selection.announcements.map(a => stampedFor(a, campaign)),
+  current: selection.current.map(a => stampedFor(a, campaign)),
+})
+
+/**
+ * Choose the subject: the article-count line, or — when there are no
+ * new articles but a new issue is out — the new-issue announcement.
+ * @param chrome Localised strings.
+ * @param articleCount New-article count.
+ * @param announcements Freshly-published issues (may be empty).
+ * @returns Subject line.
+ */
+export const subjectFor = (
+  chrome: DigestChrome,
+  articleCount: number,
+  announcements: ReadonlyArray<Article>
+): string =>
+  articleCount === 0 && announcements.length > 0
+    ? chrome.newIssueSubject(announcements[0]?.title ?? '')
+    : chrome.subject(articleCount)

--- a/services/comms-worker/src/digest/render.test.ts
+++ b/services/comms-worker/src/digest/render.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import type { NewspaperSelection } from '../newspaper/classify'
 import type { Article } from '../rss/types'
 import type { Subscriber } from '../subscribers/types'
 import { renderDigest } from './render'
@@ -154,6 +155,91 @@ describe('renderDigest — headers + body invariants', () => {
     })
     expect(d.html).toContain('prefers-color-scheme: dark')
     expect(d.html).toContain('background:#1a1a1a')
+  })
+})
+
+const NEW_ISSUE: Article = {
+  guid: 'np-new',
+  title: 'Prometheus Weekly #7',
+  link: 'https://comprom.org/en/newspaper/weekly-7',
+  lang: 'en',
+  pubDate: '2026-06-05T08:00:00.000Z',
+}
+
+const OLD_ISSUE: Article = {
+  guid: 'np-old',
+  title: 'Prometheus Weekly #6',
+  link: 'https://comprom.org/en/newspaper/weekly-6',
+  lang: 'en',
+  pubDate: '2026-05-20T08:00:00.000Z',
+}
+
+describe('renderDigest — newspaper', () => {
+  it('renders a new issue at the top with the "New issue" banner + link', () => {
+    const newspapers: NewspaperSelection = {
+      announcements: [NEW_ISSUE],
+      current: [],
+    }
+    const d = renderDigest({
+      subscriber: { ...SUB, langs: ['en'] },
+      articles: ARTICLES.filter(a => a.lang === 'en'),
+      newspapers,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.html).toContain('New issue')
+    expect(d.html).toContain('Prometheus Weekly #7')
+    expect(d.html).toContain('en/newspaper/weekly-7?utm_source=newsletter')
+    expect(d.text).toContain('New issue: Prometheus Weekly #7')
+  })
+
+  it('renders the current issue at the foot with the "Current issue" label', () => {
+    const newspapers: NewspaperSelection = {
+      announcements: [],
+      current: [OLD_ISSUE],
+    }
+    const d = renderDigest({
+      subscriber: { ...SUB, langs: ['en'] },
+      articles: ARTICLES.filter(a => a.lang === 'en'),
+      newspapers,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.html).toContain('Current issue')
+    expect(d.html).toContain('Prometheus Weekly #6')
+    expect(d.text).toContain('Current issue: Prometheus Weekly #6')
+  })
+
+  it('falls back to the new-issue subject when there are no new articles', () => {
+    const newspapers: NewspaperSelection = {
+      announcements: [NEW_ISSUE],
+      current: [],
+    }
+    const d = renderDigest({
+      subscriber: { ...SUB, langs: ['en'] },
+      articles: [],
+      newspapers,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.subject).toBe(
+      'Communist Prometheus — new issue: Prometheus Weekly #7'
+    )
+  })
+
+  it('keeps the article-count subject when articles AND a new issue exist', () => {
+    const newspapers: NewspaperSelection = {
+      announcements: [NEW_ISSUE],
+      current: [],
+    }
+    const d = renderDigest({
+      subscriber: { ...SUB, langs: ['en'] },
+      articles: ARTICLES,
+      newspapers,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.subject).toBe('Communist Prometheus — 2 new articles')
   })
 })
 

--- a/services/comms-worker/src/digest/render.ts
+++ b/services/comms-worker/src/digest/render.ts
@@ -1,15 +1,22 @@
+import type { NewspaperSelection } from '../newspaper/classify'
 import type { Article } from '../rss/types'
-import type { Lang, Subscriber } from '../subscribers/types'
-import type { LangGroups, StampedArticle } from './html'
+import type { Subscriber } from '../subscribers/types'
 import { renderHtml } from './html'
-import { CHROME } from './i18n'
+import {
+  chromeFor,
+  EMPTY_NEWSPAPERS,
+  groupByLang,
+  stampNewspapers,
+  subjectFor,
+} from './render-helpers'
 import { renderText } from './text'
-import { appendUtm, isoWeekString } from './utm'
+import { isoWeekString } from './utm'
 
 /** Inputs accepted by {@link renderDigest}. */
 export type DigestRenderInput = {
   readonly subscriber: Subscriber
   readonly articles: ReadonlyArray<Article>
+  readonly newspapers?: NewspaperSelection
   readonly unsubscribeUrl: string
   readonly tickAt: Date
 }
@@ -25,25 +32,6 @@ export type Digest = {
 
 const POST_HEADER = 'List-Unsubscribe=One-Click'
 
-const stampedFor = (a: Article, campaign: string): StampedArticle =>
-  [a, appendUtm(a.link, campaign)] as const
-
-const groupByLang = (
-  langs: ReadonlyArray<Lang>,
-  articles: ReadonlyArray<Article>,
-  campaign: string
-): LangGroups =>
-  langs
-    .map(lang => {
-      const items = articles
-        .filter(a => a.lang === lang)
-        .map(a => stampedFor(a, campaign))
-      return [lang, items] as const
-    })
-    .filter(([, items]) => items.length > 0)
-
-const chromeFor = (langs: ReadonlyArray<Lang>) => CHROME[langs[0] ?? 'en']
-
 /**
  * Build the per-subscriber digest payload — subject, HTML body, text
  * body, and the two RFC-8058 List-Unsubscribe header values. Articles
@@ -57,10 +45,16 @@ export const renderDigest = (input: DigestRenderInput): Digest => {
   const chrome = chromeFor(input.subscriber.langs)
   const campaign = isoWeekString(input.tickAt)
   const groups = groupByLang(input.subscriber.langs, input.articles, campaign)
+  const selection = input.newspapers ?? EMPTY_NEWSPAPERS
+  const papers = stampNewspapers(selection, campaign)
   return {
-    subject: chrome.subject(input.articles.length),
-    html: renderHtml(chrome, groups, input.unsubscribeUrl),
-    text: renderText(chrome, groups, input.unsubscribeUrl),
+    subject: subjectFor(
+      chrome,
+      input.articles.length,
+      selection.announcements
+    ),
+    html: renderHtml(chrome, groups, papers, input.unsubscribeUrl),
+    text: renderText(chrome, groups, papers, input.unsubscribeUrl),
     listUnsubscribe: `<${input.unsubscribeUrl}>`,
     listUnsubscribePost: POST_HEADER,
   }

--- a/services/comms-worker/src/digest/text-newspaper.ts
+++ b/services/comms-worker/src/digest/text-newspaper.ts
@@ -1,0 +1,54 @@
+import type { StampedArticle, StampedNewspapers } from './html-shared'
+import type { DigestChrome } from './i18n-types'
+
+const line = (label: string, [issue, url]: StampedArticle): string =>
+  `${label}: ${issue.title}\n  ${url}`
+
+/**
+ * Plain-text new-issue announcements for the top of the digest.
+ * @param chrome Localised strings.
+ * @param issues Stamped issues published since the cutoff.
+ * @returns Text block, or '' when there are none.
+ */
+export const renderAnnouncementsText = (
+  chrome: DigestChrome,
+  issues: ReadonlyArray<StampedArticle>
+): string =>
+  issues.length === 0
+    ? ''
+    : issues.map(i => `★ ${line(chrome.newIssueLabel, i)}`).join('\n\n')
+
+/**
+ * Plain-text "current issue" lines for the foot of the digest.
+ * @param chrome Localised strings.
+ * @param issues Stamped issues predating the cutoff.
+ * @returns Text block, or '' when there are none.
+ */
+export const renderCurrentText = (
+  chrome: DigestChrome,
+  issues: ReadonlyArray<StampedArticle>
+): string =>
+  issues.length === 0
+    ? ''
+    : issues.map(i => line(chrome.currentIssueLabel, i)).join('\n\n')
+
+/**
+ * Assemble the optional newspaper text blocks around the article
+ * sections: announcements first, sections, then current issues.
+ * @param chrome Localised strings.
+ * @param sections Already-rendered per-language article sections.
+ * @param newspapers Stamped issues split into announcements + current.
+ * @returns Joined body, dropping empty blocks.
+ */
+export const composeBody = (
+  chrome: DigestChrome,
+  sections: string,
+  newspapers: StampedNewspapers
+): string =>
+  [
+    renderAnnouncementsText(chrome, newspapers.announcements),
+    sections,
+    renderCurrentText(chrome, newspapers.current),
+  ]
+    .filter(part => part.length > 0)
+    .join('\n\n')

--- a/services/comms-worker/src/digest/text.ts
+++ b/services/comms-worker/src/digest/text.ts
@@ -1,6 +1,7 @@
 import type { Lang } from '../subscribers/types'
-import type { LangGroups, StampedArticle } from './html'
+import type { LangGroups, StampedArticle, StampedNewspapers } from './html'
 import type { DigestChrome } from './i18n-types'
+import { composeBody } from './text-newspaper'
 
 const renderItem = ([article, url]: StampedArticle): string =>
   `· ${article.title}  (${article.pubDate.slice(0, 10)})\n  ${url}`
@@ -21,12 +22,14 @@ const renderGroup = (
  * unsubscribe URL at the bottom.
  * @param chrome Localised strings for the recipient.
  * @param groups Articles grouped by language, recipient-order.
+ * @param newspapers Stamped newspaper issues (top announcements + foot current).
  * @param unsubscribeUrl Per-recipient unsubscribe URL.
  * @returns Complete plain-text string.
  */
 export const renderText = (
   chrome: DigestChrome,
   groups: LangGroups,
+  newspapers: StampedNewspapers,
   unsubscribeUrl: string
 ): string => {
   const showHeaders = groups.length > 1
@@ -36,7 +39,7 @@ export const renderText = (
   return [
     chrome.intro,
     '',
-    sections,
+    composeBody(chrome, sections, newspapers),
     '',
     '---',
     chrome.unsubscribeNote,

--- a/services/comms-worker/src/dispatch/build-deps.ts
+++ b/services/comms-worker/src/dispatch/build-deps.ts
@@ -1,3 +1,4 @@
+import { createNewspaperFetcher } from '../newspaper/fetch'
 import { createResendClient } from '../resend/client'
 import { createRssFetcher } from '../rss/fetch'
 import { createSendLogRepo } from '../send-log/repo'
@@ -27,7 +28,8 @@ export const buildRuntimeDeps = (
   subscriberRepo: createRepo({ db: env.DB, now: nowIso }),
   sendLogRepo: createSendLogRepo({ db: env.DB }),
   settingsRepo: createSettingsRepo({ db: env.DB }),
-  rss: createRssFetcher(),
+  rss: createRssFetcher({ base: env.CONTENT_BASE_URL }),
+  newspaper: createNewspaperFetcher({ base: env.CONTENT_BASE_URL }),
   resend: createResendClient({ apiKey: env.RESEND_API_KEY }),
   secret: env.UNSUBSCRIBE_SECRET,
   fromAddress: env.FROM_ADDRESS ?? DEFAULT_FROM,

--- a/services/comms-worker/src/dispatch/build-input.ts
+++ b/services/comms-worker/src/dispatch/build-input.ts
@@ -1,4 +1,5 @@
 import { type Digest, renderDigest } from '../digest/render'
+import type { NewspaperSelection } from '../newspaper/classify'
 import type { SendInput } from '../resend/types'
 import type { Article } from '../rss/types'
 import type { Subscriber } from '../subscribers/types'
@@ -29,18 +30,21 @@ const toSendInput = (
  * @param ctx Static tick-wide context.
  * @param sub The recipient.
  * @param delta Articles the subscriber will receive.
+ * @param newspapers Newspaper issues split into announcements + current.
  * @returns Fully-populated Resend send input.
  */
 export const buildSendInput = async (
   ctx: DispatchContext,
   sub: Subscriber,
-  delta: ReadonlyArray<Article>
+  delta: ReadonlyArray<Article>,
+  newspapers: NewspaperSelection
 ): Promise<SendInput> => {
   const token = await signUnsubscribeToken(sub.id, ctx.secret)
   const url = `${ctx.publicBaseUrl}/unsubscribe?t=${token}`
   const d = renderDigest({
     subscriber: sub,
     articles: delta,
+    newspapers,
     unsubscribeUrl: url,
     tickAt: ctx.tickAt,
   })

--- a/services/comms-worker/src/dispatch/context.ts
+++ b/services/comms-worker/src/dispatch/context.ts
@@ -1,3 +1,4 @@
+import type { IssuesByLang } from '../newspaper/fetch'
 import type { ResendClient } from '../resend/types'
 import type { SendLogRepo } from '../send-log/repo'
 import type { SubscriberRepo } from '../subscribers/repo'
@@ -13,5 +14,6 @@ export type DispatchContext = {
   readonly publicBaseUrl: string
   readonly tickAt: Date
   readonly byLang: ArticlesByLang
+  readonly newspapersByLang: IssuesByLang
   readonly cutoffMs: number | undefined
 }

--- a/services/comms-worker/src/dispatch/dispatch-one.ts
+++ b/services/comms-worker/src/dispatch/dispatch-one.ts
@@ -1,4 +1,5 @@
 import { computeDelta } from '../delta/calculator'
+import { classifyNewspapers } from '../newspaper/classify'
 import type { Subscriber } from '../subscribers/types'
 import { buildSendInput } from './build-input'
 import type { DispatchContext } from './context'
@@ -8,8 +9,12 @@ import { recordFailed, recordSent } from './record'
 export type DispatchOutcome = 'sent' | 'failed' | 'skipped'
 
 /**
- * Dispatch one subscriber for the given tick: compute the delta,
- * skip on empty, otherwise render + send + log per design §3.2.
+ * Dispatch one subscriber for the given tick: compute the article
+ * delta and the latest newspaper issue per language. Skip only when
+ * there is neither a new article nor a freshly-published issue; a new
+ * issue alone is reason enough to send. A "current issue" reference
+ * (already-announced) never triggers a send on its own — it rides
+ * along at the foot when something else is going out.
  * @param ctx Static tick-wide context.
  * @param sub The recipient.
  * @returns Outcome label used by the orchestrator summary.
@@ -19,12 +24,17 @@ export const dispatchOne = async (
   sub: Subscriber
 ): Promise<DispatchOutcome> => {
   const delta = computeDelta(sub, ctx.byLang, ctx.cutoffMs)
-  if (delta.length === 0) return 'skipped'
-  const result = await ctx.resend.send(await buildSendInput(ctx, sub, delta))
+  const papers = classifyNewspapers(sub, ctx.newspapersByLang, ctx.cutoffMs)
+  if (delta.length === 0 && papers.announcements.length === 0)
+    return 'skipped'
+  const count = delta.length + papers.announcements.length
+  const result = await ctx.resend.send(
+    await buildSendInput(ctx, sub, delta, papers)
+  )
   if (result.ok) {
-    await recordSent(ctx, sub, delta.length, result.id)
+    await recordSent(ctx, sub, count, result.id)
     return 'sent'
   }
-  await recordFailed(ctx, sub, delta.length, result.error)
+  await recordFailed(ctx, sub, count, result.error)
   return 'failed'
 }

--- a/services/comms-worker/src/dispatch/run-helpers.ts
+++ b/services/comms-worker/src/dispatch/run-helpers.ts
@@ -1,3 +1,4 @@
+import type { IssuesByLang } from '../newspaper/fetch'
 import type { DispatchContext } from './context'
 import type { DispatchOutcome } from './dispatch-one'
 import type { ArticlesByLang } from './fetch-articles'
@@ -38,12 +39,14 @@ export const summarise = (
  * and the resolved cutoff.
  * @param d Dispatch deps.
  * @param byLang Articles grouped by language for the tick.
+ * @param newspapersByLang Latest newspaper issue per language for the tick.
  * @param cutoffMs Resolved cutoff (undefined = no cutoff yet).
  * @returns DispatchContext.
  */
 export const buildCtx = (
   d: RunDispatchDeps,
   byLang: ArticlesByLang,
+  newspapersByLang: IssuesByLang,
   cutoffMs: number | undefined
 ): DispatchContext => ({
   subscriberRepo: d.subscriberRepo,
@@ -54,5 +57,6 @@ export const buildCtx = (
   publicBaseUrl: d.publicBaseUrl,
   tickAt: d.tickAt,
   byLang,
+  newspapersByLang,
   cutoffMs,
 })

--- a/services/comms-worker/src/dispatch/run.test.ts
+++ b/services/comms-worker/src/dispatch/run.test.ts
@@ -62,14 +62,18 @@ beforeEach(() => {
   settings = createSettingsRepo({ db })
 })
 
+const noIssue = async (): Promise<Article | undefined> => undefined
+
 const baseDeps = (
   rss: (l: Lang) => Promise<ReadonlyArray<Article>>,
-  resend: ResendClient
+  resend: ResendClient,
+  newspaper: (l: Lang) => Promise<Article | undefined> = noIssue
 ) => ({
   subscriberRepo: subs,
   sendLogRepo: log,
   settingsRepo: settings,
   rss,
+  newspaper,
   resend,
   secret: SECRET,
   fromAddress: FROM,
@@ -132,6 +136,48 @@ describe('runDispatch — happy path', () => {
       resendId: 're_42',
       articleCount: 3,
     })
+  })
+})
+
+describe('runDispatch — new newspaper issue with no new articles', () => {
+  it('sends when only a fresh issue exists past the cutoff', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await settings.setCutoffAt('2026-06-04T00:00:00.000Z')
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-01T00:00:00.000Z' })],
+    })
+    const fresh = article({
+      guid: 'np',
+      lang: 'ru',
+      link: 'https://comprom.org/ru/newspaper/issue-9',
+      pubDate: '2026-06-05T00:00:00.000Z',
+    })
+    const resend = buildResend(() => ({ ok: true, id: 're_np' }))
+    const summary = await runDispatch(
+      baseDeps(rss.fn, resend.client, async () => fresh)
+    )
+    expect(summary).toMatchObject({ sent: 1, failed: 0, skipped: 0 })
+    expect(resend.sends).toHaveLength(1)
+    expect(resend.sends[0]?.html).toContain('ru/newspaper/issue-9')
+  })
+
+  it('skips when the only issue predates the cutoff and nothing is new', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await settings.setCutoffAt('2026-06-04T00:00:00.000Z')
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-01T00:00:00.000Z' })],
+    })
+    const old = article({
+      guid: 'np-old',
+      lang: 'ru',
+      pubDate: '2026-06-02T00:00:00.000Z',
+    })
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    const summary = await runDispatch(
+      baseDeps(rss.fn, resend.client, async () => old)
+    )
+    expect(summary).toMatchObject({ sent: 0, failed: 0, skipped: 1 })
+    expect(resend.sends).toHaveLength(0)
   })
 })
 

--- a/services/comms-worker/src/dispatch/run.ts
+++ b/services/comms-worker/src/dispatch/run.ts
@@ -1,4 +1,5 @@
 import { logEvent } from '../log/structured'
+import { fetchLatestIssues } from '../newspaper/fetch-issues'
 import { advanceCutoff, loadCutoffMs } from './cutoff-cycle'
 import { type DispatchOutcome, dispatchOne } from './dispatch-one'
 import { fetchAllLangs } from './fetch-articles'
@@ -25,7 +26,11 @@ export const runDispatch = async (
     d.subscriberRepo.listActive(),
     loadCutoffMs(d),
   ])
-  const ctx = buildCtx(d, await fetchAllLangs(subs, d.rss), cutoffMs)
+  const [byLang, newspapersByLang] = await Promise.all([
+    fetchAllLangs(subs, d.rss),
+    fetchLatestIssues(subs, d.newspaper),
+  ])
+  const ctx = buildCtx(d, byLang, newspapersByLang, cutoffMs)
   const outcomes: DispatchOutcome[] = []
   for (const sub of subs) outcomes.push(await dispatchOne(ctx, sub))
   await advanceCutoff(d, outcomes.includes('sent'))

--- a/services/comms-worker/src/dispatch/runtime-env.ts
+++ b/services/comms-worker/src/dispatch/runtime-env.ts
@@ -7,6 +7,13 @@ export type DispatchEnv = {
   readonly UNSUBSCRIBE_SECRET: string
   readonly FROM_ADDRESS?: string
   readonly PUBLIC_BASE_URL?: string
+  /**
+   * Base URL of the public content site the digest reads RSS +
+   * newspaper feeds from. Unset on prod (defaults to comprom.org);
+   * the develop env points it at dev.comprom.org so test mailings
+   * never touch production content.
+   */
+  readonly CONTENT_BASE_URL?: string
 }
 
 /** Default sender displayed in the From header. */

--- a/services/comms-worker/src/dispatch/types.ts
+++ b/services/comms-worker/src/dispatch/types.ts
@@ -1,3 +1,4 @@
+import type { NewspaperFetcher } from '../newspaper/fetch'
 import type { ResendClient } from '../resend/types'
 import type { RssFetcher } from '../rss/fetch'
 import type { SendLogRepo } from '../send-log/repo'
@@ -10,6 +11,7 @@ export type RunDispatchDeps = {
   readonly sendLogRepo: SendLogRepo
   readonly settingsRepo: SettingsRepo
   readonly rss: RssFetcher
+  readonly newspaper: NewspaperFetcher
   readonly resend: ResendClient
   readonly secret: string
   readonly fromAddress: string

--- a/services/comms-worker/src/newspaper/classify.test.ts
+++ b/services/comms-worker/src/newspaper/classify.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type { Article } from '../rss/types'
+import type { Subscriber } from '../subscribers/types'
+import { classifyNewspapers } from './classify'
+import type { IssuesByLang } from './fetch'
+
+const SUB: Subscriber = {
+  id: 1,
+  email: 'r@e.test',
+  langs: ['ru', 'en'],
+  status: 'active',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  lastSentAt: undefined,
+  unsubscribedAt: undefined,
+}
+
+const issue = (overrides: Partial<Article>): Article => ({
+  guid: 'g',
+  title: 'Issue #1',
+  link: 'https://comprom.org/ru/newspaper/issue-1',
+  lang: 'ru',
+  pubDate: '2026-06-10T00:00:00.000Z',
+  ...overrides,
+})
+
+const CUTOFF = Date.parse('2026-06-05T00:00:00.000Z')
+
+describe('classifyNewspapers', () => {
+  it('routes an issue published after the cutoff into announcements', () => {
+    const byLang: IssuesByLang = {
+      ru: issue({ guid: 'ru-2', pubDate: '2026-06-08T00:00:00.000Z' }),
+    }
+    const sel = classifyNewspapers({ ...SUB, langs: ['ru'] }, byLang, CUTOFF)
+    expect(sel.announcements.map(a => a.guid)).toEqual(['ru-2'])
+    expect(sel.current).toEqual([])
+  })
+
+  it('routes an issue predating the cutoff into current', () => {
+    const byLang: IssuesByLang = {
+      ru: issue({ guid: 'ru-1', pubDate: '2026-06-01T00:00:00.000Z' }),
+    }
+    const sel = classifyNewspapers({ ...SUB, langs: ['ru'] }, byLang, CUTOFF)
+    expect(sel.announcements).toEqual([])
+    expect(sel.current.map(a => a.guid)).toEqual(['ru-1'])
+  })
+
+  it('treats every issue as new when there is no cutoff yet', () => {
+    const byLang: IssuesByLang = {
+      ru: issue({ guid: 'ru-1', pubDate: '2020-01-01T00:00:00.000Z' }),
+    }
+    const sel = classifyNewspapers(
+      { ...SUB, langs: ['ru'] },
+      byLang,
+      undefined
+    )
+    expect(sel.announcements.map(a => a.guid)).toEqual(['ru-1'])
+  })
+
+  it('de-duplicates the same issue shared across languages by guid', () => {
+    const shared = issue({
+      guid: 'shared',
+      pubDate: '2026-06-09T00:00:00.000Z',
+    })
+    const byLang: IssuesByLang = { ru: shared, en: shared }
+    const sel = classifyNewspapers(SUB, byLang, CUTOFF)
+    expect(sel.announcements).toHaveLength(1)
+    expect(sel.announcements[0]?.guid).toBe('shared')
+  })
+
+  it('drops an issue with an unparseable date (never announced)', () => {
+    const byLang: IssuesByLang = {
+      ru: issue({ guid: 'bad', pubDate: 'not-a-date' }),
+    }
+    const sel = classifyNewspapers({ ...SUB, langs: ['ru'] }, byLang, CUTOFF)
+    expect(sel.announcements).toEqual([])
+    expect(sel.current.map(a => a.guid)).toEqual(['bad'])
+  })
+})

--- a/services/comms-worker/src/newspaper/classify.ts
+++ b/services/comms-worker/src/newspaper/classify.ts
@@ -1,0 +1,49 @@
+import type { Article } from '../rss/types'
+import type { Subscriber } from '../subscribers/types'
+import type { IssuesByLang } from './fetch'
+
+/**
+ * The newspaper issues a subscriber sees, split by how they appear:
+ * `announcements` are issues published since the cutoff (a NEW issue —
+ * goes first, with the "new issue" banner); `current` are issues that
+ * predate the cutoff (already announced — go last, as "current issue").
+ * Per language at most one of the two carries that language's latest
+ * issue.
+ */
+export type NewspaperSelection = {
+  readonly announcements: ReadonlyArray<Article>
+  readonly current: ReadonlyArray<Article>
+}
+
+const isNew = (issue: Article, cutoffMs: number | undefined): boolean => {
+  const ms = Date.parse(issue.pubDate)
+  if (!Number.isFinite(ms)) return false
+  return cutoffMs === undefined || ms > cutoffMs
+}
+
+/**
+ * Classify each of a subscriber's languages' latest issue as a NEW
+ * announcement (published after the cutoff) or the CURRENT issue
+ * (already announced). De-duplicates the same issue shared across
+ * languages by `guid`, preserving the subscriber's language order.
+ * @param sub The recipient.
+ * @param byLang Latest issue per language.
+ * @param cutoffMs Global cutoff in ms (undefined = no cutoff yet).
+ * @returns Issues split into announcements + current.
+ */
+export const classifyNewspapers = (
+  sub: Subscriber,
+  byLang: IssuesByLang,
+  cutoffMs: number | undefined
+): NewspaperSelection => {
+  const announcements: Article[] = []
+  const current: Article[] = []
+  const seen = new Set<string>()
+  for (const lang of sub.langs) {
+    const issue = byLang[lang]
+    if (issue === undefined || seen.has(issue.guid)) continue
+    seen.add(issue.guid)
+    ;(isNew(issue, cutoffMs) ? announcements : current).push(issue)
+  }
+  return { announcements, current }
+}

--- a/services/comms-worker/src/newspaper/fetch-issues.ts
+++ b/services/comms-worker/src/newspaper/fetch-issues.ts
@@ -1,0 +1,31 @@
+import type { Lang, Subscriber } from '../subscribers/types'
+import type { IssuesByLang, NewspaperFetcher } from './fetch'
+
+const uniqueLangs = (
+  subs: ReadonlyArray<Subscriber>
+): ReadonlyArray<Lang> => {
+  const set = new Set<Lang>()
+  for (const s of subs) {
+    for (const l of s.langs) set.add(l)
+  }
+  return [...set]
+}
+
+/**
+ * Fetch the latest newspaper issue for every language any subscriber
+ * wants, once per tick. Languages with no issue are simply absent.
+ * @param subs Active subscribers for the current tick.
+ * @param fetcher Per-language newspaper fetcher.
+ * @returns Latest issue grouped by language.
+ */
+export const fetchLatestIssues = async (
+  subs: ReadonlyArray<Subscriber>,
+  fetcher: NewspaperFetcher
+): Promise<IssuesByLang> => {
+  const acc: IssuesByLang = {}
+  for (const lang of uniqueLangs(subs)) {
+    const issue = await fetcher(lang)
+    if (issue !== undefined) acc[lang] = issue
+  }
+  return acc
+}

--- a/services/comms-worker/src/newspaper/fetch.ts
+++ b/services/comms-worker/src/newspaper/fetch.ts
@@ -1,0 +1,47 @@
+import { FALLBACK_BASE } from '../rss/fetch'
+import { parseRss } from '../rss/parse'
+import type { Article } from '../rss/types'
+import type { Lang } from '../subscribers/types'
+
+/** The latest newspaper issue for a language, or none. */
+export type IssuesByLang = Partial<Record<Lang, Article>>
+
+type Deps = {
+  readonly base?: string
+  readonly fetch?: typeof fetch
+}
+
+/** Fetcher returning the newest published issue for one language. */
+export type NewspaperFetcher = (lang: Lang) => Promise<Article | undefined>
+
+const safeFetch = async (
+  doFetch: typeof fetch,
+  url: string
+): Promise<string | undefined> => {
+  try {
+    const res = await doFetch(url)
+    return res.ok ? await res.text() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const newest = (items: ReadonlyArray<Article>): Article | undefined =>
+  [...items].sort((a, b) => Date.parse(b.pubDate) - Date.parse(a.pubDate))[0]
+
+/**
+ * Build a per-language newspaper fetcher bound to the given base URL.
+ * Reads `/<lang>/newspaper.xml` and returns the newest published
+ * issue (or undefined on network/parse failure or an empty feed).
+ * @param d Injected base + fetch.
+ * @returns Fetcher returning the latest issue for one language.
+ */
+export const createNewspaperFetcher = (d: Deps = {}): NewspaperFetcher => {
+  const base = d.base ?? FALLBACK_BASE
+  const doFetch = d.fetch ?? globalThis.fetch.bind(globalThis)
+  return async lang => {
+    const body = await safeFetch(doFetch, `${base}/${lang}/newspaper.xml`)
+    if (body === undefined) return undefined
+    return newest(parseRss(body, lang))
+  }
+}

--- a/services/comms-worker/wrangler.jsonc
+++ b/services/comms-worker/wrangler.jsonc
@@ -34,6 +34,23 @@
       "name": "comms-worker-develop",
       "routes": [
         { "pattern": "dev-lists.comprom.org", "custom_domain": true }
+      ],
+      // Named envs do NOT inherit top-level vars / bindings — repeat
+      // them here. CONTENT_BASE_URL points the digest at the develop
+      // public site so test mailings never read production content.
+      "vars": {
+        "VERSION": "0.2.0",
+        "ADMIN_HOSTNAME": "admin.comprom.org",
+        "ALLOWED_ORIGIN": "https://admin.comprom.org",
+        "CONTENT_BASE_URL": "https://dev.comprom.org",
+        "PUBLIC_BASE_URL": "https://dev-lists.comprom.org"
+      },
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "comms-develop",
+          "database_id": "2f0dfe61-df6e-4eb1-acca-6b36fe66d7d6"
+        }
       ]
     }
   }


### PR DESCRIPTION
## What

The newsletter digest now always surfaces the latest newspaper issue per language:

- An issue published **since the cutoff** leads the digest as a "new issue" announcement (and, when there are no new articles, drives the subject line).
- An already-announced issue rides at the **foot** as the "current issue" reference.
- Links point at `/<lang>/newspaper/<slug>`.
- A fresh issue alone now justifies a send; a "current issue" never triggers one on its own.

Content base is configurable via `CONTENT_BASE_URL` (defaults to comprom.org) so the develop env reads feeds from dev.comprom.org. Also provisions the develop env (own `comms-develop` D1 + vars).

## Tests

210 passing (11 new): newspaper classification (new vs current, dedup, no-cutoff, bad date), digest render (announcement top / current foot / subject fallback), dispatch on new-issue-only. biome + oxlint + jsdoc clean.

## Verified live

Both scenarios sent end-to-end on `dev-lists.comprom.org` reading `dev.comprom.org` feeds: new-issue-leads and current-issue-at-foot, both `status: sent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)