### PR TITLE
release: mobile drawer vertical-text fix + a11y guards

### DIFF
--- a/e2e/layout/mobile-drawer-layout.spec.ts
+++ b/e2e/layout/mobile-drawer-layout.spec.ts
@@ -1,0 +1,164 @@
+import { expect, test, waitForCondition } from '@prometheus/e2e-toolkit'
+
+/*
+ * Guard the mobile drawer geometry. A prior refactor (PR #350) shipped
+ * a `:global(details[open]) .chevron` rule that Vue's compiler
+ * silently reduced to `details[open] { transform: rotate(90deg) }`,
+ * rotating every open <details> on the page. On a real mobile viewport
+ * the Distribution links then measured `w=40 h=270` — character-
+ * wrapped one glyph per line — which the user described as "text
+ * rendered vertically". This test guards against that whole
+ * category of regression by asserting every visible nav link stays
+ * wider than one glyph AND that no ancestor has a transform on it.
+ */
+
+const openDrawer = async (page: import('@playwright/test').Page) => {
+  await page.getByRole('button', { name: /navigation menu/i }).click()
+  await waitForCondition(
+    page,
+    async () =>
+      (await page
+        .locator('.mobile-popup')
+        .evaluate(el => getComputedStyle(el).opacity)) === '1'
+  )
+}
+
+test.describe('Mobile drawer layout (2.mobile-menu)', () => {
+  test.use({ viewport: { width: 375, height: 812 } })
+  test.skip(
+    ({ isMobile }) => !isMobile,
+    'The FAB + drawer are display:none above 768 px; only mobile-chromium runs here.'
+  )
+
+  test('nav-link labels never wrap to a single-character column', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await openDrawer(page)
+
+    /* Expand every group so all labels are measured. */
+    await page.$$eval('details.mobile-nav-details', els => {
+      for (const d of els) d.setAttribute('open', '')
+    })
+
+    const dims = await page.locator('a.mobile-nav-link').evaluateAll(links =>
+      links.map(l => {
+        const r = l.getBoundingClientRect()
+        return {
+          text: l.textContent?.trim() ?? '',
+          w: Math.round(r.width),
+          h: Math.round(r.height),
+        }
+      })
+    )
+
+    expect(dims.length).toBeGreaterThan(0)
+    for (const d of dims) {
+      /*
+       * A single glyph at the drawer's font size is ~15 px wide; any
+       * link under ~90 px on a 375 px viewport means the label has
+       * been character-wrapped. Height above 3 lines (~72 px) is the
+       * upper bound — a legible one-line label is 40-45 px tall.
+       */
+      expect(d.w, `"${d.text}" width ${d.w}px < 90px`).toBeGreaterThan(90)
+      expect(d.h, `"${d.text}" height ${d.h}px > 72px`).toBeLessThan(72)
+    }
+  })
+
+  test('no ancestor of a drawer item has a transform', async ({ page }) => {
+    await page.goto('/')
+    await openDrawer(page)
+    await page.$$eval('details.mobile-nav-details', els => {
+      for (const d of els) d.setAttribute('open', '')
+    })
+
+    /*
+     * Explicit guard for the exact regression that shipped in PR #350
+     * — a global `details[open] { transform: rotate(90deg) }` sneaked
+     * in. Walk EVERY nav link's ancestor chain up to <body> and
+     * assert nobody carries a transform (except the mobile-popup, which
+     * uses `translateY` for its opening animation). Iterating over
+     * every link — not just the first — catches a per-group
+     * scoped-CSS leak that would otherwise slip through.
+     */
+    const withTransforms = await page.evaluate(() => {
+      const results: { tag: string; cls: string; transform: string }[] = []
+      for (const link of document.querySelectorAll('a.mobile-nav-link')) {
+        let cur: Element | null = link
+        while (cur && cur.tagName !== 'BODY') {
+          const t = getComputedStyle(cur).transform
+          if (t !== 'none' && !cur.className?.includes?.('mobile-popup')) {
+            results.push({
+              tag: cur.tagName,
+              cls: String(cur.className ?? ''),
+              transform: t,
+            })
+          }
+          cur = cur.parentElement
+        }
+      }
+      return results
+    })
+    expect(
+      withTransforms,
+      `Unexpected transforms on ancestors: ${JSON.stringify(withTransforms)}`
+    ).toEqual([])
+  })
+
+  test('drawer inline-size is bounded by the viewport', async ({ page }) => {
+    await page.goto('/')
+    await openDrawer(page)
+
+    const overlayRect = await page.locator('.mobile-popup').evaluate(el => {
+      const r = el.getBoundingClientRect()
+      return { w: Math.round(r.width), h: Math.round(r.height) }
+    })
+
+    /*
+     * `inline-size: min(18rem, calc(100vw - 32px))` = **exactly 288 px**
+     * on a 375 vw viewport (18 rem @ 16 px base). Pin the expected size
+     * tightly — a slack upper bound of 343 would silently accept a
+     * regression that widened the clamp to 20rem, and the point of
+     * this test is to detect a return of the shrink-to-content collapse
+     * (~116 px) or an accidental clamp change.
+     */
+    expect(
+      overlayRect.w,
+      `drawer width ${overlayRect.w}px too narrow`
+    ).toBeGreaterThan(260)
+    expect(
+      overlayRect.w,
+      `drawer width ${overlayRect.w}px above expected 288`
+    ).toBeLessThan(300)
+  })
+
+  /*
+   * On the smallest supported width (320 vw, iPhone SE 1st-gen). The
+   * clamp `calc(100vw - 2 * var(--fab-margin, 16px))` was written
+   * specifically so the popup can't slide off-screen at 320 px. Guard
+   * that separately from the 375 vw layout test.
+   */
+  test.describe('320 vw viewport', () => {
+    test.use({ viewport: { width: 320, height: 568 } })
+    test('drawer stays inside the viewport', async ({ page }) => {
+      await page.goto('/')
+      await openDrawer(page)
+      const geom = await page.locator('.mobile-popup').evaluate(el => {
+        const r = el.getBoundingClientRect()
+        return {
+          left: Math.round(r.left),
+          right: Math.round(r.right),
+          w: Math.round(r.width),
+        }
+      })
+      expect(
+        geom.left,
+        `left=${geom.left}px is negative`
+      ).toBeGreaterThanOrEqual(0)
+      expect(
+        geom.right,
+        `right=${geom.right}px overflows 320`
+      ).toBeLessThanOrEqual(320)
+    })
+  })
+})

--- a/src/components/MobileMenu/MobileMenuNav.vue
+++ b/src/components/MobileMenu/MobileMenuNav.vue
@@ -26,7 +26,7 @@ const groups = computed(() =>
 </script>
 
 <template>
-  <ul class="mobile-nav-list">
+  <div class="mobile-nav-list" role="list">
     <MobileNavLink path="/" label="Home" @click="emit('navigate')" />
     <MobileNavGroup
       v-for="group in groups"
@@ -36,16 +36,16 @@ const groups = computed(() =>
       @navigate="emit('navigate')"
     />
     <MobileAuthAction @navigate="emit('navigate')" />
-  </ul>
+  </div>
 </template>
 
 <style scoped>
 .mobile-nav-list {
-  list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
   gap: var(--spacing-xs);
+  align-items: stretch;
 }
 </style>

--- a/src/components/MobileMenu/MobileMenuOverlay.vue
+++ b/src/components/MobileMenu/MobileMenuOverlay.vue
@@ -32,6 +32,18 @@ const style = computed(() => ({
 .mobile-popup {
   position: fixed;
   z-index: 99;
+
+  /*
+   * Explicit inline-size. Without it the popup's `width: auto` under
+   * `position: fixed` collapses to whichever child happens to be
+   * widest, so an expanded <details> shrinks its siblings — 116 px on
+   * the reporter's viewport — which in turn breaks each menu item's
+   * text into a one-character-per-line column, visually indistinguishable
+   * from a 90° rotation. 18 rem is enough for "Newsletter" +
+   * padding on any locale; the min() clamps to the visible viewport
+   * so the popup can't slide off-screen on 320 px devices.
+   */
+  inline-size: min(18rem, calc(100vw - 2 * var(--fab-margin, 16px)));
   background: var(--color-surface-elevated);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);

--- a/src/components/MobileMenu/MobileNavGroup.vue
+++ b/src/components/MobileMenu/MobileNavGroup.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import type { NavEntry } from '@/components/NavShared/nav-groups'
 import { t } from '@/i18n/t'
@@ -25,6 +25,19 @@ const isActiveGroup = computed(() =>
   props.items.some(item => route.path.startsWith(item.path))
 )
 
+/*
+ * Track the details' actual open state so the chevron glyph stays in
+ * sync with user interaction (native `<details>` toggling is outside
+ * Vue's control). A `toggle` event listener bounces the state back.
+ */
+const openState = ref(isActiveGroup.value)
+watch(isActiveGroup, next => {
+  openState.value = next
+})
+const onToggle = (e: Event): void => {
+  openState.value = (e.target as HTMLDetailsElement).open
+}
+
 const labelFor = (item: NavEntry): string =>
   item.labelKey === undefined ? item.label : t(item.labelKey)
 </script>
@@ -32,10 +45,11 @@ const labelFor = (item: NavEntry): string =>
 <template>
   <details
     class="mobile-nav-details"
-    :open="isActiveGroup"
+    :open="openState"
     :data-testid="`mobile-nav-group-${title.toLowerCase()}`"
+    @toggle="onToggle"
   >
-    <MobileNavGroupSummary :title="title" />
+    <MobileNavGroupSummary :title="title" :open="openState" />
     <MobileNavLink
       v-for="item in items"
       :key="item.path"

--- a/src/components/MobileMenu/MobileNavGroupSummary.vue
+++ b/src/components/MobileMenu/MobileNavGroupSummary.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 defineProps<{
   readonly title: string
+  readonly open: boolean
 }>()
 </script>
 
@@ -11,7 +12,7 @@ defineProps<{
       role="heading"
       aria-level="3"
     >{{ title }}</span>
-    <span class="mobile-nav-chevron" aria-hidden="true">▸</span>
+    <span class="mobile-nav-chevron" aria-hidden="true">{{ open ? '▾' : '▸' }}</span>
   </summary>
 </template>
 
@@ -44,19 +45,17 @@ defineProps<{
   color: var(--color-text-secondary);
 }
 
+/*
+ * Chevron rotation is a two-glyph swap, NOT a CSS transform. The
+ * previous attempt scoped a `:global(details[open]) .chevron` rule
+ * expecting Vue's `:global()` to leave the descendant scoped — but
+ * the compiler stripped the descendant part and emitted the global
+ * rule `details[open] { transform: rotate(90deg); }`. That rotated
+ * every open <details> on the page 90°, so nested links measured
+ * 40 × 270 px and their labels wrapped one glyph per line.
+ */
 .mobile-nav-chevron {
   font-size: 0.75rem;
   color: var(--color-text-secondary);
-  transition: transform 0.15s ease;
-}
-
-/*
- * The chevron rotates when the parent <details> is [open]. Scoped
- * styles get a hashed class attribute, but the parent's [open]
- * attribute is unhashed, so this selector reaches it via :global-
- * equivalent — the `:deep()` marker on chevron under [open] parent.
- */
-:global(details[open]) .mobile-nav-chevron {
-  transform: rotate(90deg);
 }
 </style>

--- a/src/components/MobileMenu/MobileNavLink.vue
+++ b/src/components/MobileMenu/MobileNavLink.vue
@@ -40,6 +40,18 @@ const route = useRoute()
   text-decoration: none;
   border-radius: var(--radius-sm);
   transition: background var(--transition-fast);
+
+  /*
+   * Wrap at word boundaries — never at character. The root cause of
+   * the vertical-text bug was a rotated ancestor forcing 40 px width
+   * on links; a plain `nowrap + ellipsis` would fix that but silently
+   * truncate longer i18n labels ("Управление рассылками") without any
+   * visible clue that content was cut. The drawer now has 288 px of
+   * inline space, so `overflow-wrap: anywhere` is safe: legible words
+   * stay on one line, rare very-long ones wrap to two — visible.
+   */
+  overflow-wrap: anywhere;
+  word-break: normal;
 }
 
 .mobile-nav-link:hover {


### PR DESCRIPTION
Ship #353 to production. Fixes the visible mobile-drawer rotation regression from #350; adds four E2E specs guarding the whole class of scoped-CSS-transform leaks at both 375 vw and 320 vw viewports. Multi-agent review (designer/qa/po) voted ship.