### PR TITLE
fix(e2e): promote 3 concurrency-defect fixes to production

### DIFF
--- a/e2e/auth/helpers.ts
+++ b/e2e/auth/helpers.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test'
+import { waitForSWControl } from '../helpers/visit-settled'
 import { BUTTON_NAMES, SELECTORS } from './constants'
 
 /**
@@ -9,7 +10,7 @@ export const loginViaMockOAuth = async (page: Page): Promise<void> => {
   await page.goto('/')
   await page.evaluate(() => localStorage.setItem('gh_token', 'mock-token'))
   await page.reload()
-  await page.waitForLoadState('networkidle')
+  await waitForSWControl(page)
 }
 
 /**

--- a/e2e/auth/setup.ts
+++ b/e2e/auth/setup.ts
@@ -1,5 +1,6 @@
 import type { FullConfig } from '@playwright/test'
 import { chromium } from '@playwright/test'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const STORAGE_PATH = 'e2e/.auth/state.json'
 
@@ -16,7 +17,7 @@ const globalSetup = async (config: FullConfig): Promise<void> => {
   await page.goto(`${baseURL}/`)
   await page.evaluate(() => localStorage.setItem('gh_token', 'mock-token'))
   await page.reload()
-  await page.waitForLoadState('networkidle')
+  await waitForSWControl(page)
   await page.context().storageState({ path: STORAGE_PATH })
   await browser.close()
 }

--- a/e2e/comms-walkthrough/scenario.spec.ts
+++ b/e2e/comms-walkthrough/scenario.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page, test } from '@playwright/test'
+import { waitForSWControl } from '../helpers/visit-settled'
 import { installCommsMocks, type MockState } from './install-routes'
 import {
   clearHighlight,
@@ -212,18 +213,20 @@ test('comms walkthrough recording', async ({ page }) => {
     document.documentElement.setAttribute('data-theme', 'dark')
   })
   await page.goto('/')
-  await page.waitForLoadState('networkidle')
+  // SW (re)registers on the first authenticated load; gate on it
+  // CONTROLLING the document before navigating away, else activation
+  // aborts the next goto (net::ERR_ABORTED). Replaces networkidle.
+  await waitForSWControl(page)
   /*
    * /comms is now a tab shell: it redirects to the Settings tab, and the
    * subscriber form + send log live on their own sub-routes. Every scene
    * below opens the tab it needs first.
    */
   await page.goto('/comms')
+  await waitForSWControl(page)
   await page.waitForSelector('[data-testid="comms-view"]')
   await page.waitForSelector('[data-testid="comms-nav"]')
   await page.waitForSelector('[data-testid="schedule-editor"]')
-  await page.waitForLoadState('networkidle')
-  await sleep(800)
 
   await installOverlay(page)
 
@@ -313,7 +316,9 @@ test('comms walkthrough recording', async ({ page }) => {
       .getByTestId('subscriber-row')
       .filter({ hasText: 'demo-reader@example.test' })
     await row.getByTestId('subscriber-remove').click()
-    await sleep(1_200)
+    // The confirm dialog mounts only after the remove click; wait for
+    // its confirm button instead of guessing a mount delay.
+    await expect(page.getByTestId('remove-subscriber-confirm')).toBeVisible()
     await page.getByTestId('remove-subscriber-confirm').click()
     await expect(
       page
@@ -363,8 +368,14 @@ test('comms walkthrough recording', async ({ page }) => {
     const input = page.getByTestId('cutoff-input')
     await input.fill('2026-06-05T12:00')
     await sleep(1_000)
+    // The cutoff save is fire-and-forget on the DOM (no rendered
+    // confirmation), so gate on the PUT round-trip completing rather
+    // than on a fixed delay.
+    const cutoffSaved = page.waitForResponse(
+      r => r.url().includes('/api/cutoff') && r.request().method() === 'PUT'
+    )
     await page.getByTestId('cutoff-save').click()
-    await sleep(1_400)
+    await cutoffSaved
     await clear()
   })
 
@@ -382,11 +393,14 @@ test('comms walkthrough recording', async ({ page }) => {
     await page.getByTestId('force-dispatch-select-all').click()
     await sleep(1_000)
     await page.getByTestId('force-dispatch-start').click()
-    await sleep(1_400)
+    // Clicking "start" flips the panel to its confirm phase; wait for
+    // the confirm button to render instead of a fixed delay.
+    await expect(page.getByTestId('force-dispatch-confirm')).toBeVisible()
     await page.getByTestId('force-dispatch-confirm').click()
-    await page.waitForSelector('[data-testid="force-dispatch-result"]', {
-      timeout: 5_000,
-    })
+    // The result panel renders when the dispatch round-trip resolves.
+    // Web-first expect uses the shared env-tunable ceiling — no
+    // per-call timeout override.
+    await expect(page.getByTestId('force-dispatch-result')).toBeVisible()
     await sleep(2_200)
     await clear()
   })
@@ -412,6 +426,9 @@ test('comms walkthrough recording', async ({ page }) => {
     ]
     await openTab(page, 'log')
     await page.reload()
+    // reload re-runs the SW claim→controllerchange handshake; settle it
+    // before anchoring on the reloaded DOM (replaces the old race).
+    await waitForSWControl(page)
     await page.waitForSelector('[data-testid="run-history-list"]')
     await installOverlay(page)
     const list = page.getByTestId('run-history-list')
@@ -433,12 +450,15 @@ test('comms walkthrough recording', async ({ page }) => {
     addFakeFailedRun(state)
     await openTab(page, 'log')
     await page.reload()
+    await waitForSWControl(page)
     await page.waitForSelector('[data-testid="run-history-list"]')
     await installOverlay(page)
     const list = page.getByTestId('run-history-list')
     await list.scrollIntoViewIfNeeded()
-    await sleep(700)
+    // The failed row is data-dependent (arrives with the reloaded run
+    // list); wait for it to render before clicking, not a fixed delay.
     const failedRow = page.getByTestId('send-log-failed').first()
+    await expect(failedRow).toBeVisible()
     await failedRow.click()
     await sleep(2_500)
   })

--- a/e2e/lighthouse/desktop-auth.spec.ts
+++ b/e2e/lighthouse/desktop-auth.spec.ts
@@ -1,11 +1,12 @@
 import { test } from '@prometheus/e2e-toolkit'
 import { playAudit } from 'playwright-lighthouse'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 test('should achieve 100 on desktop with auth', async ({ page }) => {
   await page.goto('/')
   await page.evaluate(() => localStorage.setItem('gh_token', 'mock-token'))
   await page.reload()
-  await page.waitForLoadState('networkidle')
+  await waitForSWControl(page)
 
   await playAudit({
     page,

--- a/e2e/notifications/conflicts-resolve.spec.ts
+++ b/e2e/notifications/conflicts-resolve.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
@@ -24,7 +25,7 @@ test.describe('per-file conflict resolution (4.3)', () => {
       .evaluate(() => globalThis.localStorage?.removeItem('admin-conflicts'))
       .catch(() => undefined)
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/e2e/notifications/conflicts-view.spec.ts
+++ b/e2e/notifications/conflicts-view.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
@@ -17,7 +18,7 @@ test.describe('conflicts view (4.2)', () => {
       .evaluate(() => globalThis.localStorage?.removeItem('admin-conflicts'))
       .catch(() => undefined)
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })
@@ -40,7 +41,7 @@ test.describe('conflicts view (4.2)', () => {
       1
     )
     await page.reload()
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await expect(page.locator('[data-testid="conflicts-item"]')).toHaveCount(
       1
     )

--- a/e2e/notifications/drawer.spec.ts
+++ b/e2e/notifications/drawer.spec.ts
@@ -1,9 +1,29 @@
-import { expect, test } from '@prometheus/e2e-toolkit'
+import { expect, type Page, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
+
+/*
+ * Fire the dev-trigger notifications, then wait for the unread badge to
+ * reach the expected total before reading the drawer. The queue appends
+ * synchronously, but rapid back-to-back clicks let a `toHaveCount` read a
+ * half-populated list; the badge (queue length) reaching `total` is the
+ * event that proves every notification registered. Event-driven, no delay.
+ */
+const fireAndSettle = async (
+  page: Page,
+  kinds: readonly string[]
+): Promise<void> => {
+  for (const kind of kinds) {
+    await page.locator(`[data-testid="notify-trigger-${kind}"]`).click()
+  }
+  await expect(
+    page.locator('[data-testid="notification-indicator-badge"]')
+  ).toHaveText(String(kinds.length))
+}
 
 test.describe('notifications: history drawer (1.3)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })
@@ -14,8 +34,7 @@ test.describe('notifications: history drawer (1.3)', () => {
   }) => {
     const drawer = page.locator('[data-testid="notification-drawer"]')
     await expect(drawer).toBeHidden()
-    await page.locator('[data-testid="notify-trigger-info"]').click()
-    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await fireAndSettle(page, ['info', 'error'])
     await page.locator('[data-testid="notification-indicator"]').click()
     await expect(drawer).toBeVisible()
     await expect(
@@ -30,7 +49,7 @@ test.describe('notifications: history drawer (1.3)', () => {
       page.locator('[data-testid="notification-drawer-item"]')
     ).toHaveCount(1)
     await page.reload()
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })
@@ -41,8 +60,7 @@ test.describe('notifications: history drawer (1.3)', () => {
   })
 
   test('clear all empties the history', async ({ page }) => {
-    await page.locator('[data-testid="notify-trigger-info"]').click()
-    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await fireAndSettle(page, ['info', 'error'])
     await page.locator('[data-testid="notification-indicator"]').click()
     const items = page.locator('[data-testid="notification-drawer-item"]')
     await expect(items).toHaveCount(2)
@@ -54,9 +72,7 @@ test.describe('notifications: history drawer (1.3)', () => {
   })
 
   test('filter by kind narrows the list', async ({ page }) => {
-    await page.locator('[data-testid="notify-trigger-info"]').click()
-    await page.locator('[data-testid="notify-trigger-error"]').click()
-    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await fireAndSettle(page, ['info', 'error', 'error'])
     await page.locator('[data-testid="notification-indicator"]').click()
     const items = page.locator('[data-testid="notification-drawer-item"]')
     await expect(items).toHaveCount(3)
@@ -70,8 +86,7 @@ test.describe('notifications: history drawer (1.3)', () => {
   })
 
   test('mark all read flips items to data-read=true', async ({ page }) => {
-    await page.locator('[data-testid="notify-trigger-info"]').click()
-    await page.locator('[data-testid="notify-trigger-error"]').click()
+    await fireAndSettle(page, ['info', 'error'])
     await page.locator('[data-testid="notification-indicator"]').click()
     const items = page.locator('[data-testid="notification-drawer-item"]')
     await expect(items).toHaveCount(2)

--- a/e2e/notifications/offline-watch.spec.ts
+++ b/e2e/notifications/offline-watch.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 test.describe('offline watcher (3.2)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/e2e/notifications/push-conflict.spec.ts
+++ b/e2e/notifications/push-conflict.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
@@ -14,7 +15,7 @@ ch.close()
 test.describe('push conflict bridge (4.1)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/e2e/notifications/push-error-bridge.spec.ts
+++ b/e2e/notifications/push-error-bridge.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcastError = (
   reason: 'network' | 'auth' | 'non-fast-forward' | 'validation' | 'unknown',
@@ -17,7 +18,7 @@ ch.close()
 test.describe('push error bridge → notification (2.3)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/e2e/notifications/push-retry.spec.ts
+++ b/e2e/notifications/push-retry.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcastTerminal = (
   reason: 'network' | 'auth' | 'unknown'
@@ -29,7 +30,7 @@ globalThis.__retryChannel = ch
 test.describe('push retry CTA (2.4)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/e2e/notifications/push-summary.spec.ts
+++ b/e2e/notifications/push-summary.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcastSummary = (synced: number): string => `
 const ch = new BroadcastChannel('sw-push-summary')
@@ -9,7 +10,7 @@ ch.close()
 test.describe('drain summary bridge (3.3)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/e2e/notifications/push-sync-badge.spec.ts
+++ b/e2e/notifications/push-sync-badge.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcast = (
   pending: number,
@@ -12,7 +13,7 @@ ch.close()
 test.describe('push sync badge (2.2)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/e2e/notifications/toast.spec.ts
+++ b/e2e/notifications/toast.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 test.describe('notifications: toast + indicator (1.2)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })
@@ -48,6 +49,17 @@ test.describe('notifications: toast + indicator (1.2)', () => {
     for (let i = 0; i < 5; i += 1) {
       await trigger.click()
     }
+    /*
+     * Wait for all five to register before counting. The queue appends
+     * synchronously but the stack re-renders on Vue's next tick, so a
+     * bare count can read a half-rendered stack and pass or fail by luck.
+     * The unread badge reflects the queue length and error toasts are
+     * sticky, so `badge === 5` is the event proving every notification
+     * landed — after which the three-item visible cap is deterministic.
+     */
+    await expect(
+      page.locator('[data-testid="notification-indicator-badge"]')
+    ).toHaveText('5')
     const visible = page.locator('[data-testid="notification-toast"]')
     await expect(visible).toHaveCount(3)
   })

--- a/e2e/notifications/visual-merge.spec.ts
+++ b/e2e/notifications/visual-merge.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@prometheus/e2e-toolkit'
+import { waitForSWControl } from '../helpers/visit-settled'
 
 const broadcastConflict = (files: ReadonlyArray<string>): string => `
 const ch = new BroadcastChannel('sw-push-conflict')
@@ -24,7 +25,7 @@ test.describe('visual merge editor (4.4)', () => {
       .evaluate(() => globalThis.localStorage?.removeItem('admin-conflicts'))
       .catch(() => undefined)
     await page.goto('/')
-    await page.waitForLoadState('networkidle')
+    await waitForSWControl(page)
     await page
       .locator('[data-testid="notification-indicator"]')
       .waitFor({ state: 'visible' })

--- a/src/components/DesktopNavGroup.vue
+++ b/src/components/DesktopNavGroup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute } from 'vue-router'
 import type { NavEntry } from '@/components/NavShared/nav-groups'
 import DesktopNavDropdown from './DesktopNavDropdown.vue'
 
@@ -10,7 +10,6 @@ const props = defineProps<{
 }>()
 
 const route = useRoute()
-const router = useRouter()
 const open = ref(false)
 const rootEl = ref<HTMLElement | undefined>(undefined)
 
@@ -36,7 +35,6 @@ const onPointerDown = (e: PointerEvent): void =>
 
 onMounted(() => document.addEventListener('pointerdown', onPointerDown))
 onUnmounted(() => document.removeEventListener('pointerdown', onPointerDown))
-router.afterEach(close)
 </script>
 
 <template>
@@ -52,7 +50,13 @@ router.afterEach(close)
     >
       {{ title }} ▾
     </button>
-    <DesktopNavDropdown v-if="open" :items="items" />
+    <!-- Close on a menuitem click (the RouterLink navigation the user
+         chose) rather than on every router navigation: a global
+         `afterEach(close)` also fired for programmatic redirects and the
+         late-settling initial navigation, snapping the dropdown shut the
+         instant a user opened it during load — a real race parallelism
+         surfaced. Clicks on the items bubble to this handler. -->
+    <DesktopNavDropdown v-if="open" :items="items" @click="close" />
   </div>
 </template>
 

--- a/src/composables/useSWBridge/sw-update-lifecycle.ts
+++ b/src/composables/useSWBridge/sw-update-lifecycle.ts
@@ -16,19 +16,27 @@ const isOfflineError = (e: unknown): boolean =>
  * @param reg - ServiceWorkerRegistration to monitor
  */
 export const wireUpdateLifecycle = (reg: ServiceWorkerRegistration): void => {
+  /*
+   * Reload only when an UPDATE swaps the controller — never on the first,
+   * uncontrolled load. A first visit fires `controllerchange` from the
+   * SW's initial `clients.claim()`, but that page already runs the latest
+   * network-loaded code, so the reload is pointless — and, landing late
+   * under load, it re-inits Pinia mid-interaction, wiping the in-memory
+   * notification queue (a rapid burst counted 1→2→3→4→1 in a trace). The
+   * `updatefound → activated` reload is dropped for the same reason:
+   * activation precedes control, so it fired BEFORE the claim and then
+   * `controllerchange` reloaded again. `controllerchange` alone covers
+   * updates (old SW → new SW) since activation always claims.
+   */
+  const controlledAtStart = navigator.serviceWorker.controller !== null
+
   reg.addEventListener('updatefound', () => {
-    const installing = reg.installing
-    if (!installing) return
-    log('info', 'New SW version found, waiting for activation')
-    installing.addEventListener('statechange', () => {
-      if (installing.state === 'activated') {
-        log('info', 'New SW activated — reloading page')
-        globalThis.location.reload()
-      }
-    })
+    if (reg.installing)
+      log('info', 'New SW version found, waiting for control')
   })
 
   navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (!controlledAtStart) return
     log('info', 'SW controller changed — reloading page')
     globalThis.location.reload()
   })

--- a/src/stores/notifications-history-actions.ts
+++ b/src/stores/notifications-history-actions.ts
@@ -8,66 +8,72 @@ import {
 } from './notifications-history-idb-write'
 import type { HistoryEntry } from './notifications-history-types'
 
-/**
- * Build the async history actions bound to the supplied entries
- * ref. Each action writes through to IDB and refreshes the ref.
+type Items = Ref<readonly HistoryEntry[]>
+
+const byCreatedAt = (a: HistoryEntry, b: HistoryEntry): number =>
+  a.createdAt - b.createdAt
+
+/*
+ * In-memory `items` is the source of truth; IDB is write-through.
  *
- * Every mutation runs through a single serial chain. Without it,
- * concurrent writes — the bridge fires one `appendEntry` per rapid
- * notification — interleave: a `refresh` (full `listAll`) issued
- * between two IDB commits reads a stale snapshot and overwrites
- * `items`, silently dropping the other entry. Serializing write+refresh
- * makes each refresh observe every commit that preceded it, so the ref
- * can never regress. A rejected op does not stall the chain.
+ * An earlier model rebuilt `items` from a full `listAll` after every
+ * write. Under concurrency that dropped entries: the boot-time `hydrate`
+ * refresh reads IDB once and, resolving AFTER the first live appends had
+ * committed, overwrote `items` with its stale snapshot — the drawer went
+ * empty though the notifications were there (proven by trace). Now every
+ * mutation edits the ref directly and persists; nothing replaces the ref
+ * with a bulk snapshot, so a slow read can neither clobber nor
+ * head-of-line-block live writes. `refresh` (hydrate only) MERGES the
+ * persisted set in without displacing live entries.
+ */
+const mergePersisted = async (items: Items): Promise<void> => {
+  const loaded = await listAll()
+  const have = new Set(items.value.map(entry => entry.id))
+  items.value = [
+    ...items.value,
+    ...loaded.filter(entry => !have.has(entry.id)),
+  ].sort(byCreatedAt)
+}
+
+const appendOne = async (
+  items: Items,
+  entry: HistoryEntry
+): Promise<void> => {
+  items.value = [...items.value, entry].sort(byCreatedAt)
+  await append(entry)
+}
+
+const stampAllRead = async (items: Items): Promise<void> => {
+  const readAt = Date.now()
+  items.value = items.value.map(entry =>
+    entry.readAt === undefined ? { ...entry, readAt } : entry
+  )
+  await dbMarkAllRead()
+}
+
+const dropOne = async (items: Items, id: string): Promise<void> => {
+  items.value = items.value.filter(entry => entry.id !== id)
+  await removeOne(id)
+}
+
+const dropAll = async (items: Items): Promise<void> => {
+  items.value = []
+  await dbClearAll()
+}
+
+/**
+ * Build the history actions bound to the supplied entries ref. Each
+ * mutation edits the ref directly and writes through to IDB; `refresh`
+ * (used once at boot by `hydrate`) merges the persisted set in.
  * @param items Reactive entries ref backing the store.
  * @returns Object exposing `refresh`, `appendEntry`, `markAllRead`,
  *          `removeEntry`, and `clear` actions.
  */
-const byCreatedAt = (a: HistoryEntry, b: HistoryEntry): number =>
-  a.createdAt - b.createdAt
-
-export const createHistoryActions = (items: Ref<readonly HistoryEntry[]>) => {
-  /*
-   * In-memory `items` is the source of truth; IDB is write-through.
-   *
-   * The previous model rebuilt `items` from a full `listAll` after every
-   * write. Under concurrency that dropped entries: the boot-time `hydrate`
-   * refresh reads IDB once and, resolving AFTER the first live appends had
-   * committed, overwrote `items` with its stale snapshot — the drawer went
-   * empty though the notifications were there (proven by trace). Now every
-   * mutation edits the ref directly and persists; nothing ever replaces
-   * the ref with a bulk snapshot, so a slow read can neither clobber nor
-   * head-of-line-block live writes. `refresh` (hydrate only) MERGES the
-   * persisted set in without displacing live entries.
-   */
-  const refresh = async (): Promise<void> => {
-    const loaded = await listAll()
-    const have = new Set(items.value.map(entry => entry.id))
-    items.value = [
-      ...items.value,
-      ...loaded.filter(entry => !have.has(entry.id)),
-    ].sort(byCreatedAt)
-  }
-  return {
-    refresh,
-    appendEntry: async (entry: HistoryEntry): Promise<void> => {
-      items.value = [...items.value, entry].sort(byCreatedAt)
-      await append(entry)
-    },
-    markAllRead: async (): Promise<void> => {
-      const readAt = Date.now()
-      items.value = items.value.map(entry =>
-        entry.readAt === undefined ? { ...entry, readAt } : entry
-      )
-      await dbMarkAllRead()
-    },
-    removeEntry: async (id: string): Promise<void> => {
-      items.value = items.value.filter(entry => entry.id !== id)
-      await removeOne(id)
-    },
-    clear: async (): Promise<void> => {
-      items.value = []
-      await dbClearAll()
-    },
-  }
-}
+export const createHistoryActions = (items: Items) => ({
+  refresh: (): Promise<void> => mergePersisted(items),
+  appendEntry: (entry: HistoryEntry): Promise<void> =>
+    appendOne(items, entry),
+  markAllRead: (): Promise<void> => stampAllRead(items),
+  removeEntry: (id: string): Promise<void> => dropOne(items, id),
+  clear: (): Promise<void> => dropAll(items),
+})

--- a/src/stores/notifications-history-actions.ts
+++ b/src/stores/notifications-history-actions.ts
@@ -11,31 +11,63 @@ import type { HistoryEntry } from './notifications-history-types'
 /**
  * Build the async history actions bound to the supplied entries
  * ref. Each action writes through to IDB and refreshes the ref.
+ *
+ * Every mutation runs through a single serial chain. Without it,
+ * concurrent writes — the bridge fires one `appendEntry` per rapid
+ * notification — interleave: a `refresh` (full `listAll`) issued
+ * between two IDB commits reads a stale snapshot and overwrites
+ * `items`, silently dropping the other entry. Serializing write+refresh
+ * makes each refresh observe every commit that preceded it, so the ref
+ * can never regress. A rejected op does not stall the chain.
  * @param items Reactive entries ref backing the store.
  * @returns Object exposing `refresh`, `appendEntry`, `markAllRead`,
  *          `removeEntry`, and `clear` actions.
  */
+const byCreatedAt = (a: HistoryEntry, b: HistoryEntry): number =>
+  a.createdAt - b.createdAt
+
 export const createHistoryActions = (items: Ref<readonly HistoryEntry[]>) => {
+  /*
+   * In-memory `items` is the source of truth; IDB is write-through.
+   *
+   * The previous model rebuilt `items` from a full `listAll` after every
+   * write. Under concurrency that dropped entries: the boot-time `hydrate`
+   * refresh reads IDB once and, resolving AFTER the first live appends had
+   * committed, overwrote `items` with its stale snapshot — the drawer went
+   * empty though the notifications were there (proven by trace). Now every
+   * mutation edits the ref directly and persists; nothing ever replaces
+   * the ref with a bulk snapshot, so a slow read can neither clobber nor
+   * head-of-line-block live writes. `refresh` (hydrate only) MERGES the
+   * persisted set in without displacing live entries.
+   */
   const refresh = async (): Promise<void> => {
-    items.value = await listAll()
+    const loaded = await listAll()
+    const have = new Set(items.value.map(entry => entry.id))
+    items.value = [
+      ...items.value,
+      ...loaded.filter(entry => !have.has(entry.id)),
+    ].sort(byCreatedAt)
   }
   return {
     refresh,
     appendEntry: async (entry: HistoryEntry): Promise<void> => {
+      items.value = [...items.value, entry].sort(byCreatedAt)
       await append(entry)
-      await refresh()
     },
     markAllRead: async (): Promise<void> => {
+      const readAt = Date.now()
+      items.value = items.value.map(entry =>
+        entry.readAt === undefined ? { ...entry, readAt } : entry
+      )
       await dbMarkAllRead()
-      await refresh()
     },
     removeEntry: async (id: string): Promise<void> => {
+      items.value = items.value.filter(entry => entry.id !== id)
       await removeOne(id)
-      await refresh()
     },
     clear: async (): Promise<void> => {
+      items.value = []
       await dbClearAll()
-      await refresh()
     },
   }
 }


### PR DESCRIPTION
Promotes the E2E-stabilization work to production `master`. **Code-only** (e2e specs + 3 app fixes).

Three real concurrency defects (surfaced by the 4-worker parallel E2E, two pinned by Playwright traces), now shipping to prod:
1. **Nav dropdown** — `router.afterEach(close)` closed the menu on programmatic navigation/redirects; closes on menuitem click now.
2. **SW first-load reload** — reloaded on the initial `controllerchange`, re-initing Pinia mid-interaction (jank + lost notifications); reloads only on a real update now.
3. **Notification history clobber** — `refresh` overwrote entries with a stale IDB snapshot; in-memory is now the source of truth.

Verified: full E2E suite clean 3× (zero retries) + develop deploy green (validate + 4-worker E2E + deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)