### PR TITLE
test(e2e): de-flake offline-gate + tracing (round 2)

### DIFF
--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@prometheus/e2e-toolkit'
+import { expect, expectVisible, test } from '@prometheus/e2e-toolkit'
 import { visitSettled } from '../helpers/visit-settled'
 
 /*
@@ -15,6 +15,16 @@ import { visitSettled } from '../helpers/visit-settled'
 test.describe('settings offline gate (3.4)', () => {
   test.beforeEach(async ({ page }) => {
     await visitSettled(page, '/settings', 'members-section')
+    // Gate on member-data arrival before going offline: the banner +
+    // invite control live inside the loaded members list. `members-
+    // section` is the structural shell and paints before the org-
+    // members SW round-trip resolves; a specific row proves the data
+    // landed. Settings idles after load, so the idle-gated helper is
+    // safe here (unlike the post-offline assertions below).
+    await expectVisible(
+      page,
+      page.locator('[data-testid="member-row-alice-admin"]')
+    )
   })
 
   test('offline disables invite + shows banner', async ({

--- a/e2e/tracing/overlay.spec.ts
+++ b/e2e/tracing/overlay.spec.ts
@@ -1,39 +1,49 @@
-import {
-  click,
-  expectHidden,
-  expectVisible,
-  pressKey,
-  test,
-} from '@prometheus/e2e-toolkit'
-import { visitSettled } from '../helpers/visit-settled'
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
+/*
+ * Home ('/') runs the 5s deploy-status poll, so the request graph
+ * here never reliably goes idle. The toolkit's action/assert helpers
+ * (visit/pressKey/click/expectVisible) all gate on that idle window
+ * and chain up under CI contention into a 30s timeout — a different
+ * spec each run. The overlay is pure client state (a global keydown
+ * toggles a reactive flag, no network), so raw Playwright primitives
+ * are the correct tool: they retry on the DOM predicate without
+ * requiring network quiescence. Same rationale as offline-gate.spec.
+ *
+ * The gate stays event-driven: raw goto + waitForSWControl (the SW
+ * lifecycle predicate) + a stable anchor, none of which need idle.
+ */
 test.describe('trace overlay (5.4)', () => {
   test.beforeEach(async ({ page }) => {
-    await visitSettled(page, '/', 'notification-indicator')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await waitForSWControl(page)
+    await expect(
+      page.locator('[data-testid="notification-indicator"]')
+    ).toBeVisible()
   })
 
   test('Ctrl+Shift+T toggles the overlay', async ({ page }) => {
     const overlay = page.locator('[data-testid="trace-overlay"]')
-    await expectHidden(page, overlay)
-    await pressKey(page, 'Control+Shift+T')
-    await expectVisible(page, overlay)
-    await pressKey(page, 'Control+Shift+T')
-    await expectHidden(page, overlay)
+    await expect(overlay).toBeHidden()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeVisible()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeHidden()
   })
 
   test('close button hides the overlay', async ({ page }) => {
-    await pressKey(page, 'Control+Shift+T')
     const overlay = page.locator('[data-testid="trace-overlay"]')
-    await expectVisible(page, overlay)
-    await click(page, page.locator('[data-testid="trace-overlay-close"]'))
-    await expectHidden(page, overlay)
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeVisible()
+    await page.locator('[data-testid="trace-overlay-close"]').click()
+    await expect(overlay).toBeHidden()
   })
 
   test('shows empty state when no spans recorded', async ({ page }) => {
-    await pressKey(page, 'Control+Shift+T')
-    await expectVisible(
-      page,
+    await page.keyboard.press('Control+Shift+T')
+    await expect(
       page.locator('[data-testid="trace-overlay-empty"]')
-    )
+    ).toBeVisible()
   })
 })


### PR DESCRIPTION
Continues #318. Two more deploy-gate flakes from the same root-cause family:

- **offline-gate**: gate beforeEach on the data-identity row `member-row-alice-admin` (not just the structural `members-section`) so the org-members SW load drains before going offline.
- **tracing/overlay**: home runs the 5s deploy-status poll → the toolkit's idle gate is never reliably reached → its helpers time out under contention. The overlay is pure client state, so the body uses raw Playwright primitives and the beforeEach uses raw goto + `waitForSWControl` + a stable anchor (all event-driven, idle-free). Same rationale as offline-gate's existing raw-expect block.

No timeout padding / no worker reduction. Full mock suite green locally (284 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)