### PR TITLE
feat(comms): choose test-send recipients + confirm subscriber removal

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,12 +50,16 @@ jobs:
             echo "VITE_GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_DEVELOP" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_DEVELOP" >> "$GITHUB_ENV"
+            # dev-admin talks to the develop comms worker so targeted
+            # test sends never reach production subscribers.
+            echo "VITE_COMMS_BASE=https://dev-lists.comprom.org" >> "$GITHUB_ENV"
             echo "GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy --env develop" >> "$GITHUB_ENV"
           else
             echo "VITE_GITHUB_BRANCH=master" >> "$GITHUB_ENV"
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_MASTER" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_MASTER" >> "$GITHUB_ENV"
+            echo "VITE_COMMS_BASE=https://lists.comprom.org" >> "$GITHUB_ENV"
             echo "GITHUB_BRANCH=master" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy" >> "$GITHUB_ENV"
           fi

--- a/e2e/comms-walkthrough/scenario.spec.ts
+++ b/e2e/comms-walkthrough/scenario.spec.ts
@@ -280,12 +280,14 @@ test('comms walkthrough recording', async ({ page }) => {
     await titleCard(page, {
       eyebrow: 'Сцена 4',
       title: 'Удалить подписчика',
-      sub: 'Кнопка ✕ — без подтверждения, без отмены',
+      sub: 'Кнопка ✕ открывает диалог подтверждения',
     })
     const row = page
       .getByTestId('subscriber-row')
       .filter({ hasText: 'demo-reader@example.test' })
     await row.getByTestId('subscriber-remove').click()
+    await sleep(1_200)
+    await page.getByTestId('remove-subscriber-confirm').click()
     await expect(
       page
         .getByTestId('subscriber-row')
@@ -343,13 +345,15 @@ test('comms walkthrough recording', async ({ page }) => {
     await titleCard(page, {
       eyebrow: 'Сцена 5в',
       title: 'Кнопка тестовой отправки',
-      sub: 'Отправляет дайджест прямо сейчас, расписание не двигает',
+      sub: 'Выбери получателей галочками, отправь прямо сейчас — расписание не двигается',
     })
     await page.getByTestId('force-dispatch-panel').scrollIntoViewIfNeeded()
     const clear = await highlightSelector(
       page,
       '[data-testid="force-dispatch-panel"]'
     )
+    await page.getByTestId('force-dispatch-select-all').click()
+    await sleep(1_000)
     await page.getByTestId('force-dispatch-start').click()
     await sleep(1_400)
     await page.getByTestId('force-dispatch-confirm').click()

--- a/scripts/check-vue-template-depth/config.ts
+++ b/scripts/check-vue-template-depth/config.ts
@@ -27,6 +27,7 @@ export const config: Config = {
     'src/views/CommsView/CommsView.vue',
     'src/views/CommsView/CommsSection.vue',
     'src/views/CommsView/ForceDispatchPanel.vue',
+    'src/views/CommsView/RemoveSubscriberDialog.vue',
     'src/views/CommsView/CutoffEditor.vue',
     'src/views/FeaturesView/FeaturesView.vue',
   ],

--- a/services/comms-worker/src/dispatch/build-deps.ts
+++ b/services/comms-worker/src/dispatch/build-deps.ts
@@ -19,11 +19,13 @@ const nowIso = (): string => new Date().toISOString()
  * the orchestrator calls into them.
  * @param env Worker bindings + secrets.
  * @param tickAt Tick moment used as the `tick_at` stamp on send_log rows.
+ * @param targetIds Optional subscriber-id subset for a targeted test send.
  * @returns Inputs for {@link runDispatch}.
  */
 export const buildRuntimeDeps = (
   env: DispatchEnv,
-  tickAt: Date
+  tickAt: Date,
+  targetIds?: ReadonlyArray<number>
 ): RunDispatchDeps => ({
   subscriberRepo: createRepo({ db: env.DB, now: nowIso }),
   sendLogRepo: createSendLogRepo({ db: env.DB }),
@@ -35,4 +37,5 @@ export const buildRuntimeDeps = (
   fromAddress: env.FROM_ADDRESS ?? DEFAULT_FROM,
   publicBaseUrl: env.PUBLIC_BASE_URL ?? DEFAULT_PUBLIC_BASE,
   tickAt,
+  targetIds,
 })

--- a/services/comms-worker/src/dispatch/force-route.test.ts
+++ b/services/comms-worker/src/dispatch/force-route.test.ts
@@ -86,4 +86,23 @@ describe('POST /api/dispatch — ?force=1 opt-in', () => {
     const body = (await res.json()) as { sent: number; failed: number }
     expect(body.sent).toBe(1)
   })
+
+  it('forwards the selected subscriber ids as the dispatcher target', async () => {
+    const req = new Request('http://x/api/dispatch?force=1', {
+      method: 'POST',
+      headers: {
+        Cookie: 'comprom_session=tok',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ subscriberIds: [2, 5] }),
+    })
+    const res = await build().fetch(req, env)
+    expect(res.status).toBe(202)
+    expect(dispatcher).toHaveBeenCalledWith(env, expect.any(Date), [2, 5])
+  })
+
+  it('passes undefined target when no body is supplied (everyone)', async () => {
+    await build().fetch(reqWithAccess('/api/dispatch?force=1'), env)
+    expect(dispatcher).toHaveBeenCalledWith(env, expect.any(Date), undefined)
+  })
 })

--- a/services/comms-worker/src/dispatch/force-route.ts
+++ b/services/comms-worker/src/dispatch/force-route.ts
@@ -9,19 +9,45 @@ type App = Hono<{ Bindings: object; Variables: object }>
 /** Test-time dispatcher seam (mirrors {@link Dispatcher} in scheduled.ts). */
 export type ForceDispatcher = (
   env: DispatchEnv,
-  tickAt: Date
+  tickAt: Date,
+  targetIds?: ReadonlyArray<number>
 ) => Promise<DispatchSummary>
 
-const defaultDispatcher: ForceDispatcher = (env, tickAt) =>
-  runDispatch(buildRuntimeDeps(env, tickAt))
+const defaultDispatcher: ForceDispatcher = (env, tickAt, targetIds) =>
+  runDispatch(buildRuntimeDeps(env, tickAt, targetIds))
 
 const isOptedIn = (c: Context): boolean => c.req.query('force') === '1'
+
+const isPosInt = (n: unknown): n is number =>
+  typeof n === 'number' && Number.isInteger(n) && n > 0
+
+/**
+ * Read the optional `{subscriberIds:number[]}` request body. A present
+ * array selects a targeted test send (possibly empty = nobody); an
+ * absent / malformed field returns undefined = dispatch everyone.
+ * @param c Hono context.
+ * @returns Selected ids, or undefined for the full active list.
+ */
+const parseTargetIds = async (
+  c: Context
+): Promise<ReadonlyArray<number> | undefined> => {
+  const body = (await c.req.json().catch(() => undefined)) as
+    | { readonly subscriberIds?: unknown }
+    | undefined
+  const ids = body?.subscriberIds
+  return Array.isArray(ids) ? ids.filter(isPosInt) : undefined
+}
 
 const buildHandler =
   (dispatcher: ForceDispatcher) =>
   async (c: Context): Promise<Response> => {
     if (!isOptedIn(c)) return c.json({ error: 'not_found' }, 404)
-    const summary = await dispatcher(c.env as DispatchEnv, new Date())
+    const targetIds = await parseTargetIds(c)
+    const summary = await dispatcher(
+      c.env as DispatchEnv,
+      new Date(),
+      targetIds
+    )
     return c.json(summary, 202)
   }
 

--- a/services/comms-worker/src/dispatch/run-helpers.ts
+++ b/services/comms-worker/src/dispatch/run-helpers.ts
@@ -1,10 +1,28 @@
 import type { IssuesByLang } from '../newspaper/fetch'
+import type { Subscriber } from '../subscribers/types'
 import type { DispatchContext } from './context'
 import type { DispatchOutcome } from './dispatch-one'
 import type { ArticlesByLang } from './fetch-articles'
 import type { DispatchSummary, RunDispatchDeps } from './types'
 
 const MS_PER_DAY = 86_400_000
+
+/**
+ * Narrow the active list to a targeted recipient set. Returns the
+ * full list unchanged when no target ids are supplied (the scheduled
+ * path); otherwise keeps only subscribers whose id is selected.
+ * @param active Active subscribers for the tick.
+ * @param targetIds Selected ids, or undefined for "everyone".
+ * @returns The subscribers to dispatch.
+ */
+export const selectRecipients = (
+  active: ReadonlyArray<Subscriber>,
+  targetIds: ReadonlyArray<number> | undefined
+): ReadonlyArray<Subscriber> => {
+  if (targetIds === undefined) return active
+  const wanted = new Set(targetIds)
+  return active.filter(s => wanted.has(s.id))
+}
 
 /**
  * Compute the retention cutoff ISO — `tickAt - retentionDays`. Used

--- a/services/comms-worker/src/dispatch/run-prepare.ts
+++ b/services/comms-worker/src/dispatch/run-prepare.ts
@@ -1,0 +1,35 @@
+import { fetchLatestIssues } from '../newspaper/fetch-issues'
+import type { Subscriber } from '../subscribers/types'
+import type { DispatchContext } from './context'
+import { loadCutoffMs } from './cutoff-cycle'
+import { fetchAllLangs } from './fetch-articles'
+import { buildCtx, selectRecipients } from './run-helpers'
+import type { RunDispatchDeps } from './types'
+
+/** The materialised context plus the recipients it will dispatch to. */
+export type Prepared = {
+  readonly ctx: DispatchContext
+  readonly subs: ReadonlyArray<Subscriber>
+}
+
+/**
+ * Load the tick inputs once: the active list (narrowed to any target
+ * ids), the cutoff, and the RSS + newspaper feeds for the recipients'
+ * languages, then materialise the shared dispatch context.
+ * @param d Injected dependencies.
+ * @returns The dispatch context and the recipients to send to.
+ */
+export const prepareDispatch = async (
+  d: RunDispatchDeps
+): Promise<Prepared> => {
+  const [active, cutoffMs] = await Promise.all([
+    d.subscriberRepo.listActive(),
+    loadCutoffMs(d),
+  ])
+  const subs = selectRecipients(active, d.targetIds)
+  const [byLang, newspapersByLang] = await Promise.all([
+    fetchAllLangs(subs, d.rss),
+    fetchLatestIssues(subs, d.newspaper),
+  ])
+  return { ctx: buildCtx(d, byLang, newspapersByLang, cutoffMs), subs }
+}

--- a/services/comms-worker/src/dispatch/run.test.ts
+++ b/services/comms-worker/src/dispatch/run.test.ts
@@ -181,6 +181,40 @@ describe('runDispatch — new newspaper issue with no new articles', () => {
   })
 })
 
+describe('runDispatch — targeted test send', () => {
+  it('dispatches only the targeted ids and leaves the cutoff untouched', async () => {
+    const a = await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await subs.insert({ email: 'b@b.c', langs: ['ru'] })
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-05T00:00:00.000Z' })],
+    })
+    const resend = buildResend(() => ({ ok: true, id: 're_t' }))
+    const summary = await runDispatch({
+      ...baseDeps(rss.fn, resend.client),
+      targetIds: [a.id],
+    })
+    expect(summary).toMatchObject({ sent: 1, failed: 0, skipped: 0 })
+    expect(resend.sends).toHaveLength(1)
+    expect(resend.sends[0]?.to).toBe('a@b.c')
+    // targeted sends must NOT advance the shared watermark.
+    expect(await settings.getCutoffAt()).toBeUndefined()
+  })
+
+  it('sends to nobody when the targeted set is empty', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    const rss = buildRss({
+      ru: [article({ guid: 'a', pubDate: '2026-06-05T00:00:00.000Z' })],
+    })
+    const resend = buildResend(() => ({ ok: true, id: 'r' }))
+    const summary = await runDispatch({
+      ...baseDeps(rss.fn, resend.client),
+      targetIds: [],
+    })
+    expect(summary).toMatchObject({ sent: 0, failed: 0, skipped: 0 })
+    expect(resend.sends).toHaveLength(0)
+  })
+})
+
 describe('runDispatch — RSS caching across subscribers', () => {
   it('fetches each unique lang exactly once even with many subscribers', async () => {
     await subs.insert({ email: 'a@b.c', langs: ['ru'] })

--- a/services/comms-worker/src/dispatch/run.ts
+++ b/services/comms-worker/src/dispatch/run.ts
@@ -1,9 +1,8 @@
 import { logEvent } from '../log/structured'
-import { fetchLatestIssues } from '../newspaper/fetch-issues'
-import { advanceCutoff, loadCutoffMs } from './cutoff-cycle'
+import { advanceCutoff } from './cutoff-cycle'
 import { type DispatchOutcome, dispatchOne } from './dispatch-one'
-import { fetchAllLangs } from './fetch-articles'
-import { buildCtx, retentionCutoffIso, summarise } from './run-helpers'
+import { retentionCutoffIso, summarise } from './run-helpers'
+import { prepareDispatch } from './run-prepare'
 import type { DispatchSummary, RunDispatchDeps } from './types'
 
 const DEFAULT_RETENTION_DAYS = 90
@@ -22,18 +21,11 @@ export const runDispatch = async (
 ): Promise<DispatchSummary> => {
   const start = Date.now()
   logEvent('tick.start', { tickAt: d.tickAt.toISOString() })
-  const [subs, cutoffMs] = await Promise.all([
-    d.subscriberRepo.listActive(),
-    loadCutoffMs(d),
-  ])
-  const [byLang, newspapersByLang] = await Promise.all([
-    fetchAllLangs(subs, d.rss),
-    fetchLatestIssues(subs, d.newspaper),
-  ])
-  const ctx = buildCtx(d, byLang, newspapersByLang, cutoffMs)
+  const { ctx, subs } = await prepareDispatch(d)
   const outcomes: DispatchOutcome[] = []
   for (const sub of subs) outcomes.push(await dispatchOne(ctx, sub))
-  await advanceCutoff(d, outcomes.includes('sent'))
+  const advanced = d.targetIds === undefined && outcomes.includes('sent')
+  await advanceCutoff(d, advanced)
   await d.sendLogRepo.purgeOlderThan(
     retentionCutoffIso(d.tickAt, d.retentionDays ?? DEFAULT_RETENTION_DAYS)
   )

--- a/services/comms-worker/src/dispatch/types.ts
+++ b/services/comms-worker/src/dispatch/types.ts
@@ -18,6 +18,13 @@ export type RunDispatchDeps = {
   readonly publicBaseUrl: string
   readonly tickAt: Date
   readonly retentionDays?: number
+  /**
+   * When set, dispatch only these subscriber ids (a targeted test
+   * send) and DO NOT advance the global cutoff — otherwise a test to
+   * a subset would move the watermark for everyone. Unset on the
+   * scheduled path: full active list, cutoff advances as usual.
+   */
+  readonly targetIds?: ReadonlyArray<number>
 }
 
 /** Per-tick summary returned by {@link runDispatch}. */

--- a/src/stores/dispatch-api.ts
+++ b/src/stores/dispatch-api.ts
@@ -1,4 +1,4 @@
-import { commsFetch, ensureOk } from './comms-http'
+import { commsFetch, ensureOk, jsonHeaders } from './comms-http'
 
 /** Shape of the `/api/dispatch?force=1` worker response. */
 export type ForceDispatchResult = {
@@ -20,16 +20,32 @@ const isForceDispatchResult = (
   typeof value['skipped'] === 'number' &&
   typeof value['durationMs'] === 'number'
 
+const dispatchInit = (
+  subscriberIds: readonly number[] | undefined
+): RequestInit =>
+  subscriberIds === undefined
+    ? { method: 'POST' }
+    : {
+        method: 'POST',
+        headers: jsonHeaders(),
+        body: JSON.stringify({ subscriberIds }),
+      }
+
 /**
  * POST /api/dispatch?force=1 — owner-only manual tick. Sends the
- * current digest to every active subscriber immediately. The cron
- * schedule is NOT modified; the next scheduled tick fires on its
- * own cadence. Throws on non-2xx, and on a malformed response body.
+ * current digest immediately. When `subscriberIds` is given the send
+ * is targeted at exactly those recipients and the global cutoff is
+ * left untouched; omitting it dispatches every active subscriber. The
+ * cron schedule is never modified. Throws on non-2xx or a malformed
+ * response body.
+ * @param subscriberIds Recipient ids to target, or undefined for all.
  * @returns Summary `{sent, failed, skipped, durationMs}`.
  */
-export const apiForceDispatch = async (): Promise<ForceDispatchResult> => {
+export const apiForceDispatch = async (
+  subscriberIds?: readonly number[]
+): Promise<ForceDispatchResult> => {
   const res = ensureOk(
-    await commsFetch('/api/dispatch?force=1', { method: 'POST' }),
+    await commsFetch('/api/dispatch?force=1', dispatchInit(subscriberIds)),
     'Force dispatch'
   )
   const body: unknown = await res.json().catch(() => undefined)

--- a/src/views/CommsView/CommsView.vue
+++ b/src/views/CommsView/CommsView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue'
 import { t } from '@/i18n/t'
-import { useCommsStore } from '@/stores/comms'
+import { type Subscriber, useCommsStore } from '@/stores/comms'
 import { useCutoffStore } from '@/stores/cutoff'
 import { useRunsStore } from '@/stores/runs'
 import { useScheduleStore } from '@/stores/schedule'
@@ -10,6 +10,7 @@ import CommsSection from './CommsSection.vue'
 import CutoffEditor from './CutoffEditor.vue'
 import ForceDispatchPanel from './ForceDispatchPanel.vue'
 import { buildHandlers } from './handlers'
+import RemoveSubscriberDialog from './RemoveSubscriberDialog.vue'
 import RunHistory from './RunHistory.vue'
 import ScheduleEditor from './ScheduleEditor.vue'
 import SubscribersTable from './SubscribersTable.vue'
@@ -19,11 +20,26 @@ const schedule = useScheduleStore()
 const cutoff = useCutoffStore()
 const runs = useRunsStore()
 
-const activeCount = computed(
-  () => store.subscribers.filter(s => s.status === 'active').length
+const activeSubscribers = computed(() =>
+  store.subscribers.filter(s => s.status === 'active')
 )
 const showRuns = ref(false)
+const pendingRemove = ref<Subscriber | undefined>(undefined)
 const h = buildHandlers({ comms: store, schedule, cutoff, runs })
+
+const requestRemove = (id: number): void => {
+  pendingRemove.value = store.subscribers.find(s => s.id === id)
+}
+
+const confirmRemove = (): void => {
+  const target = pendingRemove.value
+  pendingRemove.value = undefined
+  if (target) h.onRemove(target.id)
+}
+
+const cancelRemove = (): void => {
+  pendingRemove.value = undefined
+}
 
 onMounted(() => {
   void store.ensureLoaded()
@@ -77,7 +93,7 @@ onMounted(() => {
         <SubscribersTable
           :subscribers="store.subscribers"
           @langs="h.onLangs"
-          @remove="h.onRemove"
+          @remove="requestRemove"
         />
         <p
           v-if="store.loading && store.subscribers.length === 0"
@@ -93,7 +109,7 @@ onMounted(() => {
         :lead="t('comms.testDispatch.lead')"
       >
         <ForceDispatchPanel
-          :active-count="activeCount"
+          :subscribers="activeSubscribers"
           @dispatched="h.onDispatched"
         />
       </CommsSection>
@@ -116,6 +132,11 @@ onMounted(() => {
           Loading run history…
         </p>
       </CommsSection>
+      <RemoveSubscriberDialog
+        :email="pendingRemove?.email"
+        @confirm="confirmRemove"
+        @cancel="cancelRemove"
+      />
     </section>
   </AppLayout>
 </template>

--- a/src/views/CommsView/ForceDispatchPanel.vue
+++ b/src/views/CommsView/ForceDispatchPanel.vue
@@ -1,37 +1,42 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import type { Subscriber } from '@/stores/comms'
 import {
   apiForceDispatch,
   type ForceDispatchResult,
 } from '@/stores/dispatch-api'
+import { isAllSelected, toggleAll, toggleId } from './dispatch-selection'
 
-const props = defineProps<{
-  readonly activeCount: number
-}>()
-
-const emit = defineEmits<{
-  dispatched: []
-}>()
+const props = defineProps<{ readonly subscribers: readonly Subscriber[] }>()
+const emit = defineEmits<{ dispatched: [] }>()
 
 type Phase = 'idle' | 'confirm' | 'sending' | 'done' | 'error'
 
 const phase = ref<Phase>('idle')
 const result = ref<ForceDispatchResult | undefined>(undefined)
 const error = ref<string | undefined>(undefined)
+const selected = ref<number[]>([])
 
+const ids = (): number[] => props.subscribers.map(s => s.id)
+const allSelected = computed(() => isAllSelected(selected.value, ids()))
+
+const onToggle = (id: number): void => {
+  selected.value = toggleId(selected.value, id)
+}
+const onToggleAll = (): void => {
+  selected.value = toggleAll(selected.value, ids())
+}
 const ask = (): void => {
   phase.value = 'confirm'
 }
-
 const cancel = (): void => {
   phase.value = 'idle'
 }
-
 const confirm = async (): Promise<void> => {
   phase.value = 'sending'
   error.value = undefined
   try {
-    result.value = await apiForceDispatch()
+    result.value = await apiForceDispatch(selected.value)
     phase.value = 'done'
     emit('dispatched')
   } catch (e) {
@@ -44,6 +49,7 @@ const reset = (): void => {
   phase.value = 'idle'
   result.value = undefined
   error.value = undefined
+  selected.value = []
 }
 </script>
 
@@ -54,21 +60,56 @@ const reset = (): void => {
     aria-labelledby="force-dispatch-title"
   >
     <p id="force-dispatch-title" class="lead">
-      Trigger an immediate send to every active subscriber. The
-      saved schedule is <strong>not</strong> changed — the next
-      cron tick still fires at its regular time.
+      Pick who receives an immediate test send. Targeted sends do
+      <strong>not</strong> change the saved schedule or advance the
+      global cutoff — the next cron tick still fires normally for
+      everyone.
     </p>
 
-    <button
-      v-if="phase === 'idle'"
-      type="button"
-      class="btn btn-trigger"
-      data-testid="force-dispatch-start"
-      :disabled="activeCount === 0"
-      @click="ask"
-    >
-      Send test dispatch now
-    </button>
+    <div v-if="phase === 'idle'" class="idle">
+      <p
+        v-if="subscribers.length === 0"
+        class="empty"
+        data-testid="force-dispatch-empty"
+      >
+        No active subscribers to send to.
+      </p>
+      <fieldset v-else class="picker" data-testid="force-dispatch-picker">
+        <legend class="sr-only">Test recipients</legend>
+        <label class="recipient select-all">
+          <input
+            type="checkbox"
+            data-testid="force-dispatch-select-all"
+            :checked="allSelected"
+            @change="onToggleAll"
+          />
+          <span>Select all ({{ subscribers.length }})</span>
+        </label>
+        <label
+          v-for="s in subscribers"
+          :key="s.id"
+          class="recipient"
+        >
+          <input
+            type="checkbox"
+            :data-testid="`force-dispatch-pick-${s.id}`"
+            :checked="selected.includes(s.id)"
+            @change="onToggle(s.id)"
+          />
+          <span class="email">{{ s.email }}</span>
+        </label>
+      </fieldset>
+
+      <button
+        type="button"
+        class="btn btn-trigger"
+        data-testid="force-dispatch-start"
+        :disabled="selected.length === 0"
+        @click="ask"
+      >
+        Send test to {{ selected.length }} selected
+      </button>
+    </div>
 
     <div
       v-else-if="phase === 'confirm'"
@@ -78,8 +119,8 @@ const reset = (): void => {
     >
       <p id="force-confirm-warning" class="warning">
         ⚠ This sends the current digest to
-        <strong>{{ activeCount }}</strong>
-        active subscriber<span v-if="activeCount !== 1">s</span>
+        <strong>{{ selected.length }}</strong>
+        selected recipient<span v-if="selected.length !== 1">s</span>
         right now and writes a row per recipient to the run log.
       </p>
       <div class="confirm-actions">
@@ -162,6 +203,66 @@ const reset = (): void => {
   margin: 0;
   color: var(--color-text-secondary);
   font-size: 0.875rem;
+}
+
+.idle {
+  display: grid;
+  gap: var(--spacing-sm);
+  justify-items: start;
+}
+
+.picker {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  display: grid;
+  gap: var(--spacing-xs);
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.recipient {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+  cursor: pointer;
+}
+
+.recipient input {
+  cursor: pointer;
+}
+
+.recipient.select-all {
+  font-weight: 600;
+  padding-bottom: var(--spacing-xs);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.recipient .email {
+  font-family: var(--font-mono);
+}
+
+.empty {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
 }
 
 .btn {

--- a/src/views/CommsView/RemoveSubscriberDialog.vue
+++ b/src/views/CommsView/RemoveSubscriberDialog.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+defineProps<{
+  readonly email: string | undefined
+}>()
+
+const emit = defineEmits<{
+  confirm: []
+  cancel: []
+}>()
+</script>
+
+<template>
+  <section
+    v-if="email"
+    class="dialog-overlay"
+    role="alertdialog"
+    aria-labelledby="remove-subscriber-title"
+    data-testid="remove-subscriber-dialog"
+    @click.self="emit('cancel')"
+  >
+    <div class="card">
+      <h2 id="remove-subscriber-title" class="title">
+        Remove subscriber?
+      </h2>
+      <p class="body">
+        <strong class="email">{{ email }}</strong> will stop receiving
+        the newsletter. This cannot be undone.
+      </p>
+      <div class="actions">
+        <button
+          type="button"
+          class="btn btn-cancel"
+          data-testid="remove-subscriber-cancel"
+          @click="emit('cancel')"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="btn btn-danger"
+          data-testid="remove-subscriber-confirm"
+          @click="emit('confirm')"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 50%);
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.card {
+  width: min(28rem, 100%);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-lg);
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.body {
+  margin: 0;
+  font-size: 0.9375rem;
+  line-height: 1.4;
+  color: var(--color-text-secondary);
+}
+
+.email {
+  font-family: var(--font-mono);
+  color: var(--color-text-primary);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-xs);
+  flex-wrap: wrap;
+}
+
+.btn {
+  padding: 0.55rem 1rem;
+  border-radius: var(--radius-sm);
+  font: 600 0.95rem/1 var(--font-sans);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.btn-cancel {
+  background: transparent;
+  color: var(--color-text-primary);
+  border-color: var(--color-border);
+}
+
+.btn-cancel:hover {
+  border-color: var(--color-text-secondary);
+}
+
+.btn-danger {
+  background: var(--color-danger);
+  color: var(--color-background);
+  border-color: var(--color-danger);
+}
+
+.btn-danger:hover {
+  filter: brightness(1.08);
+}
+
+@media (width < 640px) {
+  .actions {
+    flex-direction: column-reverse;
+  }
+
+  .btn {
+    width: 100%;
+  }
+}
+</style>

--- a/src/views/CommsView/dispatch-selection.test.ts
+++ b/src/views/CommsView/dispatch-selection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { isAllSelected, toggleAll, toggleId } from './dispatch-selection'
+
+describe('toggleId', () => {
+  it('adds an id that is not selected', () => {
+    expect(toggleId([1], 2)).toEqual([1, 2])
+  })
+
+  it('removes an id that is already selected', () => {
+    expect(toggleId([1, 2], 1)).toEqual([2])
+  })
+})
+
+describe('isAllSelected', () => {
+  it('is true when every id is selected', () => {
+    expect(isAllSelected([2, 1], [1, 2])).toBe(true)
+  })
+
+  it('is false when some id is missing', () => {
+    expect(isAllSelected([1], [1, 2])).toBe(false)
+  })
+
+  it('is false when there is nothing to select', () => {
+    expect(isAllSelected([], [])).toBe(false)
+  })
+})
+
+describe('toggleAll', () => {
+  it('selects every id when not all are selected', () => {
+    expect(toggleAll([1], [1, 2, 3])).toEqual([1, 2, 3])
+  })
+
+  it('clears the selection when all are already selected', () => {
+    expect(toggleAll([1, 2], [1, 2])).toEqual([])
+  })
+})

--- a/src/views/CommsView/dispatch-selection.ts
+++ b/src/views/CommsView/dispatch-selection.ts
@@ -1,0 +1,35 @@
+/**
+ * Toggle a single recipient id in/out of the current selection.
+ * @param selected Currently selected ids.
+ * @param id The id to flip.
+ * @returns The next selection.
+ */
+export const toggleId = (
+  selected: readonly number[],
+  id: number
+): number[] =>
+  selected.includes(id) ? selected.filter(x => x !== id) : [...selected, id]
+
+/**
+ * Whether every available id is currently selected (and there is at
+ * least one to select).
+ * @param selected Currently selected ids.
+ * @param allIds Every selectable id.
+ * @returns True when the selection covers all ids.
+ */
+export const isAllSelected = (
+  selected: readonly number[],
+  allIds: readonly number[]
+): boolean => allIds.length > 0 && allIds.every(id => selected.includes(id))
+
+/**
+ * Flip the "select all" control: clear when everything is already
+ * selected, otherwise select every available id.
+ * @param selected Currently selected ids.
+ * @param allIds Every selectable id.
+ * @returns The next selection.
+ */
+export const toggleAll = (
+  selected: readonly number[],
+  allIds: readonly number[]
+): number[] => (isAllSelected(selected, allIds) ? [] : [...allIds])


### PR DESCRIPTION
## What

Two requested additions to the newsletter admin (`/comms`):

1. **Pick test-send recipients.** The test-dispatch panel now lists active subscribers with a checkbox each plus a **Select all** toggle. Nobody is selected by default and the send button is disabled until at least one recipient is picked. The worker `?force=1` route accepts `{subscriberIds:[…]}` and dispatches only those, **without advancing the global cutoff** — so a targeted test never moves the "what's new" watermark for everyone. An absent body keeps the old behaviour (full active list, advances cutoff) for the scheduled/legacy path.
2. **Confirm before removing a subscriber.** The ✕ now opens a modal confirmation dialog before the `DELETE` fires.

## Tests

- Worker: targeted dispatch filters recipients, leaves the cutoff untouched, and an empty target set sends to nobody; force route forwards `subscriberIds`; absent body → undefined target (everyone). 214 worker tests green.
- Frontend: selection helpers (`toggleId` / `isAllSelected` / `toggleAll`).
- `vue-tsc` type-check, biome, oxlint (sonar), vue-depth and stylelint all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)