### PR TITLE
feat(edit): sticky Save/Preview toolbar; keyboard-safe

### DIFF
--- a/e2e/content/preview-flow.spec.ts
+++ b/e2e/content/preview-flow.spec.ts
@@ -13,12 +13,16 @@ const contentPreview = (page: import('@playwright/test').Page) =>
   page.locator('[data-testid="content-preview"]')
 
 test.describe('Preview-before-save flow', () => {
-  test('edit page has Preview button, no Save button', async ({ page }) => {
+  test('edit page has both Preview and Save on the sticky top toolbar', async ({
+    page,
+  }) => {
     await edit(page)
+    // Old flow buried Save at the bottom of the preview footer, so
+    // editors had to Preview → Save even for a quick fix. New sticky
+    // top toolbar exposes both — Save works direct, Preview optional.
     await expect(preview(page)).toBeVisible()
     await expect(preview(page)).toHaveText(/preview/i)
-    // The Save button only exists on the preview page, not the edit page.
-    await expect(page.locator('[data-testid="save-button"]')).toHaveCount(0)
+    await expect(page.locator('[data-testid="save-button"]')).toBeVisible()
   })
 
   test('clicking Preview renders ContentPreview with frontmatter', async ({

--- a/src/composables/useVisualViewport/bind-viewport.ts
+++ b/src/composables/useVisualViewport/bind-viewport.ts
@@ -1,0 +1,50 @@
+/*
+ * Bind visualViewport → CSS custom properties on documentElement so
+ * every sticky UI can hug the ACTUAL visible viewport rectangle.
+ *
+ *   --app-vh = visualViewport.height (px) — the visible viewport height
+ *              minus the browser toolbars AND minus any on-screen
+ *              keyboard. Fallback is `100svh` while the script hasn't
+ *              measured yet.
+ *   --app-vt = visualViewport.offsetTop (px) — top offset of the visible
+ *              viewport within the layout viewport. Non-zero on mobile
+ *              when the top toolbar is auto-hidden or when a form input
+ *              has been scrolled to keep it above the keyboard.
+ *
+ * Consumers pin `position: fixed; top: var(--app-vt); …` and set
+ * `block-size: var(--app-vh)` to stay glued to the visible area.
+ *
+ * Idempotent — safe to call more than once; subsequent calls just
+ * re-bind the same listeners.
+ */
+
+let installed = false
+
+const write = (vv: VisualViewport | null): void => {
+  const root = document.documentElement.style
+  const h = vv?.height ?? window.innerHeight
+  const t = vv?.offsetTop ?? 0
+  root.setProperty('--app-vh', `${h}px`)
+  root.setProperty('--app-vt', `${t}px`)
+}
+
+const doInstall = (): void => {
+  installed = true
+  const vv = window.visualViewport ?? null
+  write(vv)
+  const onChange = (): void => write(vv)
+  vv?.addEventListener('resize', onChange)
+  vv?.addEventListener('scroll', onChange)
+  window.addEventListener('resize', onChange)
+}
+
+/**
+ * Attach visualViewport listeners on window and write the initial
+ * `--app-vh` / `--app-vt` values on `documentElement`. Safe to call
+ * more than once — subsequent calls are no-ops.
+ *
+ * @returns void — the binding lives for the app's lifetime; there is
+ *   no unbind path because the root element outlives every consumer.
+ */
+export const installVisualViewportBinding = (): void =>
+  installed ? undefined : doInstall()

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,11 @@ import './assets/styles/index.scss'
 
 import { createApp } from './app'
 import { applyTheme, readStoredTheme } from './composables/useTheme'
+import { installVisualViewportBinding } from './composables/useVisualViewport/bind-viewport'
 import { vChildren } from './directives/render'
 
 applyTheme(readStoredTheme())
+installVisualViewportBinding()
 
 const { app } = createApp()
 

--- a/src/views/ContentEditView.vue
+++ b/src/views/ContentEditView.vue
@@ -10,8 +10,8 @@ import LanguageSelector from '@/components/LanguageSelector/LanguageSelector.vue
 import ContentEditMain from './ContentEditView/ContentEditMain.vue'
 import ContentPreview from './ContentEditView/ContentPreview.vue'
 import EditBreadcrumb from './ContentEditView/EditBreadcrumb.vue'
+import EditToolbar from './ContentEditView/EditToolbar.vue'
 import { initEditPage } from './ContentEditView/init-edit-page'
-import PreviewFooter from './ContentEditView/PreviewFooter.vue'
 import PublishConfirmDialog from './ContentEditView/PublishConfirmDialog.vue'
 import { setupEditHandlers } from './ContentEditView/setup-handlers'
 import { setupViewer } from './ContentEditView/setup-viewer'
@@ -54,6 +54,14 @@ const {
 
 <template>
   <AppLayout>
+    <EditToolbar
+      :saving="saving"
+      :saved="saved"
+      :previewing="previewing"
+      @save="flow.onSave"
+      @preview="h.enterPreview"
+      @back-to-edit="h.exitPreview"
+    />
     <nav class="edit-nav">
       <EditBreadcrumb
         :content-type="p.contentType.value"
@@ -85,7 +93,6 @@ const {
       :lang="p.editor.currentLang.value"
       @update:body-content="h.updateBody"
       @update:frontmatter="h.updateFm"
-      @preview="h.enterPreview"
       @paste:image="p.ah.onPasteImage"
       @upload-asset="p.ah.onUploadAsset"
       @set-cover="p.ah.onSetCover"
@@ -97,13 +104,6 @@ const {
       :frontmatter-data="p.editor.frontmatterData.value"
       :cover-url="p.assets.coverUrl.value"
       :asset-url-map="p.hasAssets.value ? p.assets.urlMap.value : undefined"
-    />
-    <PreviewFooter
-      v-if="previewing"
-      :saving="saving"
-      :saved="saved"
-      @save="flow.onSave"
-      @back="h.exitPreview"
     />
     <AssetPanel
       v-if="!previewing && p.hasAssets.value && !p.editor.loadingFile.value"
@@ -139,7 +139,13 @@ const {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0;
+
+  /*
+   * Top gutter: EditToolbar is fixed at var(--app-vt); leave enough
+   * room so the breadcrumb doesn't render under it. 3rem covers a
+   * min-block-size 2.25rem button plus its padding.
+   */
+  padding: 3rem 0 0.5rem;
   font-size: clamp(0.875rem, 2vw, 1rem);
 }
 </style>

--- a/src/views/ContentEditView/ContentEditMain.vue
+++ b/src/views/ContentEditView/ContentEditMain.vue
@@ -18,7 +18,6 @@ defineProps<{
 defineEmits<{
   'update:bodyContent': [value: string]
   'update:frontmatter': [data: Record<string, unknown>]
-  preview: []
   'paste:image': [file: File]
   'upload-asset': [file: File]
   'set-cover': [name: string]
@@ -42,7 +41,6 @@ defineEmits<{
       :lang="lang"
       @update:body-content="$emit('update:bodyContent', $event)"
       @update:frontmatter="$emit('update:frontmatter', $event)"
-      @preview="$emit('preview')"
       @paste:image="$emit('paste:image', $event)"
       @upload-asset="$emit('upload-asset', $event)"
       @set-cover="$emit('set-cover', $event)"

--- a/src/views/ContentEditView/ContentEditMainBody.vue
+++ b/src/views/ContentEditView/ContentEditMainBody.vue
@@ -18,7 +18,6 @@ defineProps<{
 defineEmits<{
   'update:bodyContent': [value: string]
   'update:frontmatter': [data: Record<string, unknown>]
-  preview: []
   'paste:image': [file: File]
   'upload-asset': [file: File]
   'set-cover': [name: string]
@@ -44,7 +43,6 @@ defineEmits<{
     :asset-url-map="assetUrlMap"
     :assets="assets"
     @update:body-content="$emit('update:bodyContent', $event)"
-    @preview="$emit('preview')"
     @paste:image="$emit('paste:image', $event)"
     @upload-asset="$emit('upload-asset', $event)"
     @set-cover="$emit('set-cover', $event)"

--- a/src/views/ContentEditView/EditBodyArea.vue
+++ b/src/views/ContentEditView/EditBodyArea.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import EditorFooter from '@/components/MarkdownEditor/EditorFooter.vue'
 import MarkdownEditorBody from '@/components/MarkdownEditor/MarkdownEditorBody.vue'
 import NewspaperSourceUploads from '@/components/MarkdownEditor/NewspaperSourceUploads.vue'
 import { hasBodyEditor } from '@/components/MarkdownEditor/page-body-policy'
@@ -17,7 +16,6 @@ const props = defineProps<{
 
 defineEmits<{
   'update:bodyContent': [value: string]
-  preview: []
   'paste:image': [file: File]
   'upload-asset': [file: File]
   'set-cover': [name: string]
@@ -55,7 +53,6 @@ const fmString = (key: string): string | undefined => {
       @upload-asset="$emit('upload-asset', $event)"
       @error="$emit('error', $event)"
     />
-    <EditorFooter :disabled="false" @preview="$emit('preview')" />
   </section>
 </template>
 

--- a/src/views/ContentEditView/EditToolbar.vue
+++ b/src/views/ContentEditView/EditToolbar.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    readonly saving?: boolean
+    readonly saved?: boolean
+    readonly previewing?: boolean
+  }>(),
+  { saving: false, saved: false, previewing: false }
+)
+
+const emit = defineEmits<{
+  save: []
+  preview: []
+  'back-to-edit': []
+}>()
+</script>
+
+<template>
+  <div
+    class="edit-toolbar"
+    role="toolbar"
+    aria-label="Article actions"
+    data-testid="edit-toolbar"
+  >
+    <button
+      v-if="!previewing"
+      type="button"
+      class="btn-secondary"
+      data-testid="preview-button"
+      :disabled="saving"
+      @click="emit('preview')"
+    >
+      Preview
+    </button>
+    <button
+      v-else
+      type="button"
+      class="btn-secondary"
+      data-testid="back-to-edit-button"
+      :disabled="saving"
+      @click="emit('back-to-edit')"
+    >
+      Back to edit
+    </button>
+    <button
+      type="button"
+      class="btn-primary"
+      data-testid="save-button"
+      :disabled="saving"
+      :class="{ saving, done: saved }"
+      @click="emit('save')"
+    >
+      {{ saving ? '' : saved ? '✓ Saved' : 'Save' }}
+    </button>
+  </div>
+</template>
+
+<style scoped>
+/*
+ * Sticky top toolbar for the article editor. The old flow put Save at
+ * the BOTTOM of a preview footer, so on a long article the user had to
+ * scroll to the end just to save — worse still, Preview lived AFTER
+ * the markdown editor (below the fold on a mobile viewport too).
+ *
+ * `position: fixed; top: var(--app-vt, 0px)` pins the bar to the top
+ * of the VISIBLE viewport (visualViewport-tracked). On mobile with a
+ * virtual keyboard the layout viewport doesn't move — but the visible
+ * viewport does; the `--app-vt` offset keeps the toolbar glued to what
+ * the user actually sees, not to the layout origin.
+ *
+ * A safe-area gap lives on the parent view (ContentEditView) as a
+ * `scroll-padding-block-start` and a matching top padding so page
+ * content isn't hidden under the fixed toolbar.
+ */
+.edit-toolbar {
+  position: fixed;
+  inset-block-start: var(--app-vt, 0);
+  inset-inline: 0;
+  z-index: 20;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  padding: clamp(0.5rem, 1.5vw, 0.75rem) clamp(0.75rem, 2vw, 1rem);
+  border-bottom: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-background) 92%, transparent);
+  backdrop-filter: blur(6px);
+}
+
+button {
+  min-inline-size: 5rem;
+  min-block-size: 2.25rem;
+  padding: 0.4rem 1rem;
+  border-radius: var(--radius-md);
+  font-size: clamp(0.85rem, 2vw, 0.95rem);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.btn-primary {
+  border: none;
+  background: var(--color-border-hover);
+  color: var(--color-text);
+}
+
+.btn-primary:hover:not(:disabled) {
+  background: var(--color-border);
+}
+
+.btn-secondary {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: var(--color-background-soft);
+}
+
+button:disabled {
+  opacity: 50%;
+  cursor: not-allowed;
+}
+
+.done {
+  color: hsl(140deg 60% 50%);
+}
+
+.saving {
+  color: transparent;
+}
+
+.saving::after {
+  content: '';
+  position: absolute;
+  inline-size: 1em;
+  block-size: 1em;
+  margin-inline-start: -0.5em;
+  border: 2px solid var(--color-text-secondary);
+  border-block-start-color: var(--color-text);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+</style>


### PR DESCRIPTION
Editor complained Save/Preview are at the bottom of long articles. New sticky top toolbar (visualViewport-safe) with Preview + Save always visible. Save works direct — no Preview round-trip.