### PR TITLE
release: collapsible nav groups (compact drawer + desktop dropdowns)

### DIFF
--- a/e2e/content/language-filtering.spec.ts
+++ b/e2e/content/language-filtering.spec.ts
@@ -81,7 +81,9 @@ test.describe('Language Filtering', () => {
       selector.getByRole('button', { name: 'Русский' })
     ).toHaveClass(/active/)
 
-    await page.click('a[href="/content/positions"]')
+    /* Open the Content dropdown then click the Positions link. */
+    await page.getByTestId('nav-group-content').click()
+    await page.locator('a[href="/content/positions"]').first().click()
     await page.waitForURL('/content/positions')
     await waitForContentReady(page)
 

--- a/e2e/content/section-switching.spec.ts
+++ b/e2e/content/section-switching.spec.ts
@@ -56,6 +56,11 @@ test.describe('Content Section Switching', () => {
       .locator('[data-testid="content-item"]')
       .count()
 
+    /*
+     * Desktop nav now groups sections under a dropdown per category.
+     * Open the "Content" group first, then click the target link.
+     */
+    await click(page, page.getByTestId('nav-group-content'))
     await click(
       page,
       page.getByTestId('app-nav').locator('a[href="/content/positions"]')
@@ -74,6 +79,7 @@ test.describe('Content Section Switching', () => {
     await visit(page, '/content/positions')
     await waitForContentReady(page)
 
+    await click(page, page.getByTestId('nav-group-content'))
     await click(
       page,
       page.getByTestId('app-nav').locator('a[href="/content/pages"]')

--- a/e2e/github-content/list-content.spec.ts
+++ b/e2e/github-content/list-content.spec.ts
@@ -37,18 +37,28 @@ test.describe('GitHub Content - List', () => {
   })
 
   test('should display content types navigation', async ({ page }) => {
-    await expectVisible(page, page.getByRole('link', { name: /blog/i }))
-    await expectVisible(page, page.getByRole('link', { name: /pages/i }))
-    await expectVisible(page, page.getByRole('link', { name: /positions/i }))
+    /*
+     * Content links live inside the "Content" dropdown group now —
+     * open it before asserting the links are visible. Scope to the
+     * desktop app-nav so the mobile-drawer copies of the same links
+     * don't trip strict mode.
+     */
+    const nav = page.getByTestId('app-nav')
+    await click(page, page.getByTestId('nav-group-content'))
+    /*
+     * Inside a role="menu" dropdown the RouterLinks carry role=menuitem
+     * (proper ARIA). Query by that role, not by role=link.
+     */
+    await expectVisible(page, nav.getByRole('menuitem', { name: /blog/i }))
+    await expectVisible(page, nav.getByRole('menuitem', { name: /pages/i }))
+    await expectVisible(
+      page,
+      nav.getByRole('menuitem', { name: /positions/i })
+    )
   })
 
   test('should navigate between content types', async ({ page }) => {
-    /*
-     * Scope to the desktop content-nav: with the role-gating fix
-     * landing in PR #271, role-gated links now also render in the
-     * mobile-menu surface, so a bare `a[href]` selector matches
-     * twice and trips strict mode.
-     */
+    await click(page, page.getByTestId('nav-group-content'))
     await click(
       page,
       page.getByTestId('app-nav').locator('a[href="/content/pages"]')

--- a/e2e/helpers/nav.ts
+++ b/e2e/helpers/nav.ts
@@ -1,0 +1,41 @@
+import type { Page } from '@playwright/test'
+
+const GROUP_BY_PATH: Record<string, string> = {
+  '/content/blog': 'content',
+  '/content/positions': 'content',
+  '/content/pages': 'content',
+  '/content/common': 'content',
+  '/content/newspaper': 'content',
+  '/content/archive': 'content',
+  '/labels': 'community',
+  '/tickets': 'community',
+  '/comms': 'distribution',
+  '/features': 'distribution',
+  '/settings': 'admin',
+}
+
+const groupFor = (path: string): string | undefined =>
+  Object.entries(GROUP_BY_PATH).find(([prefix]) =>
+    path.startsWith(prefix)
+  )?.[1]
+
+/**
+ * Open the desktop nav dropdown containing `path` and click the link.
+ * Handles the group-per-menu structure introduced when the top nav
+ * was collapsed — a plain `page.click('a[href="…"]')` inside `app-nav`
+ * misses because the link is only mounted once its group is open.
+ *
+ * @param page The Playwright Page.
+ * @param path Target route path (matches a link's `href` prefix).
+ */
+export const clickAppNavLink = async (
+  page: Page,
+  path: string
+): Promise<void> => {
+  const group = groupFor(path)
+  const nav = page.getByTestId('app-nav')
+  await (group
+    ? nav.getByTestId(`nav-group-${group}`).click()
+    : Promise.resolve())
+  await nav.locator(`a[href="${path}"]`).click()
+}

--- a/e2e/pages/ContentPage.ts
+++ b/e2e/pages/ContentPage.ts
@@ -48,8 +48,11 @@ export class ContentPage {
    * @param contentType - Target content section
    */
   async switchSection(contentType: ContentType): Promise<void> {
-    // The nav renders the link twice (desktop bar + mobile menu) —
-    // target the first; only the desktop one is interactable here.
+    /*
+     * Content links live under the "Content" dropdown on the desktop
+     * nav. Open the group first so the link is mounted, then click.
+     */
+    await click(this.page, this.page.getByTestId('nav-group-content'))
     await click(
       this.page,
       this.page.locator(`a[href="/content/${contentType}"]`).first()

--- a/e2e/settings/languages.spec.ts
+++ b/e2e/settings/languages.spec.ts
@@ -13,7 +13,12 @@ import {
 test.describe('Settings - Languages', () => {
   test('should show Settings link in header navigation', async ({ page }) => {
     await visit(page, '/')
-    const settingsLink = page.locator('.app-nav a[href="/settings"]')
+    /* Settings lives in the "Admin" dropdown — open it first. Inside
+       the dropdown RouterLinks carry role=menuitem, not link. */
+    await page.getByTestId('nav-group-admin').click()
+    const settingsLink = page
+      .getByTestId('app-nav')
+      .getByRole('menuitem', { name: 'Settings' })
     await expectText(page, settingsLink, 'Settings')
   })
 

--- a/src/components/AppNavAuth.vue
+++ b/src/components/AppNavAuth.vue
@@ -1,48 +1,21 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { RouterLink, useRoute } from 'vue-router'
 import { visibleGroups } from '@/components/NavShared/visible-groups'
-import { t } from '@/i18n/t'
 import { useAuthStore } from '@/stores/auth'
 import { useRoleStore } from '@/stores/role'
+import DesktopNavGroup from './DesktopNavGroup.vue'
 
-const route = useRoute()
 const roleStore = useRoleStore()
 const auth = useAuthStore()
 
 const groups = computed(() => visibleGroups(roleStore.role, auth.ssoRoles))
-
-const labelFor = (item: {
-  readonly label: string
-  readonly labelKey?: string
-}): string => (item.labelKey === undefined ? item.label : t(item.labelKey))
 </script>
 
 <template>
-  <template v-for="group in groups" :key="group.title">
-    <span class="nav-group-sep" aria-hidden="true" />
-    <RouterLink
-      v-for="item in group.items"
-      :key="item.path"
-      :to="item.path"
-      :class="{ active: route.path.startsWith(item.path) }"
-      :title="group.title"
-    >
-      {{ labelFor(item) }}
-    </RouterLink>
-  </template>
+  <DesktopNavGroup
+    v-for="group in groups"
+    :key="group.title"
+    :title="group.title"
+    :items="group.items"
+  />
 </template>
-
-<style scoped>
-.nav-group-sep {
-  align-self: stretch;
-  inline-size: 1px;
-  margin-inline: 0.25rem;
-  background: var(--color-border);
-  opacity: 60%;
-}
-
-.nav-group-sep:first-child {
-  display: none;
-}
-</style>

--- a/src/components/DesktopNavDropdown.vue
+++ b/src/components/DesktopNavDropdown.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { RouterLink, useRoute } from 'vue-router'
+import type { NavEntry } from '@/components/NavShared/nav-groups'
+import { t } from '@/i18n/t'
+
+defineProps<{
+  readonly items: readonly NavEntry[]
+}>()
+
+const route = useRoute()
+
+const labelFor = (item: NavEntry): string =>
+  item.labelKey === undefined ? item.label : t(item.labelKey)
+</script>
+
+<template>
+  <div class="dropdown-menu" role="menu">
+    <RouterLink
+      v-for="item in items"
+      :key="item.path"
+      :to="item.path"
+      role="menuitem"
+      class="dropdown-item"
+      :class="{ active: route.path.startsWith(item.path) }"
+    >
+      {{ labelFor(item) }}
+    </RouterLink>
+  </div>
+</template>
+
+<style scoped>
+.dropdown-menu {
+  position: absolute;
+  inset-block-start: calc(100% + 0.25rem);
+  inset-inline-start: 0;
+  min-inline-size: 10rem;
+  padding: 0.25rem;
+  display: grid;
+  gap: 0.1rem;
+  background: var(--color-background);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 6px 20px rgb(0 0 0 / 20%);
+  z-index: 40;
+}
+
+.dropdown-item {
+  padding: 0.4rem 0.6rem;
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: 0.9rem;
+  border-radius: var(--radius-sm);
+}
+
+.dropdown-item:hover,
+.dropdown-item:focus-visible {
+  background: var(--color-background-soft);
+}
+
+.dropdown-item.active {
+  color: var(--color-accent);
+  font-weight: 600;
+}
+</style>

--- a/src/components/DesktopNavGroup.vue
+++ b/src/components/DesktopNavGroup.vue
@@ -40,17 +40,14 @@ router.afterEach(close)
 </script>
 
 <template>
-  <div
-    ref="rootEl"
-    class="dropdown-group"
-    :data-testid="`nav-group-${title.toLowerCase()}`"
-  >
+  <div ref="rootEl" class="dropdown-group">
     <button
       type="button"
       class="dropdown-toggle"
       :class="{ active: isActiveGroup, open }"
       :aria-expanded="open"
       aria-haspopup="menu"
+      :data-testid="`nav-group-${title.toLowerCase()}`"
       @click="toggle"
     >
       {{ title }} ▾

--- a/src/components/DesktopNavGroup.vue
+++ b/src/components/DesktopNavGroup.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import type { NavEntry } from '@/components/NavShared/nav-groups'
+import DesktopNavDropdown from './DesktopNavDropdown.vue'
+
+const props = defineProps<{
+  readonly title: string
+  readonly items: readonly NavEntry[]
+}>()
+
+const route = useRoute()
+const router = useRouter()
+const open = ref(false)
+const rootEl = ref<HTMLElement | undefined>(undefined)
+
+const isActiveGroup = computed(() =>
+  props.items.some(item => route.path.startsWith(item.path))
+)
+
+const close = (): void => {
+  open.value = false
+}
+
+const toggle = (): void => {
+  open.value = !open.value
+}
+
+const isOutside = (target: Node): boolean => {
+  const el = rootEl.value
+  return Boolean(el && !el.contains(target))
+}
+
+const onPointerDown = (e: PointerEvent): void =>
+  isOutside(e.target as Node) ? close() : undefined
+
+onMounted(() => document.addEventListener('pointerdown', onPointerDown))
+onUnmounted(() => document.removeEventListener('pointerdown', onPointerDown))
+router.afterEach(close)
+</script>
+
+<template>
+  <div
+    ref="rootEl"
+    class="dropdown-group"
+    :data-testid="`nav-group-${title.toLowerCase()}`"
+  >
+    <button
+      type="button"
+      class="dropdown-toggle"
+      :class="{ active: isActiveGroup, open }"
+      :aria-expanded="open"
+      aria-haspopup="menu"
+      @click="toggle"
+    >
+      {{ title }} ▾
+    </button>
+    <DesktopNavDropdown v-if="open" :items="items" />
+  </div>
+</template>
+
+<style scoped>
+.dropdown-group {
+  position: relative;
+  display: inline-flex;
+}
+
+.dropdown-toggle {
+  padding: 0.5rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-size: clamp(0.875rem, 2vw, 1rem);
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.dropdown-toggle:hover,
+.dropdown-toggle:focus-visible {
+  background: var(--color-background-soft);
+}
+
+.dropdown-toggle.active {
+  color: var(--color-accent);
+}
+
+/* Caret flips on open via a rotation on the ::after glyph. */
+.dropdown-toggle::after {
+  content: '';
+}
+</style>

--- a/src/components/MobileMenu/MobileNavGroup.vue
+++ b/src/components/MobileMenu/MobileNavGroup.vue
@@ -1,35 +1,41 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
 import type { NavEntry } from '@/components/NavShared/nav-groups'
 import { t } from '@/i18n/t'
+import MobileNavGroupSummary from './MobileNavGroupSummary.vue'
 import MobileNavLink from './MobileNavLink.vue'
 
-defineProps<{
+const props = defineProps<{
   readonly title: string
   readonly items: readonly NavEntry[]
 }>()
 
 defineEmits<{ navigate: [] }>()
 
+const route = useRoute()
+
+/*
+ * Auto-expand the group whose active item lives inside — otherwise
+ * every group starts collapsed so the drawer stays a single-screen
+ * list of category headers. Tapping any other header opens it and
+ * lets the default <details> behaviour handle the rest.
+ */
+const isActiveGroup = computed(() =>
+  props.items.some(item => route.path.startsWith(item.path))
+)
+
 const labelFor = (item: NavEntry): string =>
   item.labelKey === undefined ? item.label : t(item.labelKey)
 </script>
 
 <template>
-  <li class="mobile-nav-group">
-    <!--
-      role=heading + aria-level keeps the accessibility semantics but
-      avoids matching global `page.locator('h3').first()` selectors used
-      in the content list tests (the first h3 in the DOM would otherwise
-      be this heading — always mounted, invisible when the menu is
-      closed via opacity: 0 on the overlay).
-    -->
-    <span
-      class="mobile-nav-heading"
-      role="heading"
-      aria-level="3"
-    >
-      {{ title }}
-    </span>
+  <details
+    class="mobile-nav-details"
+    :open="isActiveGroup"
+    :data-testid="`mobile-nav-group-${title.toLowerCase()}`"
+  >
+    <MobileNavGroupSummary :title="title" />
     <MobileNavLink
       v-for="item in items"
       :key="item.path"
@@ -37,30 +43,15 @@ const labelFor = (item: NavEntry): string =>
       :label="labelFor(item)"
       @click="$emit('navigate')"
     />
-  </li>
+  </details>
 </template>
 
 <style scoped>
-.mobile-nav-group {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: var(--spacing-xxs, 0.15rem);
-  padding-block: var(--spacing-xs);
-}
-
-.mobile-nav-group + .mobile-nav-group {
-  border-block-start: 1px solid var(--color-border);
-}
-
-.mobile-nav-heading {
+.mobile-nav-details {
   display: block;
-  margin: 0 0 0.25rem;
-  padding-inline: var(--spacing-sm);
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--color-text-secondary);
+}
+
+.mobile-nav-details + .mobile-nav-details {
+  border-block-start: 1px solid var(--color-border);
 }
 </style>

--- a/src/components/MobileMenu/MobileNavGroupSummary.vue
+++ b/src/components/MobileMenu/MobileNavGroupSummary.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+defineProps<{
+  readonly title: string
+}>()
+</script>
+
+<template>
+  <summary class="mobile-nav-summary">
+    <span
+      class="mobile-nav-heading"
+      role="heading"
+      aria-level="3"
+    >{{ title }}</span>
+    <span class="mobile-nav-chevron" aria-hidden="true">▸</span>
+  </summary>
+</template>
+
+<style scoped>
+.mobile-nav-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem var(--spacing-sm);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  list-style: none;
+}
+
+.mobile-nav-summary::-webkit-details-marker {
+  display: none;
+}
+
+.mobile-nav-summary:hover,
+.mobile-nav-summary:focus-visible {
+  background: var(--color-surface);
+}
+
+.mobile-nav-heading {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+}
+
+.mobile-nav-chevron {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  transition: transform 0.15s ease;
+}
+
+/*
+ * The chevron rotates when the parent <details> is [open]. Scoped
+ * styles get a hashed class attribute, but the parent's [open]
+ * attribute is unhashed, so this selector reaches it via :global-
+ * equivalent — the `:deep()` marker on chevron under [open] parent.
+ */
+:global(details[open]) .mobile-nav-chevron {
+  transform: rotate(90deg);
+}
+</style>

--- a/src/components/MobileMenu/MobileNavLink.vue
+++ b/src/components/MobileMenu/MobileNavLink.vue
@@ -26,9 +26,15 @@ const route = useRoute()
 .mobile-nav-link {
   display: flex;
   align-items: center;
-  min-height: 48px;
-  padding: var(--spacing-xs) var(--spacing-sm);
-  font-size: var(--font-size-xl);
+
+  /*
+   * Compact rows so the drawer fits on a single mobile screen even
+   * with several groups expanded. 40px is Apple's minimum touch
+   * target height once a leading padding-inline is added.
+   */
+  min-height: 40px;
+  padding: 0.35rem 1rem 0.35rem 1.6rem;
+  font-size: 0.95rem;
   font-weight: 500;
   color: var(--color-text-primary);
   text-decoration: none;


### PR DESCRIPTION
Ship #350. Mobile drawer collapses each group by default; the group owning the active route auto-expands. Desktop bar uses dropdown-per-group so it's 5 buttons instead of 10 inline links.