### PR TITLE
release: publish dialog shows the real target branch

### DIFF
--- a/src/views/ContentEditView/PublishDialogCard.vue
+++ b/src/views/ContentEditView/PublishDialogCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
+import { getGitHubConfig } from '@/config/github'
 
 defineProps<{
   readonly title: string
@@ -7,6 +8,9 @@ defineProps<{
 }>()
 const emit = defineEmits<{ confirm: []; cancel: [] }>()
 const cancelBtn = ref<HTMLButtonElement>()
+// Real push target (master on prod, develop on dev) — never hardcode
+// it: telling a prod editor "develop" hides that they publish live.
+const targetBranch = getGitHubConfig().branch
 
 onMounted(() => {
   cancelBtn.value?.focus()
@@ -20,8 +24,8 @@ onMounted(() => {
     </h2>
     <p>
       Saving <strong>{{ title }}</strong> will push the commit to
-      <code>develop</code>; the change will be visible on the public site
-      in about a minute.
+      <code>{{ targetBranch }}</code>; the change will be visible on the
+      public site in about a minute.
     </p>
     <p v-if="autoPublic" class="hint">
       This content type has no draft mode — every save is a publication.


### PR DESCRIPTION
Promotes #316 to prod. The publish dialog no longer hardcodes `develop` — it shows the real push target (`master` on prod admin), so editors aren't misled into thinking a live publish is a dev draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)