### PR TITLE
feat(comms): per-subscriber message language + status filter

### DIFF
--- a/scripts/check-vue-template-depth/config.ts
+++ b/scripts/check-vue-template-depth/config.ts
@@ -19,6 +19,7 @@ export const config: Config = {
     'src/views/SettingsView/MembersSection.vue',
     'src/views/CommsView/SubscribersTable.vue',
     'src/views/CommsView/SubscriberRow.vue',
+    'src/views/CommsView/StatusLegend.vue',
     'src/views/CommsView/RunHistoryList.vue',
     'src/views/CommsView/RunHistoryRow.vue',
     'src/views/CommsView/AddSubscriberForm.vue',

--- a/services/comms-worker/migrations/0003_message_lang.sql
+++ b/services/comms-worker/migrations/0003_message_lang.sql
@@ -1,0 +1,6 @@
+-- 0003_message_lang.sql
+-- Per-subscriber message (email chrome) language, distinct from the
+-- content `langs[]`. Defaults to English for every existing and new
+-- row; the editor can change it per subscriber in the admin UI.
+
+ALTER TABLE subscribers ADD COLUMN message_lang TEXT NOT NULL DEFAULT 'en';

--- a/services/comms-worker/src/digest/render-helpers.ts
+++ b/services/comms-worker/src/digest/render-helpers.ts
@@ -45,13 +45,14 @@ export const groupByLang = (
 
 /**
  * Chrome dictionary for the email shell (subject, intro, footer,
- * unsubscribe copy). Always English by default, regardless of the
- * subscriber's languages — only the article CONTENT stays localised
- * (see {@link groupByLang}). Centralising it here keeps the one
- * decision in one place if per-language chrome ever returns.
- * @returns English chrome strings.
+ * unsubscribe copy), keyed by the subscriber's chosen MESSAGE language
+ * (defaults to English at the data layer) — independent of the article
+ * CONTENT languages in `langs[]` (see {@link groupByLang}).
+ * @param messageLang The subscriber's message language.
+ * @returns Localised chrome strings.
  */
-export const chromeFor = (): DigestChrome => CHROME.en
+export const chromeFor = (messageLang: Lang): DigestChrome =>
+  CHROME[messageLang]
 
 /**
  * UTM-stamp both arms of a newspaper selection for the campaign.

--- a/services/comms-worker/src/digest/render.test.ts
+++ b/services/comms-worker/src/digest/render.test.ts
@@ -8,6 +8,7 @@ const SUB: Subscriber = {
   id: 42,
   email: 'reader@example.test',
   langs: ['ru', 'en'],
+  messageLang: 'en',
   status: 'active',
   createdAt: '2026-05-01T00:00:00.000Z',
   lastSentAt: undefined,
@@ -53,6 +54,16 @@ describe('renderDigest — subject', () => {
       tickAt: TICK,
     })
     expect(d.subject).toBe('Communist Prometheus — 2 new articles')
+  })
+
+  it('uses Russian chrome when the subscriber opts into messageLang ru', () => {
+    const d = renderDigest({
+      subscriber: { ...SUB, messageLang: 'ru' },
+      articles: ARTICLES,
+      unsubscribeUrl: UNSUB,
+      tickAt: TICK,
+    })
+    expect(d.subject).toBe('Коммунистический Прометей — 2 новых статей')
   })
 })
 

--- a/services/comms-worker/src/digest/render.ts
+++ b/services/comms-worker/src/digest/render.ts
@@ -42,7 +42,7 @@ const POST_HEADER = 'List-Unsubscribe=One-Click'
  * @returns Complete digest ready to hand to the Resend client.
  */
 export const renderDigest = (input: DigestRenderInput): Digest => {
-  const chrome = chromeFor()
+  const chrome = chromeFor(input.subscriber.messageLang)
   const campaign = isoWeekString(input.tickAt)
   const groups = groupByLang(input.subscriber.langs, input.articles, campaign)
   const selection = input.newspapers ?? EMPTY_NEWSPAPERS

--- a/services/comms-worker/src/subscribers/repo-insert.ts
+++ b/services/comms-worker/src/subscribers/repo-insert.ts
@@ -7,7 +7,7 @@ import {
 } from './types'
 
 const SQL_INSERT =
-  'INSERT INTO subscribers (email, langs, created_at) VALUES (?, ?, ?)'
+  'INSERT INTO subscribers (email, langs, message_lang, created_at) VALUES (?, ?, ?, ?)'
 const SQL_LAST = 'SELECT * FROM subscribers WHERE rowid = last_insert_rowid()'
 const UNIQUE_MARKER = 'UNIQUE'
 
@@ -28,7 +28,7 @@ export const insertSubscriber = async (
   try {
     await db
       .prepare(SQL_INSERT)
-      .bind(email, langsToJson(input.langs), now())
+      .bind(email, langsToJson(input.langs), input.messageLang ?? 'en', now())
       .run()
   } catch (e) {
     if (e instanceof Error && e.message.includes(UNIQUE_MARKER)) {

--- a/services/comms-worker/src/subscribers/repo-status.ts
+++ b/services/comms-worker/src/subscribers/repo-status.ts
@@ -1,0 +1,27 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { findById } from './repo-read'
+import type { Subscriber, SubscriberStatus } from './types'
+
+const SQL_UPDATE_STATUS_INACTIVE =
+  'UPDATE subscribers SET status = ?, unsubscribed_at = ? WHERE id = ?'
+const SQL_UPDATE_STATUS_ACTIVE =
+  "UPDATE subscribers SET status = 'active', unsubscribed_at = NULL WHERE id = ?"
+
+/** Transition a row's status; stamps `unsubscribed_at` on leave-active. */
+export const setStatus = async (
+  db: D1Database,
+  now: () => string,
+  id: number,
+  status: SubscriberStatus
+): Promise<Subscriber | undefined> => {
+  const sql =
+    status === 'active'
+      ? SQL_UPDATE_STATUS_ACTIVE
+      : SQL_UPDATE_STATUS_INACTIVE
+  const stmt =
+    status === 'active'
+      ? db.prepare(sql).bind(id)
+      : db.prepare(sql).bind(status, now(), id)
+  await stmt.run()
+  return findById(db, id)
+}

--- a/services/comms-worker/src/subscribers/repo-write.ts
+++ b/services/comms-worker/src/subscribers/repo-write.ts
@@ -1,15 +1,13 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { findById } from './repo-read'
 import { langsToJson } from './serialize'
-import type { Lang, Subscriber, SubscriberStatus } from './types'
+import type { Lang, Subscriber } from './types'
 
 const SQL_UPDATE_LANGS = 'UPDATE subscribers SET langs = ? WHERE id = ?'
+const SQL_UPDATE_MESSAGE_LANG =
+  'UPDATE subscribers SET message_lang = ? WHERE id = ?'
 const SQL_MARK_SENT = 'UPDATE subscribers SET last_sent_at = ? WHERE id = ?'
 const SQL_DELETE = 'DELETE FROM subscribers WHERE id = ?'
-const SQL_UPDATE_STATUS_INACTIVE =
-  'UPDATE subscribers SET status = ?, unsubscribed_at = ? WHERE id = ?'
-const SQL_UPDATE_STATUS_ACTIVE =
-  "UPDATE subscribers SET status = 'active', unsubscribed_at = NULL WHERE id = ?"
 
 /** Update only the `langs[]` column on an existing row. */
 export const updateLangs = async (
@@ -18,6 +16,16 @@ export const updateLangs = async (
   langs: ReadonlyArray<Lang>
 ): Promise<Subscriber | undefined> => {
   await db.prepare(SQL_UPDATE_LANGS).bind(langsToJson(langs), id).run()
+  return findById(db, id)
+}
+
+/** Update only the `message_lang` column on an existing row. */
+export const updateMessageLang = async (
+  db: D1Database,
+  id: number,
+  messageLang: Lang
+): Promise<Subscriber | undefined> => {
+  await db.prepare(SQL_UPDATE_MESSAGE_LANG).bind(messageLang, id).run()
   return findById(db, id)
 }
 
@@ -37,23 +45,4 @@ export const removeSubscriber = async (
 ): Promise<boolean> => {
   const res = await db.prepare(SQL_DELETE).bind(id).run()
   return (res.meta.changes ?? 0) > 0
-}
-
-/** Transition a row's status; stamps `unsubscribed_at` on leave-active. */
-export const setStatus = async (
-  db: D1Database,
-  now: () => string,
-  id: number,
-  status: SubscriberStatus
-): Promise<Subscriber | undefined> => {
-  const sql =
-    status === 'active'
-      ? SQL_UPDATE_STATUS_ACTIVE
-      : SQL_UPDATE_STATUS_INACTIVE
-  const stmt =
-    status === 'active'
-      ? db.prepare(sql).bind(id)
-      : db.prepare(sql).bind(status, now(), id)
-  await stmt.run()
-  return findById(db, id)
 }

--- a/services/comms-worker/src/subscribers/repo.ts
+++ b/services/comms-worker/src/subscribers/repo.ts
@@ -1,11 +1,12 @@
 import type { D1Database } from '@cloudflare/workers-types'
 import { insertSubscriber } from './repo-insert'
 import { findById, listActive, listAll } from './repo-read'
+import { setStatus } from './repo-status'
 import {
   markSent,
   removeSubscriber,
-  setStatus,
   updateLangs,
+  updateMessageLang,
 } from './repo-write'
 import type {
   Lang,
@@ -23,6 +24,10 @@ export type SubscriberRepo = {
   readonly updateLangs: (
     id: number,
     langs: ReadonlyArray<Lang>
+  ) => Promise<Subscriber | undefined>
+  readonly updateMessageLang: (
+    id: number,
+    messageLang: Lang
   ) => Promise<Subscriber | undefined>
   readonly remove: (id: number) => Promise<boolean>
   readonly setStatus: (
@@ -45,6 +50,7 @@ export const createRepo = (d: Deps): SubscriberRepo => ({
   listAll: () => listAll(d.db),
   findById: id => findById(d.db, id),
   updateLangs: (id, langs) => updateLangs(d.db, id, langs),
+  updateMessageLang: (id, lang) => updateMessageLang(d.db, id, lang),
   remove: id => removeSubscriber(d.db, id),
   setStatus: (id, status) => setStatus(d.db, d.now, id, status),
   markSent: (id, sentAt) => markSent(d.db, id, sentAt),

--- a/services/comms-worker/src/subscribers/route-handlers.ts
+++ b/services/comms-worker/src/subscribers/route-handlers.ts
@@ -1,13 +1,11 @@
 import type { Context } from 'hono'
 import type { SubscriberRepo } from './repo'
+import { parseId } from './route-helpers'
 import { isDuplicateError } from './types'
-import { validateLangsPatch, validateNewSubscriber } from './validate'
+import { validateNewSubscriber } from './validate'
 
-/** Parse a positive integer from a path param. */
-export const parseId = (raw: string): number | undefined => {
-  const n = Number(raw)
-  return Number.isFinite(n) && n > 0 ? n : undefined
-}
+export { parseId } from './route-helpers'
+export { handlePatch } from './route-patch'
 
 /** POST /api/subscribers — create. */
 export const handleCreate = async (
@@ -23,22 +21,6 @@ export const handleCreate = async (
     if (isDuplicateError(e)) return c.json({ error: 'duplicate' }, 409)
     throw e
   }
-}
-
-/** PATCH /api/subscribers/:id — replace langs. */
-export const handlePatch = async (
-  c: Context,
-  repo: SubscriberRepo
-): Promise<Response> => {
-  const id = parseId(c.req.param('id'))
-  if (id === undefined) return c.json({ error: 'not_found' }, 404)
-  const body = await c.req.json().catch(() => undefined)
-  const parsed = validateLangsPatch(body)
-  if ('error' in parsed) return c.json({ error: parsed.error }, 422)
-  const updated = await repo.updateLangs(id, parsed.langs)
-  return updated === undefined
-    ? c.json({ error: 'not_found' }, 404)
-    : c.json(updated)
 }
 
 /** DELETE /api/subscribers/:id — hard delete. */

--- a/services/comms-worker/src/subscribers/route-helpers.ts
+++ b/services/comms-worker/src/subscribers/route-helpers.ts
@@ -1,0 +1,9 @@
+/**
+ * Parse a positive integer from a path param.
+ * @param raw Raw string path parameter.
+ * @returns The id, or undefined when it is not a positive integer.
+ */
+export const parseId = (raw: string): number | undefined => {
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : undefined
+}

--- a/services/comms-worker/src/subscribers/route-patch.ts
+++ b/services/comms-worker/src/subscribers/route-patch.ts
@@ -1,0 +1,37 @@
+import type { Context } from 'hono'
+import type { SubscriberRepo } from './repo'
+import { parseId } from './route-helpers'
+import type { Subscriber } from './types'
+import { type SubscriberPatch, validatePatch } from './validate'
+
+const applyPatch = async (
+  repo: SubscriberRepo,
+  id: number,
+  patch: SubscriberPatch
+): Promise<Subscriber | undefined> => {
+  const afterLangs =
+    patch.langs !== undefined
+      ? await repo.updateLangs(id, patch.langs)
+      : undefined
+  const afterMsg =
+    patch.messageLang !== undefined
+      ? await repo.updateMessageLang(id, patch.messageLang)
+      : undefined
+  return afterMsg ?? afterLangs
+}
+
+/** PATCH /api/subscribers/:id — update `langs` and/or `messageLang`. */
+export const handlePatch = async (
+  c: Context,
+  repo: SubscriberRepo
+): Promise<Response> => {
+  const id = parseId(c.req.param('id'))
+  if (id === undefined) return c.json({ error: 'not_found' }, 404)
+  const body = await c.req.json().catch(() => undefined)
+  const parsed = validatePatch(body)
+  if ('error' in parsed) return c.json({ error: parsed.error }, 422)
+  const updated = await applyPatch(repo, id, parsed)
+  return updated === undefined
+    ? c.json({ error: 'not_found' }, 404)
+    : c.json(updated)
+}

--- a/services/comms-worker/src/subscribers/routes.test.ts
+++ b/services/comms-worker/src/subscribers/routes.test.ts
@@ -75,6 +75,51 @@ describe('POST /api/subscribers', () => {
     expect(body.langs).toEqual(['ru'])
   })
 
+  it('defaults messageLang to en when omitted', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'a@b.c', langs: ['ru'] }),
+      }),
+      env
+    )
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as Subscriber
+    expect(body.messageLang).toBe('en')
+  })
+
+  it('persists an explicit messageLang', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: 'a@b.c',
+          langs: ['ru'],
+          messageLang: 'ru',
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(201)
+    const body = (await res.json()) as Subscriber
+    expect(body.messageLang).toBe('ru')
+  })
+
+  it('returns 422 for an unknown messageLang', async () => {
+    const res = await app.fetch(
+      reqJson('/api/subscribers', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: 'a@b.c',
+          langs: ['ru'],
+          messageLang: 'xx',
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
+  })
+
   it('returns 422 for invalid email syntax', async () => {
     const res = await app.fetch(
       reqJson('/api/subscribers', {
@@ -137,6 +182,32 @@ describe('PATCH /api/subscribers/:id', () => {
     expect(res.status).toBe(200)
     const body = (await res.json()) as Subscriber
     expect(body.langs).toEqual(['en', 'it'])
+  })
+
+  it('updates messageLang and returns the new row', async () => {
+    const s = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const res = await app.fetch(
+      reqJson(`/api/subscribers/${s.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({ messageLang: 'it' }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as Subscriber
+    expect(body.messageLang).toBe('it')
+  })
+
+  it('returns 422 for an empty patch', async () => {
+    const s = await repo.insert({ email: 'a@b.c', langs: ['ru'] })
+    const res = await app.fetch(
+      reqJson(`/api/subscribers/${s.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({}),
+      }),
+      env
+    )
+    expect(res.status).toBe(422)
   })
 
   it('returns 404 for unknown id', async () => {

--- a/services/comms-worker/src/subscribers/serialize.ts
+++ b/services/comms-worker/src/subscribers/serialize.ts
@@ -5,6 +5,7 @@ type Row = {
   readonly id: number
   readonly email: string
   readonly langs: string
+  readonly message_lang: string
   readonly status: string
   readonly created_at: string
   readonly last_sent_at: string | null
@@ -28,6 +29,7 @@ export const rowToSubscriber = (row: Row): Subscriber => ({
   id: row.id,
   email: row.email,
   langs: parseLangs(row.langs),
+  messageLang: isLang(row.message_lang) ? row.message_lang : 'en',
   status: row.status as SubscriberStatus,
   createdAt: row.created_at,
   lastSentAt: row.last_sent_at ?? undefined,

--- a/services/comms-worker/src/subscribers/test-d1.ts
+++ b/services/comms-worker/src/subscribers/test-d1.ts
@@ -47,7 +47,11 @@ const prepare = (db: BetterSqlite3.Database, sql: string) => {
  */
 export const makeTestD1 = (): D1Database => {
   const db = new BetterSqlite3(':memory:')
-  for (const file of ['0001_initial.sql', '0002_seed.sql']) {
+  for (const file of [
+    '0001_initial.sql',
+    '0002_seed.sql',
+    '0003_message_lang.sql',
+  ]) {
     db.exec(readFileSync(resolve(MIG_DIR, file), 'utf8'))
   }
   return {

--- a/services/comms-worker/src/subscribers/types.ts
+++ b/services/comms-worker/src/subscribers/types.ts
@@ -16,6 +16,8 @@ export type Subscriber = {
   readonly id: number
   readonly email: string
   readonly langs: ReadonlyArray<Lang>
+  /** Language of the email shell (subject/intro/footer); content uses `langs`. */
+  readonly messageLang: Lang
   readonly status: SubscriberStatus
   readonly createdAt: string
   readonly lastSentAt: string | undefined
@@ -26,6 +28,8 @@ export type Subscriber = {
 export type NewSubscriber = {
   readonly email: string
   readonly langs: ReadonlyArray<Lang>
+  /** Message (chrome) language; defaults to English when omitted. */
+  readonly messageLang?: Lang
 }
 
 /** Sentinel name used by `DuplicateError` instances. */

--- a/services/comms-worker/src/subscribers/validate-helpers.ts
+++ b/services/comms-worker/src/subscribers/validate-helpers.ts
@@ -1,0 +1,18 @@
+import { LANGS, type Lang } from './types'
+
+/** Loose RFC-5322-ish email shape check. */
+export const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const allowedLangs = new Set<string>(LANGS)
+
+/** Type guard for a supported language code. */
+export const isLang = (v: unknown): v is Lang =>
+  typeof v === 'string' && allowedLangs.has(v)
+
+/**
+ * Narrow an unknown value to a non-empty list of language codes.
+ * @param v Raw value.
+ * @returns The narrowed list, or undefined when invalid/absent.
+ */
+export const parseLangs = (v: unknown): ReadonlyArray<Lang> | undefined =>
+  Array.isArray(v) && v.length > 0 && v.every(isLang) ? v : undefined

--- a/services/comms-worker/src/subscribers/validate-patch.ts
+++ b/services/comms-worker/src/subscribers/validate-patch.ts
@@ -1,0 +1,39 @@
+import type { Lang } from './types'
+import { isLang, parseLangs } from './validate-helpers'
+
+/** A validated `PATCH /api/subscribers/:id` payload — at least one field. */
+export type SubscriberPatch = {
+  readonly langs?: ReadonlyArray<Lang>
+  readonly messageLang?: Lang
+}
+
+type PatchError = { readonly error: 'langs' | 'messageLang' | 'empty' }
+
+/**
+ * Validate the body of `PATCH /api/subscribers/:id`. Accepts `langs`
+ * and/or `messageLang`; at least one must be present and valid.
+ * @param body Raw parsed JSON body.
+ * @returns The fields to update, or an error code.
+ */
+export const validatePatch = (
+  body: unknown
+): SubscriberPatch | PatchError => {
+  if (typeof body !== 'object' || body === null) return { error: 'empty' }
+  const { langs, messageLang } = body as {
+    readonly langs?: unknown
+    readonly messageLang?: unknown
+  }
+  if (langs !== undefined && parseLangs(langs) === undefined) {
+    return { error: 'langs' }
+  }
+  if (messageLang !== undefined && !isLang(messageLang)) {
+    return { error: 'messageLang' }
+  }
+  const out: SubscriberPatch = {
+    langs: parseLangs(langs),
+    messageLang: isLang(messageLang) ? messageLang : undefined,
+  }
+  return out.langs === undefined && out.messageLang === undefined
+    ? { error: 'empty' }
+    : out
+}

--- a/services/comms-worker/src/subscribers/validate.ts
+++ b/services/comms-worker/src/subscribers/validate.ts
@@ -1,11 +1,8 @@
-import { LANGS, type Lang, type NewSubscriber } from './types'
+import type { NewSubscriber } from './types'
+import { EMAIL_RE, isLang, parseLangs } from './validate-helpers'
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-
-const allowedLangs = new Set<string>(LANGS)
-
-const isLang = (v: unknown): v is Lang =>
-  typeof v === 'string' && allowedLangs.has(v)
+export type { SubscriberPatch } from './validate-patch'
+export { validatePatch } from './validate-patch'
 
 /**
  * Validate the body of `POST /api/subscribers`.
@@ -14,33 +11,25 @@ const isLang = (v: unknown): v is Lang =>
  */
 export const validateNewSubscriber = (
   body: unknown
-): NewSubscriber | { readonly error: 'email' | 'langs' } => {
+): NewSubscriber | { readonly error: 'email' | 'langs' | 'messageLang' } => {
   if (typeof body !== 'object' || body === null) return { error: 'email' }
-  const { email, langs } = body as {
+  const { email, langs, messageLang } = body as {
     readonly email?: unknown
     readonly langs?: unknown
+    readonly messageLang?: unknown
   }
+  const parsedLangs = parseLangs(langs)
   if (typeof email !== 'string' || !EMAIL_RE.test(email)) {
     return { error: 'email' }
   }
-  if (!Array.isArray(langs) || langs.length === 0 || !langs.every(isLang)) {
-    return { error: 'langs' }
+  if (parsedLangs === undefined) return { error: 'langs' }
+  if (messageLang !== undefined && !isLang(messageLang)) {
+    return { error: 'messageLang' }
   }
-  return { email, langs }
-}
-
-/**
- * Validate the body of `PATCH /api/subscribers/:id`.
- * @param body Raw parsed JSON body.
- * @returns Langs array on success, error code otherwise.
- */
-export const validateLangsPatch = (
-  body: unknown
-): { readonly langs: ReadonlyArray<Lang> } | { readonly error: 'langs' } => {
-  if (typeof body !== 'object' || body === null) return { error: 'langs' }
-  const { langs } = body as { readonly langs?: unknown }
-  if (!Array.isArray(langs) || langs.length === 0 || !langs.every(isLang)) {
-    return { error: 'langs' }
+  // Default the message (chrome) language to English when unspecified.
+  return {
+    email,
+    langs: parsedLangs,
+    messageLang: isLang(messageLang) ? messageLang : 'en',
   }
-  return { langs }
 }

--- a/src/stores/comms-actions-mutations.ts
+++ b/src/stores/comms-actions-mutations.ts
@@ -1,0 +1,42 @@
+import type { Lang } from '@/validation/schemas/subscriber'
+import {
+  apiRemoveSubscriber,
+  apiUpdateLangs,
+  apiUpdateMessageLang,
+} from './comms-api'
+
+/**
+ * Build the `updateLangs` action that PATCHes one row + reloads.
+ * @param load Loader used to refresh after the write.
+ * @returns Async action returning void.
+ */
+export const createUpdateLangs =
+  (load: () => Promise<void>) =>
+  async (id: number, langs: readonly Lang[]): Promise<void> => {
+    await apiUpdateLangs(id, langs)
+    await load()
+  }
+
+/**
+ * Build the `updateMessageLang` action that PATCHes one row + reloads.
+ * @param load Loader used to refresh after the write.
+ * @returns Async action returning void.
+ */
+export const createUpdateMessageLang =
+  (load: () => Promise<void>) =>
+  async (id: number, messageLang: Lang): Promise<void> => {
+    await apiUpdateMessageLang(id, messageLang)
+    await load()
+  }
+
+/**
+ * Build the `remove` action that DELETEs one row + reloads.
+ * @param load Loader used to refresh after the write.
+ * @returns Async action returning void.
+ */
+export const createRemove =
+  (load: () => Promise<void>) =>
+  async (id: number): Promise<void> => {
+    await apiRemoveSubscriber(id)
+    await load()
+  }

--- a/src/stores/comms-actions.ts
+++ b/src/stores/comms-actions.ts
@@ -1,11 +1,12 @@
 import type { Ref } from 'vue'
 import type { Lang, Subscriber } from '@/validation/schemas/subscriber'
-import {
-  apiAddSubscriber,
-  apiListSubscribers,
-  apiRemoveSubscriber,
-  apiUpdateLangs,
-} from './comms-api'
+import { apiAddSubscriber, apiListSubscribers } from './comms-api'
+
+export {
+  createRemove,
+  createUpdateLangs,
+  createUpdateMessageLang,
+} from './comms-actions-mutations'
 
 /** Mutable refs the action factories read + write. */
 export type CommsRefs = {
@@ -39,36 +40,16 @@ export const createLoad = (r: CommsRefs) => async (): Promise<void> => {
  */
 export const createAdd =
   (r: CommsRefs, load: () => Promise<void>) =>
-  async (email: string, langs: readonly Lang[]): Promise<void> => {
+  async (
+    email: string,
+    langs: readonly Lang[],
+    messageLang: Lang
+  ): Promise<void> => {
     r.saving.value = true
     try {
-      await apiAddSubscriber(email, langs)
+      await apiAddSubscriber(email, langs, messageLang)
       await load()
     } finally {
       r.saving.value = false
     }
-  }
-
-/**
- * Build the `updateLangs` action that PATCHes one row + reloads.
- * @param load Loader used to refresh after the write.
- * @returns Async action returning void.
- */
-export const createUpdateLangs =
-  (load: () => Promise<void>) =>
-  async (id: number, langs: readonly Lang[]): Promise<void> => {
-    await apiUpdateLangs(id, langs)
-    await load()
-  }
-
-/**
- * Build the `remove` action that DELETEs one row + reloads.
- * @param load Loader used to refresh after the write.
- * @returns Async action returning void.
- */
-export const createRemove =
-  (load: () => Promise<void>) =>
-  async (id: number): Promise<void> => {
-    await apiRemoveSubscriber(id)
-    await load()
   }

--- a/src/stores/comms-api-patch.ts
+++ b/src/stores/comms-api-patch.ts
@@ -1,0 +1,38 @@
+import { decodeResponse } from '@/validation/decode-response'
+import type { Lang, Subscriber } from '@/validation/schemas/subscriber'
+import { SubscriberSchema } from '@/validation/schemas/subscriber'
+import { commsFetch, jsonHeaders } from './comms-http'
+
+const patchSubscriber = async (
+  id: number,
+  body: Readonly<Record<string, unknown>>
+): Promise<Subscriber> => {
+  const res = await commsFetch(`/api/subscribers/${id}`, {
+    method: 'PATCH',
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  })
+  return decodeResponse(SubscriberSchema)(res)
+}
+
+/**
+ * PATCH /api/subscribers/:id — replace the langs[] array.
+ * @param id Subscriber id.
+ * @param langs Replacement language list.
+ * @returns The updated subscriber row.
+ */
+export const apiUpdateLangs = (
+  id: number,
+  langs: ReadonlyArray<Lang>
+): Promise<Subscriber> => patchSubscriber(id, { langs })
+
+/**
+ * PATCH /api/subscribers/:id — change the email-shell message language.
+ * @param id Subscriber id.
+ * @param messageLang Replacement message language.
+ * @returns The updated subscriber row.
+ */
+export const apiUpdateMessageLang = (
+  id: number,
+  messageLang: Lang
+): Promise<Subscriber> => patchSubscriber(id, { messageLang })

--- a/src/stores/comms-api.test.ts
+++ b/src/stores/comms-api.test.ts
@@ -5,12 +5,14 @@ import {
   apiListSubscribers,
   apiRemoveSubscriber,
   apiUpdateLangs,
+  apiUpdateMessageLang,
 } from './comms-api'
 
 const okSubscriber: Subscriber = {
   id: 7,
   email: 'a@b.c',
   langs: ['ru', 'en'],
+  messageLang: 'en',
   status: 'active',
   createdAt: '2026-06-03T00:00:00.000Z',
   lastSentAt: undefined,
@@ -47,15 +49,17 @@ describe('apiListSubscribers', () => {
 })
 
 describe('apiAddSubscriber', () => {
-  it('POSTs the email + langs and returns the created subscriber', async () => {
+  it('POSTs the email + langs + messageLang and returns the subscriber', async () => {
     mockFetch.mockResolvedValue(
       new Response(JSON.stringify(okSubscriber), { status: 201 })
     )
-    const res = await apiAddSubscriber('a@b.c', ['ru'])
+    const res = await apiAddSubscriber('a@b.c', ['ru'], 'en')
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
     expect(url).toMatch(/\/api\/subscribers$/)
     expect(init.method).toBe('POST')
-    expect(init.body).toBe(JSON.stringify({ email: 'a@b.c', langs: ['ru'] }))
+    expect(init.body).toBe(
+      JSON.stringify({ email: 'a@b.c', langs: ['ru'], messageLang: 'en' })
+    )
     expect(res.email).toBe('a@b.c')
   })
 
@@ -63,7 +67,9 @@ describe('apiAddSubscriber', () => {
     mockFetch.mockResolvedValue(
       new Response(JSON.stringify({ error: 'email' }), { status: 422 })
     )
-    await expect(apiAddSubscriber('bad', ['ru'])).rejects.toThrow('email')
+    await expect(apiAddSubscriber('bad', ['ru'], 'en')).rejects.toThrow(
+      'email'
+    )
   })
 })
 
@@ -75,6 +81,17 @@ describe('apiUpdateLangs', () => {
     expect(url).toMatch(/\/api\/subscribers\/7$/)
     expect(init.method).toBe('PATCH')
     expect(init.body).toBe(JSON.stringify({ langs: ['en'] }))
+  })
+})
+
+describe('apiUpdateMessageLang', () => {
+  it('PATCHes the messageLang at /api/subscribers/:id', async () => {
+    mockFetch.mockResolvedValue(ok(okSubscriber))
+    await apiUpdateMessageLang(7, 'it')
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toMatch(/\/api\/subscribers\/7$/)
+    expect(init.method).toBe('PATCH')
+    expect(init.body).toBe(JSON.stringify({ messageLang: 'it' }))
   })
 })
 

--- a/src/stores/comms-api.ts
+++ b/src/stores/comms-api.ts
@@ -10,6 +10,8 @@ import {
 } from '@/validation/schemas/subscriber'
 import { commsFetch, ensureOk, jsonHeaders } from './comms-http'
 
+export { apiUpdateLangs, apiUpdateMessageLang } from './comms-api-patch'
+
 /**
  * GET /api/subscribers — list every subscriber row, regardless of status.
  * @returns Parsed list payload.
@@ -23,34 +25,18 @@ export const apiListSubscribers = async (): Promise<SubscribersList> => {
  * POST /api/subscribers — create one new active subscriber.
  * @param email Lower-case canonical email address.
  * @param langs Languages the subscriber wants in their digest.
+ * @param messageLang Language of the email shell (defaults to English).
  * @returns The persisted subscriber row.
  */
 export const apiAddSubscriber = async (
   email: string,
-  langs: ReadonlyArray<Lang>
+  langs: ReadonlyArray<Lang>,
+  messageLang: Lang
 ): Promise<Subscriber> => {
   const res = await commsFetch('/api/subscribers', {
     method: 'POST',
     headers: jsonHeaders(),
-    body: JSON.stringify({ email, langs }),
-  })
-  return decodeResponse(SubscriberSchema)(res)
-}
-
-/**
- * PATCH /api/subscribers/:id — replace the langs[] array.
- * @param id Subscriber id.
- * @param langs Replacement language list.
- * @returns The updated subscriber row.
- */
-export const apiUpdateLangs = async (
-  id: number,
-  langs: ReadonlyArray<Lang>
-): Promise<Subscriber> => {
-  const res = await commsFetch(`/api/subscribers/${id}`, {
-    method: 'PATCH',
-    headers: jsonHeaders(),
-    body: JSON.stringify({ langs }),
+    body: JSON.stringify({ email, langs, messageLang }),
   })
   return decodeResponse(SubscriberSchema)(res)
 }

--- a/src/stores/comms-state.ts
+++ b/src/stores/comms-state.ts
@@ -6,6 +6,7 @@ import {
   createLoad,
   createRemove,
   createUpdateLangs,
+  createUpdateMessageLang,
 } from './comms-actions'
 
 /**
@@ -27,6 +28,7 @@ export const createCommsState = () => {
     load,
     add: createAdd(r, load),
     updateLangs: createUpdateLangs(load),
+    updateMessageLang: createUpdateMessageLang(load),
     remove: createRemove(load),
   }
 }

--- a/src/validation/schemas/subscriber.ts
+++ b/src/validation/schemas/subscriber.ts
@@ -7,6 +7,7 @@ export const SubscriberSchema = Schema.Struct({
   id: Schema.Number,
   email: Schema.String,
   langs: Schema.Array(LangSchema),
+  messageLang: LangSchema,
   status: Schema.Literal('active', 'unsubscribed', 'bounced', 'complained'),
   createdAt: Schema.String,
   lastSentAt: Schema.UndefinedOr(Schema.String),

--- a/src/views/CommsView/AddSubscriberForm.vue
+++ b/src/views/CommsView/AddSubscriberForm.vue
@@ -3,14 +3,16 @@ import { computed, ref } from 'vue'
 import type { Lang } from '@/stores/comms'
 import { canSubmitNewSubscriber } from './draft-ops'
 import LangTogglePills from './LangTogglePills.vue'
+import MessageLangSelect from './MessageLangSelect.vue'
 
 const props = defineProps<{ readonly saving?: boolean }>()
 const emit = defineEmits<{
-  add: [email: string, langs: readonly Lang[]]
+  add: [email: string, langs: readonly Lang[], messageLang: Lang]
 }>()
 
 const email = ref('')
 const langs = ref<readonly Lang[]>([])
+const messageLang = ref<Lang>('en')
 const error = ref<string | undefined>(undefined)
 const announce = ref<string>('')
 
@@ -24,10 +26,11 @@ const submit = async (): Promise<void> => {
   if (!canSubmitNewSubscriber(email.value, langs.value)) return
   error.value = undefined
   try {
-    emit('add', email.value.trim(), langs.value)
+    emit('add', email.value.trim(), langs.value, messageLang.value)
     announce.value = `Subscriber ${email.value.trim()} added.`
     email.value = ''
     langs.value = []
+    messageLang.value = 'en'
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to add'
     announce.value = `Failed to add subscriber: ${error.value}`
@@ -61,6 +64,14 @@ const submit = async (): Promise<void> => {
       <span class="field-label">Languages</span>
       <LangTogglePills :langs="langs" :disabled="saving" @change="setLangs" />
     </label>
+    <label class="field field-msg-lang">
+      <span class="field-label">Message language</span>
+      <MessageLangSelect
+        v-model="messageLang"
+        :disabled="saving"
+        label="Message language for new subscriber"
+      />
+    </label>
     <button
       type="submit"
       class="btn btn-primary submit"
@@ -87,9 +98,13 @@ const submit = async (): Promise<void> => {
 <style scoped>
 .add-form {
   display: grid;
-  grid-template-columns: 1fr auto auto;
+  grid-template-columns: 1fr auto auto auto;
   gap: var(--spacing-sm);
   align-items: end;
+}
+
+.field-msg-lang {
+  min-width: 9rem;
 }
 
 @media (width < 640px) {

--- a/src/views/CommsView/CommsView.vue
+++ b/src/views/CommsView/CommsView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref } from 'vue'
 import { t } from '@/i18n/t'
-import { type Subscriber, useCommsStore } from '@/stores/comms'
+import { useCommsStore } from '@/stores/comms'
 import { useCutoffStore } from '@/stores/cutoff'
 import { useRunsStore } from '@/stores/runs'
 import { useScheduleStore } from '@/stores/schedule'
@@ -13,33 +13,31 @@ import { buildHandlers } from './handlers'
 import RemoveSubscriberDialog from './RemoveSubscriberDialog.vue'
 import RunHistory from './RunHistory.vue'
 import ScheduleEditor from './ScheduleEditor.vue'
+import StatusFilter from './StatusFilter.vue'
+import StatusLegend from './StatusLegend.vue'
 import SubscribersTable from './SubscribersTable.vue'
+import { useRemoveDialog } from './use-remove-dialog'
+import { useStatusFilter } from './use-status-filter'
 
 const store = useCommsStore()
 const schedule = useScheduleStore()
 const cutoff = useCutoffStore()
 const runs = useRunsStore()
+const h = buildHandlers({ comms: store, schedule, cutoff, runs })
 
 const activeSubscribers = computed(() =>
   store.subscribers.filter(s => s.status === 'active')
 )
+const {
+  statusFilter,
+  counts: statusCounts,
+  visible: visibleSubscribers,
+  setStatusFilter,
+} = useStatusFilter(() => store.subscribers)
+const { pendingRemove, requestRemove, confirmRemove, cancelRemove } =
+  useRemoveDialog(() => store.subscribers, h.onRemove)
+
 const showRuns = ref(false)
-const pendingRemove = ref<Subscriber | undefined>(undefined)
-const h = buildHandlers({ comms: store, schedule, cutoff, runs })
-
-const requestRemove = (id: number): void => {
-  pendingRemove.value = store.subscribers.find(s => s.id === id)
-}
-
-const confirmRemove = (): void => {
-  const target = pendingRemove.value
-  pendingRemove.value = undefined
-  if (target) h.onRemove(target.id)
-}
-
-const cancelRemove = (): void => {
-  pendingRemove.value = undefined
-}
 
 onMounted(() => {
   void store.ensureLoaded()
@@ -90,9 +88,17 @@ onMounted(() => {
         :lead="t('comms.subscribers.lead')"
       >
         <AddSubscriberForm :saving="store.saving" @add="h.onAdd" />
+        <StatusLegend />
+        <StatusFilter
+          :model-value="statusFilter"
+          :counts="statusCounts"
+          :total="store.subscribers.length"
+          @update:model-value="setStatusFilter"
+        />
         <SubscribersTable
-          :subscribers="store.subscribers"
+          :subscribers="visibleSubscribers"
           @langs="h.onLangs"
+          @message-lang="h.onMessageLang"
           @remove="requestRemove"
         />
         <p
@@ -102,6 +108,14 @@ onMounted(() => {
           data-testid="comms-loading"
         >
           Loading…
+        </p>
+        <p
+          v-else-if="visibleSubscribers.length === 0 && store.subscribers.length > 0"
+          class="loading"
+          role="status"
+          data-testid="comms-empty-filter"
+        >
+          No subscribers with this status.
         </p>
       </CommsSection>
       <CommsSection

--- a/src/views/CommsView/MessageLangSelect.test.ts
+++ b/src/views/CommsView/MessageLangSelect.test.ts
@@ -1,0 +1,30 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import MessageLangSelect from './MessageLangSelect.vue'
+
+describe('MessageLangSelect', () => {
+  it('reflects the bound value as the selected option', () => {
+    const w = mount(MessageLangSelect, { props: { modelValue: 'ru' } })
+    expect(
+      (
+        w.get('[data-testid="message-lang-select"]')
+          .element as HTMLSelectElement
+      ).value
+    ).toBe('ru')
+  })
+
+  it('emits update:modelValue on change', async () => {
+    const w = mount(MessageLangSelect, { props: { modelValue: 'en' } })
+    await w.get('[data-testid="message-lang-select"]').setValue('it')
+    expect(w.emitted('update:modelValue')?.[0]?.[0]).toBe('it')
+  })
+
+  it('disables the select when disabled', () => {
+    const w = mount(MessageLangSelect, {
+      props: { modelValue: 'en', disabled: true },
+    })
+    expect(
+      w.get('[data-testid="message-lang-select"]').attributes('disabled')
+    ).toBeDefined()
+  })
+})

--- a/src/views/CommsView/MessageLangSelect.vue
+++ b/src/views/CommsView/MessageLangSelect.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import type { Lang } from '@/stores/comms'
+import { ALL_LANGS } from './draft-ops'
+import { langLabel } from './lang-labels'
+
+const props = defineProps<{
+  readonly modelValue: Lang
+  readonly disabled?: boolean
+  readonly label?: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [lang: Lang]
+}>()
+
+const onChange = (event: Event): void => {
+  const value = (event.target as HTMLSelectElement).value as Lang
+  emit('update:modelValue', value)
+}
+</script>
+
+<template>
+  <select
+    class="msg-lang"
+    data-testid="message-lang-select"
+    :value="props.modelValue"
+    :disabled="props.disabled"
+    :aria-label="props.label ?? 'Message language'"
+    @change="onChange"
+  >
+    <option v-for="lang in ALL_LANGS" :key="lang" :value="lang">
+      {{ langLabel(lang) }}
+    </option>
+  </select>
+</template>
+
+<style scoped>
+.msg-lang {
+  appearance: none;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 0.4rem 1.6rem 0.4rem 0.6rem;
+  background:
+    var(--color-surface-elevated)
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%23888' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E")
+    no-repeat right 0.6rem center;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font: 400 0.85rem/1.3 var(--font-sans);
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+}
+
+.msg-lang:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+  border-color: var(--color-focus-ring);
+}
+
+.msg-lang:disabled {
+  cursor: not-allowed;
+  opacity: 50%;
+}
+
+.msg-lang:hover:not(:disabled) {
+  border-color: var(--color-text-secondary);
+}
+</style>

--- a/src/views/CommsView/StatusFilter.test.ts
+++ b/src/views/CommsView/StatusFilter.test.ts
@@ -1,0 +1,35 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import StatusFilter from './StatusFilter.vue'
+
+const COUNTS = { active: 2, unsubscribed: 1, bounced: 0, complained: 0 }
+
+const props = { modelValue: 'all' as const, counts: COUNTS, total: 3 }
+
+describe('StatusFilter', () => {
+  it('labels every chip with its count', () => {
+    const w = mount(StatusFilter, { props })
+    expect(w.get('[data-testid="status-filter-all"]').text()).toContain('(3)')
+    expect(w.get('[data-testid="status-filter-active"]').text()).toContain(
+      '(2)'
+    )
+  })
+
+  it('marks the active filter via aria-pressed', () => {
+    const w = mount(StatusFilter, {
+      props: { ...props, modelValue: 'active' },
+    })
+    expect(
+      w.get('[data-testid="status-filter-active"]').attributes('aria-pressed')
+    ).toBe('true')
+    expect(
+      w.get('[data-testid="status-filter-all"]').attributes('aria-pressed')
+    ).toBe('false')
+  })
+
+  it('emits the chosen status on click', async () => {
+    const w = mount(StatusFilter, { props })
+    await w.get('[data-testid="status-filter-bounced"]').trigger('click')
+    expect(w.emitted('update:modelValue')?.[0]?.[0]).toBe('bounced')
+  })
+})

--- a/src/views/CommsView/StatusFilter.vue
+++ b/src/views/CommsView/StatusFilter.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { STATUS_ORDER, type StatusFilterValue } from './status-counts'
+import type { SubscriberStatus } from './status-meta'
+import { STATUS_META } from './status-meta'
+
+const props = defineProps<{
+  readonly modelValue: StatusFilterValue
+  readonly counts: Readonly<Record<SubscriberStatus, number>>
+  readonly total: number
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: StatusFilterValue]
+}>()
+
+const select = (value: StatusFilterValue): void => {
+  emit('update:modelValue', value)
+}
+</script>
+
+<template>
+  <div
+    class="status-filter"
+    role="group"
+    aria-label="Filter subscribers by status"
+    data-testid="status-filter"
+  >
+    <button
+      type="button"
+      class="chip"
+      :class="{ 'chip-on': props.modelValue === 'all' }"
+      :aria-pressed="props.modelValue === 'all'"
+      data-testid="status-filter-all"
+      @click="select('all')"
+    >
+      All ({{ props.total }})
+    </button>
+    <button
+      v-for="status in STATUS_ORDER"
+      :key="status"
+      type="button"
+      class="chip"
+      :class="[`chip-${status}`, { 'chip-on': props.modelValue === status }]"
+      :aria-pressed="props.modelValue === status"
+      :data-testid="`status-filter-${status}`"
+      @click="select(status)"
+    >
+      {{ STATUS_META[status].label }} ({{ props.counts[status] }})
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.status-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-md);
+}
+
+.chip {
+  padding: 0.35rem 0.7rem;
+  border-radius: var(--radius-pill, 999px);
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: 600 0.8125rem/1 var(--font-sans);
+  cursor: pointer;
+  transition:
+    background var(--transition-fast),
+    color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.chip:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.chip:hover:not(:disabled) {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-secondary);
+}
+
+.chip-on {
+  background: var(--color-accent);
+  color: var(--color-background);
+  border-color: var(--color-accent);
+}
+</style>

--- a/src/views/CommsView/StatusLegend.vue
+++ b/src/views/CommsView/StatusLegend.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { STATUS_META, STATUS_ORDER } from './status-meta'
+</script>
+
+<template>
+  <section class="legend" aria-labelledby="status-legend-title">
+    <h3 id="status-legend-title" class="legend-title">
+      What the statuses mean
+    </h3>
+    <ul class="legend-list" role="list">
+      <li v-for="status in STATUS_ORDER" :key="status" class="legend-item">
+        <span
+          class="legend-badge"
+          :class="`status-${status}`"
+          data-testid="status-legend-badge"
+        >{{ STATUS_META[status].icon }} {{ STATUS_META[status].label }}</span>
+        <span class="legend-desc">{{ STATUS_META[status].description }}</span>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<style scoped>
+.legend {
+  margin: 0 0 var(--spacing-md);
+  padding: var(--spacing-md);
+  background: var(--color-surface-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.legend-title {
+  margin: 0 0 var(--spacing-sm);
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.legend-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--spacing-sm);
+}
+
+.legend-item {
+  display: grid;
+  grid-template-columns: minmax(8.5rem, max-content) 1fr;
+  gap: var(--spacing-sm);
+  align-items: baseline;
+}
+
+@media (width < 560px) {
+  .legend-item {
+    grid-template-columns: 1fr;
+    gap: 0.15rem;
+  }
+}
+
+.legend-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-secondary);
+}
+
+.legend-desc {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+}
+
+.status-active {
+  color: var(--color-accent);
+}
+
+.status-unsubscribed {
+  color: var(--color-muted);
+}
+
+.status-bounced,
+.status-complained {
+  color: var(--color-danger);
+}
+</style>

--- a/src/views/CommsView/SubscriberRow.vue
+++ b/src/views/CommsView/SubscriberRow.vue
@@ -1,26 +1,41 @@
 <script setup lang="ts">
 import type { Lang, Subscriber } from '@/stores/comms'
 import LangTogglePills from './LangTogglePills.vue'
+import MessageLangSelect from './MessageLangSelect.vue'
 import SubscriberStatusBadge from './SubscriberStatusBadge.vue'
 
-defineProps<{ readonly entry: Subscriber }>()
+const props = defineProps<{ readonly entry: Subscriber }>()
 const emit = defineEmits<{
   langs: [id: number, langs: readonly Lang[]]
+  messageLang: [id: number, messageLang: Lang]
   remove: [id: number]
 }>()
+
+const onMessageLang = (next: Lang): void => {
+  emit('messageLang', props.entry.id, next)
+}
 </script>
 
 <template>
   <tr class="subscriber-row" data-testid="subscriber-row">
     <td class="email" data-testid="subscriber-email">{{ entry.email }}</td>
-    <td>
+    <td class="langs-cell">
       <LangTogglePills
         :langs="entry.langs"
         :disabled="entry.status !== 'active'"
         @change="langs => emit('langs', entry.id, langs)"
       />
     </td>
-    <td>
+    <td class="msg-cell">
+      <span class="cell-label" aria-hidden="true">Message</span>
+      <MessageLangSelect
+        :model-value="entry.messageLang"
+        :disabled="entry.status !== 'active'"
+        :label="`Message language for ${entry.email}`"
+        @update:model-value="onMessageLang"
+      />
+    </td>
+    <td class="status-cell">
       <SubscriberStatusBadge :status="entry.status" />
     </td>
     <td class="actions">
@@ -90,6 +105,10 @@ const emit = defineEmits<{
   outline-offset: 2px;
 }
 
+.cell-label {
+  display: none;
+}
+
 @media (width < 640px) {
   .subscriber-row {
     display: grid;
@@ -97,6 +116,7 @@ const emit = defineEmits<{
     grid-template-areas:
       'email actions'
       'langs langs'
+      'msg msg'
       'status status';
     gap: var(--spacing-xs);
     padding: var(--spacing-sm) 0;
@@ -117,12 +137,24 @@ const emit = defineEmits<{
     align-self: start;
   }
 
-  .subscriber-row td:nth-child(2) {
+  .subscriber-row .langs-cell {
     grid-area: langs;
   }
 
-  .subscriber-row td:nth-child(3) {
+  .subscriber-row .msg-cell {
+    grid-area: msg;
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .subscriber-row .status-cell {
     grid-area: status;
+  }
+
+  .cell-label {
+    display: block;
+    font-size: 0.75rem;
+    color: var(--color-text-secondary);
   }
 }
 </style>

--- a/src/views/CommsView/SubscriberStatusBadge.vue
+++ b/src/views/CommsView/SubscriberStatusBadge.vue
@@ -1,25 +1,12 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { Subscriber } from '@/stores/comms'
+import { STATUS_META } from './status-meta'
 
 const props = defineProps<{ readonly status: Subscriber['status'] }>()
 
-const ICON: Readonly<Record<Subscriber['status'], string>> = {
-  active: '●',
-  unsubscribed: '○',
-  bounced: '⚠',
-  complained: '⚠',
-}
-
-const LABEL: Readonly<Record<Subscriber['status'], string>> = {
-  active: 'Active subscriber',
-  unsubscribed: 'Unsubscribed by recipient',
-  bounced: 'Address bounces — skipped',
-  complained: 'Marked as spam — skipped',
-}
-
-const icon = computed(() => ICON[props.status])
-const label = computed(() => LABEL[props.status])
+const icon = computed(() => STATUS_META[props.status].icon)
+const label = computed(() => STATUS_META[props.status].description)
 </script>
 
 <template>

--- a/src/views/CommsView/SubscribersTable.vue
+++ b/src/views/CommsView/SubscribersTable.vue
@@ -5,6 +5,7 @@ import SubscriberRow from './SubscriberRow.vue'
 defineProps<{ readonly subscribers: readonly Subscriber[] }>()
 const emit = defineEmits<{
   langs: [id: number, langs: readonly Lang[]]
+  messageLang: [id: number, messageLang: Lang]
   remove: [id: number]
 }>()
 </script>
@@ -19,6 +20,7 @@ const emit = defineEmits<{
       <tr>
         <th scope="col" class="th-email">Email</th>
         <th scope="col" class="th-langs">Languages</th>
+        <th scope="col" class="th-msg-lang">Message</th>
         <th scope="col" class="th-status">Status</th>
         <th scope="col" class="th-actions"><span class="sr-only">Actions</span></th>
       </tr>
@@ -29,6 +31,7 @@ const emit = defineEmits<{
         :key="entry.id"
         :entry="entry"
         @langs="(id, l) => emit('langs', id, l)"
+        @message-lang="(id, ml) => emit('messageLang', id, ml)"
         @remove="id => emit('remove', id)"
       />
     </tbody>
@@ -68,15 +71,19 @@ const emit = defineEmits<{
 }
 
 .th-email {
-  width: 38%;
+  width: 30%;
 }
 
 .th-langs {
-  width: 36%;
+  width: 28%;
+}
+
+.th-msg-lang {
+  width: 18%;
 }
 
 .th-status {
-  width: 18%;
+  width: 16%;
 }
 
 .th-actions {

--- a/src/views/CommsView/handlers.ts
+++ b/src/views/CommsView/handlers.ts
@@ -11,11 +11,14 @@ type Stores = {
 }
 
 const subscriberHandlers = (s: Stores) => ({
-  onAdd: (email: string, langs: readonly Lang[]): void => {
-    void s.comms.add(email, langs)
+  onAdd: (email: string, langs: readonly Lang[], messageLang: Lang): void => {
+    void s.comms.add(email, langs, messageLang)
   },
   onLangs: (id: number, langs: readonly Lang[]): void => {
     void s.comms.updateLangs(id, langs)
+  },
+  onMessageLang: (id: number, messageLang: Lang): void => {
+    void s.comms.updateMessageLang(id, messageLang)
   },
   onRemove: (id: number): void => {
     void s.comms.remove(id)

--- a/src/views/CommsView/lang-labels.ts
+++ b/src/views/CommsView/lang-labels.ts
@@ -1,0 +1,19 @@
+import type { Lang } from '@/validation/schemas/subscriber'
+
+/** Human-readable endonym for each supported language code. */
+export const LANG_LABELS: Readonly<Record<Lang, string>> = {
+  en: 'English',
+  ru: 'Русский',
+  it: 'Italiano',
+  es: 'Español',
+  uk: 'Українська',
+  pl: 'Polski',
+  bl: 'Беларуская',
+}
+
+/**
+ * Resolve a language code to its display label.
+ * @param lang Language code.
+ * @returns The endonym, falling back to the raw code.
+ */
+export const langLabel = (lang: Lang): string => LANG_LABELS[lang] ?? lang

--- a/src/views/CommsView/status-counts.test.ts
+++ b/src/views/CommsView/status-counts.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import type { Subscriber } from '@/stores/comms'
+import { countByStatus, filterByStatus } from './status-counts'
+
+const sub = (id: number, status: Subscriber['status']): Subscriber => ({
+  id,
+  email: `u${id}@x.test`,
+  langs: ['en'],
+  messageLang: 'en',
+  status,
+  createdAt: '2026-06-03T00:00:00.000Z',
+  lastSentAt: undefined,
+  unsubscribedAt: undefined,
+})
+
+const ROWS: readonly Subscriber[] = [
+  sub(1, 'active'),
+  sub(2, 'active'),
+  sub(3, 'unsubscribed'),
+  sub(4, 'bounced'),
+]
+
+describe('countByStatus', () => {
+  it('tallies each lifecycle status', () => {
+    expect(countByStatus(ROWS)).toEqual({
+      active: 2,
+      unsubscribed: 1,
+      bounced: 1,
+      complained: 0,
+    })
+  })
+
+  it('returns all zeros for an empty list', () => {
+    expect(countByStatus([])).toEqual({
+      active: 0,
+      unsubscribed: 0,
+      bounced: 0,
+      complained: 0,
+    })
+  })
+})
+
+describe('filterByStatus', () => {
+  it('passes every row through for "all"', () => {
+    expect(filterByStatus(ROWS, 'all')).toHaveLength(4)
+  })
+
+  it('keeps only the matching status', () => {
+    expect(filterByStatus(ROWS, 'active').map(s => s.id)).toEqual([1, 2])
+    expect(filterByStatus(ROWS, 'bounced').map(s => s.id)).toEqual([4])
+    expect(filterByStatus(ROWS, 'complained')).toHaveLength(0)
+  })
+})

--- a/src/views/CommsView/status-counts.ts
+++ b/src/views/CommsView/status-counts.ts
@@ -1,0 +1,40 @@
+import type { Subscriber } from '@/stores/comms'
+import { STATUS_ORDER, type SubscriberStatus } from './status-meta'
+
+/** The status filter value: a concrete status, or every subscriber. */
+export type StatusFilterValue = 'all' | SubscriberStatus
+
+const tally = (
+  subscribers: readonly Subscriber[],
+  status: SubscriberStatus
+): number => subscribers.filter(s => s.status === status).length
+
+/**
+ * Tally subscribers per lifecycle status.
+ * @param subscribers The full subscriber list.
+ * @returns A count for each status.
+ */
+export const countByStatus = (
+  subscribers: readonly Subscriber[]
+): Readonly<Record<SubscriberStatus, number>> => ({
+  active: tally(subscribers, 'active'),
+  unsubscribed: tally(subscribers, 'unsubscribed'),
+  bounced: tally(subscribers, 'bounced'),
+  complained: tally(subscribers, 'complained'),
+})
+
+/**
+ * Filter subscribers by the selected status, or pass them all through.
+ * @param subscribers The full subscriber list.
+ * @param filter The active status filter.
+ * @returns The subscribers matching the filter.
+ */
+export const filterByStatus = (
+  subscribers: readonly Subscriber[],
+  filter: StatusFilterValue
+): readonly Subscriber[] =>
+  filter === 'all'
+    ? subscribers
+    : subscribers.filter(s => s.status === filter)
+
+export { STATUS_ORDER }

--- a/src/views/CommsView/status-meta.ts
+++ b/src/views/CommsView/status-meta.ts
@@ -1,0 +1,45 @@
+import type { Subscriber } from '@/stores/comms'
+
+/** One of the four subscriber lifecycle states. */
+export type SubscriberStatus = Subscriber['status']
+
+/** Display metadata for a subscriber lifecycle status. */
+export type StatusMeta = {
+  readonly icon: string
+  readonly label: string
+  readonly description: string
+}
+
+/** Canonical display order for the status filter + legend. */
+export const STATUS_ORDER: ReadonlyArray<SubscriberStatus> = [
+  'active',
+  'unsubscribed',
+  'bounced',
+  'complained',
+]
+
+/** Icon, short label, and plain-language meaning for every status. */
+export const STATUS_META: Readonly<Record<SubscriberStatus, StatusMeta>> = {
+  active: {
+    icon: '●',
+    label: 'Active',
+    description:
+      'Receiving the newsletter — included in every scheduled send.',
+  },
+  unsubscribed: {
+    icon: '○',
+    label: 'Unsubscribed',
+    description: 'Opted out via the unsubscribe link — never sent to again.',
+  },
+  bounced: {
+    icon: '⚠',
+    label: 'Bounced',
+    description:
+      'Mail server rejected delivery — skipped to protect sending reputation.',
+  },
+  complained: {
+    icon: '⚠',
+    label: 'Complained',
+    description: 'Reported a send as spam — skipped permanently.',
+  },
+}

--- a/src/views/CommsView/use-remove-dialog.ts
+++ b/src/views/CommsView/use-remove-dialog.ts
@@ -1,0 +1,28 @@
+import { ref } from 'vue'
+import type { Subscriber } from '@/stores/comms'
+
+/**
+ * Remove-confirm dialog state, pulled out of CommsView so the view
+ * stays under the max-lines cap.
+ * @param source Getter for the current subscriber list.
+ * @param onRemove Handler invoked once a removal is confirmed.
+ * @returns The pending target plus request/confirm/cancel actions.
+ */
+export const useRemoveDialog = (
+  source: () => readonly Subscriber[],
+  onRemove: (id: number) => void
+) => {
+  const pendingRemove = ref<Subscriber | undefined>(undefined)
+  const requestRemove = (id: number): void => {
+    pendingRemove.value = source().find(s => s.id === id)
+  }
+  const confirmRemove = (): void => {
+    const target = pendingRemove.value
+    pendingRemove.value = undefined
+    void (target === undefined ? undefined : onRemove(target.id))
+  }
+  const cancelRemove = (): void => {
+    pendingRemove.value = undefined
+  }
+  return { pendingRemove, requestRemove, confirmRemove, cancelRemove }
+}

--- a/src/views/CommsView/use-status-filter.ts
+++ b/src/views/CommsView/use-status-filter.ts
@@ -1,0 +1,23 @@
+import { computed, ref } from 'vue'
+import type { Subscriber } from '@/stores/comms'
+import {
+  countByStatus,
+  filterByStatus,
+  type StatusFilterValue,
+} from './status-counts'
+
+/**
+ * Status-filter UI state, pulled out of CommsView so the view stays
+ * under the max-lines cap.
+ * @param source Getter for the full, unfiltered subscriber list.
+ * @returns The active filter, per-status counts, and the filtered list.
+ */
+export const useStatusFilter = (source: () => readonly Subscriber[]) => {
+  const statusFilter = ref<StatusFilterValue>('all')
+  const counts = computed(() => countByStatus(source()))
+  const visible = computed(() => filterByStatus(source(), statusFilter.value))
+  const setStatusFilter = (value: StatusFilterValue): void => {
+    statusFilter.value = value
+  }
+  return { statusFilter, counts, visible, setStatusFilter }
+}


### PR DESCRIPTION
## What

Two newsletter-admin features for the comms surface.

### A. Per-subscriber message language (default English)
- **Migration `0003_message_lang.sql`** adds `message_lang TEXT NOT NULL DEFAULT 'en'`, so every existing and new subscriber defaults to English.
- The digest **chrome** (subject / intro / footer / unsubscribe copy) now renders in the subscriber's chosen *message* language via `chromeFor(subscriber.messageLang)` — independent of the article *content* languages in `langs[]`.
- Worker: `POST /api/subscribers` accepts + validates `messageLang` (defaults to `en`); `PATCH /api/subscribers/:id` can change it (`updateMessageLang`).
- Admin: `MessageLangSelect` (endonym labels) in the add form and on every active row; schema / store / api / handlers wired for create + PATCH. Selects are disabled for non-active rows.

### B. Status filter + explanations
- `StatusLegend` explains what **active / unsubscribed / bounced / complained** mean, shown above the table.
- `StatusFilter` chips filter the table by status with per-status counts; an empty-filter state is messaged. Status copy is centralised in `status-meta` and reused by the row badge.

## Verification
- **Live on develop** (`dev-lists.comprom.org`, migration applied to `comms-develop`): unauth→401, create persists `messageLang`, PATCH updates it, empty PATCH→422, delete→204.
- **UI** verified locally (desktop + mobile): message-lang select in add form + rows, legend, filter chips with correct counts, and live filtering (Active(2) → 2 rows).
- `bun run validate` clean (type-check, biome, sonar 50-line/25-fn, jsdoc, vue-depth, css) — several files split into helpers to satisfy the caps.
- **1085 unit tests pass**, incl. new coverage for messageLang create/patch/render and the status filter/counts.

## On merge
`deploy-comms-worker.yml` applies `0003` to `comms-prod --remote` and deploys the worker; the admin pipeline ships the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
