### PR TITLE
test(content): fix stale archive-type expectations blocking admin deploy

### DIFF
--- a/src/components/MarkdownEditor/frontmatter-fields.test.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.test.ts
@@ -13,6 +13,7 @@ describe('getFields', () => {
         'published',
         'publishDate',
         'newspaper',
+        'archive',
       ])
     })
 
@@ -47,7 +48,7 @@ describe('getFields', () => {
     it('returns positions fields', () => {
       const fields = getFields('positions')
       const keys = fields.map(f => f.key)
-      expect(keys).toEqual(['title', 'published', 'publishDate'])
+      expect(keys).toEqual(['title', 'published', 'publishDate', 'archive'])
     })
   })
 

--- a/src/composables/useContent/useContentList.test.ts
+++ b/src/composables/useContent/useContentList.test.ts
@@ -49,11 +49,15 @@ describe('useContentList', () => {
         ok: true,
         json: async () => ({ items: [] }),
       })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      })
 
     const { items, loadContent } = useContentList('blog')
     await loadContent()
 
-    expect(mockSwFetch).toHaveBeenCalledTimes(5)
+    expect(mockSwFetch).toHaveBeenCalledTimes(6)
     expect(items.value).toHaveLength(1)
   })
 


### PR DESCRIPTION
## Problem

The admin SPA deploy (`deploy.yml`) has been **failing since 2026-06-14** — its `bun run test:unit --run` gate had 3 red tests, so admin.comprom.org hasn't shipped since (archive UI, newspaper-digest UI, and the new comms recipient-picker are all stuck behind it). Last green deploy: 2026-06-12.

## Cause

The archive content type (#297–299) correctly added:
- an `archive` field to blog + positions frontmatter (`fields-blog.ts`, `fields-positions.ts`), and
- a 6th content type (`archive`) to `ContentType` / the content loader.

But three tests still asserted the pre-archive shapes:
- `frontmatter-fields.test.ts` — blog + positions field lists missing `archive`.
- `useContentList.test.ts` — mocked 5 `swFetch` calls / asserted 5; the loader now fetches 6 types.

## Fix

Update the three expectations to match the shipped code. Full suite green (1047 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)