### PR TITLE
fix(comms): subscriber lang PATCH (CORS) + tap/focus on language pills

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,8 +51,11 @@ jobs:
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_DEVELOP" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_DEVELOP" >> "$GITHUB_ENV"
             # dev-admin talks to the develop comms worker so targeted
-            # test sends never reach production subscribers.
+            # test sends never reach production subscribers, and mints
+            # its SSO session against the develop auth worker (whose
+            # JWT_SECRET the develop resource workers share).
             echo "VITE_COMMS_BASE=https://dev-lists.comprom.org" >> "$GITHUB_ENV"
+            echo "VITE_AUTH_BASE=https://dev-auth.comprom.org" >> "$GITHUB_ENV"
             echo "GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy --env develop" >> "$GITHUB_ENV"
           else
@@ -60,6 +63,7 @@ jobs:
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_MASTER" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_MASTER" >> "$GITHUB_ENV"
             echo "VITE_COMMS_BASE=https://lists.comprom.org" >> "$GITHUB_ENV"
+            echo "VITE_AUTH_BASE=https://auth.comprom.org" >> "$GITHUB_ENV"
             echo "GITHUB_BRANCH=master" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy" >> "$GITHUB_ENV"
           fi

--- a/e2e/pages/ContentPage.ts
+++ b/e2e/pages/ContentPage.ts
@@ -27,7 +27,7 @@ export class ContentPage {
     const empty = this.page.getByText(/no content items found/i)
     await waitForCondition(this.page, async () => {
       const path = await first.getAttribute('data-path').catch(() => null)
-      const matches = path !== null && path.startsWith(`${contentType}/`)
+      const matches = path?.startsWith(`${contentType}/`)
       return matches || (await empty.isVisible().catch(() => false))
     })
   }

--- a/services/auth-worker/wrangler.jsonc
+++ b/services/auth-worker/wrangler.jsonc
@@ -17,7 +17,17 @@
   "env": {
     "develop": {
       "name": "auth-worker-develop",
-      "routes": [{ "pattern": "dev-auth.comprom.org", "custom_domain": true }]
+      "routes": [{ "pattern": "dev-auth.comprom.org", "custom_domain": true }],
+      // Named envs do NOT inherit top-level vars — repeat them. The
+      // allowed origin is dev-admin so the dev SPA can mint sessions
+      // here; the cookie domain stays parent-scoped so the dev
+      // resource workers (dev-lists) receive it.
+      "vars": {
+        "VERSION": "0.2.0",
+        "GITHUB_ORG": "communist-prometheus",
+        "ALLOWED_ORIGIN": "https://dev-admin.comprom.org",
+        "COOKIE_DOMAIN": ".comprom.org"
+      }
     }
   }
 }

--- a/services/auth-worker/wrangler.jsonc
+++ b/services/auth-worker/wrangler.jsonc
@@ -17,7 +17,9 @@
   "env": {
     "develop": {
       "name": "auth-worker-develop",
-      "routes": [{ "pattern": "dev-auth.comprom.org", "custom_domain": true }],
+      "routes": [
+        { "pattern": "dev-auth.comprom.org", "custom_domain": true }
+      ],
       // Named envs do NOT inherit top-level vars — repeat them. The
       // allowed origin is dev-admin so the dev SPA can mint sessions
       // here; the cookie domain stays parent-scoped so the dev

--- a/services/comms-worker/src/middleware/cors.test.ts
+++ b/services/comms-worker/src/middleware/cors.test.ts
@@ -1,0 +1,43 @@
+import { Hono } from 'hono'
+import { describe, expect, it } from 'vitest'
+import { type CorsEnv, cors } from './cors'
+
+const ORIGIN = 'https://admin.comprom.org'
+const env: CorsEnv = { ALLOWED_ORIGIN: ORIGIN }
+
+const build = () => {
+  const app = new Hono<{ Bindings: CorsEnv }>()
+  app.use('*', cors())
+  app.get('/x', c => c.json({ ok: true }))
+  app.patch('/x', c => c.json({ ok: true }))
+  return app
+}
+
+const req = (method: string, origin: string) =>
+  new Request('http://x/x', { method, headers: { origin } })
+
+describe('cors middleware', () => {
+  it('allows PATCH in the preflight for the allowed origin', async () => {
+    const res = await build().fetch(req('OPTIONS', ORIGIN), env)
+    expect(res.status).toBe(204)
+    const methods = res.headers.get('Access-Control-Allow-Methods') ?? ''
+    // The admin edits subscriber langs via PATCH; it must be allowed.
+    expect(methods.split(', ')).toEqual(
+      expect.arrayContaining(['GET', 'POST', 'PUT', 'PATCH', 'DELETE'])
+    )
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ORIGIN)
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true')
+  })
+
+  it('mirrors origin + methods on a normal cross-origin response', async () => {
+    const res = await build().fetch(req('GET', ORIGIN), env)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(ORIGIN)
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('PATCH')
+  })
+
+  it('omits CORS headers for a disallowed origin', async () => {
+    const res = await build().fetch(req('OPTIONS', 'https://evil.test'), env)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBeNull()
+  })
+})

--- a/services/comms-worker/src/middleware/cors.ts
+++ b/services/comms-worker/src/middleware/cors.ts
@@ -3,7 +3,10 @@ import type { MiddlewareHandler } from 'hono'
 export type CorsEnv = { readonly ALLOWED_ORIGIN: string }
 
 const ALLOW_HEADERS = 'Authorization, Content-Type'
-const ALLOW_METHODS = 'GET, POST, PUT, DELETE, OPTIONS'
+// PATCH is required: the admin edits subscriber langs via
+// `PATCH /api/subscribers/:id`. Omitting it made the browser block the
+// cross-origin preflight, so language changes silently failed.
+const ALLOW_METHODS = 'GET, POST, PUT, PATCH, DELETE, OPTIONS'
 
 /**
  * Hono middleware that mirrors the request origin only when it

--- a/services/comms-worker/wrangler.jsonc
+++ b/services/comms-worker/wrangler.jsonc
@@ -40,8 +40,8 @@
       // public site so test mailings never read production content.
       "vars": {
         "VERSION": "0.2.0",
-        "ADMIN_HOSTNAME": "admin.comprom.org",
-        "ALLOWED_ORIGIN": "https://admin.comprom.org",
+        "ADMIN_HOSTNAME": "dev-admin.comprom.org",
+        "ALLOWED_ORIGIN": "https://dev-admin.comprom.org",
         "CONTENT_BASE_URL": "https://dev.comprom.org",
         "PUBLIC_BASE_URL": "https://dev-lists.comprom.org"
       },

--- a/src/views/CommsView/AddSubscriberForm.vue
+++ b/src/views/CommsView/AddSubscriberForm.vue
@@ -116,6 +116,8 @@ const submit = async (): Promise<void> => {
 .field-input {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);

--- a/src/views/CommsView/CommsSection.vue
+++ b/src/views/CommsView/CommsSection.vue
@@ -22,11 +22,16 @@ defineProps<{
   display: grid;
   gap: var(--spacing-sm);
   min-height: 6rem;
+
+  /* Allow the section (and its grid descendants) to shrink below
+     content min-size so a wide child never forces page overflow. */
+  min-width: 0;
 }
 
 .head {
   display: grid;
   gap: 0.25rem;
+  min-width: 0;
 }
 
 .title {
@@ -49,5 +54,10 @@ defineProps<{
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
+  min-width: 0;
+}
+
+.body > * {
+  min-width: 0;
 }
 </style>

--- a/src/views/CommsView/CutoffEditor.vue
+++ b/src/views/CommsView/CutoffEditor.vue
@@ -127,6 +127,8 @@ const display = computed(() => (props.at === null ? '—' : props.at))
 .field-input {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);

--- a/src/views/CommsView/ForceDispatchPanel.vue
+++ b/src/views/CommsView/ForceDispatchPanel.vue
@@ -197,6 +197,7 @@ const reset = (): void => {
 .force-dispatch {
   display: grid;
   gap: var(--spacing-sm);
+  min-width: 0;
 }
 
 .lead {
@@ -209,11 +210,16 @@ const reset = (): void => {
   display: grid;
   gap: var(--spacing-sm);
   justify-items: start;
+  min-width: 0;
 }
 
 .picker {
   width: 100%;
   box-sizing: border-box;
+
+  /* A <fieldset> defaults to min-inline-size: min-content, which a
+     long recipient email would force past the viewport — pin it to 0. */
+  min-width: 0;
   margin: 0;
   padding: var(--spacing-sm);
   border: 1px solid var(--color-border);
@@ -228,6 +234,7 @@ const reset = (): void => {
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
+  min-width: 0;
   font-size: 0.875rem;
   color: var(--color-text-primary);
   cursor: pointer;
@@ -245,6 +252,8 @@ const reset = (): void => {
 
 .recipient .email {
   font-family: var(--font-mono);
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .empty {

--- a/src/views/CommsView/LangTogglePills.test.ts
+++ b/src/views/CommsView/LangTogglePills.test.ts
@@ -1,0 +1,36 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import LangTogglePills from './LangTogglePills.vue'
+
+describe('LangTogglePills', () => {
+  it('adds a language on click and emits the new set', async () => {
+    const w = mount(LangTogglePills, { props: { langs: ['en'] } })
+    await w.get('[data-testid="lang-toggle-ru"]').trigger('click')
+    expect(w.emitted('change')?.[0]?.[0]).toEqual(['en', 'ru'])
+  })
+
+  it('removes an already-selected language on click', async () => {
+    const w = mount(LangTogglePills, { props: { langs: ['en', 'ru'] } })
+    await w.get('[data-testid="lang-toggle-en"]').trigger('click')
+    expect(w.emitted('change')?.[0]?.[0]).toEqual(['ru'])
+  })
+
+  it('marks selected pills via aria-pressed', () => {
+    const w = mount(LangTogglePills, { props: { langs: ['ru'] } })
+    expect(
+      w.get('[data-testid="lang-toggle-ru"]').attributes('aria-pressed')
+    ).toBe('true')
+    expect(
+      w.get('[data-testid="lang-toggle-en"]').attributes('aria-pressed')
+    ).toBe('false')
+  })
+
+  it('disables every pill when disabled', () => {
+    const w = mount(LangTogglePills, {
+      props: { langs: ['en'], disabled: true },
+    })
+    expect(
+      w.get('[data-testid="lang-toggle-en"]').attributes('disabled')
+    ).toBeDefined()
+  })
+})

--- a/src/views/CommsView/LangTogglePills.vue
+++ b/src/views/CommsView/LangTogglePills.vue
@@ -11,8 +11,16 @@ const emit = defineEmits<{
   change: [langs: readonly Lang[]]
 }>()
 
-const onClick = (lang: Lang): void => {
+const onClick = (lang: Lang, event: MouseEvent): void => {
   emit('change', toggleLang(props.langs, lang))
+  // `detail === 0` means keyboard (Enter/Space) — keep focus + ring for
+  // a11y. A pointer tap/click leaves the button focused and re-renders
+  // on save, which some browsers flag as :focus-visible; blur it so no
+  // ring lingers after a tap.
+  const el = event.currentTarget
+  if (event.detail !== 0 && el instanceof HTMLElement) {
+    el.blur()
+  }
 }
 </script>
 
@@ -32,7 +40,7 @@ const onClick = (lang: Lang): void => {
       :disabled="disabled"
       :data-testid="`lang-toggle-${lang}`"
       :aria-pressed="langs.includes(lang)"
-      @click="onClick(lang)"
+      @click="onClick(lang, $event)"
     >
       {{ lang }}
     </button>

--- a/src/views/CommsView/LangTogglePills.vue
+++ b/src/views/CommsView/LangTogglePills.vue
@@ -41,9 +41,11 @@ const onClick = (lang: Lang): void => {
 
 <style scoped>
 .lang-toggle {
-  display: inline-flex;
+  display: flex;
   flex-wrap: wrap;
   gap: var(--spacing-xs);
+  max-width: 100%;
+  min-width: 0;
 }
 
 .pill {
@@ -67,6 +69,11 @@ const onClick = (lang: Lang): void => {
 .pill:disabled {
   cursor: not-allowed;
   opacity: 50%;
+}
+
+/* Suppress the ring on pointer (tap/click); keep it for keyboard nav. */
+.pill:focus {
+  outline: none;
 }
 
 .pill:focus-visible {

--- a/src/views/CommsView/LangTogglePills.vue
+++ b/src/views/CommsView/LangTogglePills.vue
@@ -68,6 +68,9 @@ const onClick = (lang: Lang, event: MouseEvent): void => {
   letter-spacing: 0.04em;
   text-transform: uppercase;
   cursor: pointer;
+
+  /* Kill the mobile tap-highlight square that covers the whole pill. */
+  -webkit-tap-highlight-color: transparent;
   transition:
     background var(--transition-fast),
     color var(--transition-fast),

--- a/src/views/CommsView/ScheduleEditor.vue
+++ b/src/views/CommsView/ScheduleEditor.vue
@@ -106,6 +106,8 @@ const submit = (): void => emit('save', { ...draft.value })
 .field-input {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);

--- a/src/views/CommsView/SubscriberRow.vue
+++ b/src/views/CommsView/SubscriberRow.vue
@@ -51,10 +51,12 @@ const emit = defineEmits<{
   font-size: 0.875rem;
   vertical-align: middle;
   color: var(--color-text-primary);
+  min-width: 0;
 }
 
 .email {
   font-family: var(--font-mono);
+  overflow-wrap: anywhere;
 }
 
 .actions {

--- a/src/views/CommsView/TimezoneSelect.vue
+++ b/src/views/CommsView/TimezoneSelect.vue
@@ -46,6 +46,8 @@ const onChange = (e: Event): void => {
 .field-select {
   appearance: none;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   padding: 0.55rem 0.85rem;
   background: var(--color-surface-elevated);
   color: var(--color-text-primary);


### PR DESCRIPTION
Ships to prod. Root cause: worker CORS omitted PATCH, so subscriber language edits (PATCH /api/subscribers/:id) were blocked cross-origin — language couldn't change. Adds PATCH + cors regression test. Also removes the mobile tap-highlight square on the pills and keeps the focus ring keyboard-only (blur on tap). Component test for the toggle. 🤖 Generated with Claude Code