### PR TITLE
fix(rbac): User-Agent on GitHub membership call (roles API 403)

### DIFF
--- a/src/api/roles/role-caller.ts
+++ b/src/api/roles/role-caller.ts
@@ -28,6 +28,9 @@ const callerMembership = async (
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.github+json',
+      // GitHub's API rejects requests without a User-Agent (403). CF
+      // Workers' fetch does not set one, so it must be explicit here.
+      'User-Agent': 'prometheus-admin',
     },
   })
   const body = await res.json().catch(() => ({}))


### PR DESCRIPTION
Follow-up to #329. CF Workers' fetch sends no User-Agent; GitHub's API 403s such requests, so `/api/roles/me` resolved everyone as 'Not an active org member' on the live worker (local curl/node added a default UA, hiding it). Add an explicit User-Agent header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)