### PR TITLE
test(content): cover unpublish — unchecking Publish writes published:false

### DIFF
--- a/e2e-realmode/unpublish-blog.spec.ts
+++ b/e2e-realmode/unpublish-blog.spec.ts
@@ -1,0 +1,91 @@
+import {
+  expect,
+  expectVisible,
+  fill,
+  test,
+  visit,
+  waitForCondition,
+} from '@prometheus/e2e-toolkit'
+import { assertAstroAccepts } from './helpers/astro-validate'
+import { bootRealmode, SLOW } from './helpers/realmode-page'
+import { resetSandboxBaseline } from './helpers/reset-baseline'
+import { headSha, waitForHeadAdvance } from './helpers/sandbox-head'
+import { readFile } from './helpers/sandbox-read'
+import { saveAndConfirm } from './helpers/save-flow'
+
+const TARGET = '/content/blog/edit/welcome'
+const FILE = 'blog/welcome/index.en.md'
+
+const PUBLISHED_TRUE = /^published:\s+true\s*$/m
+const PUBLISHED_FALSE = /^published:\s+false\s*$/m
+
+test.beforeEach(async () => {
+  await resetSandboxBaseline()
+})
+
+// Reproduction for the prod report: "I unchecked Publish, it redeployed,
+// but the article did NOT leave the public site." The public build only
+// ships blog entries with `published === true`, so unpublishing has to
+// rewrite the frontmatter to `published: false` AND that commit has to
+// reach the remote. This exercises the REAL service-worker git push
+// (isomorphic-git → sandbox repo), not the mock store: it polls the
+// GitHub ref to prove the unpublish commit actually landed, then reads
+// the pushed bytes back and asserts the flag flipped.
+test('unpublish: unchecking Publish flips the pushed file to published:false', async ({
+  page,
+}) => {
+  test.setTimeout(180_000)
+  await bootRealmode(page, 'unpublish-blog')
+  await visit(page, TARGET, SLOW)
+
+  const editor = page.locator('[data-testid="editor-body"]')
+  await expectVisible(page, editor, SLOW)
+  // SW finishes its clone before the textarea hydrates — wait on the
+  // non-empty value, never a blind timeout.
+  await waitForCondition(
+    page,
+    async () =>
+      editor
+        .inputValue()
+        .then(v => v.length > 0)
+        .catch(() => false),
+    SLOW
+  )
+
+  const publish = page.locator('#fm-published')
+  await expectVisible(page, publish, SLOW)
+
+  // Phase 1 — establish a known published state on the remote. Check the
+  // box and add a body marker so HEAD always advances regardless of the
+  // baseline's initial flag, then confirm the publish.
+  const before = await editor.inputValue()
+  const marker = `<!-- realmode unpublish ${Date.now()} -->`
+  await fill(page, editor, `${before}\n\n${marker}`, SLOW)
+  await publish.check()
+  const sha0 = await headSha()
+  await saveAndConfirm(page)
+  await waitForHeadAdvance(sha0)
+
+  const published = await readFile(FILE)
+  expect(published, `${FILE} must exist on sandbox`).toBeTruthy()
+  expect(published ?? '', 'phase-1 file is published').toMatch(PUBLISHED_TRUE)
+
+  // Phase 2 — the actual bug: UNcheck Publish and save. A draft save has
+  // no confirm dialog. The pushed file must flip to `published: false`.
+  await publish.uncheck()
+  const sha1 = await headSha()
+  await saveAndConfirm(page)
+  await waitForHeadAdvance(sha1)
+
+  const unpublished = await readFile(FILE)
+  expect(unpublished, `${FILE} must exist on sandbox`).toBeTruthy()
+  expect(unpublished ?? '', 'unpublish reached the remote').toMatch(
+    PUBLISHED_FALSE
+  )
+  expect(unpublished ?? '', 'no stale published:true remains').not.toMatch(
+    PUBLISHED_TRUE
+  )
+
+  // What admin commits must still parse against public-website's schema.
+  await assertAstroAccepts('blog', unpublished ?? '')
+})

--- a/e2e/content/unpublish-removes-from-site.spec.ts
+++ b/e2e/content/unpublish-removes-from-site.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from '@prometheus/e2e-toolkit'
+import { openPreview, saveAndConfirm } from './preview-save'
+
+// Reproduction for the prod report: "I unchecked Publish on an article,
+// it redeployed, but the article did NOT leave the public site."
+//
+// The public build only ships blog entries whose frontmatter has
+// `published === true` (getBlogPosts + the [...slug] getStaticPaths
+// filter). So an article leaves the live site precisely when the admin
+// rewrites its frontmatter from `published: true` to `published: false`.
+// This test drives the real editor: publish, then UNcheck Publish and
+// save, and asserts the persisted markdown flips to `published: false`.
+// If it stays `published: true`, the admin never unpublishes and the
+// public site can never drop the article.
+
+interface FileReadResult {
+  readonly status: number
+  readonly content?: string
+}
+
+const readFile = async (
+  page: import('@playwright/test').Page,
+  path: string
+): Promise<FileReadResult> =>
+  page.evaluate(async p => {
+    const r = await fetch(`/api/github/file?path=${encodeURIComponent(p)}`)
+    if (r.status !== 200) return { status: r.status }
+    const data = (await r.json()) as { content: string }
+    return { status: r.status, content: data.content }
+  }, path)
+
+const createPublishedArticle = async (
+  page: import('@playwright/test').Page,
+  slug: string
+): Promise<void> => {
+  await page.goto('/content/blog')
+  await page.locator('[data-testid="create-button"]').click()
+  await page.locator('input#slug').fill(slug)
+  await page.locator('input#title').fill(`Unpublish ${slug}`)
+  await page.locator('textarea#description').fill('unpublish-regression')
+  const cat = page.locator('select#category').first()
+  await expect
+    .poll(() => cat.locator('option').count(), { timeout: 20000 })
+    .toBeGreaterThan(1)
+  await cat.selectOption({ index: 1 })
+  await page.locator('[data-testid="create-submit"]').click()
+  await page.waitForURL(new RegExp(`/edit/${slug}$`), { timeout: 15000 })
+  await page
+    .locator('[data-testid="frontmatter-editor"]')
+    .waitFor({ state: 'visible', timeout: 10000 })
+}
+
+test.describe('Content - unchecking Publish removes article from site', () => {
+  test.setTimeout(60000)
+
+  test('unchecking Publish persists `published: false`', async ({ page }) => {
+    const slug = `unpub-${Date.now()}`
+    const file = `blog/${slug}/index.en.md`
+
+    await createPublishedArticle(page, slug)
+
+    // 1. Publish: check the box and save (publish-confirm dialog fires).
+    await page.locator('#fm-published').check()
+    await saveAndConfirm(page, await openPreview(page))
+
+    await expect
+      .poll(async () => (await readFile(page, file)).content, {
+        timeout: 15000,
+      })
+      .toMatch(/^published:\s+true\s*$/m)
+
+    // Reload the editor so the article comes back FROM THE SAVED FILE with
+    // `published: true` — this is the real user path (open an already-
+    // published article and unpublish it), exercising the load / draft-
+    // cache restore that the in-session create path skips.
+    await page.goto(`/content/blog/edit/${slug}`)
+    await page
+      .locator('[data-testid="frontmatter-editor"]')
+      .waitFor({ state: 'visible', timeout: 10000 })
+    await expect(page.locator('#fm-published')).toBeChecked()
+
+    // 2. Unpublish: UNcheck the box and save again (no dialog — draft).
+    await page.locator('#fm-published').uncheck()
+    await saveAndConfirm(page, await openPreview(page))
+
+    // The file must flip to `published: false` — otherwise the public
+    // build keeps shipping the article and it never leaves the site.
+    await expect
+      .poll(async () => (await readFile(page, file)).content, {
+        timeout: 15000,
+      })
+      .toMatch(/^published:\s+false\s*$/m)
+
+    const final = await readFile(page, file)
+    expect(final.content ?? '').not.toMatch(/^published:\s+true\s*$/m)
+  })
+})


### PR DESCRIPTION
## Why

Prod report: *"I unchecked Publish on an article, it redeployed, but the article did NOT leave the public site."* There was **no automated test** covering the unpublish path, so I added it — and used it to verify the behaviour end-to-end.

## What

- **`e2e/content/unpublish-removes-from-site.spec.ts` (mock)** — loads an already-published article *from the saved file* (real user path, including the load/draft-cache restore the create flow skips), unchecks Publish, saves, and asserts the persisted markdown flips to `published: false` with no stale `published: true`.
- **`e2e-realmode/unpublish-blog.spec.ts` (real push)** — the gold-standard gate: publish, then uncheck Publish and save, **polling the GitHub sandbox ref** to prove the unpublish commit actually lands, reading the pushed bytes back, and validating them against public-website's Astro blog schema.

## Result

Both green. The admin **correctly writes and pushes `published: false`**, which the public build (`getBlogPosts` + the `[...slug]` `getStaticPaths` `published === true` filter) drops from the live site. No admin save/push bug was found — the unpublish path works end-to-end; this locks it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)