### PR TITLE
feat(comms): promote Resend quota auto-pause to production

### DIFF
--- a/services/comms-worker/src/dispatch/chunk-fallback.ts
+++ b/services/comms-worker/src/dispatch/chunk-fallback.ts
@@ -1,4 +1,5 @@
 import { logEvent } from '../log/structured'
+import type { QuotaKind } from '../resend/response'
 import type { DispatchContext } from './context'
 import type { SendPlan } from './plan'
 import { recordFailed, recordSent } from './record'
@@ -7,6 +8,13 @@ import { recordFailed, recordSent } from './record'
 export type ChunkCounts = {
   readonly sent: number
   readonly failed: number
+  /**
+   * Set when the chunk was rejected by an account-wide quota. The
+   * caller stops sending further chunks and pauses the dispatch until
+   * the quota resets, rather than recording every remaining recipient
+   * as failed.
+   */
+  readonly quota?: QuotaKind
 }
 
 const sendOne = async (

--- a/services/comms-worker/src/dispatch/pause-gate.ts
+++ b/services/comms-worker/src/dispatch/pause-gate.ts
@@ -1,0 +1,39 @@
+import { logEvent } from '../log/structured'
+import type { SettingsRepo } from '../settings/repo'
+
+/**
+ * Whether this tick is still inside a quota pause. A pause set on a
+ * `daily_quota_exceeded` holds every tick until the quota resets; once
+ * `tickAt` reaches it the pause is dropped and the tick proceeds, so
+ * the deferred recipients replay on the first tick after the reset.
+ * @param repo Settings repo bound to this tick's DB.
+ * @param tickAt The tick moment.
+ * @returns True when the dispatch is still paused (skip this tick).
+ */
+const isPaused = async (
+  repo: SettingsRepo,
+  tickAt: Date
+): Promise<boolean> => {
+  const until = await repo.getPausedUntil()
+  if (until === undefined) return false
+  const untilMs = Date.parse(until)
+  if (Number.isFinite(untilMs) && tickAt.getTime() < untilMs) return true
+  await repo.clearPausedUntil()
+  return false
+}
+
+/**
+ * Gate a matched tick on the quota pause: logs and returns false when the
+ * dispatch is still paused for this tick, true when it may proceed.
+ * @param repo Settings repo bound to this tick's DB.
+ * @param tickAt The tick moment.
+ * @returns True when the tick may dispatch.
+ */
+export const mayDispatch = async (
+  repo: SettingsRepo,
+  tickAt: Date
+): Promise<boolean> => {
+  if (!(await isPaused(repo, tickAt))) return true
+  logEvent('tick.paused', { until: await repo.getPausedUntil() })
+  return false
+}

--- a/services/comms-worker/src/dispatch/pause-window.test.ts
+++ b/services/comms-worker/src/dispatch/pause-window.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { nextUtcMidnight, nextUtcMonth, resumeAt } from './pause-window'
+
+describe('nextUtcMidnight', () => {
+  it('returns the next 00:00 UTC after a mid-day tick', () => {
+    expect(
+      nextUtcMidnight(new Date('2026-06-06T09:00:00.000Z')).toISOString()
+    ).toBe('2026-06-07T00:00:00.000Z')
+  })
+
+  it('advances a full day even when the tick is at midnight', () => {
+    expect(
+      nextUtcMidnight(new Date('2026-06-06T00:00:00.000Z')).toISOString()
+    ).toBe('2026-06-07T00:00:00.000Z')
+  })
+
+  it('rolls over month and year boundaries', () => {
+    expect(
+      nextUtcMidnight(new Date('2026-06-30T23:59:59.000Z')).toISOString()
+    ).toBe('2026-07-01T00:00:00.000Z')
+    expect(
+      nextUtcMidnight(new Date('2026-12-31T12:00:00.000Z')).toISOString()
+    ).toBe('2027-01-01T00:00:00.000Z')
+  })
+})
+
+describe('nextUtcMonth', () => {
+  it('returns the first instant of the next calendar month', () => {
+    expect(
+      nextUtcMonth(new Date('2026-06-06T09:00:00.000Z')).toISOString()
+    ).toBe('2026-07-01T00:00:00.000Z')
+  })
+
+  it('rolls over the year boundary', () => {
+    expect(
+      nextUtcMonth(new Date('2026-12-15T09:00:00.000Z')).toISOString()
+    ).toBe('2027-01-01T00:00:00.000Z')
+  })
+})
+
+describe('resumeAt', () => {
+  it('resolves a daily quota to the next UTC midnight', () => {
+    expect(
+      resumeAt('daily', new Date('2026-06-06T09:00:00.000Z')).toISOString()
+    ).toBe('2026-06-07T00:00:00.000Z')
+  })
+
+  it('resolves a monthly quota to the next UTC month start', () => {
+    expect(
+      resumeAt('monthly', new Date('2026-06-06T09:00:00.000Z')).toISOString()
+    ).toBe('2026-07-01T00:00:00.000Z')
+  })
+})

--- a/services/comms-worker/src/dispatch/pause-window.ts
+++ b/services/comms-worker/src/dispatch/pause-window.ts
@@ -1,0 +1,51 @@
+import type { QuotaKind } from '../resend/response'
+
+/**
+ * Start of the next UTC day, strictly after `from`. This is when
+ * Resend's daily sending quota resets (midnight UTC), so a dispatch
+ * paused on a `daily_quota_exceeded` may resume at exactly this moment.
+ * `Date.UTC` normalises the day-overflow across month/year boundaries.
+ * @param from Tick moment the quota was hit at.
+ * @returns The next 00:00:00.000 UTC after `from`.
+ */
+export const nextUtcMidnight = (from: Date): Date =>
+  new Date(
+    Date.UTC(
+      from.getUTCFullYear(),
+      from.getUTCMonth(),
+      from.getUTCDate() + 1,
+      0,
+      0,
+      0,
+      0
+    )
+  )
+
+/**
+ * Start of the next UTC month, strictly after `from` — when Resend's
+ * monthly quota resets. `Date.UTC` normalises the month-overflow at the
+ * year boundary.
+ * @param from Tick moment the quota was hit at.
+ * @returns The first instant of the next calendar month, UTC.
+ */
+export const nextUtcMonth = (from: Date): Date =>
+  new Date(
+    Date.UTC(from.getUTCFullYear(), from.getUTCMonth() + 1, 1, 0, 0, 0, 0)
+  )
+
+const RESET_BY_KIND: Record<QuotaKind, (from: Date) => Date> = {
+  daily: nextUtcMidnight,
+  monthly: nextUtcMonth,
+}
+
+/**
+ * The moment a dispatch paused on a quota rejection may resume — the
+ * next reset boundary for that quota kind. Deferring un-sent recipients
+ * to this instant is what turns an hourly-hammering failure loop into a
+ * single "retry after the quota resets".
+ * @param quota Which Resend quota was exhausted.
+ * @param from Tick moment the quota was hit at.
+ * @returns The resume instant.
+ */
+export const resumeAt = (quota: QuotaKind, from: Date): Date =>
+  RESET_BY_KIND[quota](from)

--- a/services/comms-worker/src/dispatch/report-body.ts
+++ b/services/comms-worker/src/dispatch/report-body.ts
@@ -7,13 +7,24 @@ const addressOf = (row: SendLogWithEmail): string =>
 const withError = (row: SendLogWithEmail): string =>
   `${addressOf(row)} — ${row.error ?? 'unknown error'}`
 
-/** The three buckets a run report is written from. */
+/** The buckets a run report is written from. */
 export type ReportParts = {
   readonly tickAt: Date
   readonly sent: ReadonlyArray<SendLogWithEmail>
   readonly failed: ReadonlyArray<SendLogWithEmail>
   readonly skipped: number
+  /**
+   * ISO resume instant when the tick paused on an account-wide Resend
+   * quota; undefined on a normal tick. When set, the un-sent recipients
+   * are deferred to the first tick at/after it, not lost.
+   */
+  readonly pausedUntil?: string
 }
+
+const pausedLine = (pausedUntil: string | undefined): string =>
+  pausedUntil === undefined
+    ? ''
+    : `Paused: daily quota hit — dispatch deferred, resumes ${pausedUntil}`
 
 /**
  * Plain-text report body — the failures first, because that is the only
@@ -27,6 +38,7 @@ export const textBody = (p: ReportParts): string =>
     `Sent: ${p.sent.length}`,
     `Failed: ${p.failed.length}`,
     `Skipped (no new content): ${p.skipped}`,
+    ...(p.pausedUntil === undefined ? [] : [pausedLine(p.pausedUntil)]),
     '',
     p.failed.length > 0 ? 'FAILED' : 'No failures.',
     ...p.failed.map(r => `  ${withError(r)}`),
@@ -53,6 +65,9 @@ export const htmlBody = (p: ReportParts): string =>
     `<p><strong>${p.sent.length}</strong> sent, `,
     `<strong>${p.failed.length}</strong> failed, `,
     `${p.skipped} skipped (no new content).</p>`,
+    ...(p.pausedUntil === undefined
+      ? []
+      : [`<p><strong>${htmlEscape(pausedLine(p.pausedUntil))}</strong></p>`]),
     '<h3>Failed</h3>',
     list(p.failed.map(withError)),
     '<h3>Sent</h3>',

--- a/services/comms-worker/src/dispatch/report.ts
+++ b/services/comms-worker/src/dispatch/report.ts
@@ -23,18 +23,25 @@ const dayOf = (tickAt: Date): string => tickAt.toISOString().slice(0, 10)
  * @param tickAt Tick moment.
  * @param rows Every send_log row written by this tick.
  * @param skipped Subscribers with no new content this tick.
+ * @param pausedUntil ISO resume instant when the tick paused on a quota.
  * @returns Ready-to-send Resend payload.
  */
 export const buildReport = (
   fromAddress: string,
   tickAt: Date,
   rows: ReadonlyArray<SendLogWithEmail>,
-  skipped: number
+  skipped: number,
+  pausedUntil?: string
 ): SendInput => {
   const sent = rows.filter(r => r.status === 'sent')
   const failed = rows.filter(r => r.status === 'failed')
-  const parts = { tickAt, sent, failed, skipped }
-  const verdict = failed.length === 0 ? 'OK' : 'FAILED'
+  const parts = { tickAt, sent, failed, skipped, pausedUntil }
+  const verdict =
+    pausedUntil !== undefined
+      ? 'PAUSED'
+      : failed.length === 0
+        ? 'OK'
+        : 'FAILED'
   return {
     from: fromAddress,
     to: fromAddress,

--- a/services/comms-worker/src/dispatch/run-finish.ts
+++ b/services/comms-worker/src/dispatch/run-finish.ts
@@ -10,15 +10,17 @@ const DEFAULT_RETENTION_DAYS = 90
  * throws: a broken report must not fail the tick that just succeeded.
  * @param d Dispatch deps.
  * @param skipped Subscribers with no new content this tick.
+ * @param pausedUntil ISO resume instant when the tick paused on a quota.
  */
 export const reportRun = async (
   d: RunDispatchDeps,
-  skipped: number
+  skipped: number,
+  pausedUntil?: string
 ): Promise<void> => {
   try {
     const rows = await d.sendLogRepo.listByTick(d.tickAt.toISOString())
     const res = await d.resend.send(
-      buildReport(d.fromAddress, d.tickAt, rows, skipped)
+      buildReport(d.fromAddress, d.tickAt, rows, skipped, pausedUntil)
     )
     logEvent('report.sent', { ok: res.ok })
   } catch (e) {
@@ -33,12 +35,14 @@ export const reportRun = async (
  * that reached nobody is exactly the one worth hearing about.
  * @param d Dispatch deps.
  * @param skipped Subscribers with no new content this tick.
+ * @param pausedUntil ISO resume instant when the tick paused on a quota.
  */
 export const finishTick = async (
   d: RunDispatchDeps,
-  skipped: number
+  skipped: number,
+  pausedUntil?: string
 ): Promise<void> => {
-  await reportRun(d, skipped)
+  await reportRun(d, skipped, pausedUntil)
   await d.sendLogRepo.purgeOlderThan(
     retentionCutoffIso(d.tickAt, d.retentionDays ?? DEFAULT_RETENTION_DAYS)
   )

--- a/services/comms-worker/src/dispatch/run-quota.test.ts
+++ b/services/comms-worker/src/dispatch/run-quota.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { BatchResult, ResendClient, SendInput } from '../resend/types'
+import type { Article } from '../rss/types'
+import { createSendLogRepo, type SendLogRepo } from '../send-log/repo'
+import { createSettingsRepo, type SettingsRepo } from '../settings/repo'
+import { createRepo, type SubscriberRepo } from '../subscribers/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import type { Lang } from '../subscribers/types'
+import { runDispatch } from './run'
+
+const TICK = new Date('2026-06-06T09:00:00.000Z')
+const NEXT_MIDNIGHT = '2026-06-07T00:00:00.000Z'
+const FROM = 'Communist Prometheus <newsletter@comprom.org>'
+
+const article = (guid: string): Article => ({
+  guid,
+  title: 't',
+  link: 'https://x/y',
+  lang: 'ru',
+  pubDate: '2026-06-05T00:00:00.000Z',
+})
+
+/** A resend whose BATCH endpoint reports the daily quota exhausted. */
+const quotaResend = (
+  quota: 'daily' | 'monthly'
+): { client: ResendClient; batchCalls: number; reports: SendInput[] } => {
+  const reports: SendInput[] = []
+  let batchCalls = 0
+  return {
+    reports,
+    get batchCalls() {
+      return batchCalls
+    },
+    client: {
+      send: async input => {
+        reports.push(input)
+        return { ok: true, id: 'report' }
+      },
+      sendBatch: async (): Promise<BatchResult> => {
+        batchCalls += 1
+        return {
+          ok: false,
+          error: `resend ${quota}_quota_exceeded`,
+          definitive: false,
+          quota,
+        }
+      },
+    },
+  }
+}
+
+let subs: SubscriberRepo
+let log: SendLogRepo
+let settings: SettingsRepo
+
+beforeEach(() => {
+  const db = makeTestD1()
+  subs = createRepo({ db, now: () => '2026-05-01T00:00:00.000Z' })
+  log = createSendLogRepo({ db })
+  settings = createSettingsRepo({ db })
+})
+
+const buildRss =
+  (byLang: Readonly<Partial<Record<Lang, ReadonlyArray<Article>>>>) =>
+  async (l: Lang): Promise<ReadonlyArray<Article>> =>
+    byLang[l] ?? []
+
+const noIssue = async (): Promise<Article | undefined> => undefined
+
+const deps = (resend: ResendClient) => ({
+  subscriberRepo: subs,
+  sendLogRepo: log,
+  settingsRepo: settings,
+  rss: buildRss({ ru: [article('a')] }),
+  magazine: noIssue,
+  resend,
+  secret: 'shhh-secret-key-1234567890',
+  fromAddress: FROM,
+  publicBaseUrl: 'https://lists.comprom.org',
+  tickAt: TICK,
+})
+
+describe('runDispatch — daily quota', () => {
+  it('pauses the dispatch until the next quota reset', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    const resend = quotaResend('daily')
+    const summary = await runDispatch(deps(resend.client))
+
+    expect(summary.pausedUntil).toBe(NEXT_MIDNIGHT)
+    expect(await settings.getPausedUntil()).toBe(NEXT_MIDNIGHT)
+  })
+
+  it('does NOT advance the cutoff, so the un-sent address replays after reset', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    await runDispatch(deps(quotaResend('daily').client))
+
+    // Global cutoff not advanced, and the address's own watermark stays
+    // at its seed (2026-05-01) rather than moving to the tick — so the
+    // 2026-06-05 article is still "new" on tomorrow's tick.
+    expect(await settings.getCutoffAt()).toBeUndefined()
+    const s = (await subs.listActive())[0]
+    expect(s?.lastSentAt).toBe('2026-05-01T00:00:00.000Z')
+    expect(s?.lastSentAt).not.toBe(TICK.toISOString())
+  })
+
+  it('records the attempted recipient as failed, not sent', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    const summary = await runDispatch(deps(quotaResend('daily').client))
+
+    expect(summary).toMatchObject({ sent: 0, failed: 1 })
+    const rows = await log.listRecent(10)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ status: 'failed' })
+  })
+
+  it('mails a PAUSED run report naming the resume instant', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    const resend = quotaResend('daily')
+    await runDispatch(deps(resend.client))
+
+    expect(resend.reports).toHaveLength(1)
+    expect(resend.reports[0]?.subject).toContain('PAUSED')
+    expect(resend.reports[0]?.text).toContain(NEXT_MIDNIGHT)
+  })
+
+  it('pauses until the next month on a monthly quota', async () => {
+    await subs.insert({ email: 'a@b.c', langs: ['ru'] })
+    const summary = await runDispatch(deps(quotaResend('monthly').client))
+    expect(summary.pausedUntil).toBe('2026-07-01T00:00:00.000Z')
+  })
+})

--- a/services/comms-worker/src/dispatch/run-summary.ts
+++ b/services/comms-worker/src/dispatch/run-summary.ts
@@ -1,0 +1,28 @@
+import { logEvent } from '../log/structured'
+import type { DispatchSummary } from './types'
+
+/**
+ * Assemble the per-tick summary, stamp its wall-clock duration, log the
+ * `tick.done` event and hand the summary back to the caller.
+ * @param counts Sent / failed / skipped tallies for this tick.
+ * @param start `Date.now()` captured at tick start.
+ * @param pausedUntil ISO resume instant when a quota paused the run.
+ * @returns The dispatch summary.
+ */
+export const summarize = (
+  counts: {
+    readonly sent: number
+    readonly failed: number
+    readonly skipped: number
+  },
+  start: number,
+  pausedUntil?: string
+): DispatchSummary => {
+  const result: DispatchSummary = {
+    ...counts,
+    durationMs: Date.now() - start,
+    ...(pausedUntil ? { pausedUntil } : {}),
+  }
+  logEvent('tick.done', { ...result })
+  return result
+}

--- a/services/comms-worker/src/dispatch/run.ts
+++ b/services/comms-worker/src/dispatch/run.ts
@@ -5,6 +5,7 @@ import { resumeAt } from './pause-window'
 import { planOne, type SendPlan } from './plan'
 import { finishTick } from './run-finish'
 import { prepareDispatch } from './run-prepare'
+import { summarize } from './run-summary'
 import { sendInBatches } from './send-batches'
 import type { DispatchSummary, RunDispatchDeps } from './types'
 
@@ -57,13 +58,5 @@ export const runDispatch = async (
     quota === undefined ? undefined : await pauseForQuota(d, quota)
   const skipped = subs.length - plans.length
   await finishTick(d, skipped, pausedUntil)
-  const result: DispatchSummary = {
-    sent,
-    failed,
-    skipped,
-    durationMs: Date.now() - start,
-    ...(pausedUntil ? { pausedUntil } : {}),
-  }
-  logEvent('tick.done', { ...result })
-  return result
+  return summarize({ sent, failed, skipped }, start, pausedUntil)
 }

--- a/services/comms-worker/src/dispatch/run.ts
+++ b/services/comms-worker/src/dispatch/run.ts
@@ -1,5 +1,7 @@
 import { logEvent } from '../log/structured'
+import type { QuotaKind } from '../resend/response'
 import { advanceCutoff } from './cutoff-cycle'
+import { resumeAt } from './pause-window'
 import { planOne, type SendPlan } from './plan'
 import { finishTick } from './run-finish'
 import { prepareDispatch } from './run-prepare'
@@ -7,6 +9,24 @@ import { sendInBatches } from './send-batches'
 import type { DispatchSummary, RunDispatchDeps } from './types'
 
 const isPlan = (p: SendPlan | undefined): p is SendPlan => p !== undefined
+
+/**
+ * Pause the dispatch until the exhausted quota resets, so the cron
+ * stops re-attempting a send that can only fail until then. Returns the
+ * resume instant for the summary + report.
+ * @param d Dispatch deps.
+ * @param quota The quota Resend reported exhausted.
+ * @returns ISO resume instant.
+ */
+const pauseForQuota = async (
+  d: RunDispatchDeps,
+  quota: QuotaKind
+): Promise<string> => {
+  const until = resumeAt(quota, d.tickAt).toISOString()
+  await d.settingsRepo.setPausedUntil(until)
+  logEvent('dispatch.paused', { quota, until })
+  return until
+}
 
 /**
  * Execute one dispatch tick: load the shared cutoff, fetch RSS per
@@ -30,16 +50,19 @@ export const runDispatch = async (
   const plans = (await Promise.all(subs.map(s => planOne(ctx, s)))).filter(
     isPlan
   )
-  const { sent, failed } = await sendInBatches(ctx, plans)
+  const { sent, failed, quota } = await sendInBatches(ctx, plans)
   const clean = plans.length > 0 && failed === 0 && d.targetIds === undefined
   await advanceCutoff(d, clean)
+  const pausedUntil =
+    quota === undefined ? undefined : await pauseForQuota(d, quota)
   const skipped = subs.length - plans.length
-  await finishTick(d, skipped)
+  await finishTick(d, skipped, pausedUntil)
   const result: DispatchSummary = {
     sent,
     failed,
     skipped,
     durationMs: Date.now() - start,
+    ...(pausedUntil ? { pausedUntil } : {}),
   }
   logEvent('tick.done', { ...result })
   return result

--- a/services/comms-worker/src/dispatch/scheduled-pause.test.ts
+++ b/services/comms-worker/src/dispatch/scheduled-pause.test.ts
@@ -1,0 +1,60 @@
+import type { D1Database } from '@cloudflare/workers-types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createSettingsRepo, type SettingsRepo } from '../settings/repo'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { handleScheduled, type ScheduledEnv } from './scheduled'
+
+const MATCH_TICK = new Date('2026-06-06T09:00:00.000Z')
+
+let db: D1Database
+let env: ScheduledEnv
+let settings: SettingsRepo
+
+const summary = { sent: 0, failed: 0, skipped: 0, durationMs: 1 }
+
+beforeEach(async () => {
+  db = makeTestD1()
+  env = { DB: db, RESEND_API_KEY: 'rk_test', UNSUBSCRIBE_SECRET: 'shhh' }
+  settings = createSettingsRepo({ db })
+  await settings.setSchedule(
+    { cron: '0 12 * * 6', timezone: 'Europe/Moscow' },
+    MATCH_TICK
+  )
+})
+
+describe('handleScheduled — quota pause gate', () => {
+  it('skips a matching tick while the pause is still in the future', async () => {
+    await settings.setPausedUntil('2026-06-07T00:00:00.000Z')
+    const dispatcher = vi.fn()
+    const out = await handleScheduled(
+      { scheduledTime: MATCH_TICK.getTime() },
+      env,
+      { dispatcher }
+    )
+    expect(out).toBeUndefined()
+    expect(dispatcher).not.toHaveBeenCalled()
+    // Pause is preserved so later ticks stay held too.
+    expect(await settings.getPausedUntil()).toBe('2026-06-07T00:00:00.000Z')
+  })
+
+  it('resumes and clears the pause once the tick reaches the resume instant', async () => {
+    await settings.setPausedUntil('2026-06-06T00:00:00.000Z')
+    const dispatcher = vi.fn().mockResolvedValue(summary)
+    const out = await handleScheduled(
+      { scheduledTime: MATCH_TICK.getTime() },
+      env,
+      { dispatcher }
+    )
+    expect(dispatcher).toHaveBeenCalledOnce()
+    expect(out).toMatchObject({ sent: 0 })
+    expect(await settings.getPausedUntil()).toBeUndefined()
+  })
+
+  it('runs normally when no pause is set', async () => {
+    const dispatcher = vi.fn().mockResolvedValue(summary)
+    await handleScheduled({ scheduledTime: MATCH_TICK.getTime() }, env, {
+      dispatcher,
+    })
+    expect(dispatcher).toHaveBeenCalledOnce()
+  })
+})

--- a/services/comms-worker/src/dispatch/scheduled.ts
+++ b/services/comms-worker/src/dispatch/scheduled.ts
@@ -1,7 +1,8 @@
 import { matchesTick } from '../cron/matcher'
 import { logEvent } from '../log/structured'
-import { createSettingsRepo, type SettingsRepo } from '../settings/repo'
+import { createSettingsRepo } from '../settings/repo'
 import { buildRuntimeDeps } from './build-deps'
+import { mayDispatch } from './pause-gate'
 import { runDispatch } from './run'
 import type { DispatchEnv } from './runtime-env'
 import type { DispatchSummary } from './types'
@@ -21,27 +22,6 @@ export type HandleScheduledOptions = {
 
 const defaultDispatcher: Dispatcher = (env, tickAt) =>
   runDispatch(buildRuntimeDeps(env, tickAt))
-
-/**
- * Whether this tick is still inside a quota pause. A pause set on a
- * `daily_quota_exceeded` holds every tick until the quota resets; once
- * `tickAt` reaches it the pause is dropped and the tick proceeds, so
- * the deferred recipients replay on the first tick after the reset.
- * @param repo Settings repo bound to this tick's DB.
- * @param tickAt The tick moment.
- * @returns True when the dispatch is still paused (skip this tick).
- */
-const isPaused = async (
-  repo: SettingsRepo,
-  tickAt: Date
-): Promise<boolean> => {
-  const until = await repo.getPausedUntil()
-  if (until === undefined) return false
-  const untilMs = Date.parse(until)
-  if (Number.isFinite(untilMs) && tickAt.getTime() < untilMs) return true
-  await repo.clearPausedUntil()
-  return false
-}
 
 /**
  * Cron handler: load the saved schedule, decide whether this tick is
@@ -70,10 +50,7 @@ export const handleScheduled = async (
     timezone: sched.timezone,
   })
   if (!matched) return undefined
-  if (await isPaused(settings, tickAt)) {
-    logEvent('tick.paused', { until: await settings.getPausedUntil() })
-    return undefined
-  }
+  if (!(await mayDispatch(settings, tickAt))) return undefined
   const run = opts.dispatcher ?? defaultDispatcher
   return run(env, tickAt)
 }

--- a/services/comms-worker/src/dispatch/scheduled.ts
+++ b/services/comms-worker/src/dispatch/scheduled.ts
@@ -1,6 +1,6 @@
 import { matchesTick } from '../cron/matcher'
 import { logEvent } from '../log/structured'
-import { createSettingsRepo } from '../settings/repo'
+import { createSettingsRepo, type SettingsRepo } from '../settings/repo'
 import { buildRuntimeDeps } from './build-deps'
 import { runDispatch } from './run'
 import type { DispatchEnv } from './runtime-env'
@@ -23,6 +23,27 @@ const defaultDispatcher: Dispatcher = (env, tickAt) =>
   runDispatch(buildRuntimeDeps(env, tickAt))
 
 /**
+ * Whether this tick is still inside a quota pause. A pause set on a
+ * `daily_quota_exceeded` holds every tick until the quota resets; once
+ * `tickAt` reaches it the pause is dropped and the tick proceeds, so
+ * the deferred recipients replay on the first tick after the reset.
+ * @param repo Settings repo bound to this tick's DB.
+ * @param tickAt The tick moment.
+ * @returns True when the dispatch is still paused (skip this tick).
+ */
+const isPaused = async (
+  repo: SettingsRepo,
+  tickAt: Date
+): Promise<boolean> => {
+  const until = await repo.getPausedUntil()
+  if (until === undefined) return false
+  const untilMs = Date.parse(until)
+  if (Number.isFinite(untilMs) && tickAt.getTime() < untilMs) return true
+  await repo.clearPausedUntil()
+  return false
+}
+
+/**
  * Cron handler: load the saved schedule, decide whether this tick is
  * one the editor asked for, and (only then) fire the dispatch loop.
  * @param event CF ScheduledEvent-shaped object (`scheduledTime` ms).
@@ -36,7 +57,8 @@ export const handleScheduled = async (
   opts: HandleScheduledOptions = {}
 ): Promise<DispatchSummary | undefined> => {
   const tickAt = new Date(event.scheduledTime)
-  const sched = await createSettingsRepo({ db: env.DB }).getSchedule(tickAt)
+  const settings = createSettingsRepo({ db: env.DB })
+  const sched = await settings.getSchedule(tickAt)
   if (sched === undefined) {
     logEvent('tick.match', { matched: false, reason: 'no-schedule' })
     return undefined
@@ -48,6 +70,10 @@ export const handleScheduled = async (
     timezone: sched.timezone,
   })
   if (!matched) return undefined
+  if (await isPaused(settings, tickAt)) {
+    logEvent('tick.paused', { until: await settings.getPausedUntil() })
+    return undefined
+  }
   const run = opts.dispatcher ?? defaultDispatcher
   return run(env, tickAt)
 }

--- a/services/comms-worker/src/dispatch/send-batches.ts
+++ b/services/comms-worker/src/dispatch/send-batches.ts
@@ -1,3 +1,4 @@
+import type { QuotaKind } from '../resend/response'
 import type { DispatchContext } from './context'
 import type { SendPlan } from './plan'
 import { sendChunk } from './send-chunk'
@@ -9,6 +10,12 @@ const CHUNK_SIZE = 100
 export type SendCounts = {
   readonly sent: number
   readonly failed: number
+  /**
+   * Set once any chunk hit an account-wide quota. Sending stopped at
+   * that chunk — the recipients after it were never attempted, so they
+   * carry no failed rows and replay on the tick after the quota resets.
+   */
+  readonly quota?: QuotaKind
 }
 
 const chunk = (
@@ -40,6 +47,7 @@ export const sendInBatches = async (
     const c = await sendChunk(ctx, groups[i] ?? [], i)
     sent += c.sent
     failed += c.failed
+    if (c.quota !== undefined) return { sent, failed, quota: c.quota }
   }
   return { sent, failed }
 }

--- a/services/comms-worker/src/dispatch/send-chunk.ts
+++ b/services/comms-worker/src/dispatch/send-chunk.ts
@@ -45,8 +45,12 @@ export const sendChunk = async (
     await recordSentChunk(ctx, group, res.ids)
     return { sent: group.length, failed: 0 }
   }
-  logEvent('batch.fail', { error: res.error, definitive: res.definitive })
-  return res.definitive
-    ? sendIndividually(ctx, group)
-    : recordFailedChunk(ctx, group, res.error)
+  logEvent('batch.fail', {
+    error: res.error,
+    definitive: res.definitive,
+    quota: res.quota,
+  })
+  if (res.definitive) return sendIndividually(ctx, group)
+  const counts = await recordFailedChunk(ctx, group, res.error)
+  return res.quota === undefined ? counts : { ...counts, quota: res.quota }
 }

--- a/services/comms-worker/src/dispatch/types.ts
+++ b/services/comms-worker/src/dispatch/types.ts
@@ -33,4 +33,10 @@ export type DispatchSummary = {
   readonly failed: number
   readonly skipped: number
   readonly durationMs: number
+  /**
+   * Set when the tick hit an account-wide Resend quota and paused the
+   * dispatch until this ISO instant (the quota's next reset). The
+   * un-sent recipients replay on the first matching tick at/after it.
+   */
+  readonly pausedUntil?: string
 }

--- a/services/comms-worker/src/resend/batch-classify.ts
+++ b/services/comms-worker/src/resend/batch-classify.ts
@@ -1,0 +1,35 @@
+import type { BatchVerdict } from './batch'
+import { readQuotaKind } from './quota'
+import { isRetryableStatus, retryAfterMs } from './response'
+
+const parseIds = (body: unknown): ReadonlyArray<string> => {
+  const data = (body as { data?: unknown } | undefined)?.data
+  if (!Array.isArray(data)) return []
+  return data.map(e => {
+    const id = (e as { id?: unknown } | null)?.id
+    return typeof id === 'string' ? id : ''
+  })
+}
+
+/**
+ * Read a Resend batch response into a {@link BatchVerdict}: success with
+ * ids in input order, a retryable hint (carrying the quota when a 429 was
+ * an account cap rather than a burst), or a terminal failure.
+ * @param res The batch response.
+ * @returns Discriminated verdict.
+ */
+export const classifyBatch = async (res: Response): Promise<BatchVerdict> => {
+  if (res.ok) {
+    const body = await res.json().catch(() => undefined)
+    return { kind: 'ok', ids: parseIds(body) }
+  }
+  if (!isRetryableStatus(res.status))
+    return { kind: 'fail', error: `resend ${res.status}` }
+  const quota = res.status === 429 ? await readQuotaKind(res) : undefined
+  return {
+    kind: 'retry',
+    waitMs: retryAfterMs(res),
+    status: res.status,
+    ...(quota ? { quota } : {}),
+  }
+}

--- a/services/comms-worker/src/resend/batch-retry.ts
+++ b/services/comms-worker/src/resend/batch-retry.ts
@@ -1,7 +1,22 @@
 import { sendBatchOnce } from './batch'
 import { buildBatchInit } from './batch-request'
-import { exhaustedError } from './response'
+import { exhaustedError, type QuotaKind } from './response'
 import type { BatchResult, SendInput } from './types'
+
+/**
+ * A quota rejection ends the retry loop at once: the daily / monthly
+ * cap will not clear in the seconds a backoff buys, so backing off just
+ * burns the tick's wall-clock. Surface it so the dispatcher can pause
+ * until the quota actually resets.
+ * @param quota Which quota Resend reported exhausted.
+ * @returns An all-failed batch result carrying the quota kind.
+ */
+const quotaResult = (quota: QuotaKind): BatchResult => ({
+  ok: false,
+  error: `resend ${quota}_quota_exceeded`,
+  definitive: false,
+  quota,
+})
 
 /**
  * Attempts per batch, and the base backoff between them.
@@ -45,6 +60,7 @@ export const sendBatchWithRetry = async (
     if (verdict.kind === 'ok') return { ok: true, ids: verdict.ids }
     if (verdict.kind === 'fail')
       return { ok: false, error: verdict.error, definitive: true }
+    if (verdict.quota !== undefined) return quotaResult(verdict.quota)
     lastStatus = verdict.status
     if (attempt < MAX_ATTEMPTS)
       await doSleep(backoffMs(attempt, verdict.waitMs))

--- a/services/comms-worker/src/resend/batch.ts
+++ b/services/comms-worker/src/resend/batch.ts
@@ -2,6 +2,8 @@ import { RESEND_BATCH_URL } from './batch-request'
 import {
   DEFAULT_BACKOFF_MS,
   isRetryableStatus,
+  type QuotaKind,
+  readQuotaKind,
   retryAfterMs,
 } from './response'
 
@@ -12,6 +14,8 @@ export type BatchVerdict =
       readonly kind: 'retry'
       readonly waitMs: number
       readonly status: number
+      /** Set when the 429 was a quota rejection, not a rate-limit burst. */
+      readonly quota?: QuotaKind
     }
   | { readonly kind: 'fail'; readonly error: string }
 
@@ -29,9 +33,15 @@ const classifyBatch = async (res: Response): Promise<BatchVerdict> => {
     const body = await res.json().catch(() => undefined)
     return { kind: 'ok', ids: parseIds(body) }
   }
-  return isRetryableStatus(res.status)
-    ? { kind: 'retry', waitMs: retryAfterMs(res), status: res.status }
-    : { kind: 'fail', error: `resend ${res.status}` }
+  if (!isRetryableStatus(res.status))
+    return { kind: 'fail', error: `resend ${res.status}` }
+  const quota = res.status === 429 ? await readQuotaKind(res) : undefined
+  return {
+    kind: 'retry',
+    waitMs: retryAfterMs(res),
+    status: res.status,
+    ...(quota ? { quota } : {}),
+  }
 }
 
 const attemptBatch = async (

--- a/services/comms-worker/src/resend/batch.ts
+++ b/services/comms-worker/src/resend/batch.ts
@@ -1,11 +1,6 @@
+import { classifyBatch } from './batch-classify'
 import { RESEND_BATCH_URL } from './batch-request'
-import {
-  DEFAULT_BACKOFF_MS,
-  isRetryableStatus,
-  type QuotaKind,
-  readQuotaKind,
-  retryAfterMs,
-} from './response'
+import { DEFAULT_BACKOFF_MS, type QuotaKind } from './response'
 
 /** Discriminated outcome of one Resend batch round-trip. */
 export type BatchVerdict =
@@ -18,31 +13,6 @@ export type BatchVerdict =
       readonly quota?: QuotaKind
     }
   | { readonly kind: 'fail'; readonly error: string }
-
-const parseIds = (body: unknown): ReadonlyArray<string> => {
-  const data = (body as { data?: unknown } | undefined)?.data
-  if (!Array.isArray(data)) return []
-  return data.map(e => {
-    const id = (e as { id?: unknown } | null)?.id
-    return typeof id === 'string' ? id : ''
-  })
-}
-
-const classifyBatch = async (res: Response): Promise<BatchVerdict> => {
-  if (res.ok) {
-    const body = await res.json().catch(() => undefined)
-    return { kind: 'ok', ids: parseIds(body) }
-  }
-  if (!isRetryableStatus(res.status))
-    return { kind: 'fail', error: `resend ${res.status}` }
-  const quota = res.status === 429 ? await readQuotaKind(res) : undefined
-  return {
-    kind: 'retry',
-    waitMs: retryAfterMs(res),
-    status: res.status,
-    ...(quota ? { quota } : {}),
-  }
-}
 
 const attemptBatch = async (
   doFetch: typeof fetch,

--- a/services/comms-worker/src/resend/quota.test.ts
+++ b/services/comms-worker/src/resend/quota.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { sendBatchWithRetry } from './batch-retry'
+import { quotaKindFromName, readQuotaKind } from './response'
+import type { SendInput } from './types'
+
+const INPUT: SendInput = {
+  from: 'a@b.c',
+  to: 'x@y.z',
+  subject: 's',
+  html: '<p>h</p>',
+  text: 't',
+}
+
+const jsonResponse = (name: string, status = 429): Response =>
+  new Response(JSON.stringify({ name, message: 'm' }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+/** A `fetch` stub that always answers with the given Resend error. */
+const fetchReturning = (name: string) =>
+  vi.fn<typeof fetch>(async () => jsonResponse(name))
+
+/** A backoff sleeper that resolves at once, tracking its call count. */
+const sleepSpy = () =>
+  vi.fn<(ms: number) => Promise<void>>(async () => undefined)
+
+describe('quotaKindFromName', () => {
+  it('maps the Resend quota error names', () => {
+    expect(quotaKindFromName('daily_quota_exceeded')).toBe('daily')
+    expect(quotaKindFromName('monthly_quota_exceeded')).toBe('monthly')
+  })
+
+  it('is undefined for a per-second rate limit and for junk', () => {
+    expect(quotaKindFromName('rate_limit_exceeded')).toBeUndefined()
+    expect(quotaKindFromName('validation_error')).toBeUndefined()
+    expect(quotaKindFromName(undefined)).toBeUndefined()
+    expect(quotaKindFromName(42)).toBeUndefined()
+  })
+})
+
+describe('readQuotaKind', () => {
+  it('reads the quota without consuming the response body', async () => {
+    const res = jsonResponse('daily_quota_exceeded')
+    expect(await readQuotaKind(res)).toBe('daily')
+    // Body still readable by the caller — clone() protected the stream.
+    expect(await res.json()).toMatchObject({ name: 'daily_quota_exceeded' })
+  })
+})
+
+describe('sendBatchWithRetry — quota', () => {
+  it('short-circuits a daily quota: no retries, no backoff, quota surfaced', async () => {
+    const doFetch = fetchReturning('daily_quota_exceeded')
+    const doSleep = sleepSpy()
+    const res = await sendBatchWithRetry(doFetch, doSleep, 'rk', [INPUT])
+    expect(res).toEqual({
+      ok: false,
+      error: 'resend daily_quota_exceeded',
+      definitive: false,
+      quota: 'daily',
+    })
+    expect(doFetch).toHaveBeenCalledTimes(1)
+    expect(doSleep).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a monthly quota the same way', async () => {
+    const res = await sendBatchWithRetry(
+      fetchReturning('monthly_quota_exceeded'),
+      sleepSpy(),
+      'rk',
+      [INPUT]
+    )
+    expect(res).toMatchObject({
+      ok: false,
+      quota: 'monthly',
+      definitive: false,
+    })
+  })
+
+  it('still retries a per-second rate limit and never sets quota', async () => {
+    const doFetch = fetchReturning('rate_limit_exceeded')
+    const doSleep = sleepSpy()
+    const res = await sendBatchWithRetry(doFetch, doSleep, 'rk', [INPUT])
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.quota).toBeUndefined()
+    // MAX_ATTEMPTS is 4 → four sends, three backoffs.
+    expect(doFetch).toHaveBeenCalledTimes(4)
+    expect(doSleep).toHaveBeenCalledTimes(3)
+  })
+})

--- a/services/comms-worker/src/resend/quota.test.ts
+++ b/services/comms-worker/src/resend/quota.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { sendBatchWithRetry } from './batch-retry'
-import { quotaKindFromName, readQuotaKind } from './response'
+import { quotaKindFromName, readQuotaKind } from './quota'
 import type { SendInput } from './types'
 
 const INPUT: SendInput = {

--- a/services/comms-worker/src/resend/quota.ts
+++ b/services/comms-worker/src/resend/quota.ts
@@ -1,0 +1,34 @@
+import type { QuotaKind } from './response'
+
+const QUOTA_BY_NAME: Readonly<Record<string, QuotaKind>> = {
+  daily_quota_exceeded: 'daily',
+  monthly_quota_exceeded: 'monthly',
+}
+
+/**
+ * Map a Resend error `name` to the quota it reports, or undefined when
+ * the name is not a quota error (e.g. `rate_limit_exceeded`, or a body
+ * we could not read). See https://resend.com/docs/api-reference/errors.
+ * @param name The `name` field of a Resend error body.
+ * @returns The quota kind, or undefined.
+ */
+export const quotaKindFromName = (name: unknown): QuotaKind | undefined =>
+  typeof name === 'string' ? QUOTA_BY_NAME[name] : undefined
+
+/**
+ * Read the quota kind from a Resend error response WITHOUT disturbing a
+ * caller that also needs the body: clones the response first, so the
+ * original stream stays readable. Returns undefined on any non-quota or
+ * unreadable body.
+ * @param res A non-ok Resend response (status 429).
+ * @returns The quota kind, or undefined.
+ */
+export const readQuotaKind = async (
+  res: Response
+): Promise<QuotaKind | undefined> => {
+  const body = (await res
+    .clone()
+    .json()
+    .catch(() => undefined)) as { name?: unknown } | undefined
+  return quotaKindFromName(body?.name)
+}

--- a/services/comms-worker/src/resend/response.ts
+++ b/services/comms-worker/src/resend/response.ts
@@ -12,39 +12,6 @@ export const DEFAULT_BACKOFF_MS = 1_000
  */
 export type QuotaKind = 'daily' | 'monthly'
 
-const QUOTA_BY_NAME: Readonly<Record<string, QuotaKind>> = {
-  daily_quota_exceeded: 'daily',
-  monthly_quota_exceeded: 'monthly',
-}
-
-/**
- * Map a Resend error `name` to the quota it reports, or undefined when
- * the name is not a quota error (e.g. `rate_limit_exceeded`, or a body
- * we could not read). See https://resend.com/docs/api-reference/errors.
- * @param name The `name` field of a Resend error body.
- * @returns The quota kind, or undefined.
- */
-export const quotaKindFromName = (name: unknown): QuotaKind | undefined =>
-  typeof name === 'string' ? QUOTA_BY_NAME[name] : undefined
-
-/**
- * Read the quota kind from a Resend error response WITHOUT disturbing a
- * caller that also needs the body: clones the response first, so the
- * original stream stays readable. Returns undefined on any non-quota or
- * unreadable body.
- * @param res A non-ok Resend response (status 429).
- * @returns The quota kind, or undefined.
- */
-export const readQuotaKind = async (
-  res: Response
-): Promise<QuotaKind | undefined> => {
-  const body = (await res
-    .clone()
-    .json()
-    .catch(() => undefined)) as { name?: unknown } | undefined
-  return quotaKindFromName(body?.name)
-}
-
 /**
  * Status codes eligible for a retry.
  *

--- a/services/comms-worker/src/resend/response.ts
+++ b/services/comms-worker/src/resend/response.ts
@@ -4,6 +4,48 @@ import type { SendResult } from './types'
 export const DEFAULT_BACKOFF_MS = 1_000
 
 /**
+ * Which Resend sending quota was exhausted. Distinct from the
+ * per-second `rate_limit_exceeded`, which is a transient burst worth a
+ * short retry — a quota is account-wide and only resets on a calendar
+ * boundary, so the whole dispatch must pause until then instead of
+ * re-attempting every tick.
+ */
+export type QuotaKind = 'daily' | 'monthly'
+
+const QUOTA_BY_NAME: Readonly<Record<string, QuotaKind>> = {
+  daily_quota_exceeded: 'daily',
+  monthly_quota_exceeded: 'monthly',
+}
+
+/**
+ * Map a Resend error `name` to the quota it reports, or undefined when
+ * the name is not a quota error (e.g. `rate_limit_exceeded`, or a body
+ * we could not read). See https://resend.com/docs/api-reference/errors.
+ * @param name The `name` field of a Resend error body.
+ * @returns The quota kind, or undefined.
+ */
+export const quotaKindFromName = (name: unknown): QuotaKind | undefined =>
+  typeof name === 'string' ? QUOTA_BY_NAME[name] : undefined
+
+/**
+ * Read the quota kind from a Resend error response WITHOUT disturbing a
+ * caller that also needs the body: clones the response first, so the
+ * original stream stays readable. Returns undefined on any non-quota or
+ * unreadable body.
+ * @param res A non-ok Resend response (status 429).
+ * @returns The quota kind, or undefined.
+ */
+export const readQuotaKind = async (
+  res: Response
+): Promise<QuotaKind | undefined> => {
+  const body = (await res
+    .clone()
+    .json()
+    .catch(() => undefined)) as { name?: unknown } | undefined
+  return quotaKindFromName(body?.name)
+}
+
+/**
  * Status codes eligible for a retry.
  *
  * 409 is an idempotency conflict. Because the key is unique per (tick,

--- a/services/comms-worker/src/resend/types.ts
+++ b/services/comms-worker/src/resend/types.ts
@@ -1,3 +1,5 @@
+import type { QuotaKind } from './response'
+
 /** Resend transactional email payload, as sent by the worker. */
 export type SendInput = {
   readonly from: string
@@ -32,6 +34,13 @@ export type BatchResult =
       readonly ok: false
       readonly error: string
       readonly definitive: boolean
+      /**
+       * Set when the batch was rejected by an account-wide sending
+       * quota (`daily_quota_exceeded` / `monthly_quota_exceeded`). The
+       * dispatcher pauses until that quota resets rather than replaying
+       * the un-sent recipients every tick.
+       */
+      readonly quota?: QuotaKind
     }
 
 /** Thin send client facade — single + batched transactional email. */

--- a/services/comms-worker/src/settings/pause-repo.test.ts
+++ b/services/comms-worker/src/settings/pause-repo.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { makeTestD1 } from '../subscribers/test-d1'
+import { createSettingsRepo, type SettingsRepo } from './repo'
+
+let repo: SettingsRepo
+
+beforeEach(() => {
+  repo = createSettingsRepo({ db: makeTestD1() })
+})
+
+describe('SettingsRepo pausedUntil', () => {
+  it('is undefined until a pause is set', async () => {
+    expect(await repo.getPausedUntil()).toBeUndefined()
+  })
+
+  it('round-trips the resume instant', async () => {
+    await repo.setPausedUntil('2026-06-07T00:00:00.000Z')
+    expect(await repo.getPausedUntil()).toBe('2026-06-07T00:00:00.000Z')
+  })
+
+  it('overwrites a previous pause rather than duplicating it', async () => {
+    await repo.setPausedUntil('2026-06-07T00:00:00.000Z')
+    await repo.setPausedUntil('2026-07-01T00:00:00.000Z')
+    expect(await repo.getPausedUntil()).toBe('2026-07-01T00:00:00.000Z')
+  })
+
+  it('clears the pause', async () => {
+    await repo.setPausedUntil('2026-06-07T00:00:00.000Z')
+    await repo.clearPausedUntil()
+    expect(await repo.getPausedUntil()).toBeUndefined()
+  })
+
+  it('does not disturb the cutoff watermark', async () => {
+    await repo.setCutoffAt('2026-06-06T09:00:00.000Z')
+    await repo.setPausedUntil('2026-06-07T00:00:00.000Z')
+    expect(await repo.getCutoffAt()).toBe('2026-06-06T09:00:00.000Z')
+  })
+})

--- a/services/comms-worker/src/settings/pause-repo.ts
+++ b/services/comms-worker/src/settings/pause-repo.ts
@@ -1,0 +1,50 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+type Row = { readonly value: string }
+
+const KEY = 'paused_until'
+const SQL_GET = 'SELECT value FROM settings WHERE key = ?'
+const SQL_UPSERT =
+  'INSERT INTO settings (key, value) VALUES (?, ?) ' +
+  'ON CONFLICT(key) DO UPDATE SET value = excluded.value'
+const SQL_DELETE = 'DELETE FROM settings WHERE key = ?'
+
+/**
+ * Read the "dispatch paused until" watermark, or undefined when the
+ * dispatch is not paused. Set when Resend rejects a send with a quota
+ * error (daily / monthly) so the cron stops re-attempting until the
+ * quota resets.
+ * @param db D1 database binding.
+ * @returns ISO string of the resume instant, or undefined.
+ */
+export const fetchPausedUntil = async (
+  db: D1Database
+): Promise<string | undefined> => {
+  const row = (await db.prepare(SQL_GET).bind(KEY).first()) as Row | null
+  return row === null
+    ? undefined
+    : (JSON.parse(row.value) as { at: string }).at
+}
+
+/**
+ * Persist the resume instant — the dispatch is held until this moment.
+ * @param db D1 database binding.
+ * @param iso ISO string of the resume instant.
+ */
+export const persistPausedUntil = async (
+  db: D1Database,
+  iso: string
+): Promise<void> => {
+  await db
+    .prepare(SQL_UPSERT)
+    .bind(KEY, JSON.stringify({ at: iso }))
+    .run()
+}
+
+/**
+ * Drop the pause so the next matching tick dispatches normally.
+ * @param db D1 database binding.
+ */
+export const dropPausedUntil = async (db: D1Database): Promise<void> => {
+  await db.prepare(SQL_DELETE).bind(KEY).run()
+}

--- a/services/comms-worker/src/settings/repo.ts
+++ b/services/comms-worker/src/settings/repo.ts
@@ -2,6 +2,11 @@ import type { D1Database } from '@cloudflare/workers-types'
 import type { Schedule } from '../cron/matcher'
 import { dropCutoffAt, fetchCutoffAt, persistCutoffAt } from './cutoff-repo'
 import {
+  dropPausedUntil,
+  fetchPausedUntil,
+  persistPausedUntil,
+} from './pause-repo'
+import {
   fetchSchedule,
   persistSchedule,
   type ScheduleWithNext,
@@ -19,6 +24,9 @@ export type SettingsRepo = {
   readonly getCutoffAt: () => Promise<string | undefined>
   readonly setCutoffAt: (iso: string) => Promise<void>
   readonly clearCutoffAt: () => Promise<void>
+  readonly getPausedUntil: () => Promise<string | undefined>
+  readonly setPausedUntil: (iso: string) => Promise<void>
+  readonly clearPausedUntil: () => Promise<void>
 }
 
 type Deps = { readonly db: D1Database }
@@ -36,4 +44,7 @@ export const createSettingsRepo = (d: Deps): SettingsRepo => ({
   getCutoffAt: () => fetchCutoffAt(d.db),
   setCutoffAt: iso => persistCutoffAt(d.db, iso),
   clearCutoffAt: () => dropCutoffAt(d.db),
+  getPausedUntil: () => fetchPausedUntil(d.db),
+  setPausedUntil: iso => persistPausedUntil(d.db, iso),
+  clearPausedUntil: () => dropPausedUntil(d.db),
 })


### PR DESCRIPTION
Promotes #368 to production `master` so the daily/monthly Resend quota auto-reschedule actually runs in prod. Code-only (comms-worker).

## Why
Task: when Resend hits its daily limit, recipients that couldn't be sent must be auto-rescheduled to the next day. The logic (global pause until the quota resets, cutoff not advanced so un-sent addresses replay) is on `develop` but not yet on the production comms-worker — so the next quota hit would still drop recipients.

## What promotes
- On `daily_quota_exceeded` / `monthly_quota_exceeded`: dispatch pauses until the next UTC midnight / month, records `paused_until`, does NOT advance the cutoff (un-sent addresses stay "new" and replay after reset), and mails a PAUSED run report naming the resume instant.
- Quota 429s short-circuit (no 8s backoff), are distinguished from per-second rate limits, and the scheduled tick is gated by `paused_until`.

289 tests green on the source PR (#368).

🤖 Generated with [Claude Code](https://claude.com/claude-code)