### PR TITLE
topics: manage editorial topics and assign them to articles

### DIFF
--- a/e2e/settings/topics.spec.ts
+++ b/e2e/settings/topics.spec.ts
@@ -1,0 +1,62 @@
+import {
+  click,
+  expectCount,
+  expectMinCount,
+  expectText,
+  expectVisible,
+  test,
+  visit,
+} from '@prometheus/e2e-toolkit'
+
+test.describe('Settings - Topics', () => {
+  test('exposes a Topics section reachable from the settings nav', async ({
+    page,
+  }) => {
+    await visit(page, '/settings/topics')
+    await expectText(page, page.locator('h1'), 'Settings')
+    await expectVisible(
+      page,
+      page.locator('[data-testid="settings-nav-topics"]')
+    )
+    await expectText(page, page.locator('h2').first(), 'Topics')
+  })
+
+  test('renders the topics editor table', async ({ page }) => {
+    await visit(page, '/settings/topics')
+    /*
+     * Wait on the editor's Add button first: it only mounts once the
+     * topics store has finished loading (the v-else branch), so it is
+     * the deterministic "editor is ready" signal. The table can be
+     * empty when the sandbox has no topics.json, so gating on the
+     * button — not a fixed delay — avoids the first-load SW race.
+     */
+    await expectVisible(page, page.locator('[data-testid="add-topic"]'))
+    await expectVisible(page, page.locator('[data-testid="topics-table"]'))
+  })
+
+  test('adds a topic row with a colour picker', async ({ page }) => {
+    await visit(page, '/settings/topics')
+    const rows = page.locator('[data-testid="topic-row"]')
+    const initial = await rows.count()
+
+    await click(page, page.locator('[data-testid="add-topic"]'))
+    await expectCount(page, rows, initial + 1)
+    await expectVisible(
+      page,
+      rows.last().locator('[data-testid="topic-color"]')
+    )
+  })
+
+  test('removes a topic row', async ({ page }) => {
+    await visit(page, '/settings/topics')
+    const rows = page.locator('[data-testid="topic-row"]')
+
+    /* Guarantee at least one row exists before removing one. */
+    await click(page, page.locator('[data-testid="add-topic"]'))
+    await expectMinCount(page, rows, 1)
+
+    const count = await rows.count()
+    await click(page, page.locator('[data-testid="remove-topic"]').last())
+    await expectCount(page, rows, count - 1)
+  })
+})

--- a/src/components/MarkdownEditor/FrontmatterField.vue
+++ b/src/components/MarkdownEditor/FrontmatterField.vue
@@ -46,7 +46,7 @@ const handleInput = (event: Event) => {
 }
 
 const onSelect = (v: string): void => {
-  emit('update', parseFieldValue('select', v))
+  emit('update', v === '' ? undefined : parseFieldValue('select', v))
 }
 </script>
 

--- a/src/components/MarkdownEditor/FrontmatterSelect.vue
+++ b/src/components/MarkdownEditor/FrontmatterSelect.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useLabelsStore } from '@/stores/labels'
+import { useTopicsStore } from '@/stores/topics'
 import type { Language } from '@/types/language'
 import type { FieldDefinition } from './field-types'
-import { buildLabelOptions } from './select-options'
+import { buildLabelOptions, buildTopicOptions } from './select-options'
 
 const props = defineProps<{
   readonly field: FieldDefinition
@@ -14,13 +15,21 @@ const props = defineProps<{
 const emit = defineEmits<{ change: [v: string] }>()
 
 const labelsStore = useLabelsStore()
+const topicsStore = useTopicsStore()
 void labelsStore.ensureLoaded()
+void topicsStore.ensureLoaded()
 
-const options = computed(() =>
-  props.field.type === 'select' && props.field.optionsSource === 'labels'
-    ? buildLabelOptions(labelsStore.labels, props.lang, props.value)
-    : []
+const source = computed(() =>
+  props.field.type === 'select' ? props.field.optionsSource : undefined
 )
+
+const options = computed(() => {
+  if (source.value === 'labels')
+    return buildLabelOptions(labelsStore.labels, props.lang, props.value)
+  if (source.value === 'topics')
+    return buildTopicOptions(topicsStore.topics, props.lang, props.value)
+  return []
+})
 
 const onChange = (e: Event): void => {
   emit('change', (e.target as HTMLSelectElement).value)
@@ -35,8 +44,8 @@ const onChange = (e: Event): void => {
     class="field-input"
     @change="onChange"
   >
-    <option value="" disabled>
-      Select {{ field.label.toLowerCase() }}
+    <option value="" :disabled="field.required">
+      {{ field.required ? `Select ${field.label.toLowerCase()}` : '— none —' }}
     </option>
     <option
       v-for="opt in options"

--- a/src/components/MarkdownEditor/field-types.ts
+++ b/src/components/MarkdownEditor/field-types.ts
@@ -1,5 +1,5 @@
 /** Discriminator for select-typed fields, naming the data source. */
-export type SelectOptionsSource = 'labels'
+export type SelectOptionsSource = 'labels' | 'topics'
 
 interface BaseField {
   readonly key: string

--- a/src/components/MarkdownEditor/fields-blog.ts
+++ b/src/components/MarkdownEditor/fields-blog.ts
@@ -26,6 +26,12 @@ export const blogFields: readonly FieldDefinition[] = [
     optionsSource: 'labels',
     required: true,
   },
+  {
+    key: 'topic',
+    label: 'Topic (optional)',
+    type: 'select',
+    optionsSource: 'topics',
+  },
   { key: 'published', label: 'Published', type: 'checkbox' },
   { key: 'publishDate', label: 'Publish Date', type: 'date' },
   {

--- a/src/components/MarkdownEditor/frontmatter-fields.test.ts
+++ b/src/components/MarkdownEditor/frontmatter-fields.test.ts
@@ -10,6 +10,7 @@ describe('getFields', () => {
         'title',
         'description',
         'category',
+        'topic',
         'published',
         'publishDate',
         'magazine',
@@ -32,6 +33,16 @@ describe('getFields', () => {
       expect(
         category?.type === 'select' ? category.optionsSource : undefined
       ).toBe('labels')
+    })
+
+    it('exposes topic as an optional topics-sourced select', () => {
+      const fields = getFields('blog')
+      const topic = fields.find(f => f.key === 'topic')
+      expect(topic?.type).toBe('select')
+      expect(topic?.required).toBeUndefined()
+      expect(
+        topic?.type === 'select' ? topic.optionsSource : undefined
+      ).toBe('topics')
     })
   })
 

--- a/src/components/MarkdownEditor/select-options.test.ts
+++ b/src/components/MarkdownEditor/select-options.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { LabelEntry } from '@/stores/labels'
-import { buildLabelOptions } from './select-options'
+import type { TopicEntry } from '@/stores/topics'
+import { buildLabelOptions, buildTopicOptions } from './select-options'
 
 const labels: readonly LabelEntry[] = [
   { key: 'news', translations: { en: 'News', uk: 'Новини' } },
@@ -40,5 +41,39 @@ describe('buildLabelOptions', () => {
   it('treats empty current as known (no fallback prepended)', () => {
     const options = buildLabelOptions(labels, 'en', '')
     expect(options[0]?.disabled).toBeUndefined()
+  })
+})
+
+const topics: readonly TopicEntry[] = [
+  {
+    key: 'editorial',
+    color: '#b03a2e',
+    name: { en: 'Editorial', ru: 'От редакции' },
+    subtitle: {},
+  },
+  { key: 'translation', color: '#2563eb', name: { en: 'Translation' }, subtitle: {} },
+]
+
+describe('buildTopicOptions', () => {
+  it('returns one option per topic, localised by name', () => {
+    const options = buildTopicOptions(topics, 'ru', '')
+    expect(options).toEqual([
+      { value: 'editorial', label: 'От редакции' },
+      { value: 'translation', label: 'translation' },
+    ])
+  })
+
+  it('falls back to the key when the language has no name', () => {
+    const options = buildTopicOptions(topics, 'it', '')
+    expect(options[0]).toEqual({ value: 'editorial', label: 'editorial' })
+  })
+
+  it('prepends a disabled fallback when current is unknown', () => {
+    const options = buildTopicOptions(topics, 'en', 'legacy')
+    expect(options[0]).toEqual({
+      value: 'legacy',
+      label: '(unknown: legacy)',
+      disabled: true,
+    })
   })
 })

--- a/src/components/MarkdownEditor/select-options.ts
+++ b/src/components/MarkdownEditor/select-options.ts
@@ -1,4 +1,5 @@
 import type { LabelEntry } from '@/stores/labels'
+import type { TopicEntry } from '@/stores/topics'
 
 /** A single option for a `<select>` control. */
 export interface SelectOption {
@@ -7,14 +8,18 @@ export interface SelectOption {
   readonly disabled?: boolean
 }
 
-const localise = (entry: LabelEntry, lang: string): string =>
-  entry.translations[lang] ?? entry.key
-
-const toOption =
+const toLabelOption =
   (lang: string) =>
   (entry: LabelEntry): SelectOption => ({
     value: entry.key,
-    label: localise(entry, lang),
+    label: entry.translations[lang] ?? entry.key,
+  })
+
+const toTopicOption =
+  (lang: string) =>
+  (entry: TopicEntry): SelectOption => ({
+    value: entry.key,
+    label: entry.name[lang] ?? entry.key,
   })
 
 const unknownOption = (key: string): SelectOption => ({
@@ -29,8 +34,22 @@ const includesKey =
     opt.value === key
 
 /**
- * Build select options from labels, keeping the current value
- * accessible even when it is not part of the labels store.
+ * Keep the current value selectable even when it is not part of the
+ * source store, so an unknown key stays visible instead of vanishing.
+ * @param base - Options built from the store
+ * @param current - Current selected value (may be unknown)
+ * @returns Ordered options ready to render in a `<select>`
+ */
+const withCurrent = (
+  base: readonly SelectOption[],
+  current: string
+): readonly SelectOption[] => {
+  const isKnown = current === '' || base.some(includesKey(current))
+  return isKnown ? base : [unknownOption(current), ...base]
+}
+
+/**
+ * Build select options from labels.
  * @param labels - Available label entries
  * @param lang - Current language for option text
  * @param current - Current selected value (may be unknown)
@@ -40,8 +59,19 @@ export const buildLabelOptions = (
   labels: readonly LabelEntry[],
   lang: string,
   current: string
-): readonly SelectOption[] => {
-  const base = labels.map(toOption(lang))
-  const isKnown = current === '' || base.some(includesKey(current))
-  return isKnown ? base : [unknownOption(current), ...base]
-}
+): readonly SelectOption[] =>
+  withCurrent(labels.map(toLabelOption(lang)), current)
+
+/**
+ * Build select options from editorial topics (localized by name).
+ * @param topics - Available topic entries
+ * @param lang - Current language for option text
+ * @param current - Current selected value (may be unknown)
+ * @returns Ordered options ready to render in a `<select>`
+ */
+export const buildTopicOptions = (
+  topics: readonly TopicEntry[],
+  lang: string,
+  current: string
+): readonly SelectOption[] =>
+  withCurrent(topics.map(toTopicOption(lang)), current)

--- a/src/components/TopicsEditor/TopicColorInput.vue
+++ b/src/components/TopicsEditor/TopicColorInput.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+defineProps<{ readonly value: string }>()
+const emit = defineEmits<{ input: [value: string] }>()
+
+const handleInput = (event: Event) => {
+  const target = event.target
+  if (target instanceof HTMLInputElement) emit('input', target.value)
+}
+</script>
+
+<template>
+  <td data-label="Colour">
+    <input
+      :value="value"
+      type="color"
+      class="color-input"
+      data-testid="topic-color"
+      aria-label="Topic colour"
+      @input="handleInput"
+    />
+  </td>
+</template>
+
+<style scoped>
+.color-input {
+  inline-size: 3rem;
+  block-size: 2rem;
+  padding: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  cursor: pointer;
+}
+</style>

--- a/src/components/TopicsEditor/TopicKeyInput.vue
+++ b/src/components/TopicsEditor/TopicKeyInput.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+defineProps<{ readonly value: string }>()
+const emit = defineEmits<{ input: [value: string] }>()
+
+const handleInput = (event: Event) => {
+  const target = event.target
+  if (target instanceof HTMLInputElement) emit('input', target.value)
+}
+</script>
+
+<template>
+  <td data-label="Key">
+    <input
+      :value="value"
+      type="text"
+      placeholder="topic-key"
+      class="key-input"
+      data-testid="topic-key"
+      @input="handleInput"
+    />
+  </td>
+</template>
+
+<style scoped>
+.key-input {
+  width: 8rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono, monospace);
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+</style>

--- a/src/components/TopicsEditor/TopicLangCell.vue
+++ b/src/components/TopicsEditor/TopicLangCell.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+const props = defineProps<{
+  readonly name: string
+  readonly subtitle: string
+  readonly langCode: string
+  readonly langLabel: string
+}>()
+
+const emit = defineEmits<{
+  'update-name': [value: string]
+  'update-subtitle': [value: string]
+}>()
+
+const onName = (event: Event) => {
+  const target = event.target
+  if (target instanceof HTMLInputElement) emit('update-name', target.value)
+}
+
+const onSubtitle = (event: Event) => {
+  const target = event.target
+  if (target instanceof HTMLInputElement) emit('update-subtitle', target.value)
+}
+
+const cellLabel = `${props.langLabel} (${props.langCode})`
+</script>
+
+<template>
+  <td :data-label="cellLabel" class="lang-cell">
+    <input
+      :value="name"
+      type="text"
+      :placeholder="`${langCode} — name`"
+      class="lang-input"
+      data-testid="topic-name"
+      @input="onName"
+    />
+    <input
+      :value="subtitle"
+      type="text"
+      :placeholder="`${langCode} — subtitle`"
+      class="lang-input"
+      data-testid="topic-subtitle"
+      @input="onSubtitle"
+    />
+  </td>
+</template>
+
+<style scoped>
+.lang-cell {
+  min-inline-size: 12rem;
+}
+
+.lang-input {
+  width: 100%;
+  margin-block-end: 0.25rem;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+</style>

--- a/src/components/TopicsEditor/TopicRemoveButton.vue
+++ b/src/components/TopicsEditor/TopicRemoveButton.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+defineEmits<{ click: [] }>()
+</script>
+
+<template>
+  <td class="remove-cell">
+    <button
+      type="button"
+      class="remove-btn"
+      data-testid="remove-topic"
+      aria-label="Remove topic"
+      @click="$emit('click')"
+    >
+      &times;
+    </button>
+  </td>
+</template>
+
+<style scoped>
+.remove-btn {
+  background: none;
+  border: none;
+  color: var(--color-text-secondary);
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+
+  &:hover {
+    color: var(--color-danger, #e53e3e);
+    background: var(--color-surface);
+  }
+}
+</style>

--- a/src/components/TopicsEditor/TopicRow.vue
+++ b/src/components/TopicsEditor/TopicRow.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import type { LanguageEntry } from '@/stores/settings'
+import type { TopicEntry } from '@/stores/topics'
+import TopicColorInput from './TopicColorInput.vue'
+import TopicKeyInput from './TopicKeyInput.vue'
+import TopicLangCell from './TopicLangCell.vue'
+import TopicRemoveButton from './TopicRemoveButton.vue'
+
+const props = defineProps<{
+  readonly entry: TopicEntry
+  readonly languages: readonly LanguageEntry[]
+}>()
+
+const emit = defineEmits<{
+  'update-key': [value: string]
+  'update-color': [value: string]
+  'update-name': [lang: string, value: string]
+  'update-subtitle': [lang: string, value: string]
+  remove: []
+}>()
+</script>
+
+<template>
+  <tr data-testid="topic-row">
+    <TopicKeyInput
+      :value="props.entry.key"
+      @input="emit('update-key', $event)"
+    />
+    <TopicColorInput
+      :value="props.entry.color"
+      @input="emit('update-color', $event)"
+    />
+    <TopicLangCell
+      v-for="lang in props.languages"
+      :key="lang.code"
+      :name="props.entry.name[lang.code] ?? ''"
+      :subtitle="props.entry.subtitle[lang.code] ?? ''"
+      :lang-code="lang.code"
+      :lang-label="lang.label"
+      @update-name="emit('update-name', lang.code, $event)"
+      @update-subtitle="emit('update-subtitle', lang.code, $event)"
+    />
+    <TopicRemoveButton @click="emit('remove')" />
+  </tr>
+</template>

--- a/src/components/TopicsEditor/TopicsActions.vue
+++ b/src/components/TopicsEditor/TopicsActions.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+defineProps<{ readonly saving?: boolean }>()
+defineEmits<{ add: []; save: [] }>()
+</script>
+
+<template>
+  <button
+    type="button"
+    class="add-btn"
+    data-testid="add-topic"
+    @click="$emit('add')"
+  >
+    + Add Topic
+  </button>
+  <button
+    type="button"
+    class="save-btn"
+    data-testid="save-topics"
+    :disabled="saving"
+    @click="$emit('save')"
+  >
+    {{ saving ? 'Saving...' : 'Save' }}
+  </button>
+</template>
+
+<style scoped>
+.add-btn {
+  padding: 0.5rem 1rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text);
+}
+
+.save-btn {
+  padding: 0.5rem 1.5rem;
+  background: var(--color-accent);
+  color: var(--color-on-accent, #fff);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-weight: 600;
+
+  &:disabled {
+    opacity: 50%;
+    cursor: not-allowed;
+  }
+}
+</style>

--- a/src/components/TopicsEditor/TopicsEditor.vue
+++ b/src/components/TopicsEditor/TopicsEditor.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import type { LanguageEntry } from '@/stores/settings'
+import type { TopicEntry } from '@/stores/topics'
+import {
+  cloneTopic,
+  emptyTopic,
+  isValidEntry,
+  updateColor,
+  updateKey,
+  updateName,
+  updateSubtitle,
+} from './draft-ops'
+import TopicsActions from './TopicsActions.vue'
+import TopicsTable from './TopicsTable.vue'
+
+const props = defineProps<{
+  readonly topics: readonly TopicEntry[]
+  readonly languages: readonly LanguageEntry[]
+  readonly saving?: boolean
+}>()
+
+const emit = defineEmits<{
+  save: [entries: readonly TopicEntry[]]
+}>()
+
+const draft = ref<TopicEntry[]>([])
+const set = (next: TopicEntry[]) => {
+  draft.value = next
+}
+
+watch(
+  () => props.topics,
+  val => set(val.map(cloneTopic)),
+  { immediate: true }
+)
+
+const onKey = (i: number, v: string) => set(updateKey(draft.value, i, v))
+const onColor = (i: number, v: string) => set(updateColor(draft.value, i, v))
+const onName = (i: number, l: string, v: string) =>
+  set(updateName(draft.value, i, l, v))
+const onSubtitle = (i: number, l: string, v: string) =>
+  set(updateSubtitle(draft.value, i, l, v))
+const removeTopic = (i: number) => set(draft.value.filter((_, j) => j !== i))
+const addTopic = () => set([...draft.value, emptyTopic()])
+const handleSave = () => emit('save', draft.value.filter(isValidEntry))
+</script>
+
+<template>
+  <TopicsTable
+    :topics="draft"
+    :languages="languages"
+    data-testid="topics-editor"
+    @update-key="onKey"
+    @update-color="onColor"
+    @update-name="onName"
+    @update-subtitle="onSubtitle"
+    @remove="removeTopic"
+  />
+  <TopicsActions
+    :saving="saving"
+    @add="addTopic"
+    @save="handleSave"
+  />
+</template>

--- a/src/components/TopicsEditor/TopicsEditor.vue
+++ b/src/components/TopicsEditor/TopicsEditor.vue
@@ -50,7 +50,6 @@ const handleSave = () => emit('save', draft.value.filter(isValidEntry))
   <TopicsTable
     :topics="draft"
     :languages="languages"
-    data-testid="topics-editor"
     @update-key="onKey"
     @update-color="onColor"
     @update-name="onName"

--- a/src/components/TopicsEditor/TopicsHeaderRow.vue
+++ b/src/components/TopicsEditor/TopicsHeaderRow.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { LanguageEntry } from '@/stores/settings'
+
+defineProps<{
+  readonly languages: readonly LanguageEntry[]
+}>()
+</script>
+
+<template>
+  <tr class="topic-header-row">
+    <th>Key</th>
+    <th>Colour</th>
+    <th
+      v-for="lang in languages"
+      :key="lang.code"
+    >
+      {{ lang.label }} ({{ lang.code }})
+    </th>
+    <th>Remove</th>
+  </tr>
+</template>
+
+<style scoped>
+th {
+  text-align: left;
+  padding: 0.375rem 0.5rem;
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border);
+}
+</style>

--- a/src/components/TopicsEditor/TopicsTable.vue
+++ b/src/components/TopicsEditor/TopicsTable.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import type { LanguageEntry } from '@/stores/settings'
+import type { TopicEntry } from '@/stores/topics'
+import TopicRow from './TopicRow.vue'
+import TopicsHeaderRow from './TopicsHeaderRow.vue'
+
+defineProps<{
+  readonly topics: readonly TopicEntry[]
+  readonly languages: readonly LanguageEntry[]
+}>()
+
+defineEmits<{
+  'update-key': [index: number, value: string]
+  'update-color': [index: number, value: string]
+  'update-name': [index: number, lang: string, value: string]
+  'update-subtitle': [index: number, lang: string, value: string]
+  remove: [index: number]
+}>()
+</script>
+
+<template>
+  <table class="topics-table" data-testid="topics-table">
+    <TopicsHeaderRow :languages="languages" />
+    <TopicRow
+      v-for="(entry, index) in topics"
+      :key="index"
+      :entry="entry"
+      :languages="languages"
+      @update-key="$emit('update-key', index, $event)"
+      @update-color="$emit('update-color', index, $event)"
+      @update-name="(lang, val) => $emit('update-name', index, lang, val)"
+      @update-subtitle="
+        (lang, val) => $emit('update-subtitle', index, lang, val)
+      "
+      @remove="$emit('remove', index)"
+    />
+  </table>
+</template>
+
+<style scoped>
+.topics-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+@media (width < 768px) {
+  .topics-table,
+  .topics-table :deep(tbody),
+  .topics-table :deep(tr),
+  .topics-table :deep(td) {
+    display: block;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .topics-table :deep(tr.topic-header-row) {
+    display: none;
+  }
+
+  .topics-table :deep(tr:not(.topic-header-row)) {
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 0.75rem;
+    margin-bottom: 0.75rem;
+    background: var(--color-surface, var(--color-background-mute));
+    position: relative;
+  }
+
+  .topics-table :deep(td) {
+    display: grid;
+    grid-template-columns: minmax(5rem, auto) 1fr;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    padding: 0.25rem 0;
+    box-sizing: border-box;
+  }
+
+  .topics-table :deep(td::before) {
+    content: attr(data-label);
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+
+  .topics-table :deep(td.remove-cell) {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 0.5rem;
+    margin-top: 0.25rem;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .topics-table :deep(td.remove-cell::before) {
+    content: none;
+  }
+
+  .topics-table :deep(.key-input),
+  .topics-table :deep(.lang-input) {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+}
+</style>

--- a/src/components/TopicsEditor/draft-ops.test.ts
+++ b/src/components/TopicsEditor/draft-ops.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import type { TopicEntry } from '@/stores/topics'
+import {
+  cloneTopic,
+  emptyTopic,
+  isValidEntry,
+  updateColor,
+  updateKey,
+  updateName,
+  updateSubtitle,
+} from './draft-ops'
+
+const sample: readonly TopicEntry[] = [
+  { key: 'editorial', color: '#b03a2e', name: { en: 'Editorial' }, subtitle: {} },
+  { key: 'translation', color: '#2563eb', name: {}, subtitle: {} },
+]
+
+describe('emptyTopic', () => {
+  it('creates a blank entry with a default colour and empty maps', () => {
+    const topic = emptyTopic()
+    expect(topic.key).toBe('')
+    expect(topic.color).toMatch(/^#[0-9a-f]{6}$/i)
+    expect(topic.name).toEqual({})
+    expect(topic.subtitle).toEqual({})
+  })
+})
+
+describe('updateKey / updateColor', () => {
+  it('updates only the targeted entry key', () => {
+    const next = updateKey(sample, 1, 'likbez')
+    expect(next[1]?.key).toBe('likbez')
+    expect(next[0]?.key).toBe('editorial')
+  })
+
+  it('updates only the targeted entry colour', () => {
+    const next = updateColor(sample, 0, '#000000')
+    expect(next[0]?.color).toBe('#000000')
+    expect(next[1]?.color).toBe('#2563eb')
+  })
+})
+
+describe('updateName / updateSubtitle', () => {
+  it('sets a localized name without touching other languages', () => {
+    const next = updateName(sample, 0, 'ru', 'От редакции')
+    expect(next[0]?.name).toEqual({ en: 'Editorial', ru: 'От редакции' })
+  })
+
+  it('sets a localized subtitle independently of the name', () => {
+    const next = updateSubtitle(sample, 0, 'en', 'Our own position')
+    expect(next[0]?.subtitle).toEqual({ en: 'Our own position' })
+    expect(next[0]?.name).toEqual({ en: 'Editorial' })
+  })
+})
+
+describe('cloneTopic', () => {
+  it('detaches the localized maps from the source', () => {
+    const [first] = sample
+    const copy = cloneTopic(first as TopicEntry)
+    expect(copy.name).not.toBe(first?.name)
+    expect(copy.subtitle).not.toBe(first?.subtitle)
+    expect(copy).toEqual(first)
+  })
+})
+
+describe('isValidEntry', () => {
+  it('rejects entries with a blank key', () => {
+    expect(isValidEntry(emptyTopic())).toBe(false)
+    expect(isValidEntry({ ...emptyTopic(), key: '  ' })).toBe(false)
+  })
+
+  it('accepts entries with a non-empty key', () => {
+    expect(isValidEntry({ ...emptyTopic(), key: 'editorial' })).toBe(true)
+  })
+})

--- a/src/components/TopicsEditor/draft-ops.ts
+++ b/src/components/TopicsEditor/draft-ops.ts
@@ -1,0 +1,86 @@
+import type { TopicEntry } from '@/stores/topics'
+
+const DEFAULT_COLOR = '#3b82f6'
+
+type LocalizedField = 'name' | 'subtitle'
+
+/**
+ * Create a new empty topic entry with a default colour.
+ * @returns Topic entry with empty key and localized maps
+ */
+export const emptyTopic = (): TopicEntry => ({
+  key: '',
+  color: DEFAULT_COLOR,
+  name: {},
+  subtitle: {},
+})
+
+/**
+ * Update the key of a topic entry at a given index.
+ * @param draft - Current draft array
+ * @param index - Index of the entry to update
+ * @param value - New key value
+ * @returns Updated draft array
+ */
+export const updateKey = (
+  draft: readonly TopicEntry[],
+  index: number,
+  value: string
+): TopicEntry[] =>
+  draft.map((e, i) => (i === index ? { ...e, key: value } : e))
+
+/**
+ * Update the colour of a topic entry at a given index.
+ * @param draft - Current draft array
+ * @param index - Index of the entry to update
+ * @param value - New colour value
+ * @returns Updated draft array
+ */
+export const updateColor = (
+  draft: readonly TopicEntry[],
+  index: number,
+  value: string
+): TopicEntry[] =>
+  draft.map((e, i) => (i === index ? { ...e, color: value } : e))
+
+/**
+ * Build an updater for a localized map field (name or subtitle).
+ * @param field - Which localized field to write
+ * @returns Updater producing a new draft with the value set
+ */
+const updateLocalized =
+  (field: LocalizedField) =>
+  (
+    draft: readonly TopicEntry[],
+    index: number,
+    lang: string,
+    value: string
+  ): TopicEntry[] =>
+    draft.map((e, i) =>
+      i === index ? { ...e, [field]: { ...e[field], [lang]: value } } : e
+    )
+
+/** Update a localized name for a topic entry. */
+export const updateName = updateLocalized('name')
+
+/** Update a localized subtitle (приписка) for a topic entry. */
+export const updateSubtitle = updateLocalized('subtitle')
+
+/**
+ * Deep-clone a topic entry so draft edits never mutate store state.
+ * @param entry - Topic entry to clone
+ * @returns A detached copy with fresh localized maps
+ */
+export const cloneTopic = (entry: TopicEntry): TopicEntry => ({
+  ...entry,
+  name: { ...entry.name },
+  subtitle: { ...entry.subtitle },
+})
+
+/**
+ * Check if a topic entry has meaningful content.
+ * @param entry - Topic entry to validate
+ * @returns Whether the entry has a non-empty key
+ */
+export const isValidEntry = (entry: TopicEntry): boolean =>
+  entry.key.trim() !== ''

--- a/src/router/settings-routes.ts
+++ b/src/router/settings-routes.ts
@@ -25,6 +25,11 @@ export const settingsRoute: RouteRecordRaw = {
       component: () => import('../views/SettingsView/pages/LinksPage.vue'),
     },
     {
+      path: 'topics',
+      name: 'settings-topics',
+      component: () => import('../views/SettingsView/pages/TopicsPage.vue'),
+    },
+    {
       path: 'members',
       name: 'settings-members',
       component: () => import('../views/SettingsView/pages/MembersPage.vue'),

--- a/src/stores/topics-api.ts
+++ b/src/stores/topics-api.ts
@@ -1,0 +1,51 @@
+import { swFetch } from '@/composables/useSWBridge/sw-fetch'
+import { parseJsonAs } from '@/validation/decode'
+import { decodeResponse } from '@/validation/decode-response'
+import type { FileData } from '@/validation/schemas/api-response'
+import { FileDataSchema } from '@/validation/schemas/api-response'
+import type { TopicEntry } from '@/validation/schemas/topics'
+import { TopicArraySchema } from '@/validation/schemas/topics'
+
+const TOPICS_PATH = 'settings/topics.json'
+
+/**
+ * Fetch the topics JSON file from the SW.
+ * @returns File data or undefined if not found
+ */
+export const fetchTopicsFile = async (): Promise<FileData | undefined> => {
+  const res = await swFetch(
+    `/api/github/file?path=${encodeURIComponent(TOPICS_PATH)}`
+  )
+  return res.ok ? decodeResponse(FileDataSchema)(res) : undefined
+}
+
+/**
+ * Parse topic entries from JSON content.
+ * @param content - Raw JSON string
+ * @returns Parsed topic entries
+ */
+export const parseTopics = (content: string): readonly TopicEntry[] =>
+  parseJsonAs(TopicArraySchema)(content) ?? []
+
+/**
+ * Save topics file via SW API.
+ * @param entries - Topic entries to save
+ * @param sha - Current file SHA for conflict detection
+ * @returns Fetch response
+ */
+export const saveTopicsFile = async (
+  entries: readonly TopicEntry[],
+  sha: string
+) => {
+  const content = `${JSON.stringify(entries, null, 2)}\n`
+  return swFetch('/api/github/file', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      path: TOPICS_PATH,
+      content,
+      sha,
+      message: 'Update topics configuration',
+    }),
+  })
+}

--- a/src/stores/topics-load.ts
+++ b/src/stores/topics-load.ts
@@ -1,0 +1,30 @@
+import type { Ref } from 'vue'
+import type { TopicEntry } from '@/validation/schemas/topics'
+import { fetchTopicsFile, parseTopics } from './topics-api'
+
+/**
+ * Create loader that fetches and parses topics.
+ * @param topics - Reactive topics ref
+ * @param fileSha - Reactive file SHA ref
+ * @param loading - Reactive loading ref
+ * @param loaded - Reactive loaded ref
+ * @returns Async function that loads topics
+ */
+export const createLoadTopics =
+  (
+    topics: Ref<readonly TopicEntry[]>,
+    fileSha: Ref<string>,
+    loading: Ref<boolean>,
+    loaded: Ref<boolean>
+  ) =>
+  async (): Promise<void> => {
+    loading.value = true
+    try {
+      const file = await fetchTopicsFile()
+      topics.value = file ? parseTopics(file.content) : topics.value
+      fileSha.value = file ? file.sha : fileSha.value
+      loaded.value = true
+    } finally {
+      loading.value = false
+    }
+  }

--- a/src/stores/topics-state.ts
+++ b/src/stores/topics-state.ts
@@ -1,0 +1,25 @@
+import { ref } from 'vue'
+import type { TopicEntry } from '@/validation/schemas/topics'
+import { createLoadTopics } from './topics-load'
+import { createUpdateTopics } from './topics-update'
+
+/**
+ * Create the reactive state and actions for topics store.
+ * @returns Store state, getters, and actions
+ */
+export const createTopicsState = () => {
+  const topics = ref<readonly TopicEntry[]>([])
+  const fileSha = ref('')
+  const loading = ref(false)
+  const loaded = ref(false)
+  const loadTopics = createLoadTopics(topics, fileSha, loading, loaded)
+
+  return {
+    topics,
+    fileSha,
+    loading,
+    loaded,
+    loadTopics,
+    updateTopics: createUpdateTopics(topics, fileSha),
+  }
+}

--- a/src/stores/topics-update.ts
+++ b/src/stores/topics-update.ts
@@ -1,0 +1,22 @@
+import type { Ref } from 'vue'
+import type { TopicEntry } from '@/validation/schemas/topics'
+import { saveTopicsFile } from './topics-api'
+
+/**
+ * Create updater that saves topics to the API.
+ * @param topics - Reactive topics ref
+ * @param fileSha - Reactive file SHA ref
+ * @returns Async function that updates topics
+ */
+export const createUpdateTopics =
+  (topics: Ref<readonly TopicEntry[]>, fileSha: Ref<string>) =>
+  async (entries: readonly TopicEntry[]): Promise<boolean> => {
+    const res = await saveTopicsFile(entries, fileSha.value)
+    const commit = async (): Promise<void> => {
+      topics.value = entries
+      const data = await res.json()
+      fileSha.value = data.content?.sha ?? fileSha.value
+    }
+    await (res.ok ? commit() : Promise.resolve())
+    return res.ok
+  }

--- a/src/stores/topics.ts
+++ b/src/stores/topics.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+import { createTopicsState } from './topics-state'
+
+export type { TopicEntry } from '@/validation/schemas/topics'
+
+/** Pinia store for editorial topic management. */
+export const useTopicsStore = defineStore('topics', () => {
+  const s = createTopicsState()
+
+  /** Load topics if not already loaded. */
+  const ensureLoaded = async (): Promise<void> => {
+    await (s.loaded.value ? Promise.resolve() : s.loadTopics())
+  }
+
+  return { ...s, ensureLoaded }
+})

--- a/src/validation/schemas/topics.ts
+++ b/src/validation/schemas/topics.ts
@@ -1,0 +1,28 @@
+import { Schema } from 'effect'
+
+/**
+ * Schema for a single editorial topic entry.
+ * A topic has a key, a single colour, and localized name + subtitle
+ * (приписка) maps keyed by language code.
+ */
+export const TopicEntrySchema = Schema.Struct({
+  key: Schema.String,
+  color: Schema.String,
+  name: Schema.Record({
+    key: Schema.String,
+    value: Schema.String,
+  }),
+  subtitle: Schema.Record({
+    key: Schema.String,
+    value: Schema.String,
+  }),
+})
+
+/** Topic entry type derived from schema. */
+export type TopicEntry = typeof TopicEntrySchema.Type
+
+/**
+ * Schema for an array of topic entries.
+ * Used to validate the parsed topics.json file.
+ */
+export const TopicArraySchema = Schema.Array(TopicEntrySchema)

--- a/src/views/SettingsView/SettingsNav.vue
+++ b/src/views/SettingsView/SettingsNav.vue
@@ -9,6 +9,7 @@ interface SectionEntry {
 const SECTIONS: readonly SectionEntry[] = [
   { path: '/settings/languages', label: 'Languages' },
   { path: '/settings/links', label: 'Links' },
+  { path: '/settings/topics', label: 'Topics' },
   { path: '/settings/members', label: 'Members' },
   { path: '/settings/history', label: 'Action history' },
   { path: '/settings/reset', label: 'Reset' },

--- a/src/views/SettingsView/TopicsSection.vue
+++ b/src/views/SettingsView/TopicsSection.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { LanguageEntry } from '@/stores/settings'
+import type { TopicEntry } from '@/stores/topics'
+import TopicsSectionBody from './TopicsSectionBody.vue'
+
+defineProps<{
+  readonly loading: boolean
+  readonly topics: readonly TopicEntry[]
+  readonly languages: readonly LanguageEntry[]
+  readonly saving: boolean
+}>()
+
+defineEmits<{
+  save: [entries: readonly TopicEntry[]]
+}>()
+</script>
+
+<template>
+  <section class="topics-section">
+    <h2>Topics</h2>
+    <TopicsSectionBody
+      :loading="loading"
+      :topics="topics"
+      :languages="languages"
+      :saving="saving"
+      @save="$emit('save', $event)"
+    />
+  </section>
+</template>
+
+<style scoped>
+.topics-section {
+  margin-bottom: 2rem;
+}
+
+h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+</style>

--- a/src/views/SettingsView/TopicsSectionBody.vue
+++ b/src/views/SettingsView/TopicsSectionBody.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import TopicsEditor from '@/components/TopicsEditor/TopicsEditor.vue'
+import type { LanguageEntry } from '@/stores/settings'
+import type { TopicEntry } from '@/stores/topics'
+
+defineProps<{
+  readonly loading: boolean
+  readonly topics: readonly TopicEntry[]
+  readonly languages: readonly LanguageEntry[]
+  readonly saving: boolean
+}>()
+
+defineEmits<{
+  save: [entries: readonly TopicEntry[]]
+}>()
+</script>
+
+<template>
+  <p class="section-description">
+    Editorial topics mark articles as editorial pieces, translations or
+    likbez readers. Each topic has a colour plus a per-language name and
+    subtitle (приписка) shown on the article header and cards.
+  </p>
+  <p v-if="loading" class="loading">Loading...</p>
+  <TopicsEditor
+    v-else
+    :topics="topics"
+    :languages="languages"
+    :saving="saving"
+    @save="$emit('save', $event)"
+  />
+</template>
+
+<style scoped>
+.section-description {
+  color: var(--color-text-secondary);
+  margin-bottom: 1.5rem;
+  font-size: 0.9375rem;
+}
+
+.loading {
+  color: var(--color-text-secondary);
+}
+</style>

--- a/src/views/SettingsView/pages/TopicsPage.vue
+++ b/src/views/SettingsView/pages/TopicsPage.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import { useSettingsStore } from '@/stores/settings'
+import { type TopicEntry, useTopicsStore } from '@/stores/topics'
+import TopicsSection from '../TopicsSection.vue'
+
+const topicsStore = useTopicsStore()
+const settingsStore = useSettingsStore()
+const saving = ref(false)
+
+onMounted(() => {
+  topicsStore.ensureLoaded()
+  /* Languages come from the settings store — names/subtitles are per-language. */
+  settingsStore.ensureLoaded()
+})
+
+const onSave = async (entries: readonly TopicEntry[]): Promise<void> => {
+  saving.value = true
+  try {
+    await topicsStore.updateTopics(entries)
+  } finally {
+    saving.value = false
+  }
+}
+</script>
+
+<template>
+  <TopicsSection
+    :loading="topicsStore.loading"
+    :topics="topicsStore.topics"
+    :languages="settingsStore.languages"
+    :saving="saving"
+    @save="onSave"
+  />
+</template>


### PR DESCRIPTION
Adds a **Topics** taxonomy the editors manage in Settings, plus a topic selector on the blog frontmatter form. Pairs with public-website#188.

## What
- `validation/schemas/topics`: Effect schema for topic entries
- `stores/topics*`: load/save `settings/topics.json` via the SW (labels-style cluster; branchless per the Match-only rule)
- `components/TopicsEditor/*`: draft-based CRUD table with a colour picker and per-language name/subtitle cells (+ draft-ops unit tests)
- Settings: `TopicsSection`/`Body`, `TopicsPage`, `/settings/topics` route, Topics nav entry
- MarkdownEditor: `topics` select source, `buildTopicOptions`, a clearable optional select, and a `topic` field on the blog form
- E2E `settings/topics`: nav, table render, add-with-colour, remove

## Verification
- `bun run validate` green (type-check, biome, oxlint, eslint, vue-depth, css)
- 205 unit tests green (incl. topics draft-ops, select-options, frontmatter-fields)
- `settings/topics` E2E green ×2 (chromium, mock auth) against the sandbox git backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)