### PR TITLE
auth: keep mock/dev init unauthenticated until a session exists

### DIFF
--- a/src/composables/useAuth/get-initial-user.test.ts
+++ b/src/composables/useAuth/get-initial-user.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ensureFreshToken } from './ensure-fresh-token'
+import { fetchGitHubUser } from './fetch-github-user'
+import { getInitialUser } from './get-initial-user'
+
+vi.mock('./ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }))
+vi.mock('./mint-session', () => ({ mintSession: vi.fn() }))
+vi.mock('./profile-cache', () => ({ saveProfile: vi.fn() }))
+vi.mock('./fetch-github-user', async importOriginal => {
+  const actual = await importOriginal<typeof import('./fetch-github-user')>()
+  return { ...actual, fetchGitHubUser: vi.fn() }
+})
+
+const ensureMock = vi.mocked(ensureFreshToken)
+const fetchMock = vi.mocked(fetchGitHubUser)
+
+describe('getInitialUser', () => {
+  beforeEach(() => {
+    ensureMock.mockReset()
+    fetchMock.mockReset()
+    vi.stubEnv('VITE_DEV_TOKEN', '')
+  })
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('stays unauthenticated with no session, even in mock mode', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'true')
+    ensureMock.mockResolvedValue(undefined)
+    expect(await getInitialUser()).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the mock user (no real fetch) when mock mode has a session', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'true')
+    ensureMock.mockResolvedValue('t')
+    expect(await getInitialUser()).not.toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches the real user in non-mock mode with a session', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'false')
+    ensureMock.mockResolvedValue('t')
+    fetchMock.mockResolvedValue({
+      username: 'andswew',
+      name: 'A',
+      avatar: 'x',
+      accessToken: 't',
+    })
+    expect((await getInitialUser())?.username).toBe('andswew')
+  })
+})

--- a/src/composables/useAuth/get-initial-user.ts
+++ b/src/composables/useAuth/get-initial-user.ts
@@ -41,10 +41,11 @@ const fetchUser = async (token: string): Promise<User | null> => {
   }
 }
 
-const fromRealSession = async (): Promise<User | null> => {
-  const token = await ensureFreshToken()
-  return token ? fetchUser(token) : null
-}
+// Mock auth only substitutes the profile fetch — it still requires a live
+// session, so empty storage stays unauthenticated (login button) exactly
+// like production. Checking isMockAuth() before the token would auto-log-in.
+const resolveUser = (token: string): User | Promise<User | null> =>
+  isMockAuth() ? getMockUser() : fetchUser(token)
 
 /**
  * Resolve the initial user, guaranteeing a fresh (renewed if needed)
@@ -54,5 +55,6 @@ const fromRealSession = async (): Promise<User | null> => {
  */
 export const getInitialUser = async (): Promise<User | null> => {
   persistDevToken()
-  return isMockAuth() ? getMockUser() : fromRealSession()
+  const token = await ensureFreshToken()
+  return token ? resolveUser(token) : null
 }


### PR DESCRIPTION
## Regression fix (follow-up to #378)

#378's token-refresh refactor moved the `isMockAuth()` check **ahead of** the token lookup in `getInitialUser`. In a `VITE_MOCK_AUTH` build (the E2E build) with empty storage, the app then **auto-logged-in** as the mock user, so the login button never rendered.

The full `e2e` suite (298 tests, runs on the **deploy**, not on the `realmode` PR gate) caught it: 4 timeouts — `auth/login.spec.ts` (login button when unauthenticated), `auth/popup-login.spec.ts` (load content after login), `content/auth-required.spec.ts` (login button in header), `vue.spec.ts` (root url).

## Fix
Restore the original ordering: mock auth only substitutes the **profile fetch** and still requires a live session, so empty storage stays unauthenticated exactly like production.

- Guarded by a new `get-initial-user` unit test (mock+no session → null; mock+session → mock user; real+session → fetch).
- Reproduced the 4 specs locally against the E2E build: **10/10 pass** (16.5s). `validate` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbzLcqvQ76TaBK2dEYsvhZ