### PR TITLE
release: stabilize the E2E deploy gate

### DIFF
--- a/e2e/auth/popup-login.spec.ts
+++ b/e2e/auth/popup-login.spec.ts
@@ -6,7 +6,6 @@ import {
   visit,
 } from '@prometheus/e2e-toolkit'
 import { waitForContentReady } from '../helpers/content-ready'
-import { waitForSWControl } from '../helpers/visit-settled'
 
 test.use({ storageState: { cookies: [], origins: [] } })
 
@@ -24,12 +23,18 @@ test.describe('Login Flow', () => {
       page.getByRole('button', { name: /test user/i })
     )
 
-    // The first authenticated load registers the SW; activation
-    // claims the client and aborts an in-flight goto
-    // (net::ERR_ABORTED). Gate on the lifecycle before navigating —
-    // event-driven, no sleep.
-    await waitForSWControl(page)
-    await visit(page, '/content/blog')
+    // The first authenticated load registers the SW; its one-time
+    // claim fires controllerchange and the app reloads the page
+    // (sw-update-lifecycle), which aborts an in-flight goto
+    // (net::ERR_ABORTED) or tears the page mid-navigation. Gating on
+    // the SW lifecycle can't avoid it — `controller` flips at the very
+    // controllerchange that triggers the reload. Retry the navigation
+    // until it sticks: the SW claims exactly once, so this converges
+    // the instant the reload settles. Event-driven (Playwright polls),
+    // no fixed sleep.
+    await expect(async () => {
+      await page.goto('/content/blog', { waitUntil: 'domcontentloaded' })
+    }).toPass()
     await waitForContentReady(page)
 
     const items = page.locator('[data-testid="content-item"]')

--- a/e2e/content/asset-paste.spec.ts
+++ b/e2e/content/asset-paste.spec.ts
@@ -10,13 +10,13 @@ test.describe('Asset Paste Image', () => {
     await am.navigateToBlog('media-showcase')
     await am.expectPanelVisible()
 
-    const initialCount = await am.getAssetCount()
     await am.getEditorBody().click()
     await dispatchMediaPaste(page, 'test.png', 'image/png')
 
-    await expect(am.getAssetThumbnails()).toHaveCount(initialCount + 1, {
-      timeout: 10000,
-    })
+    // Identity wait: the pasted asset renders its own data-name. A
+    // relative count against getAssetCount() raced the committed-list
+    // SW round-trip (baseline read as 0 mid-load, target settled at 6).
+    await expect(am.getThumbByName('test.png')).toBeVisible()
   })
 
   test('should insert markdown reference on paste', async ({ page }) => {

--- a/e2e/helpers/visit-settled.ts
+++ b/e2e/helpers/visit-settled.ts
@@ -30,7 +30,19 @@ export const waitForSWControl = async (page: Page): Promise<void> => {
   await page.waitForFunction(async () => {
     const sw = navigator.serviceWorker
     const reg = sw ? await sw.getRegistration() : undefined
-    return !sw || sw.controller !== null || Boolean(reg?.active)
+    const ua = navigator.userAgent
+    // The `reg.active` branch is a WebKit-only escape hatch: WebKit
+    // never exposes `controller` in Playwright. Applied to Chromium it
+    // resolved at ACTIVATION — before clients.claim() fires
+    // controllerchange, which the app turns into a one-time reload.
+    // The gate then returned too early and the next navigation raced
+    // (and was aborted by) that reload → cold SW re-init → 30s-budget
+    // timeout, surfacing as a different random spec each CI run.
+    // Gate Chromium/Firefox on the real `controller` signal so the
+    // claim→reload settles first.
+    const isWebKit =
+      /\bAppleWebKit\b/.test(ua) && !/\b(?:Chrome|Chromium|Edg)\b/.test(ua)
+    return !sw || (isWebKit ? Boolean(reg?.active) : sw.controller !== null)
   })
 }
 

--- a/e2e/settings/members.spec.ts
+++ b/e2e/settings/members.spec.ts
@@ -13,6 +13,15 @@ import { visitSettled } from '../helpers/visit-settled'
 
 const gotoSettings = async (page: Page): Promise<void> => {
   await visitSettled(page, '/settings', 'members-section')
+  // Gate on member-data arrival, not just the structural section.
+  // `members-section` paints before the org-members SW round-trip
+  // resolves; a specific row renders only after it does. Without this
+  // the dialog helpers (which wait for the request graph to go idle)
+  // fight the in-flight load for the whole 30s budget under CI.
+  await expectVisible(
+    page,
+    page.locator('[data-testid="member-row-alice-admin"]')
+  )
 }
 
 test.describe('Members — unified org list with CRUD', () => {

--- a/e2e/settings/offline-gate.spec.ts
+++ b/e2e/settings/offline-gate.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@prometheus/e2e-toolkit'
+import { expect, expectVisible, test } from '@prometheus/e2e-toolkit'
 import { visitSettled } from '../helpers/visit-settled'
 
 /*
@@ -15,6 +15,16 @@ import { visitSettled } from '../helpers/visit-settled'
 test.describe('settings offline gate (3.4)', () => {
   test.beforeEach(async ({ page }) => {
     await visitSettled(page, '/settings', 'members-section')
+    // Gate on member-data arrival before going offline: the banner +
+    // invite control live inside the loaded members list. `members-
+    // section` is the structural shell and paints before the org-
+    // members SW round-trip resolves; a specific row proves the data
+    // landed. Settings idles after load, so the idle-gated helper is
+    // safe here (unlike the post-offline assertions below).
+    await expectVisible(
+      page,
+      page.locator('[data-testid="member-row-alice-admin"]')
+    )
   })
 
   test('offline disables invite + shows banner', async ({

--- a/e2e/tracing/overlay.spec.ts
+++ b/e2e/tracing/overlay.spec.ts
@@ -1,39 +1,49 @@
-import {
-  click,
-  expectHidden,
-  expectVisible,
-  pressKey,
-  test,
-} from '@prometheus/e2e-toolkit'
-import { visitSettled } from '../helpers/visit-settled'
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
+/*
+ * Home ('/') runs the 5s deploy-status poll, so the request graph
+ * here never reliably goes idle. The toolkit's action/assert helpers
+ * (visit/pressKey/click/expectVisible) all gate on that idle window
+ * and chain up under CI contention into a 30s timeout — a different
+ * spec each run. The overlay is pure client state (a global keydown
+ * toggles a reactive flag, no network), so raw Playwright primitives
+ * are the correct tool: they retry on the DOM predicate without
+ * requiring network quiescence. Same rationale as offline-gate.spec.
+ *
+ * The gate stays event-driven: raw goto + waitForSWControl (the SW
+ * lifecycle predicate) + a stable anchor, none of which need idle.
+ */
 test.describe('trace overlay (5.4)', () => {
   test.beforeEach(async ({ page }) => {
-    await visitSettled(page, '/', 'notification-indicator')
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    await waitForSWControl(page)
+    await expect(
+      page.locator('[data-testid="notification-indicator"]')
+    ).toBeVisible()
   })
 
   test('Ctrl+Shift+T toggles the overlay', async ({ page }) => {
     const overlay = page.locator('[data-testid="trace-overlay"]')
-    await expectHidden(page, overlay)
-    await pressKey(page, 'Control+Shift+T')
-    await expectVisible(page, overlay)
-    await pressKey(page, 'Control+Shift+T')
-    await expectHidden(page, overlay)
+    await expect(overlay).toBeHidden()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeVisible()
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeHidden()
   })
 
   test('close button hides the overlay', async ({ page }) => {
-    await pressKey(page, 'Control+Shift+T')
     const overlay = page.locator('[data-testid="trace-overlay"]')
-    await expectVisible(page, overlay)
-    await click(page, page.locator('[data-testid="trace-overlay-close"]'))
-    await expectHidden(page, overlay)
+    await page.keyboard.press('Control+Shift+T')
+    await expect(overlay).toBeVisible()
+    await page.locator('[data-testid="trace-overlay-close"]').click()
+    await expect(overlay).toBeHidden()
   })
 
   test('shows empty state when no spans recorded', async ({ page }) => {
-    await pressKey(page, 'Control+Shift+T')
-    await expectVisible(
-      page,
+    await page.keyboard.press('Control+Shift+T')
+    await expect(
       page.locator('[data-testid="trace-overlay-empty"]')
-    )
+    ).toBeVisible()
   })
 })


### PR DESCRIPTION
Promotes the deploy-gate stabilization (#318, #319, #320) to master.

The deploy gate (mock E2E, 4 workers, retries:0, 30s timeout) was flaking a different random spec each run, blocking prod deploys (incl. the publish-dialog fix #317, whose post-merge deploy failed 5× on unrelated flaky tests). Three root causes, all event-driven fixes (no timeout padding, no worker reduction):

1. **Structural anchor vs data arrival** (asset-paste, members, offline-gate): gate on a data-identity signal, not the structural shell that paints before the SW round-trip resolves.
2. **SW-claim reload race** (popup-login): the first authenticated load's controllerchange → app reload aborts an in-flight goto; retry the navigation with `toPass` (converges after the one-time reload).
3. **Idle gate on a polling page** (tracing): home runs the 5s deploy poll so the request graph never idles; use raw Playwright primitives for the client-side overlay + an idle-free SW-control gate.

Also corrects the shared `waitForSWControl` to gate Chromium/Firefox on the real `controller` (the `reg.active` fallback is now WebKit-only, detected in-page).

**Validation:** 3 consecutive clean deploy-gate runs on develop under CI contention; full mock suite green locally (284 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)