### PR TITLE
fix(editor): publish dialog shows real target branch (not hardcoded develop)

### DIFF
--- a/src/views/ContentEditView/PublishDialogCard.vue
+++ b/src/views/ContentEditView/PublishDialogCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { getGitHubConfig } from '@/config/github'
 
 defineProps<{
   readonly title: string
@@ -7,6 +8,9 @@ defineProps<{
 }>()
 const emit = defineEmits<{ confirm: []; cancel: [] }>()
 const cancelBtn = ref<HTMLButtonElement>()
+// Real push target (master on prod, develop on dev) — never hardcode
+// it: telling a prod editor "develop" hides that they publish live.
+const targetBranch = getGitHubConfig().branch
 
 onMounted(() => {
   cancelBtn.value?.focus()
@@ -20,8 +24,8 @@ onMounted(() => {
     </h2>
     <p>
       Saving <strong>{{ title }}</strong> will push the commit to
-      <code>develop</code>; the change will be visible on the public site
-      in about a minute.
+      <code>{{ targetBranch }}</code>; the change will be visible on the
+      public site in about a minute.
     </p>
     <p v-if="autoPublic" class="hint">
       This content type has no draft mode — every save is a publication.


### PR DESCRIPTION
## Problem

The publish confirmation dialog hardcoded `develop`: *"will push the commit to `develop`"*. On **prod admin** (which targets `master`) this is actively misleading — an editor sees "develop" and may think the save is a dev-only draft, when it publishes straight to the live site.

## Fix

Read the real target from `getGitHubConfig().branch` → the dialog says `master` on prod, `develop` on dev.

`validate` (type-check, biome, oxlint, eslint, vue-depth, stylelint) + client build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)