### PR TITLE
release: /sw.js no-store header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+# Cloudflare Workers static-assets header rules.
+# The service worker MUST never be cached by the browser or the CF edge:
+# a stale /sw.js pins users on an old worker after a deploy (the June
+# incident — the fix shipped but users kept the broken SW). The worker.ts
+# fallback only runs when assets route through the Worker; this rule
+# applies whether or not that is configured.
+/sw.js
+  Cache-Control: no-store


### PR DESCRIPTION
Promotes the _headers no-store rule for /sw.js so a stale CF-edge service worker can't pin users on old code after a deploy. Completes the SW-propagation hardening from the reliable-content-push work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)