### PR TITLE
fix(rbac): prod editors push to develop; classify GH006 as auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,15 @@ jobs:
             echo "GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy --env develop" >> "$GITHUB_ENV"
           else
-            echo "VITE_GITHUB_BRANCH=master" >> "$GITHUB_ENV"
+            # Prod editors push to `develop` on the content repo, not
+            # `master` — master is protected by `guard` status checks
+            # and rejects direct pushes as GH006 (isomorphic-git surfaces
+            # this as "Unexpected error", which read like a client bug
+            # to editors). Content-repo Actions ff-merges develop into
+            # master via the CONTENT_MERGE_TOKEN admin PAT, so from the
+            # editor's point of view "save" still lands in production —
+            # just through an unprotected staging branch.
+            echo "VITE_GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_MASTER" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_MASTER" >> "$GITHUB_ENV"
             echo "VITE_COMMS_BASE=https://lists.comprom.org" >> "$GITHUB_ENV"

--- a/src/sw/push-queue/classify-error.test.ts
+++ b/src/sw/push-queue/classify-error.test.ts
@@ -32,6 +32,27 @@ describe('classifyPushError', () => {
     expect(classifyPushError(new Error('Bad credentials'))).toBe('auth')
   })
 
+  /*
+   * GH006 = protected-branch push rejection. Same recovery as auth
+   * (broaden access); previously read as `unknown` and the toast said
+   * "Unexpected error", which read like a client bug.
+   */
+  it('detects protected-branch rejection (GH006)', () => {
+    expect(
+      classifyPushError(
+        new Error(
+          'GH006: Protected branch update failed for refs/heads/master'
+        )
+      )
+    ).toBe('auth')
+    expect(
+      classifyPushError(
+        new Error('remote: error: GH006: Protected branch update failed')
+      )
+    ).toBe('auth')
+    expect(classifyPushError(new Error('protected branch'))).toBe('auth')
+  })
+
   it('detects validation failures', () => {
     expect(classifyPushError(new Error('422 Unprocessable Entity'))).toBe(
       'validation'

--- a/src/sw/push-queue/classify-error.ts
+++ b/src/sw/push-queue/classify-error.ts
@@ -15,6 +15,15 @@ const AUTH_PATTERNS: ReadonlyArray<RegExp> = [
   /unauthorized/i,
   /forbidden/i,
   /bad credentials/i,
+  /*
+   * GH006 = "Protected branch update failed". GitHub returns this when
+   * a caller without bypass rights direct-pushes into a branch that has
+   * required status checks or reviews. Same recovery as auth (the caller
+   * needs their access broadened) — a bare "Unexpected error" toast made
+   * this indistinguishable from a client bug.
+   */
+  /GH006/,
+  /protected branch/i,
 ]
 
 const FF_PATTERNS: ReadonlyArray<RegExp> = [


### PR DESCRIPTION
Prod was pointing SW pushes at protected `master` → editors got "Unexpected error (master)" (GH006 doesn't match any classifier pattern). Fix: prod build uses `VITE_GITHUB_BRANCH=develop`; content-repo auto-merge workflow ff-forwards master via CONTENT_MERGE_TOKEN. classify-error also matches GH006/protected branch → legible auth toast.