### PR TITLE
feat(settings): hard-reset button that wipes every local cache

### DIFF
--- a/src/composables/useHardReset/clear-caches.ts
+++ b/src/composables/useHardReset/clear-caches.ts
@@ -1,0 +1,13 @@
+const dropAll = async (): Promise<void> => {
+  const keys = await caches.keys().catch(() => [] as string[])
+  await Promise.all(keys.map(k => caches.delete(k).catch(() => false)))
+}
+
+/**
+ * Drop every entry in the browser's CacheStorage. Missing API (older
+ * Safari / private modes) is treated as "nothing to clear".
+ *
+ * @returns Resolves once all `caches.delete()` calls settle.
+ */
+export const clearCaches = async (): Promise<void> =>
+  typeof caches === 'undefined' ? undefined : dropAll()

--- a/src/composables/useHardReset/clear-idb.ts
+++ b/src/composables/useHardReset/clear-idb.ts
@@ -1,0 +1,39 @@
+/*
+ * indexedDB.databases() is supported on Chromium 71+ and Safari 14+ but
+ * NOT on Firefox as of this writing. Where unavailable we still hit the
+ * known SW-owned DBs by name so the essentials get wiped even on FF.
+ */
+const KNOWN_DB_NAMES = ['sw-git', 'sw-meta']
+
+const deleteDbByName = (name: string): Promise<void> =>
+  new Promise(resolve => {
+    const req = indexedDB.deleteDatabase(name)
+    req.onsuccess = () => resolve()
+    req.onerror = () => resolve()
+    req.onblocked = () => resolve()
+  })
+
+const listViaApi = async (): Promise<readonly string[]> => {
+  const list = await (
+    indexedDB.databases as () => Promise<{ readonly name?: string }[]>
+  )().catch(() => [] as { readonly name?: string }[])
+  return list.map(d => d.name).filter((n): n is string => Boolean(n))
+}
+
+const listAllDbs = async (): Promise<readonly string[]> =>
+  'databases' in indexedDB ? listViaApi() : []
+
+const wipeAll = async (): Promise<void> => {
+  const names = [...new Set([...KNOWN_DB_NAMES, ...(await listAllDbs())])]
+  await Promise.all(names.map(n => deleteDbByName(n)))
+}
+
+/**
+ * Drop every IndexedDB the origin owns — the discovered ones plus the
+ * known SW-owned names, so essentials are wiped even on browsers that
+ * don't support `indexedDB.databases()`.
+ *
+ * @returns Resolves once every deleteDatabase() request settles.
+ */
+export const clearAllIDB = async (): Promise<void> =>
+  typeof indexedDB === 'undefined' ? undefined : wipeAll()

--- a/src/composables/useHardReset/clear-storage.ts
+++ b/src/composables/useHardReset/clear-storage.ts
@@ -1,0 +1,20 @@
+/**
+ * Wipe localStorage AND sessionStorage. Private modes / disabled storage
+ * throw on write; catch and move on — there's nothing to clear.
+ *
+ * @returns Resolves immediately (the underlying API is synchronous;
+ *   returning a Promise keeps this composable with the same shape as
+ *   the other steps so the orchestrator can await it uniformly).
+ */
+export const clearWebStorage = async (): Promise<void> => {
+  try {
+    localStorage.clear()
+  } catch {
+    /* private mode / disabled — nothing to clear */
+  }
+  try {
+    sessionStorage.clear()
+  } catch {
+    /* private mode / disabled — nothing to clear */
+  }
+}

--- a/src/composables/useHardReset/hard-reset.test.ts
+++ b/src/composables/useHardReset/hard-reset.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Guard the sequential contract of the hard-reset routine:
+ *   - progress is emitted BEFORE each step runs (so the UI can render
+ *     the label while the step's async work is in flight)
+ *   - steps run in strict order
+ *   - a failing step still fires the reload tick? no — a throw
+ *     propagates to the caller. The composable catches it into the
+ *     `error` ref; that path is covered by useHardReset.test.
+ *   - `location.reload()` is called exactly once at the end
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const sendSWMessage = vi.fn(async (_msg: unknown) => ({ ok: true }))
+vi.mock('../useSWBridge/send-message', () => ({
+  sendSWMessage: (msg: unknown) => sendSWMessage(msg),
+}))
+
+interface FakeCaches {
+  keys: () => Promise<readonly string[]>
+  delete: (k: string) => Promise<boolean>
+}
+
+const setupWindow = (): {
+  readonly reload: ReturnType<typeof vi.fn>
+  readonly regsUnregister: readonly ReturnType<typeof vi.fn>[]
+  readonly cachesDelete: ReturnType<typeof vi.fn>
+  readonly idbDelete: ReturnType<typeof vi.fn>
+} => {
+  const reload = vi.fn()
+  const locationStub = { reload }
+  vi.stubGlobal('location', locationStub)
+
+  const cachesDelete = vi.fn(async () => true)
+  const cachesStub: FakeCaches = {
+    keys: async () => ['a', 'b'],
+    delete: cachesDelete,
+  }
+  vi.stubGlobal('caches', cachesStub)
+
+  const idbDelete = vi.fn((_name: string) => {
+    const req = {
+      onsuccess: (): void => undefined,
+      onerror: (): void => undefined,
+      onblocked: (): void => undefined,
+    }
+    setTimeout(() => req.onsuccess(), 0)
+    return req
+  })
+  vi.stubGlobal('indexedDB', {
+    databases: async () => [{ name: 'sw-git' }, { name: 'extra' }],
+    deleteDatabase: idbDelete,
+  })
+
+  const regsUnregister = [vi.fn(async () => true), vi.fn(async () => true)]
+  vi.stubGlobal('navigator', {
+    serviceWorker: {
+      getRegistrations: async () =>
+        regsUnregister.map(unregister => ({ unregister })),
+    },
+    storage: {},
+  })
+  const localStorageMap = new Map<string, string>([
+    ['gh_token', 'x'],
+    ['profile', 'y'],
+  ])
+  const sessionStorageMap = new Map<string, string>()
+  const asStorage = (m: Map<string, string>): Storage => ({
+    clear: () => m.clear(),
+    getItem: k => m.get(k) ?? null,
+    setItem: (k, v) => {
+      m.set(k, v)
+    },
+    removeItem: k => {
+      m.delete(k)
+    },
+    key: () => null,
+    get length() {
+      return m.size
+    },
+  })
+  vi.stubGlobal('localStorage', asStorage(localStorageMap))
+  vi.stubGlobal('sessionStorage', asStorage(sessionStorageMap))
+
+  return { reload, regsUnregister, cachesDelete, idbDelete }
+}
+
+describe('runHardReset', () => {
+  let ctx: ReturnType<typeof setupWindow>
+  beforeEach(() => {
+    sendSWMessage.mockClear()
+    ctx = setupWindow()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('emits a progress tick before each step, in order, plus a final Reloading tick', async () => {
+    const { runHardReset } = await import('./hard-reset')
+    const ticks: string[] = []
+    await runHardReset(p => ticks.push(p.label))
+    expect(ticks).toEqual([
+      'Wiping git repository…',
+      'Clearing HTTP caches…',
+      'Clearing local databases…',
+      'Clearing local storage…',
+      'Unregistering service worker…',
+      'Reloading…',
+    ])
+  })
+
+  it('increments step counters against a fixed total', async () => {
+    const { runHardReset } = await import('./hard-reset')
+    const ticks: readonly { step: number; total: number }[] = []
+    await runHardReset(p =>
+      (ticks as { step: number; total: number }[]).push(p)
+    )
+    /* 5 real steps + the terminal Reloading tick = 6 ticks, total = 6. */
+    expect(ticks.map(t => t.step)).toEqual([1, 2, 3, 4, 5, 6])
+    expect(new Set(ticks.map(t => t.total))).toEqual(new Set([6]))
+  })
+
+  it('sends SW_INVALIDATE, drops every listed cache, deletes every IDB, unregisters every worker, and reloads', async () => {
+    const { runHardReset } = await import('./hard-reset')
+    await runHardReset(() => undefined)
+    expect(sendSWMessage).toHaveBeenCalledWith({ type: 'SW_INVALIDATE' })
+    expect(ctx.cachesDelete).toHaveBeenCalledWith('a')
+    expect(ctx.cachesDelete).toHaveBeenCalledWith('b')
+    /*
+     * KNOWN_DB_NAMES ('sw-git', 'sw-meta') get merged with what
+     * indexedDB.databases() returned ('sw-git', 'extra'); sw-git dedupes.
+     */
+    const deletedNames = ctx.idbDelete.mock.calls.map(c => c[0] as string)
+    expect(new Set(deletedNames)).toEqual(
+      new Set(['sw-git', 'sw-meta', 'extra'])
+    )
+    expect(ctx.regsUnregister.every(u => u.mock.calls.length === 1)).toBe(
+      true
+    )
+    expect(ctx.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears local + session storage', async () => {
+    const { runHardReset } = await import('./hard-reset')
+    localStorage.setItem('gh_token', 'x')
+    sessionStorage.setItem('scratch', 'y')
+    await runHardReset(() => undefined)
+    expect(localStorage.getItem('gh_token')).toBeNull()
+    expect(sessionStorage.getItem('scratch')).toBeNull()
+  })
+
+  it('swallows SW_INVALIDATE errors so a bad SW does not block the rest', async () => {
+    sendSWMessage.mockRejectedValueOnce(new Error('sw offline'))
+    const { runHardReset } = await import('./hard-reset')
+    await runHardReset(() => undefined)
+    expect(ctx.reload).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/composables/useHardReset/hard-reset.ts
+++ b/src/composables/useHardReset/hard-reset.ts
@@ -1,0 +1,67 @@
+/*
+ * Full-reset orchestrator: nuke every locally-cached artefact and
+ * reload with a fresh SW. Runs sequentially so a UI progress bar can
+ * track each stage. Each step lives in its own file.
+ *
+ * Sequence:
+ *   1. Wipe cloned git repo through the SW so its in-memory state
+ *      (config, last-sync, commit-sha) is dropped too — otherwise the
+ *      wiped filesystem would be immediately re-cloned with stale config.
+ *   2. Drop every CacheStorage entry (SW precache + runtime caches).
+ *   3. Drop every IndexedDB the origin owns.
+ *   4. Clear localStorage + sessionStorage (includes the OAuth token —
+ *      user is logged out on the next load).
+ *   5. Unregister every ServiceWorkerRegistration and reload.
+ */
+
+import { sendSWMessage } from '../useSWBridge/send-message'
+import { clearCaches } from './clear-caches'
+import { clearAllIDB } from './clear-idb'
+import { clearWebStorage } from './clear-storage'
+import { unregisterAllSW } from './unregister-sw'
+
+/** One step's payload published to the UI for the progress bar. */
+export interface HardResetProgress {
+  readonly step: number
+  readonly total: number
+  readonly label: string
+}
+
+interface Step {
+  readonly label: string
+  readonly run: () => Promise<void>
+}
+
+const swInvalidate = async (): Promise<void> => {
+  await sendSWMessage({ type: 'SW_INVALIDATE' }).catch(() => undefined)
+}
+
+const STEPS: readonly Step[] = [
+  { label: 'Wiping git repository…', run: swInvalidate },
+  { label: 'Clearing HTTP caches…', run: clearCaches },
+  { label: 'Clearing local databases…', run: clearAllIDB },
+  { label: 'Clearing local storage…', run: clearWebStorage },
+  { label: 'Unregistering service worker…', run: unregisterAllSW },
+]
+
+/**
+ * Run the hard reset. Progress is reported synchronously BEFORE each
+ * step starts so the UI can render the step label while the (possibly
+ * slow) work runs.
+ *
+ * @param onProgress Callback invoked once per step, plus a final
+ *   "Reloading…" tick right before `location.reload()`.
+ * @returns Never resolves — the last step reloads the tab.
+ */
+export const runHardReset = async (
+  onProgress: (p: HardResetProgress) => void
+): Promise<void> => {
+  const total = STEPS.length + 1
+  for (let i = 0; i < STEPS.length; i++) {
+    const step = STEPS[i] as Step
+    onProgress({ step: i + 1, total, label: step.label })
+    await step.run()
+  }
+  onProgress({ step: total, total, label: 'Reloading…' })
+  location.reload()
+}

--- a/src/composables/useHardReset/index.ts
+++ b/src/composables/useHardReset/index.ts
@@ -1,0 +1,2 @@
+export { type HardResetProgress, runHardReset } from './hard-reset'
+export { useHardReset } from './useHardReset'

--- a/src/composables/useHardReset/unregister-sw.ts
+++ b/src/composables/useHardReset/unregister-sw.ts
@@ -1,0 +1,15 @@
+const dropAll = async (): Promise<void> => {
+  const regs = await navigator.serviceWorker
+    .getRegistrations()
+    .catch(() => [])
+  await Promise.all(regs.map(r => r.unregister().catch(() => false)))
+}
+
+/**
+ * Unregister every ServiceWorkerRegistration under this origin. The next
+ * page load starts with no controller and installs a fresh /sw.js.
+ *
+ * @returns Resolves once every unregister() settles.
+ */
+export const unregisterAllSW = async (): Promise<void> =>
+  'serviceWorker' in navigator ? dropAll() : undefined

--- a/src/composables/useHardReset/useHardReset.test.ts
+++ b/src/composables/useHardReset/useHardReset.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runHardReset = vi.fn()
+vi.mock('./hard-reset', () => ({
+  runHardReset: (cb: (p: unknown) => void) => runHardReset(cb),
+}))
+
+describe('useHardReset', () => {
+  beforeEach(() => {
+    runHardReset.mockReset()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('starts idle: not running, no progress, no error', async () => {
+    const { useHardReset } = await import('./useHardReset')
+    const s = useHardReset()
+    expect(s.running).toBe(false)
+    expect(s.progress).toBeUndefined()
+    expect(s.error).toBeUndefined()
+  })
+
+  it('flips running=true when start() is called and publishes progress from the routine', async () => {
+    /* runHardReset invokes its onProgress callback with a sequence. */
+    runHardReset.mockImplementation(async (cb: (p: unknown) => void) => {
+      cb({ step: 1, total: 3, label: 'a' })
+      cb({ step: 2, total: 3, label: 'b' })
+      cb({ step: 3, total: 3, label: 'c' })
+      /* Simulate the reload path by never resolving. */
+      await new Promise(() => undefined)
+    })
+
+    const { useHardReset } = await import('./useHardReset')
+    const s = useHardReset()
+    void s.start()
+    /* Microtask flush so the async chain reaches the onProgress calls. */
+    await Promise.resolve()
+    expect(s.running).toBe(true)
+    expect(s.progress?.label).toBe('c')
+    expect(s.progress?.step).toBe(3)
+  })
+
+  it('publishes error and resets running=false when the routine throws', async () => {
+    runHardReset.mockRejectedValueOnce(new Error('boom'))
+    const { useHardReset } = await import('./useHardReset')
+    const s = useHardReset()
+    await s.start()
+    expect(s.error).toBe('boom')
+    expect(s.running).toBe(false)
+  })
+
+  it('ignores start() while already running', async () => {
+    runHardReset.mockImplementation(() => new Promise<void>(() => undefined))
+    const { useHardReset } = await import('./useHardReset')
+    const s = useHardReset()
+    void s.start()
+    void s.start()
+    void s.start()
+    expect(runHardReset).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/composables/useHardReset/useHardReset.ts
+++ b/src/composables/useHardReset/useHardReset.ts
@@ -1,0 +1,61 @@
+import { type Ref, ref } from 'vue'
+import { type HardResetProgress, runHardReset } from './hard-reset'
+
+interface HardResetState {
+  readonly running: boolean
+  readonly progress: HardResetProgress | undefined
+  readonly error: string | undefined
+  readonly start: () => Promise<void>
+}
+
+interface Slots {
+  readonly running: Ref<boolean>
+  readonly progress: Ref<HardResetProgress | undefined>
+  readonly error: Ref<string | undefined>
+}
+
+const runOnce = async (s: Slots): Promise<void> => {
+  s.running.value = true
+  s.error.value = undefined
+  try {
+    await runHardReset(p => {
+      s.progress.value = p
+    })
+    /* No `finally { running = false }` — a successful run reloads. */
+  } catch (e) {
+    s.error.value = e instanceof Error ? e.message : String(e)
+    s.running.value = false
+  }
+}
+
+const makeStart =
+  (s: Slots): (() => Promise<void>) =>
+  async () =>
+    s.running.value ? undefined : runOnce(s)
+
+/**
+ * Vue composable wrapping the sequential hard-reset routine. Publishes
+ * reactive `running`/`progress`/`error` flags for a progress-bar UI. The
+ * last step of a successful run calls `location.reload()`, so consumers
+ * do not need to react to a "done" state — the whole page unmounts.
+ *
+ * @returns Reactive state + `start()` method.
+ */
+export const useHardReset = (): HardResetState => {
+  const running = ref(false)
+  const progress = ref<HardResetProgress | undefined>(undefined)
+  const error = ref<string | undefined>(undefined)
+  const start = makeStart({ running, progress, error })
+  return {
+    get running() {
+      return running.value
+    },
+    get progress() {
+      return progress.value
+    },
+    get error() {
+      return error.value
+    },
+    start,
+  }
+}

--- a/src/views/SettingsView/HardResetConfirmActions.vue
+++ b/src/views/SettingsView/HardResetConfirmActions.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+defineEmits<{
+  cancel: []
+  confirm: []
+}>()
+</script>
+
+<template>
+  <footer class="actions">
+    <button
+      type="button"
+      class="btn-cancel"
+      data-testid="hard-reset-cancel"
+      @click="$emit('cancel')"
+    >
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="btn-danger"
+      data-testid="hard-reset-confirm-yes"
+      @click="$emit('confirm')"
+    >
+      Yes, reset
+    </button>
+  </footer>
+</template>
+
+<style scoped>
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.btn-cancel,
+.btn-danger {
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.btn-cancel {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-secondary);
+}
+
+.btn-danger {
+  border: 1px solid var(--color-error, #e53935);
+  background: transparent;
+  color: var(--color-error, #e53935);
+}
+
+.btn-danger:hover,
+.btn-danger:focus-visible {
+  background: color-mix(in srgb, var(--color-error, #e53935) 12%, transparent);
+}
+</style>

--- a/src/views/SettingsView/HardResetConfirmDialog.vue
+++ b/src/views/SettingsView/HardResetConfirmDialog.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import HardResetConfirmActions from './HardResetConfirmActions.vue'
+
+defineEmits<{
+  cancel: []
+  confirm: []
+}>()
+</script>
+
+<template>
+  <section
+    class="dialog-overlay"
+    role="alertdialog"
+    aria-labelledby="hard-reset-title"
+    data-testid="hard-reset-confirm"
+  >
+    <h3 id="hard-reset-title" class="dialog-title">Reset local data?</h3>
+    <p class="dialog-body">
+      This will delete every cached artefact the admin app wrote to this
+      device (git repository, HTTP caches, IndexedDB, local storage, and the
+      service worker) and reload the page. You will be signed out. This can
+      not be undone.
+    </p>
+    <HardResetConfirmActions
+      @cancel="$emit('cancel')"
+      @confirm="$emit('confirm')"
+    />
+  </section>
+</template>
+
+<style scoped>
+.dialog-overlay {
+  position: fixed;
+  inset: 2rem;
+  margin: auto;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: 1.25rem;
+  min-width: 300px;
+  max-width: 460px;
+  block-size: fit-content;
+  display: grid;
+  gap: 0.75rem;
+  z-index: 1000;
+  box-shadow:
+    0 0 0 100vmax rgb(0 0 0 / 60%),
+    0 8px 24px rgb(0 0 0 / 40%);
+  clip-path: inset(-100vmax);
+}
+
+.dialog-title {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.dialog-body {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+</style>

--- a/src/views/SettingsView/HardResetProgressBar.vue
+++ b/src/views/SettingsView/HardResetProgressBar.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { HardResetProgress } from '@/composables/useHardReset'
+
+const props = defineProps<{
+  readonly progress: HardResetProgress
+}>()
+
+const percent = computed(() =>
+  Math.round((props.progress.step / props.progress.total) * 100)
+)
+const summary = computed(
+  () =>
+    `${props.progress.label} · ${props.progress.step} / ${props.progress.total}`
+)
+const fillStyle = computed(() => ({ '--fill': `${percent.value}%` }))
+</script>
+
+<template>
+  <output
+    class="progress"
+    aria-live="polite"
+    data-testid="hard-reset-progress"
+  >
+    <span
+      class="progress-bar"
+      role="progressbar"
+      :aria-valuenow="percent"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      :style="fillStyle"
+      data-testid="hard-reset-fill"
+    />
+    <span class="progress-label" data-testid="hard-reset-label">
+      {{ summary }}
+    </span>
+  </output>
+</template>
+
+<style scoped>
+.progress {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.progress-bar {
+  block-size: 8px;
+  inline-size: 100%;
+  background: linear-gradient(
+    to right,
+    var(--color-accent) var(--fill, 0%),
+    transparent var(--fill, 0%)
+  );
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  overflow: hidden;
+  transition: --fill 0.2s ease;
+}
+
+.progress-label {
+  font-size: 0.85rem;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+}
+
+@property --fill {
+  syntax: '<percentage>';
+  inherits: false;
+  initial-value: 0%;
+}
+</style>

--- a/src/views/SettingsView/HardResetSection.vue
+++ b/src/views/SettingsView/HardResetSection.vue
@@ -1,0 +1,114 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useHardReset } from '@/composables/useHardReset'
+import HardResetConfirmDialog from './HardResetConfirmDialog.vue'
+import HardResetProgressBar from './HardResetProgressBar.vue'
+
+const { running, progress, error, start } = useHardReset()
+
+const confirming = ref(false)
+
+const onOpenConfirm = (): void => {
+  confirming.value = true
+}
+const onCancel = (): void => {
+  confirming.value = false
+}
+const onConfirm = (): void => {
+  confirming.value = false
+  void start()
+}
+</script>
+
+<template>
+  <section
+    class="hard-reset-section danger-zone"
+    data-testid="hard-reset-section"
+  >
+    <h2>Reset local data</h2>
+    <p class="section-hint">
+      Wipes every cached asset the admin app writes on this device — the
+      cloned Git repository, HTTP caches, IndexedDB databases, local storage,
+      and the service worker — then reloads with a fresh copy. You will be
+      signed out and need to log in again.
+    </p>
+    <button
+      v-if="!running"
+      type="button"
+      class="btn-danger"
+      data-testid="hard-reset-open"
+      :disabled="confirming"
+      @click="onOpenConfirm"
+    >
+      Full reset
+    </button>
+    <p
+      v-if="error"
+      class="error-hint"
+      data-testid="hard-reset-error"
+    >
+      {{ error }}
+    </p>
+    <HardResetProgressBar v-if="running && progress" :progress="progress" />
+    <HardResetConfirmDialog
+      v-if="confirming"
+      @cancel="onCancel"
+      @confirm="onConfirm"
+    />
+  </section>
+</template>
+
+<style scoped>
+.hard-reset-section {
+  padding: 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-background);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.danger-zone {
+  border-color: color-mix(in srgb, var(--color-error, #e53935) 45%, var(--color-border));
+}
+
+.hard-reset-section h2 {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-error, #e53935);
+}
+
+.section-hint {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.btn-danger {
+  justify-self: start;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--color-error, #e53935);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-error, #e53935);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.btn-danger:hover,
+.btn-danger:focus-visible {
+  background: color-mix(in srgb, var(--color-error, #e53935) 12%, transparent);
+}
+
+.btn-danger:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
+.error-hint {
+  margin: 0;
+  color: var(--color-error, #e53935);
+  font-size: 0.85rem;
+}
+</style>

--- a/src/views/SettingsView/SettingsPage.vue
+++ b/src/views/SettingsView/SettingsPage.vue
@@ -3,6 +3,7 @@ import type { LabelEntry } from '@/stores/labels'
 import type { LinkEntry } from '@/stores/links'
 import type { LanguageEntry } from '@/stores/settings'
 import ActionHistorySection from './ActionHistorySection.vue'
+import HardResetSection from './HardResetSection.vue'
 import LabelsSection from './LabelsSection.vue'
 import LanguagesSection from './LanguagesSection.vue'
 import LinksSection from './LinksSection.vue'
@@ -55,6 +56,7 @@ defineEmits<{
     />
     <MembersSection />
     <ActionHistorySection />
+    <HardResetSection />
   </section>
 </template>
 


### PR DESCRIPTION
## Summary

Settings → new "Reset local data" danger-zone section with a **Full reset** button. Confirmation dialog → sequential wipe with a live progress bar, then reload.

Steps:
1. SW_INVALIDATE — through the SW so its in-memory state (config, last-sync, commit-sha) is dropped along with the LightningFS git IndexedDB.
2. Every CacheStorage entry (SW precache + runtime caches).
3. Every IndexedDB the origin owns via \`indexedDB.databases()\`, plus SW-owned names hard-coded (\`sw-git\`, \`sw-meta\`) so Firefox — which doesn't support \`databases()\` — still wipes the essentials.
4. \`localStorage.clear()\` + \`sessionStorage.clear()\` (**user is logged out on next load**).
5. Unregister every \`ServiceWorkerRegistration\`.
6. \`location.reload()\`.

## Test plan

- [x] 1133/1133 unit tests pass
- [x] \`bun run validate\` clean (biome, oxlint, eslint, stylelint, vue-tsc, vue-depth)
- [ ] Manual on dev-admin.comprom.org: open Settings → Full reset → confirm → progress bar advances step by step → page reloads → OAuth prompt appears (logged out) → after login, git repo re-clones fresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD5SEV8ohYy295LP9WwoPo