### PR TITLE
Comms: mobile overflow fix + dev-admin auth/comms wiring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,8 +51,11 @@ jobs:
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_DEVELOP" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_DEVELOP" >> "$GITHUB_ENV"
             # dev-admin talks to the develop comms worker so targeted
-            # test sends never reach production subscribers.
+            # test sends never reach production subscribers, and mints
+            # its SSO session against the develop auth worker (whose
+            # JWT_SECRET the develop resource workers share).
             echo "VITE_COMMS_BASE=https://dev-lists.comprom.org" >> "$GITHUB_ENV"
+            echo "VITE_AUTH_BASE=https://dev-auth.comprom.org" >> "$GITHUB_ENV"
             echo "GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy --env develop" >> "$GITHUB_ENV"
           else
@@ -60,6 +63,7 @@ jobs:
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_MASTER" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_MASTER" >> "$GITHUB_ENV"
             echo "VITE_COMMS_BASE=https://lists.comprom.org" >> "$GITHUB_ENV"
+            echo "VITE_AUTH_BASE=https://auth.comprom.org" >> "$GITHUB_ENV"
             echo "GITHUB_BRANCH=master" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy" >> "$GITHUB_ENV"
           fi

--- a/e2e/pages/ContentPage.ts
+++ b/e2e/pages/ContentPage.ts
@@ -27,7 +27,7 @@ export class ContentPage {
     const empty = this.page.getByText(/no content items found/i)
     await waitForCondition(this.page, async () => {
       const path = await first.getAttribute('data-path').catch(() => null)
-      const matches = path !== null && path.startsWith(`${contentType}/`)
+      const matches = path?.startsWith(`${contentType}/`)
       return matches || (await empty.isVisible().catch(() => false))
     })
   }

--- a/services/auth-worker/wrangler.jsonc
+++ b/services/auth-worker/wrangler.jsonc
@@ -17,7 +17,17 @@
   "env": {
     "develop": {
       "name": "auth-worker-develop",
-      "routes": [{ "pattern": "dev-auth.comprom.org", "custom_domain": true }]
+      "routes": [{ "pattern": "dev-auth.comprom.org", "custom_domain": true }],
+      // Named envs do NOT inherit top-level vars — repeat them. The
+      // allowed origin is dev-admin so the dev SPA can mint sessions
+      // here; the cookie domain stays parent-scoped so the dev
+      // resource workers (dev-lists) receive it.
+      "vars": {
+        "VERSION": "0.2.0",
+        "GITHUB_ORG": "communist-prometheus",
+        "ALLOWED_ORIGIN": "https://dev-admin.comprom.org",
+        "COOKIE_DOMAIN": ".comprom.org"
+      }
     }
   }
 }

--- a/services/auth-worker/wrangler.jsonc
+++ b/services/auth-worker/wrangler.jsonc
@@ -17,7 +17,9 @@
   "env": {
     "develop": {
       "name": "auth-worker-develop",
-      "routes": [{ "pattern": "dev-auth.comprom.org", "custom_domain": true }],
+      "routes": [
+        { "pattern": "dev-auth.comprom.org", "custom_domain": true }
+      ],
       // Named envs do NOT inherit top-level vars — repeat them. The
       // allowed origin is dev-admin so the dev SPA can mint sessions
       // here; the cookie domain stays parent-scoped so the dev

--- a/services/comms-worker/wrangler.jsonc
+++ b/services/comms-worker/wrangler.jsonc
@@ -40,8 +40,8 @@
       // public site so test mailings never read production content.
       "vars": {
         "VERSION": "0.2.0",
-        "ADMIN_HOSTNAME": "admin.comprom.org",
-        "ALLOWED_ORIGIN": "https://admin.comprom.org",
+        "ADMIN_HOSTNAME": "dev-admin.comprom.org",
+        "ALLOWED_ORIGIN": "https://dev-admin.comprom.org",
         "CONTENT_BASE_URL": "https://dev.comprom.org",
         "PUBLIC_BASE_URL": "https://dev-lists.comprom.org"
       },

--- a/src/views/CommsView/AddSubscriberForm.vue
+++ b/src/views/CommsView/AddSubscriberForm.vue
@@ -116,6 +116,8 @@ const submit = async (): Promise<void> => {
 .field-input {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);

--- a/src/views/CommsView/CommsSection.vue
+++ b/src/views/CommsView/CommsSection.vue
@@ -22,11 +22,16 @@ defineProps<{
   display: grid;
   gap: var(--spacing-sm);
   min-height: 6rem;
+
+  /* Allow the section (and its grid descendants) to shrink below
+     content min-size so a wide child never forces page overflow. */
+  min-width: 0;
 }
 
 .head {
   display: grid;
   gap: 0.25rem;
+  min-width: 0;
 }
 
 .title {
@@ -49,5 +54,10 @@ defineProps<{
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
+  min-width: 0;
+}
+
+.body > * {
+  min-width: 0;
 }
 </style>

--- a/src/views/CommsView/CutoffEditor.vue
+++ b/src/views/CommsView/CutoffEditor.vue
@@ -127,6 +127,8 @@ const display = computed(() => (props.at === null ? '—' : props.at))
 .field-input {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);

--- a/src/views/CommsView/ForceDispatchPanel.vue
+++ b/src/views/CommsView/ForceDispatchPanel.vue
@@ -197,6 +197,7 @@ const reset = (): void => {
 .force-dispatch {
   display: grid;
   gap: var(--spacing-sm);
+  min-width: 0;
 }
 
 .lead {
@@ -209,11 +210,16 @@ const reset = (): void => {
   display: grid;
   gap: var(--spacing-sm);
   justify-items: start;
+  min-width: 0;
 }
 
 .picker {
   width: 100%;
   box-sizing: border-box;
+
+  /* A <fieldset> defaults to min-inline-size: min-content, which a
+     long recipient email would force past the viewport — pin it to 0. */
+  min-width: 0;
   margin: 0;
   padding: var(--spacing-sm);
   border: 1px solid var(--color-border);
@@ -228,6 +234,7 @@ const reset = (): void => {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
+  min-width: 0;
   font-size: 0.875rem;
   color: var(--color-text-primary);
   cursor: pointer;
@@ -245,6 +252,8 @@ const reset = (): void => {
 
 .recipient .email {
   font-family: var(--font-mono);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .empty {

--- a/src/views/CommsView/LangTogglePills.vue
+++ b/src/views/CommsView/LangTogglePills.vue
@@ -41,9 +41,11 @@ const onClick = (lang: Lang): void => {
 
 <style scoped>
 .lang-toggle {
-  display: inline-flex;
+  display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-xs);
+  max-width: 100%;
+  min-width: 0;
 }
 
 .pill {
@@ -67,6 +69,11 @@ const onClick = (lang: Lang): void => {
 .pill:disabled {
   cursor: not-allowed;
   opacity: 50%;
+}
+
+/* Suppress the ring on pointer (tap/click); keep it for keyboard nav. */
+.pill:focus {
+  outline: none;
 }
 
 .pill:focus-visible {

--- a/src/views/CommsView/ScheduleEditor.vue
+++ b/src/views/CommsView/ScheduleEditor.vue
@@ -106,6 +106,8 @@ const submit = (): void => emit('save', { ...draft.value })
 .field-input {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);

--- a/src/views/CommsView/SubscriberRow.vue
+++ b/src/views/CommsView/SubscriberRow.vue
@@ -51,10 +51,12 @@ const emit = defineEmits<{
   font-size: 0.875rem;
   vertical-align: middle;
   color: var(--color-text-primary);
+  min-width: 0;
 }
 
 .email {
   font-family: var(--font-mono);
+  overflow-wrap: anywhere;
 }
 
 .actions {

--- a/src/views/CommsView/TimezoneSelect.vue
+++ b/src/views/CommsView/TimezoneSelect.vue
@@ -46,6 +46,8 @@ const onChange = (e: Event): void => {
 .field-select {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);


### PR DESCRIPTION
Propagates develop → master (dev-first). UI: fixes mobile horizontal overflow in /comms (recipient fieldset min-content + non-wrapping language pills + input box-sizing) and makes the pill focus ring keyboard-only — verified at 390px (0 overflow). Dev-env: VITE_AUTH_BASE per branch so dev-admin uses dev-auth/dev-lists; master keeps prod values. 🤖 Generated with Claude Code