### PR TITLE
refactor(archive): clear lint debt blocking the admin SPA deploy

### DIFF
--- a/e2e/content/archive-viewer.spec.ts
+++ b/e2e/content/archive-viewer.spec.ts
@@ -2,9 +2,10 @@ import { expect, test } from '@prometheus/e2e-toolkit'
 import { AssetManagerPage } from '../pages/AssetManagerPage'
 
 const ARCHIVE_SLUG = 'founding-documents'
-const IMAGE_A = 'flag.svg' // first image (index 0)
-const IMAGE_B = 'manifesto-poster.svg' // second image (index 1)
-const DOC_FILE = 'notes.txt' // non-image (index 2)
+// Asset order in the fixture: two images (index 0, 1) then a non-image.
+const IMAGE_A = 'flag.svg'
+const IMAGE_B = 'manifesto-poster.svg'
+const DOC_FILE = 'notes.txt'
 
 const open = async (page: import('@playwright/test').Page, name: string) => {
   const am = new AssetManagerPage(page)
@@ -48,7 +49,8 @@ test.describe('Archive — viewer', () => {
   test('navigates with buttons and arrows, bounded at the ends', async ({
     page,
   }) => {
-    await open(page, IMAGE_A) // index 0
+    // Start at index 0.
+    await open(page, IMAGE_A)
     await expect(page.getByTestId('file-viewer-prev')).toBeDisabled()
     await expect(page.getByTestId('file-viewer-next')).toBeEnabled()
 
@@ -78,8 +80,9 @@ test.describe('Archive — viewer', () => {
   test('unsupported file downloads under its name from the viewer', async ({
     page,
   }) => {
-    await open(page, IMAGE_B) // index 1
-    await page.getByTestId('file-viewer-next').click() // -> notes.txt
+    // Start at index 1, then advance to the non-image notes.txt.
+    await open(page, IMAGE_B)
+    await page.getByTestId('file-viewer-next').click()
     await expect(page.getByTestId('file-viewer-unsupported')).toBeVisible()
 
     const started = page.waitForEvent('download')
@@ -89,7 +92,8 @@ test.describe('Archive — viewer', () => {
   })
 
   test('advances on a left-swipe', async ({ page }) => {
-    await open(page, IMAGE_A) // index 0
+    // Start at index 0.
+    await open(page, IMAGE_A)
     await expect(page.getByTestId('file-viewer-status')).toContainText(
       'File 1 of 3'
     )

--- a/src/components/FileViewer/FileViewer.vue
+++ b/src/components/FileViewer/FileViewer.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
-import { fireAndForward } from '@/utils/fire-and-forward'
+import { useTemplateRef } from 'vue'
 import FileViewerStage from './FileViewerStage.vue'
 import FileViewerToolbar from './FileViewerToolbar.vue'
+import { exitFullscreen } from './fullscreen'
 import NavButton from './NavButton.vue'
 import { VIEWER_ID, VIEWER_STATUS_ID } from './test-ids'
 import type { ViewerFile } from './types'
+import { useFullscreen } from './use-fullscreen'
+import { useViewerEvents } from './use-viewer-events'
+import { handleViewerKey, useViewerState } from './viewer-logic'
 import { moveIndex, swipeStep } from './viewer-nav'
 
 const SWIPE_THRESHOLD_PX = 50
@@ -22,18 +25,17 @@ const emit = defineEmits<{
 }>()
 
 const dialog = useTemplateRef<HTMLDialogElement>('dialog')
-const isFullscreen = ref(false)
+const {
+  isFullscreen,
+  sync: syncFullscreen,
+  toggle: toggleFullscreen,
+} = useFullscreen(dialog)
 
-const total = computed(() => props.files.length)
-const current = computed((): ViewerFile | undefined => props.files[props.index])
-const position = computed(() => `${props.index + 1} / ${total.value}`)
-const statusText = computed(() =>
-  current.value
-    ? `File ${props.index + 1} of ${total.value}: ${current.value.name}`
-    : ''
-)
-const atStart = computed(() => props.index <= 0)
-const atEnd = computed(() => props.index >= total.value - 1)
+const { total, current, position, statusText, atStart, atEnd } =
+  useViewerState(
+    () => props.files,
+    () => props.index
+  )
 
 const move = (step: number): void => {
   emit('update:index', moveIndex(props.index, step, total.value))
@@ -44,47 +46,17 @@ const onSwipe = (deltaX: number): void => {
   if (step !== 0) move(step)
 }
 
-const syncFullscreen = (): void => {
-  isFullscreen.value = document.fullscreenElement === dialog.value
-}
-
-const exitFullscreen = (): void => {
-  if (document.fullscreenElement) fireAndForward(document.exitFullscreen())
-}
-
-const toggleFullscreen = (): void => {
-  const el = dialog.value
-  if (isFullscreen.value || !el) exitFullscreen()
-  else fireAndForward(el.requestFullscreen())
-}
-
-const onKeydown = (e: KeyboardEvent): void => {
-  if (e.key === 'ArrowRight') move(1)
-  else if (e.key === 'ArrowLeft') move(-1)
-  else if (e.key === 'Escape') {
-    e.preventDefault()
-    if (isFullscreen.value) exitFullscreen()
-    else emit('close')
-  }
-}
+const onKeydown = (e: KeyboardEvent): void =>
+  handleViewerKey(e, move, () => emit('close'), isFullscreen.value)
 
 const onBackdrop = (e: MouseEvent): void => {
   if (e.target === dialog.value) emit('close')
 }
 
-onMounted(() => {
-  dialog.value?.showModal()
-  // Keydown on document, not the dialog: when a nav button disables at
-  // an end it loses focus, and a dialog-scoped listener would then miss
-  // the arrow keys. The viewer is the only thing up while mounted.
-  document.addEventListener('keydown', onKeydown)
-  document.addEventListener('fullscreenchange', syncFullscreen)
-})
-
-onBeforeUnmount(() => {
-  document.removeEventListener('keydown', onKeydown)
-  document.removeEventListener('fullscreenchange', syncFullscreen)
-  exitFullscreen()
+useViewerEvents(dialog, {
+  onKeydown,
+  onFullscreenChange: syncFullscreen,
+  onUnmount: exitFullscreen,
 })
 </script>
 
@@ -154,7 +126,7 @@ onBeforeUnmount(() => {
   margin: -1px;
   padding: 0;
   overflow: hidden;
-  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/src/components/FileViewer/NavButton.vue
+++ b/src/components/FileViewer/NavButton.vue
@@ -55,10 +55,6 @@ const isPrev = props.direction === 'prev'
   inset-inline-end: clamp(0.5rem, 2vw, 1.5rem);
 }
 
-.nav-btn:hover:not(:disabled) {
-  background: rgb(0 0 0 / 55%);
-}
-
 .nav-btn:disabled {
   opacity: 35%;
   cursor: default;
@@ -67,5 +63,9 @@ const isPrev = props.direction === 'prev'
 .nav-btn:focus-visible {
   outline: 2px solid #fff;
   outline-offset: 2px;
+}
+
+.nav-btn:hover:not(:disabled) {
+  background: rgb(0 0 0 / 55%);
 }
 </style>

--- a/src/components/FileViewer/fullscreen.ts
+++ b/src/components/FileViewer/fullscreen.ts
@@ -1,0 +1,33 @@
+import { fireAndForward } from '@/utils/fire-and-forward'
+
+/**
+ * Whether the given dialog is the current fullscreen element.
+ * @param dialog - The viewer dialog element (or null before mount).
+ * @returns True when the dialog is fullscreen.
+ */
+export const isDialogFullscreen = (
+  dialog: HTMLDialogElement | null
+): boolean => document.fullscreenElement === dialog
+
+/**
+ * Exit fullscreen when anything is currently fullscreen; no-op otherwise.
+ */
+export const exitFullscreen = (): void => {
+  void (document.fullscreenElement
+    ? fireAndForward(document.exitFullscreen())
+    : undefined)
+}
+
+/**
+ * Toggle fullscreen for the dialog given the current state.
+ * @param dialog - The viewer dialog element (or null).
+ * @param isFullscreen - Whether the dialog is already fullscreen.
+ */
+export const toggleFullscreen = (
+  dialog: HTMLDialogElement | null,
+  isFullscreen: boolean
+): void => {
+  void (isFullscreen || !dialog
+    ? exitFullscreen()
+    : fireAndForward(dialog.requestFullscreen()))
+}

--- a/src/components/FileViewer/use-fullscreen.ts
+++ b/src/components/FileViewer/use-fullscreen.ts
@@ -1,0 +1,18 @@
+import { type Ref, ref } from 'vue'
+import { isDialogFullscreen, toggleFullscreen } from './fullscreen'
+
+/**
+ * Track and toggle fullscreen for the viewer dialog.
+ * @param dialog - Ref to the viewer dialog element.
+ * @returns The isFullscreen flag plus sync + toggle actions.
+ */
+export const useFullscreen = (dialog: Ref<HTMLDialogElement | null>) => {
+  const isFullscreen = ref(false)
+  const sync = (): void => {
+    isFullscreen.value = isDialogFullscreen(dialog.value)
+  }
+  const toggle = (): void => {
+    toggleFullscreen(dialog.value, isFullscreen.value)
+  }
+  return { isFullscreen, sync, toggle }
+}

--- a/src/components/FileViewer/use-viewer-events.ts
+++ b/src/components/FileViewer/use-viewer-events.ts
@@ -1,0 +1,35 @@
+import { onBeforeUnmount, onMounted, type Ref } from 'vue'
+
+/** Document/dialog event wiring for the file viewer. */
+export type ViewerEventHandlers = {
+  readonly onKeydown: (e: KeyboardEvent) => void
+  readonly onFullscreenChange: () => void
+  readonly onUnmount: () => void
+}
+
+/**
+ * Open the dialog modally on mount and bind the document listeners the
+ * viewer needs (keydown on document — a nav button disabling at an end
+ * loses focus, so a dialog-scoped listener would miss arrow keys), then
+ * tear them all down on unmount.
+ * @param dialog - Ref to the viewer dialog element.
+ * @param handlers - Keydown, fullscreen-change, and unmount callbacks.
+ */
+export const useViewerEvents = (
+  dialog: Ref<HTMLDialogElement | null>,
+  handlers: ViewerEventHandlers
+): void => {
+  onMounted(() => {
+    dialog.value?.showModal()
+    document.addEventListener('keydown', handlers.onKeydown)
+    document.addEventListener('fullscreenchange', handlers.onFullscreenChange)
+  })
+  onBeforeUnmount(() => {
+    document.removeEventListener('keydown', handlers.onKeydown)
+    document.removeEventListener(
+      'fullscreenchange',
+      handlers.onFullscreenChange
+    )
+    handlers.onUnmount()
+  })
+}

--- a/src/components/FileViewer/viewer-logic.ts
+++ b/src/components/FileViewer/viewer-logic.ts
@@ -1,0 +1,52 @@
+import { Match } from 'effect'
+import { computed } from 'vue'
+import { exitFullscreen } from './fullscreen'
+import type { ViewerFile } from './types'
+
+/**
+ * Reactive position/bounds state derived from the file list + index.
+ * @param files - Accessor for the current files.
+ * @param index - Accessor for the active index.
+ * @returns Total, current file, position label, status text, bounds.
+ */
+export const useViewerState = (
+  files: () => readonly ViewerFile[],
+  index: () => number
+) => {
+  const total = computed(() => files().length)
+  const current = computed<ViewerFile | undefined>(() => files()[index()])
+  const position = computed(() => `${index() + 1} / ${total.value}`)
+  const statusText = computed(() =>
+    current.value
+      ? `File ${index() + 1} of ${total.value}: ${current.value.name}`
+      : ''
+  )
+  const atStart = computed(() => index() <= 0)
+  const atEnd = computed(() => index() >= total.value - 1)
+  return { total, current, position, statusText, atStart, atEnd }
+}
+
+/**
+ * Handle a viewer keydown: arrows page, Escape exits fullscreen or closes.
+ * @param e - The keyboard event.
+ * @param move - Page-by-step callback.
+ * @param close - Close-the-viewer callback.
+ * @param isFullscreen - Whether the viewer is currently fullscreen.
+ */
+export const handleViewerKey = (
+  e: KeyboardEvent,
+  move: (step: number) => void,
+  close: () => void,
+  isFullscreen: boolean
+): void => {
+  const onEscape = (): void => {
+    e.preventDefault()
+    void (isFullscreen ? exitFullscreen() : close())
+  }
+  void Match.value(e.key).pipe(
+    Match.when('ArrowRight', () => move(1)),
+    Match.when('ArrowLeft', () => move(-1)),
+    Match.when('Escape', onEscape),
+    Match.orElse(() => undefined)
+  )
+}

--- a/src/components/FileViewer/viewer-nav.ts
+++ b/src/components/FileViewer/viewer-nav.ts
@@ -38,8 +38,5 @@ export const moveIndex = (
  * @param threshold - Minimum absolute displacement to count, px
  * @returns +1 next, -1 previous, 0 none
  */
-export const swipeStep = (deltaX: number, threshold: number): number => {
-  if (deltaX <= -threshold) return 1
-  if (deltaX >= threshold) return -1
-  return 0
-}
+export const swipeStep = (deltaX: number, threshold: number): number =>
+  deltaX <= -threshold ? 1 : deltaX >= threshold ? -1 : 0

--- a/src/components/MarkdownEditor/FrontmatterField.vue
+++ b/src/components/MarkdownEditor/FrontmatterField.vue
@@ -30,12 +30,7 @@ const articlesValue = (): readonly string[] | undefined =>
     ? props.value.filter((s): s is string => typeof s === 'string')
     : undefined
 
-const issueValue = (): string | undefined =>
-  typeof props.value === 'string' && props.value !== ''
-    ? props.value
-    : undefined
-
-const archiveValue = (): string | undefined =>
+const optionalStringValue = (): string | undefined =>
   typeof props.value === 'string' && props.value !== ''
     ? props.value
     : undefined
@@ -87,12 +82,12 @@ const onSelect = (v: string): void => {
   />
   <IssuePicker
     v-else-if="field.type === 'issue'"
-    :value="issueValue()"
+    :value="optionalStringValue()"
     @update="emit('update', $event)"
   />
   <ArchivePicker
     v-else-if="field.type === 'archive-ref'"
-    :value="archiveValue()"
+    :value="optionalStringValue()"
     @update="emit('update', $event)"
   />
   <FrontmatterSelect

--- a/src/composables/useFileViewer/useFileViewer.ts
+++ b/src/composables/useFileViewer/useFileViewer.ts
@@ -6,6 +6,15 @@ import {
 } from '@/composables/useAssets/download-asset'
 import type { AssetDisplay } from '@/composables/useAssets/types'
 
+const toViewerFiles = (
+  assets: readonly AssetDisplay[]
+): readonly ViewerFile[] =>
+  assets.map(a => ({
+    name: a.name,
+    mimeType: a.mimeType,
+    url: a.thumbnailUrl,
+  }))
+
 /**
  * Drive the file viewer over a live list of display assets: open at an
  * index, page through, and download the current file. The viewer
@@ -22,13 +31,7 @@ export const useFileViewer = (
   const open = ref(false)
   const index = ref(0)
 
-  const files = computed<readonly ViewerFile[]>(() =>
-    assets().map(a => ({
-      name: a.name,
-      mimeType: a.mimeType,
-      url: a.thumbnailUrl,
-    }))
-  )
+  const files = computed<readonly ViewerFile[]>(() => toViewerFiles(assets()))
 
   const openAt = (at: number): void => {
     index.value = at
@@ -45,7 +48,7 @@ export const useFileViewer = (
 
   const downloadAt = (at: number): void => {
     const asset = assets()[at]
-    if (asset) download(assetToDownloadable(asset))
+    void (asset ? download(assetToDownloadable(asset)) : undefined)
   }
 
   return { open, index, files, openAt, close, setIndex, downloadAt }

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -7,7 +7,6 @@ import ErrorMessage from '@/components/common/ErrorMessage.vue'
 import LoadingOverlay from '@/components/common/LoadingOverlay.vue'
 import FileViewer from '@/components/FileViewer/FileViewer.vue'
 import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue'
-import { useFileViewer } from '@/composables/useFileViewer/useFileViewer'
 import ContentEditMain from './ContentEditView/ContentEditMain.vue'
 import ContentPreview from './ContentEditView/ContentPreview.vue'
 import EditBreadcrumb from './ContentEditView/EditBreadcrumb.vue'
@@ -15,6 +14,7 @@ import { initEditPage } from './ContentEditView/init-edit-page'
 import PreviewFooter from './ContentEditView/PreviewFooter.vue'
 import PublishConfirmDialog from './ContentEditView/PublishConfirmDialog.vue'
 import { setupEditHandlers } from './ContentEditView/setup-handlers'
+import { setupViewer } from './ContentEditView/setup-viewer'
 import { useSaveFlow } from './ContentEditView/use-save-flow'
 import { useEditPage } from './ContentEditView/useEditPage'
 
@@ -49,12 +49,7 @@ const {
   close: closeViewer,
   setIndex: setViewerIndex,
   downloadAt: downloadViewerFile,
-} = useFileViewer(
-  () => (p.hasAssets.value ? p.assets.allAssets.value : []),
-  asset => {
-    void p.ah.onDownloadAsset(asset)
-  }
-)
+} = setupViewer(p)
 </script>
 
 <template>

--- a/src/views/ContentEditView/setup-viewer.ts
+++ b/src/views/ContentEditView/setup-viewer.ts
@@ -1,0 +1,16 @@
+import { useFileViewer } from '@/composables/useFileViewer/useFileViewer'
+import type { useEditPage } from './useEditPage'
+
+/**
+ * Wire the file viewer to the edit page's assets: page over the live
+ * asset list and route downloads back through the asset handlers.
+ * @param p - The edit-page state bundle.
+ * @returns The file-viewer reactive state + actions.
+ */
+export const setupViewer = (p: ReturnType<typeof useEditPage>) =>
+  useFileViewer(
+    () => (p.hasAssets.value ? p.assets.allAssets.value : []),
+    asset => {
+      void p.ah.onDownloadAsset(asset)
+    }
+  )


### PR DESCRIPTION
## Why

With the unit-test gate fixed (#304), the admin SPA deploy advanced to the `build` step and surfaced a backlog of `lint:sonar` / `lint:jsdoc` / `lint:css` violations — all pre-existing debt from the archive/FileViewer iterations (#297-299) that the long-red deploy never gated. This clears them so admin.comprom.org can ship again (incl. the new comms recipient-picker UI).

## Changes (no behaviour change)

- **max-lines**: `FileViewer.vue` (70→<50) + `ContentEditView.vue` (55→<50) split into helpers (`fullscreen.ts`, `use-fullscreen.ts`, `use-viewer-events.ts`, `viewer-logic.ts`, `setup-viewer.ts`).
- **max-lines-per-function**: `useFileViewer` loader trimmed via a `toViewerFiles` helper.
- **no-identical-functions**: `FrontmatterField` deduped the identical issue/archive value getters.
- **no-restricted-syntax (no `if`)**: converted to ternaries / `effect` `Match`; void side-effects via the `void` operator (matching `applyTheme`).
- **no-inline-comments**: archive-viewer e2e comments moved to their own lines.
- **CSS**: `NavButton` selector order (no-descending-specificity); `FileViewer` `clip` → `clip-path`.

## Verification

`type-check`, `lint:sonar`, `lint:jsdoc`, `lint:vue-depth`, `lint:css` all clean; full unit suite **1047 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)