### PR TITLE
fix(notifications): full-width drawer on mobile

### DIFF
--- a/src/components/NotificationDrawer/NotificationDrawer.vue
+++ b/src/components/NotificationDrawer/NotificationDrawer.vue
@@ -60,4 +60,16 @@ const onClearAll = (): void => {
   padding: 12px;
   overflow-y: auto;
 }
+
+/*
+ * Below the desktop breakpoint a 360px right-anchored panel left a
+ * broken-looking sliver of the page exposed on the left (no scrim).
+ * Span the full viewport instead so the drawer reads as a sheet.
+ */
+@media (width <= 768px) {
+  .drawer {
+    left: 0;
+    width: auto;
+  }
+}
 </style>


### PR DESCRIPTION
## Problem

Users reported the admin "interface got messed up" on mobile. Root cause: the **notifications drawer** is a 360px right-anchored panel with no backdrop. On a phone (~412px) that leaves a ~50px sliver of the clipped underlying page exposed on the left, which reads as a broken layout. Matches the reported screenshot exactly.

## Fix

Below the 768px desktop breakpoint the drawer now spans the full viewport (`left: 0; width: auto`) and reads as a full-screen sheet. Desktop side-panel behaviour is unchanged.

## Verification

Reproduced and verified at a 412px mobile viewport via chrome-devtools MCP against live admin:
- **Before:** 360px panel + exposed page sliver on the left (broken look).
- **After:** drawer fills the viewport, no sliver, header + `all/info/warn/error/conflict/network` filter chips fit cleanly.

`validate` (type-check, biome, oxlint, eslint, vue-depth, stylelint) + client build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)