### PR TITLE
release: KV role now syncs GitHub team membership

### DIFF
--- a/src/api/roles/assign-role.ts
+++ b/src/api/roles/assign-role.ts
@@ -1,0 +1,48 @@
+import type { RolesKv } from './kv-types'
+import type { RoleAssignment, RoleMap } from './role-map'
+import { applyRole } from './role-mutate'
+import { writeRoles } from './role-store'
+import { syncTeamMembership } from './sync-team-membership'
+
+const toMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e)
+
+/**
+ * Persist the KV role change AND sync GitHub team membership.
+ *
+ * Editors and chief-editors get push access on the content repo via
+ * team membership — content edits push with the caller's OWN OAuth
+ * token via isomorphic-git, so the KV grant alone doesn't unlock push.
+ *
+ * KV is written first (fast path, effective immediately for UI). The
+ * team sync runs after; on failure we surface 502 with the GitHub
+ * error and the admin retries. That leaves KV briefly ahead of team
+ * state, but a stale 502 message is better than a silent divergence
+ * where the UI says "editor" but the push fails with 403.
+ *
+ * @param kv KV binding for the role store.
+ * @param token Admin caller's OAuth token (admin:org scope).
+ * @param map Current role map (pre-mutation).
+ * @param login Target GitHub login.
+ * @param role Role to assign, or `none` to clear.
+ * @returns The updated map (200) or the sync-failure envelope (502).
+ */
+export const storeRoleAndSync = async (
+  kv: RolesKv,
+  token: string,
+  map: RoleMap,
+  login: string,
+  role: RoleAssignment
+): Promise<Response> => {
+  const next = applyRole(map, login, role)
+  await writeRoles(kv, next)
+  try {
+    await syncTeamMembership(token, login, role)
+  } catch (e) {
+    return new Response(
+      `Role stored but team membership sync failed: ${toMessage(e)}`,
+      { status: 502 }
+    )
+  }
+  return Response.json(next)
+}

--- a/src/api/roles/put-role.ts
+++ b/src/api/roles/put-role.ts
@@ -1,27 +1,15 @@
 import type { Context } from 'hono'
 import type { Env } from '../app'
+import { storeRoleAndSync } from './assign-role'
 import { toAssignment } from './assignment'
 import { bearer, preflight } from './gate'
 import type { RolesKv } from './kv-types'
 import { resolveCaller } from './role-caller'
-import type { RoleAssignment, RoleMap } from './role-map'
-import { applyRole } from './role-mutate'
-import { readRoles, writeRoles } from './role-store'
+import { readRoles } from './role-store'
 
 interface AssignBody {
   readonly login?: string
   readonly role?: string
-}
-
-const store = async (
-  kv: RolesKv,
-  map: RoleMap,
-  login: string,
-  role: RoleAssignment
-): Promise<Response> => {
-  const next = applyRole(map, login, role)
-  await writeRoles(kv, next)
-  return Response.json(next)
 }
 
 const assign = async (
@@ -36,16 +24,18 @@ const assign = async (
   return caller?.role !== 'admin'
     ? new Response('Admin only', { status: 403 })
     : kv && login && role
-      ? store(kv, map, login, role)
+      ? storeRoleAndSync(kv, token, map, login, role)
       : new Response('Bad request', { status: 400 })
 }
 
 /**
  * PUT /api/roles — assign `{ login, role }` (role ∈ editor | chief-editor
  * | admin | none). Admin only, caller re-derived from their own token.
- * Writes KV so the grant is effective immediately, no content commit.
- * @param c - Hono context (Env carries ROLES_KV).
- * @returns 200 updated map, 400 bad body, or 403 for non-admins.
+ * Writes KV AND syncs GitHub team membership so the grant is effective
+ * both in the UI and for content-repo push access.
+ *
+ * @param c Hono context (Env carries ROLES_KV).
+ * @returns 200 updated map, 400 bad body, 403 non-admin, 502 sync fail.
  */
 export const putRole = async (
   c: Context<{ Bindings: Env }>

--- a/src/api/roles/sync-team-membership.test.ts
+++ b/src/api/roles/sync-team-membership.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { syncTeamMembership } from './sync-team-membership'
+
+interface Call {
+  readonly method: string
+  readonly url: string
+}
+
+const ORG = 'communist-prometheus'
+const EDITORS = `https://api.github.com/orgs/${ORG}/teams/editors/memberships/alice`
+const CHIEFS = `https://api.github.com/orgs/${ORG}/teams/chief-editors/memberships/alice`
+
+const stubFetch = (
+  route: (call: Call) => Response
+): { readonly calls: Call[] } => {
+  const calls: Call[] = []
+  vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    const method = init?.method ?? 'GET'
+    calls.push({ method, url })
+    return route({ method, url })
+  })
+  return { calls }
+}
+
+const ok = (): Response => new Response('{}', { status: 200 })
+const noContent = (): Response => new Response(null, { status: 204 })
+const notFound = (): Response => new Response('not found', { status: 404 })
+const forbidden = (): Response => new Response('forbidden', { status: 403 })
+
+describe('syncTeamMembership', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('editor: PUT editors membership + DELETE from chief-editors', async () => {
+    const { calls } = stubFetch(call =>
+      call.method === 'PUT' ? ok() : noContent()
+    )
+    await syncTeamMembership('tok', 'alice', 'editor')
+    expect(calls).toContainEqual({ method: 'PUT', url: EDITORS })
+    expect(calls).toContainEqual({ method: 'DELETE', url: CHIEFS })
+    /* No stray operations. */
+    expect(calls.length).toBe(2)
+  })
+
+  it('chief-editor: PUT chief-editors membership + DELETE from editors', async () => {
+    const { calls } = stubFetch(call =>
+      call.method === 'PUT' ? ok() : noContent()
+    )
+    await syncTeamMembership('tok', 'alice', 'chief-editor')
+    expect(calls).toContainEqual({ method: 'PUT', url: CHIEFS })
+    expect(calls).toContainEqual({ method: 'DELETE', url: EDITORS })
+    expect(calls.length).toBe(2)
+  })
+
+  it('admin: DELETE from both teams (admins are org-level, no team)', async () => {
+    const { calls } = stubFetch(() => noContent())
+    await syncTeamMembership('tok', 'alice', 'admin')
+    const methods = calls.map(c => c.method)
+    expect(methods).toEqual(['DELETE', 'DELETE'])
+    expect(new Set(calls.map(c => c.url))).toEqual(new Set([EDITORS, CHIEFS]))
+  })
+
+  it('none: DELETE from both teams', async () => {
+    const { calls } = stubFetch(() => noContent())
+    await syncTeamMembership('tok', 'alice', 'none')
+    expect(calls.length).toBe(2)
+    expect(calls.every(c => c.method === 'DELETE')).toBe(true)
+  })
+
+  it('accepts 404 on DELETE (login was not a member of that team)', async () => {
+    stubFetch(call => (call.method === 'PUT' ? ok() : notFound()))
+    await expect(
+      syncTeamMembership('tok', 'alice', 'editor')
+    ).resolves.toBeUndefined()
+  })
+
+  it('throws when PUT is rejected (surfaces GitHub message)', async () => {
+    stubFetch(call => (call.method === 'PUT' ? forbidden() : noContent()))
+    await expect(
+      syncTeamMembership('tok', 'alice', 'editor')
+    ).rejects.toThrow(/add to team editors: 403/)
+  })
+
+  it('throws when a non-404 DELETE fails (real removal failure)', async () => {
+    stubFetch(() => forbidden())
+    await expect(syncTeamMembership('tok', 'alice', 'none')).rejects.toThrow(
+      /remove from team/
+    )
+  })
+
+  it('sends admin:org-scoped Bearer + User-Agent + accept header', async () => {
+    let seen: RequestInit | undefined
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {
+      seen = init
+      return noContent()
+    })
+    await syncTeamMembership('secret-tok', 'alice', 'none')
+    const headers = seen?.headers as Record<string, string>
+    expect(headers['Authorization']).toBe('Bearer secret-tok')
+    expect(headers['Accept']).toBe('application/vnd.github+json')
+    expect(headers['User-Agent']).toBe('prometheus-admin')
+  })
+
+  it('PUT body sets team role to "member" (not maintainer)', async () => {
+    let putBody: string | undefined
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') putBody = init.body as string
+      return init?.method === 'PUT' ? ok() : noContent()
+    })
+    await syncTeamMembership('tok', 'alice', 'editor')
+    expect(putBody).toBeDefined()
+    expect(JSON.parse(putBody as string)).toEqual({ role: 'member' })
+  })
+})

--- a/src/api/roles/sync-team-membership.ts
+++ b/src/api/roles/sync-team-membership.ts
@@ -1,0 +1,77 @@
+/*
+ * KV role assignment → GitHub team membership sync.
+ *
+ * The KV role map controls what the app allows the user to do in the
+ * admin UI. It does NOT grant push access to the content repo — that
+ * comes from GitHub team membership, because content edits are pushed
+ * with the caller's own OAuth token via isomorphic-git.
+ *
+ * When an admin changes a login's role we mirror it into GitHub team
+ * membership so the caller can actually push:
+ *   editor       → member of `editors`, removed from `chief-editors`
+ *   chief-editor → member of `chief-editors`, removed from `editors`
+ *   admin        → removed from both (admins are org-level)
+ *   none         → removed from both
+ */
+
+import type { RoleAssignment } from './role-map'
+import {
+  deleteTeamMembership,
+  putTeamMembership,
+} from './team-membership-api'
+import { requireDelete, requirePut } from './team-response-guards'
+
+const TEAM_SLUGS = {
+  editor: 'editors',
+  'chief-editor': 'chief-editors',
+} as const
+
+type TeamKey = keyof typeof TEAM_SLUGS
+const ALL_TEAM_SLUGS = Object.values(TEAM_SLUGS)
+
+const targetTeam = (role: RoleAssignment): TeamKey | undefined =>
+  role === 'editor' || role === 'chief-editor' ? role : undefined
+
+const applyKeep = async (
+  token: string,
+  login: string,
+  keepSlug: string | undefined
+): Promise<void> =>
+  keepSlug === undefined
+    ? undefined
+    : requirePut(await putTeamMembership(token, keepSlug, login), keepSlug)
+
+const removeFromOthers = async (
+  token: string,
+  login: string,
+  keepSlug: string | undefined
+): Promise<void> => {
+  const toDrop = ALL_TEAM_SLUGS.filter(slug => slug !== keepSlug)
+  await Promise.all(
+    toDrop.map(slug =>
+      deleteTeamMembership(token, slug, login).then(res =>
+        requireDelete(res, slug)
+      )
+    )
+  )
+}
+
+/**
+ * Sync GitHub team membership to match a KV role assignment.
+ *
+ * @param token Admin caller's OAuth token; admin:org scope required.
+ * @param login GitHub login whose membership is being aligned.
+ * @param role The role now written to KV.
+ * @returns Resolves once every membership PUT/DELETE settles OK.
+ * @throws Error with a `status ...` prefix when GitHub rejects a call.
+ */
+export const syncTeamMembership = async (
+  token: string,
+  login: string,
+  role: RoleAssignment
+): Promise<void> => {
+  const target = targetTeam(role)
+  const keepSlug = target ? TEAM_SLUGS[target] : undefined
+  await applyKeep(token, login, keepSlug)
+  await removeFromOthers(token, login, keepSlug)
+}

--- a/src/api/roles/team-membership-api.ts
+++ b/src/api/roles/team-membership-api.ts
@@ -1,0 +1,52 @@
+const ORG = 'communist-prometheus'
+const GH = 'https://api.github.com'
+
+const headers = (token: string): Record<string, string> => ({
+  Authorization: `Bearer ${token}`,
+  Accept: 'application/vnd.github+json',
+  'User-Agent': 'prometheus-admin',
+  'content-type': 'application/json',
+})
+
+const membershipUrl = (teamSlug: string, login: string): string =>
+  `${GH}/orgs/${ORG}/teams/${teamSlug}/memberships/${login}`
+
+/**
+ * PUT the user's membership in a GitHub team. 200 = updated, 201 =
+ * pending invite created (login isn't in the org yet). The `member`
+ * role — not `maintainer` — is enough for content-repo push access.
+ *
+ * @param token Admin caller's OAuth token (admin:org scope required).
+ * @param teamSlug Target team's URL slug.
+ * @param login GitHub login to add.
+ * @returns The raw fetch Response.
+ */
+export const putTeamMembership = async (
+  token: string,
+  teamSlug: string,
+  login: string
+): Promise<Response> =>
+  fetch(membershipUrl(teamSlug, login), {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify({ role: 'member' }),
+  })
+
+/**
+ * DELETE the user's team membership. 204 = removed, 404 = wasn't a
+ * member. Both are non-errors from the sync's point of view.
+ *
+ * @param token Admin caller's OAuth token (admin:org scope required).
+ * @param teamSlug Target team's URL slug.
+ * @param login GitHub login to remove.
+ * @returns The raw fetch Response.
+ */
+export const deleteTeamMembership = async (
+  token: string,
+  teamSlug: string,
+  login: string
+): Promise<Response> =>
+  fetch(membershipUrl(teamSlug, login), {
+    method: 'DELETE',
+    headers: headers(token),
+  })

--- a/src/api/roles/team-response-guards.ts
+++ b/src/api/roles/team-response-guards.ts
@@ -1,0 +1,44 @@
+const readError = async (res: Response, context: string): Promise<string> => {
+  const txt = await res.text().catch(() => '')
+  return `${context}: ${res.status} ${txt}`.trim()
+}
+
+const throwIfFatal = async (
+  res: Response,
+  ok: boolean,
+  context: string
+): Promise<void> =>
+  ok ? undefined : Promise.reject(new Error(await readError(res, context)))
+
+/**
+ * Assert that a PUT team-membership response landed. 200 = updated,
+ * 201 = pending invite created (login not in the org yet); anything
+ * else — even 404 — is a real failure and this rejects with the raw
+ * GitHub error text so the admin sees the mismatch instead of a
+ * silent no-op.
+ *
+ * @param res Raw fetch Response from the PUT membership call.
+ * @param teamSlug Target team's URL slug (used in the error message).
+ * @returns Resolves on success; rejects with an Error on failure.
+ */
+export const requirePut = (res: Response, teamSlug: string): Promise<void> =>
+  throwIfFatal(res, res.ok, `add to team ${teamSlug}`)
+
+/**
+ * Assert that a DELETE team-membership response landed. 204 = removed,
+ * 404 = wasn't a member (both are fine — the desired end state is "not
+ * a member"). Anything else rejects with the raw GitHub error text.
+ *
+ * @param res Raw fetch Response from the DELETE membership call.
+ * @param teamSlug Target team's URL slug (used in the error message).
+ * @returns Resolves on success; rejects with an Error on failure.
+ */
+export const requireDelete = (
+  res: Response,
+  teamSlug: string
+): Promise<void> =>
+  throwIfFatal(
+    res,
+    res.ok || res.status === 404,
+    `remove from team ${teamSlug}`
+  )


### PR DESCRIPTION
## Summary

Ship #339 to production.

Editors assigned via the KV role UI now automatically land in the matching GitHub team (\`editors\` / \`chief-editors\`) so their content pushes stop failing with 403. Fixes the "Push failed - Re-authenticate to retry" the user hit while testing with a fresh editor account.

## Test plan

- [x] 1142/1142 unit tests + validate clean on #339
- [ ] Manual on **admin.comprom.org** (prod): assign a login as editor → push succeeds from that account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD5SEV8ohYy295LP9WwoPo