### PR TITLE
release: push NFF/force-push recovery + mobile notifications drawer

### DIFF
--- a/documentation/architecture/sw-git-bff.md
+++ b/documentation/architecture/sw-git-bff.md
@@ -55,6 +55,23 @@ Initial clone: `depth: 1, singleBranch: true, noTags: true`.
 Subsequent syncs: `git.fetch` + fast-forward merge. Full re-clone
 only via explicit user action or SW invalidation.
 
+### Push-rejection recovery
+
+A push that loses the fast-forward race is classified by
+`push-queue/classify-error.ts` and recovered automatically:
+
+- **non-fast-forward** → auto-merge the remote (`attempt-merge.ts`)
+  and re-push. isomorphic-git's literal wording is
+  `not a simple fast-forward` — the classifier must match that exact
+  phrase, not just `not a fast-forward`.
+- **unrelated histories** → if the remote was force-pushed (e.g. an
+  identity rewrite), `git.pull` aborts with `MergeNotSupportedError`
+  because there is no common ancestor. `merge-unrelated.ts` recovers
+  with an explicit `fetch` + `merge({ allowUnrelatedHistories: true })`:
+  identical blobs merge cleanly, so only a genuine same-path content
+  divergence surfaces as a conflict. `git.pull` cannot do this — it
+  never forwards the flag to `merge`.
+
 ## Service Worker Communication Protocol
 
 ### Fetch Interception (Data)

--- a/src/components/NotificationDrawer/NotificationDrawer.vue
+++ b/src/components/NotificationDrawer/NotificationDrawer.vue
@@ -60,4 +60,16 @@ const onClearAll = (): void => {
   padding: 12px;
   overflow-y: auto;
 }
+
+/*
+ * Below the desktop breakpoint a 360px right-anchored panel left a
+ * broken-looking sliver of the page exposed on the left (no scrim).
+ * Span the full viewport instead so the drawer reads as a sheet.
+ */
+@media (width <= 768px) {
+  .drawer {
+    left: 0;
+    width: auto;
+  }
+}
 </style>

--- a/src/sw/push-queue/attempt-merge.ts
+++ b/src/sw/push-queue/attempt-merge.ts
@@ -2,26 +2,35 @@ import { fs, REPO_DIR } from '../git/fs'
 import { loadGit } from '../git/load-git'
 import { buildAuthOpts } from '../git/remote/build-auth-opts'
 import type { SWGitConfig } from '../protocol'
-import { filesFromError, filesFromStatus } from './merge-conflict-files'
+import { collectConflictFiles } from './collect-conflict-files'
+import {
+  isMergeConflict,
+  isUnrelatedHistories,
+  type MergeOutcome,
+} from './merge-classify'
+import { mergeUnrelated } from './merge-unrelated'
 
-/** Outcome of a single auto-merge attempt. */
-export type MergeOutcome =
-  | { readonly kind: 'clean' }
-  | {
-      readonly kind: 'conflict'
-      readonly files: ReadonlyArray<string>
-    }
-  | { readonly kind: 'fail'; readonly error: unknown }
+export type { MergeOutcome } from './merge-classify'
 
-const isMergeConflict = (error: unknown): boolean =>
-  error instanceof Error && error.name === 'MergeConflictError'
+const conflictOutcome = async (error: unknown): Promise<MergeOutcome> => ({
+  kind: 'conflict',
+  files: await collectConflictFiles(error),
+})
 
-const collectConflictFiles = async (
+/*
+ * A force-pushed remote leaves no common ancestor; pull bails with
+ * MergeNotSupportedError. Recover via an explicit unrelated merge.
+ * Everything else is a genuine failure surfaced to the caller.
+ */
+const classifyMergeError = (
+  config: SWGitConfig,
   error: unknown
-): Promise<ReadonlyArray<string>> => {
-  const fromError = filesFromError(error)
-  return fromError.length > 0 ? fromError : await filesFromStatus()
-}
+): Promise<MergeOutcome> | MergeOutcome =>
+  isMergeConflict(error)
+    ? conflictOutcome(error)
+    : isUnrelatedHistories(error)
+      ? mergeUnrelated(config)
+      : { kind: 'fail', error }
 
 /**
  * Attempt to fast-forward / auto-merge the local branch against
@@ -50,8 +59,6 @@ export const attemptMerge = async (
     })
     return { kind: 'clean' }
   } catch (error) {
-    return isMergeConflict(error)
-      ? { kind: 'conflict', files: await collectConflictFiles(error) }
-      : { kind: 'fail', error }
+    return classifyMergeError(config, error)
   }
 }

--- a/src/sw/push-queue/classify-error.test.ts
+++ b/src/sw/push-queue/classify-error.test.ts
@@ -11,6 +11,21 @@ describe('classifyPushError', () => {
     )
   })
 
+  it('detects isomorphic-git PushRejectedError wording', () => {
+    // The literal message isomorphic-git 1.37.x throws on a
+    // non-fast-forward push. The interposed "simple" used to break
+    // the /not a fast-?forward/ pattern, misclassifying every NFF
+    // push as `unknown` ("Unexpected error").
+    expect(
+      classifyPushError(
+        new Error(
+          'Push rejected because it was not a simple fast-forward. ' +
+            'Use "force: true" to override.'
+        )
+      )
+    ).toBe('non-fast-forward')
+  })
+
   it('detects auth failures', () => {
     expect(classifyPushError(new Error('401 Unauthorized'))).toBe('auth')
     expect(classifyPushError(new Error('403 Forbidden'))).toBe('auth')

--- a/src/sw/push-queue/classify-error.ts
+++ b/src/sw/push-queue/classify-error.ts
@@ -19,6 +19,10 @@ const AUTH_PATTERNS: ReadonlyArray<RegExp> = [
 
 const FF_PATTERNS: ReadonlyArray<RegExp> = [
   /not a fast-?forward/i,
+  // isomorphic-git's literal PushRejectedError wording — the
+  // interposed "simple" keeps it from matching the bare pattern
+  // above, so it must be listed explicitly.
+  /not a simple fast-forward/i,
   /fetch first/i,
   /non-fast-forward/i,
   /push declined.*non-fast/i,

--- a/src/sw/push-queue/collect-conflict-files.ts
+++ b/src/sw/push-queue/collect-conflict-files.ts
@@ -1,0 +1,14 @@
+import { filesFromError, filesFromStatus } from './merge-conflict-files'
+
+/**
+ * Resolve the conflicting file list, preferring the paths carried
+ * on the error and falling back to a working-tree scan.
+ * @param error Raw merge-conflict error.
+ * @returns Paths of files in conflict.
+ */
+export const collectConflictFiles = async (
+  error: unknown
+): Promise<ReadonlyArray<string>> => {
+  const fromError = filesFromError(error)
+  return fromError.length > 0 ? fromError : await filesFromStatus()
+}

--- a/src/sw/push-queue/merge-classify.test.ts
+++ b/src/sw/push-queue/merge-classify.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { isMergeConflict, isUnrelatedHistories } from './merge-classify'
+
+const named = (name: string): Error => {
+  const e = new Error(name)
+  e.name = name
+  return e
+}
+
+describe('merge-classify', () => {
+  it('detects isomorphic-git merge conflicts', () => {
+    expect(isMergeConflict(named('MergeConflictError'))).toBe(true)
+    expect(isMergeConflict(named('MergeNotSupportedError'))).toBe(false)
+    expect(isMergeConflict(new Error('plain'))).toBe(false)
+    expect(isMergeConflict('not an error')).toBe(false)
+  })
+
+  it('detects unrelated histories (force-pushed remote)', () => {
+    expect(isUnrelatedHistories(named('MergeNotSupportedError'))).toBe(true)
+    expect(isUnrelatedHistories(named('MergeConflictError'))).toBe(false)
+    expect(isUnrelatedHistories(new Error('plain'))).toBe(false)
+    expect(isUnrelatedHistories(undefined)).toBe(false)
+  })
+})

--- a/src/sw/push-queue/merge-classify.ts
+++ b/src/sw/push-queue/merge-classify.ts
@@ -1,0 +1,26 @@
+/** Outcome of a single auto-merge attempt. */
+export type MergeOutcome =
+  | { readonly kind: 'clean' }
+  | {
+      readonly kind: 'conflict'
+      readonly files: ReadonlyArray<string>
+    }
+  | { readonly kind: 'fail'; readonly error: unknown }
+
+/**
+ * True when the error is isomorphic-git's merge-conflict signal.
+ * @param error Raw error thrown by a merge/pull attempt.
+ * @returns Whether the error denotes content conflicts.
+ */
+export const isMergeConflict = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'MergeConflictError'
+
+/**
+ * True when isomorphic-git refuses the merge for lack of a common
+ * ancestor — the state every browser clone fell into after the
+ * content repo's history was force-pushed (identity rewrite).
+ * @param error Raw error thrown by a merge/pull attempt.
+ * @returns Whether the histories are unrelated.
+ */
+export const isUnrelatedHistories = (error: unknown): boolean =>
+  error instanceof Error && error.name === 'MergeNotSupportedError'

--- a/src/sw/push-queue/merge-unrelated.ts
+++ b/src/sw/push-queue/merge-unrelated.ts
@@ -1,0 +1,30 @@
+import { log } from '../logging/logger'
+import type { workerState } from '../state/state'
+import { collectConflictFiles } from './collect-conflict-files'
+import { isMergeConflict, type MergeOutcome } from './merge-classify'
+import { runUnrelatedMerge } from './run-unrelated-merge'
+
+type SWGitConfig = NonNullable<typeof workerState.config>
+
+/**
+ * Reconcile a remote whose history shares no ancestor with the
+ * local clone — the state every browser clone fell into after the
+ * content repo was force-pushed (identity rewrite). Identical
+ * blobs merge cleanly; only a genuine same-path content divergence
+ * surfaces as a conflict.
+ * @param config Validated SW git configuration.
+ * @returns Discriminated merge outcome (clean / conflict / fail).
+ */
+export const mergeUnrelated = async (
+  config: SWGitConfig
+): Promise<MergeOutcome> => {
+  try {
+    await runUnrelatedMerge(config)
+    log('info', 'git', 'merged unrelated remote history after force-push')
+    return { kind: 'clean' }
+  } catch (error) {
+    return isMergeConflict(error)
+      ? { kind: 'conflict', files: await collectConflictFiles(error) }
+      : { kind: 'fail', error }
+  }
+}

--- a/src/sw/push-queue/run-unrelated-merge.ts
+++ b/src/sw/push-queue/run-unrelated-merge.ts
@@ -1,0 +1,37 @@
+import { fs, REPO_DIR } from '../git/fs'
+import { loadGit } from '../git/load-git'
+import { buildAuthOpts } from '../git/remote/build-auth-opts'
+import type { workerState } from '../state/state'
+
+type SWGitConfig = NonNullable<typeof workerState.config>
+
+const authorOf = (config: SWGitConfig) => ({
+  name: config.authorName ?? 'Admin',
+  email: config.authorEmail ?? 'admin@prometheus.org',
+})
+
+/**
+ * Fetch the force-pushed remote ref and merge it into the local
+ * branch with `allowUnrelatedHistories`, then materialise the
+ * result into the working tree. `git.pull` cannot do this — it
+ * never forwards the unrelated-histories flag to `merge`.
+ * @param config Validated SW git configuration.
+ * @returns Resolves once the branch points at the merge commit.
+ */
+export const runUnrelatedMerge = async (
+  config: SWGitConfig
+): Promise<void> => {
+  const git = await loadGit()
+  const { default: http } = await import('isomorphic-git/http/web')
+  const opts = buildAuthOpts(config, http)
+  await git.fetch({ ...opts, ref: config.branch, singleBranch: true })
+  await git.merge({
+    fs,
+    dir: REPO_DIR,
+    ours: config.branch,
+    theirs: `refs/remotes/origin/${config.branch}`,
+    allowUnrelatedHistories: true,
+    author: authorOf(config),
+  })
+  await git.checkout({ fs, dir: REPO_DIR, ref: config.branch })
+}


### PR DESCRIPTION
Promotes the two production fixes verified on dev-admin to **master** (prod admin).

### #313 — content saves reach the repo again
Root cause of "Push failed — Unexpected error (master)": the push-queue classifier missed isomorphic-git's literal `not a simple fast-forward` wording (→ `unknown`, and the NFF auto-merge was skipped), and the recovery merge couldn't bridge the force-pushed (unrelated) history. Fixed both; recovers via `merge({ allowUnrelatedHistories })`.

### #314 — notifications drawer full-width on mobile
The 360px right-anchored drawer left a broken-looking page sliver on phones ("interface got messed up"). Now spans the viewport below 768px.

### Verification on dev-admin (develop)
- Real save → push to content `develop` succeeded end-to-end (no error); published the «Иллюзия социализма…» article via the docx import.
- Drawer verified full-width at 412px.
- realmode E2E + full validate green on both PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)