### PR TITLE
fix(rbac): no-store on GitHub membership fetch (stale/cross-user cache)

### DIFF
--- a/src/api/roles/role-caller.ts
+++ b/src/api/roles/role-caller.ts
@@ -32,6 +32,11 @@ const callerMembership = async (
       // Workers' fetch does not set one, so it must be explicit here.
       'User-Agent': 'prometheus-admin',
     },
+    // This is per-caller, authenticated data behind ONE URL (the
+    // authenticated user's own membership). The CF fetch cache keys on
+    // URL and would both serve a stale result and leak one caller's
+    // membership to another — never cache it.
+    cache: 'no-store',
   })
   const body = await res.json().catch(() => ({}))
   return res.ok && body?.state === 'active'


### PR DESCRIPTION
Follow-up to #330. The membership check fetches `/user/memberships/orgs/{org}` — per-caller data behind one URL. CF's fetch cache served a stale 403 (cached from the pre-User-Agent deploy, keyed on URL) so the UA fix appeared to do nothing; it would also leak membership across callers. Add `cache: 'no-store'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)