### PR TITLE
topics: per-language description field for the banner disclaimer

### DIFF
--- a/src/components/MarkdownEditor/select-options.test.ts
+++ b/src/components/MarkdownEditor/select-options.test.ts
@@ -50,12 +50,14 @@ const topics: readonly TopicEntry[] = [
     color: '#b03a2e',
     name: { en: 'Editorial', ru: 'От редакции' },
     subtitle: {},
+    description: {},
   },
   {
     key: 'translation',
     color: '#2563eb',
     name: { en: 'Translation' },
     subtitle: {},
+    description: {},
   },
 ]
 

--- a/src/components/TopicsEditor/TopicLangCell.vue
+++ b/src/components/TopicsEditor/TopicLangCell.vue
@@ -2,6 +2,7 @@
 const props = defineProps<{
   readonly name: string
   readonly subtitle: string
+  readonly description: string
   readonly langCode: string
   readonly langLabel: string
 }>()
@@ -9,16 +10,28 @@ const props = defineProps<{
 const emit = defineEmits<{
   'update-name': [value: string]
   'update-subtitle': [value: string]
+  'update-description': [value: string]
 }>()
 
-const onName = (event: Event) => {
-  const target = event.target
-  if (target instanceof HTMLInputElement) emit('update-name', target.value)
+const readValue = (event: Event): string | undefined =>
+  event.target instanceof HTMLInputElement ||
+  event.target instanceof HTMLTextAreaElement
+    ? event.target.value
+    : undefined
+
+const onName = (e: Event) => {
+  const v = readValue(e)
+  if (v !== undefined) emit('update-name', v)
 }
 
-const onSubtitle = (event: Event) => {
-  const target = event.target
-  if (target instanceof HTMLInputElement) emit('update-subtitle', target.value)
+const onSubtitle = (e: Event) => {
+  const v = readValue(e)
+  if (v !== undefined) emit('update-subtitle', v)
+}
+
+const onDescription = (e: Event) => {
+  const v = readValue(e)
+  if (v !== undefined) emit('update-description', v)
 }
 
 const cellLabel = `${props.langLabel} (${props.langCode})`
@@ -37,17 +50,25 @@ const cellLabel = `${props.langLabel} (${props.langCode})`
     <input
       :value="subtitle"
       type="text"
-      :placeholder="`${langCode} — subtitle`"
+      :placeholder="`${langCode} — tag (short)`"
       class="lang-input"
       data-testid="topic-subtitle"
       @input="onSubtitle"
+    />
+    <textarea
+      :value="description"
+      :placeholder="`${langCode} — banner disclaimer (long)`"
+      class="lang-input lang-textarea"
+      data-testid="topic-description"
+      rows="2"
+      @input="onDescription"
     />
   </td>
 </template>
 
 <style scoped>
 .lang-cell {
-  min-inline-size: 12rem;
+  min-inline-size: 14rem;
 }
 
 .lang-input {
@@ -58,5 +79,10 @@ const cellLabel = `${props.langLabel} (${props.langCode})`
   border-radius: var(--radius-sm);
   background: var(--color-bg);
   color: var(--color-text);
+}
+
+.lang-textarea {
+  resize: vertical;
+  font: inherit;
 }
 </style>

--- a/src/components/TopicsEditor/TopicRow.vue
+++ b/src/components/TopicsEditor/TopicRow.vue
@@ -16,6 +16,7 @@ const emit = defineEmits<{
   'update-color': [value: string]
   'update-name': [lang: string, value: string]
   'update-subtitle': [lang: string, value: string]
+  'update-description': [lang: string, value: string]
   remove: []
 }>()
 </script>
@@ -35,10 +36,12 @@ const emit = defineEmits<{
       :key="lang.code"
       :name="props.entry.name[lang.code] ?? ''"
       :subtitle="props.entry.subtitle[lang.code] ?? ''"
+      :description="props.entry.description[lang.code] ?? ''"
       :lang-code="lang.code"
       :lang-label="lang.label"
       @update-name="emit('update-name', lang.code, $event)"
       @update-subtitle="emit('update-subtitle', lang.code, $event)"
+      @update-description="emit('update-description', lang.code, $event)"
     />
     <TopicRemoveButton @click="emit('remove')" />
   </tr>

--- a/src/components/TopicsEditor/TopicsEditor.vue
+++ b/src/components/TopicsEditor/TopicsEditor.vue
@@ -7,6 +7,7 @@ import {
   emptyTopic,
   isValidEntry,
   updateColor,
+  updateDescription,
   updateKey,
   updateName,
   updateSubtitle,
@@ -41,6 +42,8 @@ const onName = (i: number, l: string, v: string) =>
   set(updateName(draft.value, i, l, v))
 const onSubtitle = (i: number, l: string, v: string) =>
   set(updateSubtitle(draft.value, i, l, v))
+const onDescription = (i: number, l: string, v: string) =>
+  set(updateDescription(draft.value, i, l, v))
 const removeTopic = (i: number) => set(draft.value.filter((_, j) => j !== i))
 const addTopic = () => set([...draft.value, emptyTopic()])
 const handleSave = () => emit('save', draft.value.filter(isValidEntry))
@@ -54,6 +57,7 @@ const handleSave = () => emit('save', draft.value.filter(isValidEntry))
     @update-color="onColor"
     @update-name="onName"
     @update-subtitle="onSubtitle"
+    @update-description="onDescription"
     @remove="removeTopic"
   />
   <TopicsActions

--- a/src/components/TopicsEditor/TopicsTable.vue
+++ b/src/components/TopicsEditor/TopicsTable.vue
@@ -14,6 +14,7 @@ defineEmits<{
   'update-color': [index: number, value: string]
   'update-name': [index: number, lang: string, value: string]
   'update-subtitle': [index: number, lang: string, value: string]
+  'update-description': [index: number, lang: string, value: string]
   remove: [index: number]
 }>()
 </script>
@@ -31,6 +32,9 @@ defineEmits<{
       @update-name="(lang, val) => $emit('update-name', index, lang, val)"
       @update-subtitle="
         (lang, val) => $emit('update-subtitle', index, lang, val)
+      "
+      @update-description="
+        (lang, val) => $emit('update-description', index, lang, val)
       "
       @remove="$emit('remove', index)"
     />

--- a/src/components/TopicsEditor/draft-ops.test.ts
+++ b/src/components/TopicsEditor/draft-ops.test.ts
@@ -5,6 +5,7 @@ import {
   emptyTopic,
   isValidEntry,
   updateColor,
+  updateDescription,
   updateKey,
   updateName,
   updateSubtitle,
@@ -16,8 +17,15 @@ const sample: readonly TopicEntry[] = [
     color: '#b03a2e',
     name: { en: 'Editorial' },
     subtitle: {},
+    description: {},
   },
-  { key: 'translation', color: '#2563eb', name: {}, subtitle: {} },
+  {
+    key: 'translation',
+    color: '#2563eb',
+    name: {},
+    subtitle: {},
+    description: {},
+  },
 ]
 
 describe('emptyTopic', () => {
@@ -27,6 +35,7 @@ describe('emptyTopic', () => {
     expect(topic.color).toMatch(/^#[0-9a-f]{6}$/i)
     expect(topic.name).toEqual({})
     expect(topic.subtitle).toEqual({})
+    expect(topic.description).toEqual({})
   })
 })
 
@@ -44,7 +53,7 @@ describe('updateKey / updateColor', () => {
   })
 })
 
-describe('updateName / updateSubtitle', () => {
+describe('localized updates', () => {
   it('sets a localized name without touching other languages', () => {
     const next = updateName(sample, 0, 'ru', 'От редакции')
     expect(next[0]?.name).toEqual({ en: 'Editorial', ru: 'От редакции' })
@@ -55,6 +64,12 @@ describe('updateName / updateSubtitle', () => {
     expect(next[0]?.subtitle).toEqual({ en: 'Our own position' })
     expect(next[0]?.name).toEqual({ en: 'Editorial' })
   })
+
+  it('sets a localized description independently of the subtitle', () => {
+    const next = updateDescription(sample, 1, 'en', 'A long disclaimer.')
+    expect(next[1]?.description).toEqual({ en: 'A long disclaimer.' })
+    expect(next[1]?.subtitle).toEqual({})
+  })
 })
 
 describe('cloneTopic', () => {
@@ -63,6 +78,7 @@ describe('cloneTopic', () => {
     const copy = cloneTopic(first as TopicEntry)
     expect(copy.name).not.toBe(first?.name)
     expect(copy.subtitle).not.toBe(first?.subtitle)
+    expect(copy.description).not.toBe(first?.description)
     expect(copy).toEqual(first)
   })
 })

--- a/src/components/TopicsEditor/draft-ops.ts
+++ b/src/components/TopicsEditor/draft-ops.ts
@@ -2,7 +2,7 @@ import type { TopicEntry } from '@/stores/topics'
 
 const DEFAULT_COLOR = '#3b82f6'
 
-type LocalizedField = 'name' | 'subtitle'
+type LocalizedField = 'name' | 'subtitle' | 'description'
 
 /**
  * Create a new empty topic entry with a default colour.
@@ -13,6 +13,7 @@ export const emptyTopic = (): TopicEntry => ({
   color: DEFAULT_COLOR,
   name: {},
   subtitle: {},
+  description: {},
 })
 
 /**
@@ -66,6 +67,9 @@ export const updateName = updateLocalized('name')
 /** Update a localized subtitle (приписка) for a topic entry. */
 export const updateSubtitle = updateLocalized('subtitle')
 
+/** Update a localized description (article-banner disclaimer). */
+export const updateDescription = updateLocalized('description')
+
 /**
  * Deep-clone a topic entry so draft edits never mutate store state.
  * @param entry - Topic entry to clone
@@ -75,6 +79,7 @@ export const cloneTopic = (entry: TopicEntry): TopicEntry => ({
   ...entry,
   name: { ...entry.name },
   subtitle: { ...entry.subtitle },
+  description: { ...entry.description },
 })
 
 /**

--- a/src/validation/schemas/topics.ts
+++ b/src/validation/schemas/topics.ts
@@ -16,6 +16,10 @@ export const TopicEntrySchema = Schema.Struct({
     key: Schema.String,
     value: Schema.String,
   }),
+  description: Schema.Record({
+    key: Schema.String,
+    value: Schema.String,
+  }),
 })
 
 /** Topic entry type derived from schema. */


### PR DESCRIPTION
Follow-up to the topics feature. Adds a long `description` (article-banner disclaimer) per language alongside the short `subtitle` (card tag): schema, draft-ops (+ tests), and the row/table/editor wiring; CRUD editor gains a description textarea per language.

Pairs with public-website topics PR.

- `bun run validate` green; TopicsEditor unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)