### PR TITLE
Promote: GitHub App token refresh lifecycle (#378, #379)

### DIFF
--- a/e2e-realmode/fixtures/astro-schema/content.config.ts
+++ b/e2e-realmode/fixtures/astro-schema/content.config.ts
@@ -29,6 +29,7 @@ const blogSchema = (allowed: ReadonlySet<string>) =>
     title: z.string(),
     description: z.string().optional(),
     category: z.string(),
+    topic: z.string().optional(),
     pubDate: z.union([z.string(), z.date()]).optional(),
     published: z.boolean().optional(),
     publishDate: z.union([z.string(), z.date()]).optional(),

--- a/src/api/token-fields.ts
+++ b/src/api/token-fields.ts
@@ -1,15 +1,29 @@
-/** Only the PKCE exchange fields — nothing else passes through. */
+/**
+ * Fields forwarded to GitHub. Covers both the PKCE authorization-code
+ * exchange (`code`/`code_verifier`) and the refresh grant
+ * (`grant_type=refresh_token` + `refresh_token`). Nothing else passes.
+ */
 export const FORWARDED: readonly string[] = [
   'code',
   'redirect_uri',
   'code_verifier',
+  'grant_type',
+  'refresh_token',
 ]
 
-/** Only the documented token-response fields reach the browser. */
+/**
+ * Token-response fields relayed to the browser. Includes the
+ * user-to-server expiry material (`refresh_token`, `expires_in`,
+ * `refresh_token_expires_in`) so the client can renew an 8-hour
+ * token instead of dying with it.
+ */
 export const RETURNED: readonly string[] = [
   'access_token',
   'token_type',
   'scope',
+  'refresh_token',
+  'expires_in',
+  'refresh_token_expires_in',
   'error',
   'error_description',
 ]
@@ -38,3 +52,13 @@ export const pickFields = (
  */
 export const toRecord = (v: unknown): Record<string, unknown> =>
   typeof v === 'object' && v !== null ? { ...v } : {}
+
+/**
+ * Coerce a JSON scalar to string. GitHub sends `expires_in` /
+ * `refresh_token_expires_in` as numbers, so a string-only filter would
+ * silently drop them; numbers are stringified and re-parsed client-side.
+ * @param v - Parsed JSON value
+ * @returns String form, or undefined for non-scalars
+ */
+export const asScalarString = (v: unknown): string | undefined =>
+  typeof v === 'string' ? v : typeof v === 'number' ? String(v) : undefined

--- a/src/api/token-handler.test.ts
+++ b/src/api/token-handler.test.ts
@@ -35,6 +35,9 @@ beforeEach(() => {
         access_token: 'gho_abc',
         token_type: 'bearer',
         scope: 'repo',
+        refresh_token: 'ghr_new',
+        expires_in: 28_800,
+        refresh_token_expires_in: 15_897_600,
         internal_field: 'leak-me',
       }),
       { status: 200 }
@@ -55,8 +58,39 @@ describe('tokenHandler client pinning', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('rejects a missing code', async () => {
+  it('rejects a request with neither code nor refresh_token', async () => {
     const res = await post({ client_id: CLIENT_ID })
+    expect(res.status).toBe(400)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when GITHUB_CLIENT_ID is unset', async () => {
+    const res = await post(
+      { client_id: CLIENT_ID, code: 'c' },
+      { GITHUB_CLIENT_ID: undefined }
+    )
+    expect(res.status).toBe(500)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a refresh grant and forwards it with the secret', async () => {
+    const res = await post({
+      client_id: CLIENT_ID,
+      grant_type: 'refresh_token',
+      refresh_token: 'ghr_old',
+    })
+    expect(res.status).toBe(200)
+    const sent = String(fetchMock.mock.calls[0]?.[1]?.body)
+    expect(sent).toContain('grant_type=refresh_token')
+    expect(sent).toContain('refresh_token=ghr_old')
+    expect(sent).toContain('client_secret=s3cret')
+  })
+
+  it('rejects grant_type=refresh_token without a refresh_token', async () => {
+    const res = await post({
+      client_id: CLIENT_ID,
+      grant_type: 'refresh_token',
+    })
     expect(res.status).toBe(400)
     expect(fetchMock).not.toHaveBeenCalled()
   })
@@ -86,6 +120,15 @@ describe('tokenHandler response filtering', () => {
     const body: Record<string, unknown> = await res.json()
     expect(body.access_token).toBe('gho_abc')
     expect(body.internal_field).toBeUndefined()
+  })
+
+  it('relays the refresh material so the client can renew', async () => {
+    const res = await post({ client_id: CLIENT_ID, code: 'c' })
+    const body: Record<string, unknown> = await res.json()
+    expect(body.refresh_token).toBe('ghr_new')
+    // expires_in is a number from GitHub; it survives as a string.
+    expect(body.expires_in).toBe('28800')
+    expect(body.refresh_token_expires_in).toBe('15897600')
   })
 
   it('survives a non-JSON GitHub response', async () => {

--- a/src/api/token-handler.ts
+++ b/src/api/token-handler.ts
@@ -1,6 +1,12 @@
 import type { Context } from 'hono'
 import type { Env } from './app'
-import { FORWARDED, pickFields, RETURNED, toRecord } from './token-fields'
+import {
+  asScalarString,
+  FORWARDED,
+  pickFields,
+  RETURNED,
+  toRecord,
+} from './token-fields'
 
 const TOKEN_URL = 'https://github.com/login/oauth/access_token'
 
@@ -9,6 +15,18 @@ const json = (payload: unknown, status: number): Response =>
     status,
     headers: { 'Content-Type': 'application/json' },
   })
+
+/**
+ * A request is a valid grant when it carries either an authorization
+ * `code` (PKCE exchange) or a `refresh_token` under
+ * `grant_type=refresh_token` (renewal). Anything else is rejected
+ * before contacting GitHub.
+ * @param p - Inbound form parameters
+ * @returns True when the grant is exchangeable
+ */
+const isExchangeableGrant = (p: URLSearchParams): boolean =>
+  !!p.get('code') ||
+  (p.get('grant_type') === 'refresh_token' && !!p.get('refresh_token'))
 
 const exchange = async (body: URLSearchParams): Promise<Response> =>
   fetch(TOKEN_URL, {
@@ -32,23 +50,22 @@ export const tokenHandler = async (
   c: Context<{ Bindings: Env }>
 ): Promise<Response> => {
   const secret = c.env.GITHUB_CLIENT_SECRET
-  if (!secret) return json({ error: 'server_config' }, 500)
-  const inbound = new URLSearchParams(await c.req.text())
   const expected = c.env.GITHUB_CLIENT_ID
-  const clientId = inbound.get('client_id') ?? ''
-  if (expected && clientId !== expected)
+  // Fail closed: a deploy missing either secret cannot relay arbitrary
+  // client ids to GitHub with our credentials.
+  if (!secret || !expected) return json({ error: 'server_config' }, 500)
+  const inbound = new URLSearchParams(await c.req.text())
+  if (inbound.get('client_id') !== expected)
     return json({ error: 'invalid_client' }, 400)
-  if (!inbound.get('code')) return json({ error: 'invalid_request' }, 400)
+  if (!isExchangeableGrant(inbound))
+    return json({ error: 'invalid_request' }, 400)
   const body = new URLSearchParams({
     ...pickFields(k => inbound.get(k) ?? undefined, FORWARDED),
-    client_id: clientId,
+    client_id: expected,
     client_secret: secret,
   })
   const gh = await exchange(body)
   const record = toRecord(await gh.json().catch(() => ({})))
-  const safe = pickFields(k => {
-    const v = record[k]
-    return typeof v === 'string' ? v : undefined
-  }, RETURNED)
+  const safe = pickFields(k => asScalarString(record[k]), RETURNED)
   return json(safe, gh.status)
 }

--- a/src/composables/useAuth/complete-callback.ts
+++ b/src/composables/useAuth/complete-callback.ts
@@ -1,8 +1,8 @@
 import { extractString } from '@/validation/extract-string'
-import { exchangeCodeForToken } from './exchange-token'
+import { exchangeCodeForSession } from './exchange-token'
 import { mintSession } from './mint-session'
 import { loadAndClearState, loadAndClearVerifier } from './pkce-storage'
-import { saveToken } from './token-storage'
+import { saveSession } from './session-storage'
 
 type QueryValue = string | null | undefined | (string | null)[]
 
@@ -36,12 +36,12 @@ export const completeCallback = async (
   const code = extractString(codeRaw) ?? fail('Missing code or verifier')
   const verifier = loadAndClearVerifier() ?? fail('Missing code or verifier')
   requireStateMatch(extractString(stateRaw), loadAndClearState())
-  const token = await exchangeCodeForToken(code, verifier)
-  saveToken(token)
+  const session = await exchangeCodeForSession(code, verifier)
+  saveSession(session)
   // Mint the parent-domain SSO cookie so subsequent calls to
   // *.comprom.org workers carry auth automatically. Fire-and-forget
   // — if the user is not yet on the admins team, the SPA still
   // loads but cookie-gated workers will 401 until membership lands.
-  void mintSession(token)
-  return token
+  void mintSession(session.accessToken)
+  return session.accessToken
 }

--- a/src/composables/useAuth/ensure-fresh-token.test.ts
+++ b/src/composables/useAuth/ensure-fresh-token.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ensureFreshToken } from './ensure-fresh-token'
+import { refreshSession } from './exchange-token'
+import type { GitHubSession } from './session'
+import { loadSession, saveSession } from './session-storage'
+
+vi.mock('./exchange-token', () => ({
+  refreshSession: vi.fn(),
+}))
+
+const refreshMock = vi.mocked(refreshSession)
+const NOW = 1_000_000_000_000
+const MIN = 60_000
+
+const store = (session: GitHubSession): void => saveSession(session)
+
+describe('ensureFreshToken', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => {
+    localStorage.clear()
+    refreshMock.mockReset()
+  })
+
+  it('returns undefined when no session is stored', async () => {
+    expect(await ensureFreshToken(NOW)).toBeUndefined()
+  })
+
+  it('returns a non-expiring token without refreshing', async () => {
+    store({ accessToken: 'legacy' })
+    expect(await ensureFreshToken(NOW)).toBe('legacy')
+    expect(refreshMock).not.toHaveBeenCalled()
+  })
+
+  it('returns a still-fresh token without refreshing', async () => {
+    store({ accessToken: 'fresh', expiresAt: NOW + 30 * MIN })
+    expect(await ensureFreshToken(NOW)).toBe('fresh')
+    expect(refreshMock).not.toHaveBeenCalled()
+  })
+
+  it('de-duplicates concurrent refreshes into a single rotation', async () => {
+    store({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      expiresAt: NOW - MIN,
+      refreshTokenExpiresAt: NOW + 1_000 * MIN,
+    })
+    refreshMock.mockResolvedValue({
+      accessToken: 'new',
+      refreshToken: 'r2',
+      expiresAt: NOW + 480 * MIN,
+    })
+    const [a, b] = await Promise.all([
+      ensureFreshToken(NOW),
+      ensureFreshToken(NOW),
+    ])
+    // Single-flight: one rotation, both callers see the new token, and the
+    // session survives (a second rotation would invalidate r1 and could
+    // clear the just-persisted session).
+    expect(refreshMock).toHaveBeenCalledTimes(1)
+    expect([a, b]).toEqual(['new', 'new'])
+    expect(loadSession()?.accessToken).toBe('new')
+  })
+
+  it('renews and persists a near-expiry token', async () => {
+    store({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      expiresAt: NOW + 2 * MIN,
+      refreshTokenExpiresAt: NOW + 1_000 * MIN,
+    })
+    refreshMock.mockResolvedValue({
+      accessToken: 'new',
+      refreshToken: 'r2',
+      expiresAt: NOW + 480 * MIN,
+    })
+    expect(await ensureFreshToken(NOW)).toBe('new')
+    expect(refreshMock).toHaveBeenCalledWith('r1')
+    expect(loadSession()?.accessToken).toBe('new')
+    expect(loadSession()?.refreshToken).toBe('r2')
+  })
+
+  it('clears the session when the refresh token itself has expired', async () => {
+    store({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      expiresAt: NOW - MIN,
+      refreshTokenExpiresAt: NOW - MIN,
+    })
+    expect(await ensureFreshToken(NOW)).toBeUndefined()
+    expect(refreshMock).not.toHaveBeenCalled()
+    expect(loadSession()).toBeUndefined()
+  })
+
+  it('keeps the still-valid token when a refresh attempt fails transiently', async () => {
+    store({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      expiresAt: NOW + 2 * MIN,
+      refreshTokenExpiresAt: NOW + 1_000 * MIN,
+    })
+    refreshMock.mockRejectedValue(new Error('network'))
+    expect(await ensureFreshToken(NOW)).toBe('old')
+    expect(loadSession()?.accessToken).toBe('old')
+  })
+
+  it('clears the session when refresh fails and the token is already expired', async () => {
+    store({
+      accessToken: 'old',
+      refreshToken: 'r1',
+      expiresAt: NOW - MIN,
+      refreshTokenExpiresAt: NOW + 1_000 * MIN,
+    })
+    refreshMock.mockRejectedValue(new Error('bad_refresh_token'))
+    expect(await ensureFreshToken(NOW)).toBeUndefined()
+    expect(loadSession()).toBeUndefined()
+  })
+})

--- a/src/composables/useAuth/ensure-fresh-token.ts
+++ b/src/composables/useAuth/ensure-fresh-token.ts
@@ -1,0 +1,50 @@
+import { dead, renewOnce } from './renew-session'
+import {
+  canRefresh,
+  type GitHubSession,
+  isExpired,
+  needsRefresh,
+} from './session'
+import { loadSession } from './session-storage'
+
+/** Renew this many ms before the access token actually expires. */
+const SKEW_MS = 10 * 60 * 1000
+
+/*
+ * Within the skew window with no usable refresh token: clear only once the
+ * token is genuinely past expiry — otherwise return it and let the app use
+ * the remaining minutes.
+ */
+const withoutRefresh = (
+  session: GitHubSession,
+  now: number
+): string | undefined =>
+  isExpired(session, now) ? dead() : session.accessToken
+
+const resolveFresh = (
+  session: GitHubSession,
+  now: number
+): Promise<string | undefined> | string | undefined => {
+  const refreshToken = session.refreshToken
+  return needsRefresh(session, now, SKEW_MS)
+    ? refreshToken && canRefresh(session, now)
+      ? renewOnce(session, refreshToken, now)
+      : withoutRefresh(session, now)
+    : session.accessToken
+}
+
+/**
+ * Return an access token guaranteed fresh for the immediate call, renewing
+ * it via the refresh token when it is near or past expiry. Returns
+ * undefined (and clears the session) only when the token is dead and cannot
+ * be renewed — the caller should then route to login. Non-expiring/legacy
+ * tokens are returned unchanged.
+ * @param now - Current epoch ms (injectable for tests)
+ * @returns A usable access token, or undefined when the session is dead
+ */
+export const ensureFreshToken = async (
+  now = Date.now()
+): Promise<string | undefined> => {
+  const session = loadSession()
+  return session ? resolveFresh(session, now) : undefined
+}

--- a/src/composables/useAuth/exchange-token.ts
+++ b/src/composables/useAuth/exchange-token.ts
@@ -1,55 +1,58 @@
-import { Effect, pipe } from 'effect'
+import { postToken } from './post-token'
+import {
+  type GitHubSession,
+  sessionFromResponse,
+  type TokenResponse,
+} from './session'
+
+const clientId = (): string => import.meta.env.VITE_GITHUB_CLIENT_ID ?? ''
+
+const raise = (message: string): never => {
+  throw new Error(message)
+}
 
 /**
- * Get the token exchange endpoint URL.
- * @returns Token exchange endpoint URL
+ * Turn a token response into a session, anchoring lifetimes to now.
+ * Throws the GitHub error (or a generic message) when no token came back.
+ * @param response - Proxied token response
+ * @returns The resulting session
  */
-const getTokenUrl = (): string =>
-  import.meta.env.VITE_TOKEN_PROXY ?? '/api/oauth/token'
+const toSession = (response: TokenResponse): GitHubSession =>
+  sessionFromResponse(response, Date.now()) ??
+  raise(response.error ?? 'Token exchange failed')
 
-/**
- * Build URL-encoded token exchange body.
- * @param code - OAuth authorization code
- * @param verifier - PKCE code verifier
- * @returns URLSearchParams body
- */
-const buildTokenBody = (code: string, verifier: string): URLSearchParams =>
+const codeBody = (code: string, verifier: string): URLSearchParams =>
   new URLSearchParams({
-    client_id: import.meta.env.VITE_GITHUB_CLIENT_ID ?? '',
+    client_id: clientId(),
     code,
     code_verifier: verifier,
   })
 
-interface TokenData {
-  readonly access_token?: string
-  readonly error?: string
-}
+const refreshBody = (refreshToken: string): URLSearchParams =>
+  new URLSearchParams({
+    client_id: clientId(),
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  })
 
 /**
- * Exchange OAuth code + PKCE verifier for access token.
- * @param code - Authorization code from callback
+ * Exchange an OAuth code + PKCE verifier for a fresh session.
+ * @param code - Authorization code from the callback
  * @param verifier - PKCE code verifier
- * @returns GitHub access token
+ * @returns The new session (access token + refresh material)
  */
-export const exchangeCodeForToken = (
+export const exchangeCodeForSession = async (
   code: string,
   verifier: string
-): Promise<string> =>
-  pipe(
-    Effect.tryPromise(() =>
-      fetch(getTokenUrl(), {
-        method: 'POST',
-        body: buildTokenBody(code, verifier),
-      })
-    ),
-    Effect.flatMap(res =>
-      Effect.tryPromise((): Promise<TokenData> => res.json())
-    ),
-    Effect.filterOrFail(
-      (d): d is TokenData & { access_token: string } =>
-        !d.error && !!d.access_token,
-      d => new Error(d.error ?? 'Token exchange failed')
-    ),
-    Effect.map(d => d.access_token),
-    Effect.runPromise
-  )
+): Promise<GitHubSession> =>
+  toSession(await postToken(codeBody(code, verifier)))
+
+/**
+ * Exchange a refresh token for a renewed (rotated) session.
+ * @param refreshToken - The current refresh token
+ * @returns The renewed session
+ */
+export const refreshSession = async (
+  refreshToken: string
+): Promise<GitHubSession> =>
+  toSession(await postToken(refreshBody(refreshToken)))

--- a/src/composables/useAuth/fetch-github-user.test.ts
+++ b/src/composables/useAuth/fetch-github-user.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchGitHubUser, GitHubAuthError } from './fetch-github-user'
+
+const fetchMock = vi.fn()
+const ghUser = { login: 'andswew', name: 'A', avatar_url: 'x' }
+
+beforeEach(() => vi.stubGlobal('fetch', fetchMock))
+afterEach(() => {
+  vi.unstubAllGlobals()
+  fetchMock.mockReset()
+})
+
+describe('fetchGitHubUser', () => {
+  it('maps a 200 response to a User carrying the token', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(ghUser), { status: 200 })
+    )
+    expect(await fetchGitHubUser('tok')).toEqual({
+      username: 'andswew',
+      name: 'A',
+      avatar: 'x',
+      accessToken: 'tok',
+    })
+  })
+
+  it('throws GitHubAuthError on 401 (dead token)', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 401 }))
+    await expect(fetchGitHubUser('tok')).rejects.toBeInstanceOf(
+      GitHubAuthError
+    )
+  })
+
+  it('throws GitHubAuthError on 403', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 403 }))
+    await expect(fetchGitHubUser('tok')).rejects.toBeInstanceOf(
+      GitHubAuthError
+    )
+  })
+
+  it('throws a non-auth error on 500 (transient)', async () => {
+    fetchMock.mockResolvedValue(new Response('', { status: 500 }))
+    const error = await fetchGitHubUser('tok').catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(GitHubAuthError)
+  })
+})

--- a/src/composables/useAuth/fetch-github-user.ts
+++ b/src/composables/useAuth/fetch-github-user.ts
@@ -3,29 +3,46 @@ import type { User } from '@/types/user'
 const API_URL = 'https://api.github.com/user'
 
 /**
- * Fetch authenticated GitHub user profile.
+ * Thrown when GitHub rejects the token itself (401/403). Distinguished from
+ * transient errors (network, 5xx) so callers clear the session on a dead
+ * token but preserve it across a blip.
+ */
+export class GitHubAuthError extends Error {}
+
+interface GitHubUserData {
+  readonly login: string
+  readonly name: string | undefined
+  readonly avatar_url: string
+}
+
+const raise = (error: Error): never => {
+  throw error
+}
+
+const httpError = (status: number): Error =>
+  status === 401 || status === 403
+    ? new GitHubAuthError(`GitHub auth error: ${status}`)
+    : new Error(`GitHub API error: ${status}`)
+
+const toUser = (data: GitHubUserData, token: string): User => ({
+  username: data.login,
+  name: data.name ?? data.login,
+  avatar: data.avatar_url,
+  accessToken: token,
+})
+
+/**
+ * Fetch the authenticated GitHub user profile.
  * @param token - GitHub access token
  * @returns User object with username, name, avatar, accessToken
+ * @throws GitHubAuthError on 401/403; a plain Error on other failures
  */
 export const fetchGitHubUser = async (token: string): Promise<User> => {
   const res = await fetch(API_URL, {
     headers: { Authorization: `Bearer ${token}` },
   })
-
-  if (!res.ok) {
-    throw new Error(`GitHub API error: ${res.status}`)
-  }
-
-  const data: {
-    login: string
-    name: string | undefined
-    avatar_url: string
-  } = await res.json()
-
-  return {
-    username: data.login,
-    name: data.name ?? data.login,
-    avatar: data.avatar_url,
-    accessToken: token,
-  }
+  const data: GitHubUserData = res.ok
+    ? await res.json()
+    : raise(httpError(res.status))
+  return toUser(data, token)
 }

--- a/src/composables/useAuth/get-initial-user.test.ts
+++ b/src/composables/useAuth/get-initial-user.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ensureFreshToken } from './ensure-fresh-token'
+import { fetchGitHubUser } from './fetch-github-user'
+import { getInitialUser } from './get-initial-user'
+
+vi.mock('./ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }))
+vi.mock('./mint-session', () => ({ mintSession: vi.fn() }))
+vi.mock('./profile-cache', () => ({ saveProfile: vi.fn() }))
+vi.mock('./fetch-github-user', async importOriginal => {
+  const actual = await importOriginal<typeof import('./fetch-github-user')>()
+  return { ...actual, fetchGitHubUser: vi.fn() }
+})
+
+const ensureMock = vi.mocked(ensureFreshToken)
+const fetchMock = vi.mocked(fetchGitHubUser)
+
+describe('getInitialUser', () => {
+  beforeEach(() => {
+    ensureMock.mockReset()
+    fetchMock.mockReset()
+    vi.stubEnv('VITE_DEV_TOKEN', '')
+  })
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('stays unauthenticated with no session, even in mock mode', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'true')
+    ensureMock.mockResolvedValue(undefined)
+    expect(await getInitialUser()).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns the mock user (no real fetch) when mock mode has a session', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'true')
+    ensureMock.mockResolvedValue('t')
+    expect(await getInitialUser()).not.toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('fetches the real user in non-mock mode with a session', async () => {
+    vi.stubEnv('VITE_MOCK_AUTH', 'false')
+    ensureMock.mockResolvedValue('t')
+    fetchMock.mockResolvedValue({
+      username: 'andswew',
+      name: 'A',
+      avatar: 'x',
+      accessToken: 't',
+    })
+    expect((await getInitialUser())?.username).toBe('andswew')
+  })
+})

--- a/src/composables/useAuth/get-initial-user.ts
+++ b/src/composables/useAuth/get-initial-user.ts
@@ -41,10 +41,11 @@ const fetchUser = async (token: string): Promise<User | null> => {
   }
 }
 
-const fromRealSession = async (): Promise<User | null> => {
-  const token = await ensureFreshToken()
-  return token ? fetchUser(token) : null
-}
+// Mock auth only substitutes the profile fetch — it still requires a live
+// session, so empty storage stays unauthenticated (login button) exactly
+// like production. Checking isMockAuth() before the token would auto-log-in.
+const resolveUser = (token: string): User | Promise<User | null> =>
+  isMockAuth() ? getMockUser() : fetchUser(token)
 
 /**
  * Resolve the initial user, guaranteeing a fresh (renewed if needed)
@@ -54,5 +55,6 @@ const fromRealSession = async (): Promise<User | null> => {
  */
 export const getInitialUser = async (): Promise<User | null> => {
   persistDevToken()
-  return isMockAuth() ? getMockUser() : fromRealSession()
+  const token = await ensureFreshToken()
+  return token ? resolveUser(token) : null
 }

--- a/src/composables/useAuth/get-initial-user.ts
+++ b/src/composables/useAuth/get-initial-user.ts
@@ -1,61 +1,58 @@
-import { Effect, Option, pipe } from 'effect'
 import type { User } from '@/types/user'
-import { fetchGitHubUser } from './fetch-github-user'
+import { ensureFreshToken } from './ensure-fresh-token'
+import { fetchGitHubUser, GitHubAuthError } from './fetch-github-user'
 import { mintSession } from './mint-session'
 import { getMockUser } from './mock-user'
 import { saveProfile } from './profile-cache'
-import { loadToken, saveToken } from './token-storage'
+import { clearToken, saveToken } from './token-storage'
+
+const isMockAuth = (): boolean => import.meta.env.VITE_MOCK_AUTH === 'true'
+
+const persistDevToken = (): void => {
+  const dev = import.meta.env.VITE_DEV_TOKEN
+  void (dev ? saveToken(dev) : undefined)
+}
+
+const cacheAndMint = (user: User): User => {
+  saveProfile({
+    username: user.username,
+    name: user.name,
+    avatar: user.avatar,
+  })
+  // Refresh the *.comprom.org SSO cookie so cookie-gated workers carry
+  // auth. Fire-and-forget — failure only delays the next call by a retry.
+  void mintSession(user.accessToken)
+  return user
+}
+
+/*
+ * A GitHubAuthError means the token is dead despite the refresh attempt
+ * (revoked authorization, or the refresh token itself expired): clear the
+ * corpse so the app treats the user as logged-out instead of looping on a
+ * bad token. A transient error (network/5xx) leaves the session intact so a
+ * blip at boot does not force a re-login.
+ */
+const fetchUser = async (token: string): Promise<User | null> => {
+  try {
+    return cacheAndMint(await fetchGitHubUser(token))
+  } catch (error) {
+    void (error instanceof GitHubAuthError ? clearToken() : undefined)
+    return null
+  }
+}
+
+const fromRealSession = async (): Promise<User | null> => {
+  const token = await ensureFreshToken()
+  return token ? fetchUser(token) : null
+}
 
 /**
- * Resolve auth token from dev env or localStorage.
- * @returns Token Option from dev env or localStorage
+ * Resolve the initial user, guaranteeing a fresh (renewed if needed)
+ * access token before hitting GitHub. Returns null when no live session
+ * exists so the caller routes to login.
+ * @returns The authenticated user, or null
  */
-const resolveToken = (): Option.Option<string> =>
-  pipe(
-    Option.fromNullable(import.meta.env.VITE_DEV_TOKEN),
-    Option.tap(t => {
-      saveToken(t)
-      return Option.some(t)
-    }),
-    Option.orElse(() => Option.fromNullable(loadToken()))
-  )
-
-const isMockAuth = () => import.meta.env.VITE_MOCK_AUTH === 'true'
-
-const fetchAndCache = (token: string) =>
-  Effect.tryPromise(() => fetchGitHubUser(token)).pipe(
-    Effect.tap(u =>
-      Effect.sync(() => {
-        saveProfile({
-          username: u.username,
-          name: u.name,
-          avatar: u.avatar,
-        })
-        // Returning visitor with a persisted gh_token: refresh the
-        // *.comprom.org SSO cookie in case it was never minted or
-        // has since expired. Fire-and-forget — failure here just
-        // delays the next cookie-gated worker call by one 401-retry.
-        void mintSession(token)
-      })
-    )
-  )
-
-/**
- * Get initial user from token or mock.
- * Saves profile to cache on successful fetch.
- * @returns Promise resolving to User or null
- */
-export const getInitialUser = (): Promise<User | null> =>
-  pipe(
-    resolveToken(),
-    Option.match({
-      onNone: () => Effect.succeed<User | null>(null),
-      onSome: token =>
-        isMockAuth()
-          ? Effect.sync<User>(() => getMockUser())
-          : fetchAndCache(token).pipe(
-              Effect.catchAll(() => Effect.succeed<User | null>(null))
-            ),
-    }),
-    Effect.runPromise
-  )
+export const getInitialUser = async (): Promise<User | null> => {
+  persistDevToken()
+  return isMockAuth() ? getMockUser() : fromRealSession()
+}

--- a/src/composables/useAuth/post-token.ts
+++ b/src/composables/useAuth/post-token.ts
@@ -1,0 +1,47 @@
+import type { TokenResponse } from './session'
+
+const tokenProxyUrl = (): string =>
+  import.meta.env.VITE_TOKEN_PROXY ?? '/api/oauth/token'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const pick = (
+  record: Record<string, unknown>,
+  key: string
+): string | undefined => {
+  const value = record[key]
+  return typeof value === 'string' ? value : undefined
+}
+
+/*
+ * Narrow untrusted JSON to the known token fields (all string scalars —
+ * the proxy stringifies GitHub's numeric expires_in), rather than asserting
+ * a shape over the network response.
+ */
+const toTokenResponse = (value: unknown): TokenResponse => {
+  const record = isRecord(value) ? value : {}
+  return {
+    access_token: pick(record, 'access_token'),
+    refresh_token: pick(record, 'refresh_token'),
+    expires_in: pick(record, 'expires_in'),
+    refresh_token_expires_in: pick(record, 'refresh_token_expires_in'),
+    error: pick(record, 'error'),
+  }
+}
+
+/**
+ * POST a token request (code exchange or refresh grant) to the same-origin
+ * proxy that injects the client secret. Never throws on a non-2xx body: a
+ * GitHub error payload is returned verbatim so the caller can inspect
+ * `error`; a non-JSON body degrades to an empty response.
+ * @param body - URL-encoded grant parameters
+ * @returns The parsed token response
+ */
+export const postToken = async (
+  body: URLSearchParams
+): Promise<TokenResponse> => {
+  const res = await fetch(tokenProxyUrl(), { method: 'POST', body })
+  const parsed: unknown = await res.json().catch(() => ({}))
+  return toTokenResponse(parsed)
+}

--- a/src/composables/useAuth/refresh-notify.test.ts
+++ b/src/composables/useAuth/refresh-notify.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyToken, type SchedulerState } from './refresh-notify'
+
+const hooks = () => ({ onRefreshed: vi.fn(), onDead: vi.fn() })
+
+describe('applyToken', () => {
+  it('fires onDead for a dead session (undefined token)', () => {
+    const h = hooks()
+    const state: SchedulerState = { lastToken: 'x', stopped: false }
+    applyToken(undefined, state, h)
+    expect(h.onDead).toHaveBeenCalledOnce()
+    expect(h.onRefreshed).not.toHaveBeenCalled()
+  })
+
+  it('notifies once for a new token and records it', () => {
+    const h = hooks()
+    const state: SchedulerState = { lastToken: undefined, stopped: false }
+    applyToken('t1', state, h)
+    expect(h.onRefreshed).toHaveBeenCalledWith('t1')
+    expect(state.lastToken).toBe('t1')
+  })
+
+  it('stays silent when the token is unchanged', () => {
+    const h = hooks()
+    const state: SchedulerState = { lastToken: 't1', stopped: false }
+    applyToken('t1', state, h)
+    expect(h.onRefreshed).not.toHaveBeenCalled()
+    expect(h.onDead).not.toHaveBeenCalled()
+  })
+})

--- a/src/composables/useAuth/refresh-notify.ts
+++ b/src/composables/useAuth/refresh-notify.ts
@@ -1,0 +1,40 @@
+/** Callbacks the scheduler drives as the session evolves. */
+export interface RefreshHooks {
+  readonly onRefreshed: (token: string) => void
+  readonly onDead: () => void
+}
+
+/** Mutable state threaded through scheduler ticks. */
+export interface SchedulerState {
+  lastToken: string | undefined
+  stopped: boolean
+}
+
+const notifyNew = (
+  token: string,
+  state: SchedulerState,
+  hooks: RefreshHooks
+): void => {
+  state.lastToken = token
+  hooks.onRefreshed(token)
+}
+
+/**
+ * Route a freshly-resolved token to the right callback: a dead session
+ * fires `onDead`; an unchanged token does nothing; a new token fires
+ * `onRefreshed` exactly once.
+ * @param token - Result of ensureFreshToken
+ * @param state - Mutable scheduler state (last token seen)
+ * @param hooks - Refresh/dead callbacks
+ */
+export const applyToken = (
+  token: string | undefined,
+  state: SchedulerState,
+  hooks: RefreshHooks
+): void => {
+  void (token === undefined
+    ? hooks.onDead()
+    : token === state.lastToken
+      ? undefined
+      : notifyNew(token, state, hooks))
+}

--- a/src/composables/useAuth/refresh-scheduler.ts
+++ b/src/composables/useAuth/refresh-scheduler.ts
@@ -1,0 +1,46 @@
+import { ensureFreshToken } from './ensure-fresh-token'
+import {
+  applyToken,
+  type RefreshHooks,
+  type SchedulerState,
+} from './refresh-notify'
+
+export type { RefreshHooks } from './refresh-notify'
+
+/*
+ * Poll on a coarse interval rather than a single timer at the exact
+ * expiry: an interval resumes cleanly after the machine sleeps, and
+ * ensureFreshToken only renews once inside its skew window, so ticks are
+ * cheap. Visibility/focus ticks catch a tab left open past expiry.
+ */
+const CHECK_INTERVAL_MS = 5 * 60 * 1000
+
+/**
+ * Start proactively renewing the access token before it expires. Invokes
+ * `onRefreshed` with each newly-rotated token (so callers can re-init the
+ * Service Worker) and `onDead` when the session can no longer be renewed.
+ * @param hooks - Refresh/dead callbacks
+ * @returns A stop function that removes all timers and listeners
+ */
+export const startTokenRefresh = (hooks: RefreshHooks): (() => void) => {
+  const state: SchedulerState = { lastToken: undefined, stopped: false }
+  const tick = async (): Promise<void> => {
+    const token = await ensureFreshToken()
+    void (state.stopped ? undefined : applyToken(token, state, hooks))
+  }
+  const run = (): void => void tick()
+  const onVisible = (): void => {
+    void (globalThis.document?.visibilityState === 'visible'
+      ? run()
+      : undefined)
+  }
+  const interval = globalThis.setInterval(run, CHECK_INTERVAL_MS)
+  globalThis.document?.addEventListener('visibilitychange', onVisible)
+  globalThis.addEventListener?.('focus', run)
+  return (): void => {
+    state.stopped = true
+    globalThis.clearInterval(interval)
+    globalThis.document?.removeEventListener('visibilitychange', onVisible)
+    globalThis.removeEventListener?.('focus', run)
+  }
+}

--- a/src/composables/useAuth/renew-session.ts
+++ b/src/composables/useAuth/renew-session.ts
@@ -1,0 +1,61 @@
+import { refreshSession } from './exchange-token'
+import { type GitHubSession, isExpired } from './session'
+import { saveSession } from './session-storage'
+import { clearToken } from './token-storage'
+
+/**
+ * Clear the dead session so the app forces an honest re-login.
+ * @returns undefined, for use as an expression in the resolve chain
+ */
+export const dead = (): undefined => {
+  clearToken()
+  return undefined
+}
+
+/*
+ * Renew failed: clear only a token already past expiry; otherwise keep the
+ * still-valid token so a later attempt can renew within the remaining
+ * window (this absorbs transient network blips).
+ */
+const onFailure = (
+  session: GitHubSession,
+  now: number
+): string | undefined =>
+  isExpired(session, now) ? dead() : session.accessToken
+
+const renew = async (
+  session: GitHubSession,
+  refreshToken: string,
+  now: number
+): Promise<string | undefined> => {
+  try {
+    const next = await refreshSession(refreshToken)
+    saveSession(next)
+    return next.accessToken
+  } catch {
+    return onFailure(session, now)
+  }
+}
+
+let inFlight: Promise<string | undefined> | undefined
+
+/**
+ * Renew the session, de-duplicating concurrent callers so a refresh-token
+ * rotation happens exactly once. Without this, a second concurrent refresh
+ * would reuse the now-invalidated refresh token, fail, and could clear the
+ * session the first refresh just persisted.
+ * @param session - Current session
+ * @param refreshToken - Its refresh token
+ * @param now - Current epoch ms
+ * @returns The renewed access token, or undefined when the session died
+ */
+export const renewOnce = (
+  session: GitHubSession,
+  refreshToken: string,
+  now: number
+): Promise<string | undefined> => {
+  inFlight ??= renew(session, refreshToken, now).finally(() => {
+    inFlight = undefined
+  })
+  return inFlight
+}

--- a/src/composables/useAuth/revalidate-user.test.ts
+++ b/src/composables/useAuth/revalidate-user.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { User } from '@/types/user'
+import { getCachedUser } from './cached-user'
+import { ensureFreshToken } from './ensure-fresh-token'
+import { fetchGitHubUser, GitHubAuthError } from './fetch-github-user'
+import { revalidateUser } from './revalidate-user'
+
+vi.mock('./ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }))
+vi.mock('./cached-user', () => ({ getCachedUser: vi.fn() }))
+vi.mock('./profile-cache', () => ({ saveProfile: vi.fn() }))
+vi.mock('./fetch-github-user', async importOriginal => {
+  const actual = await importOriginal<typeof import('./fetch-github-user')>()
+  return { ...actual, fetchGitHubUser: vi.fn() }
+})
+
+const ensureMock = vi.mocked(ensureFreshToken)
+const fetchMock = vi.mocked(fetchGitHubUser)
+const cachedMock = vi.mocked(getCachedUser)
+
+const user = (name: string): User => ({
+  username: name,
+  name,
+  avatar: 'a',
+  accessToken: 't',
+})
+
+describe('revalidateUser', () => {
+  beforeEach(() => {
+    ensureMock.mockReset()
+    fetchMock.mockReset()
+    cachedMock.mockReset()
+  })
+
+  it('returns undefined when the session is dead', async () => {
+    ensureMock.mockResolvedValue(undefined)
+    expect(await revalidateUser()).toBeUndefined()
+  })
+
+  it('returns the fresh user on success', async () => {
+    ensureMock.mockResolvedValue('t')
+    fetchMock.mockResolvedValue(user('fresh'))
+    expect((await revalidateUser())?.username).toBe('fresh')
+  })
+
+  it('logs out (undefined) on an auth failure', async () => {
+    ensureMock.mockResolvedValue('t')
+    fetchMock.mockRejectedValue(new GitHubAuthError('401'))
+    expect(await revalidateUser()).toBeUndefined()
+    expect(cachedMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps the cached user on a transient failure', async () => {
+    ensureMock.mockResolvedValue('t')
+    fetchMock.mockRejectedValue(new Error('network'))
+    cachedMock.mockReturnValue(user('cached'))
+    expect((await revalidateUser())?.username).toBe('cached')
+  })
+})

--- a/src/composables/useAuth/revalidate-user.ts
+++ b/src/composables/useAuth/revalidate-user.ts
@@ -1,36 +1,39 @@
-import { Effect, Option, pipe } from 'effect'
 import type { User } from '@/types/user'
-import { fetchGitHubUser } from './fetch-github-user'
+import { getCachedUser } from './cached-user'
+import { ensureFreshToken } from './ensure-fresh-token'
+import { fetchGitHubUser, GitHubAuthError } from './fetch-github-user'
 import { saveProfile } from './profile-cache'
-import { loadToken } from './token-storage'
 
-const fetchAndCache = (token: string) =>
-  Effect.tryPromise(() => fetchGitHubUser(token)).pipe(
-    Effect.tap(u =>
-      Effect.sync(() =>
-        saveProfile({
-          username: u.username,
-          name: u.name,
-          avatar: u.avatar,
-        })
-      )
-    )
-  )
+const cache = (user: User): User => {
+  saveProfile({
+    username: user.username,
+    name: user.name,
+    avatar: user.avatar,
+  })
+  return user
+}
+
+/*
+ * Auth failure -> undefined so the caller logs out. Transient failure ->
+ * fall back to the cached user so an offline blip on a returning tab does
+ * not force a re-login (undefined only if there is no cached user either).
+ */
+const tryFetch = async (token: string): Promise<User | undefined> => {
+  try {
+    return cache(await fetchGitHubUser(token))
+  } catch (error) {
+    return error instanceof GitHubAuthError ? undefined : getCachedUser()
+  }
+}
 
 /**
- * Revalidate user by fetching fresh profile from GitHub.
- * Updates the profile cache on success.
- * @returns Fresh User or undefined on failure
+ * Revalidate the cached user against GitHub, first renewing the access
+ * token if it is near expiry. Returns undefined when the session is dead
+ * (the caller then logs out), which keeps a returning tab from running on
+ * an expired token.
+ * @returns Fresh User, or undefined on a dead session / network failure
  */
-export const revalidateUser = (): Promise<User | undefined> =>
-  pipe(
-    Option.fromNullable(loadToken()),
-    Option.match({
-      onNone: () => Effect.succeed<User | undefined>(undefined),
-      onSome: (t: string) =>
-        fetchAndCache(t).pipe(
-          Effect.catchAll(() => Effect.succeed<User | undefined>(undefined))
-        ),
-    }),
-    Effect.runPromise
-  )
+export const revalidateUser = async (): Promise<User | undefined> => {
+  const token = await ensureFreshToken()
+  return token ? tryFetch(token) : undefined
+}

--- a/src/composables/useAuth/session-meta.ts
+++ b/src/composables/useAuth/session-meta.ts
@@ -1,0 +1,50 @@
+/**
+ * Sidecar fields persisted beside the access token.
+ *
+ * Accepted tradeoff: the ~6-month refresh token lives in localStorage (an
+ * XSS payload gains long persistence). This is inherent to an SPA that
+ * drives client-side git with the GitHub token — there is no HttpOnly
+ * option for a token isomorphic-git must read — so it is documented rather
+ * than avoided.
+ */
+export interface SessionMeta {
+  readonly refreshToken?: string
+  readonly expiresAt?: number
+  readonly refreshTokenExpiresAt?: number
+}
+
+const META_KEY = 'gh_session_meta'
+
+const isMeta = (value: unknown): value is SessionMeta =>
+  typeof value === 'object' && value !== null
+
+const parseMeta = (raw: string): SessionMeta => {
+  try {
+    const value: unknown = JSON.parse(raw)
+    return isMeta(value) ? value : {}
+  } catch {
+    return {}
+  }
+}
+
+/**
+ * Read the sidecar meta, tolerating absent or corrupt JSON.
+ * @returns The stored meta, or an empty object
+ */
+export const loadMeta = (): SessionMeta => {
+  const raw = localStorage.getItem(META_KEY)
+  return raw ? parseMeta(raw) : {}
+}
+
+/**
+ * Persist the sidecar meta.
+ * @param meta - Refresh material and expiry deadlines
+ */
+export const saveMeta = (meta: SessionMeta): void => {
+  localStorage.setItem(META_KEY, JSON.stringify(meta))
+}
+
+/** Remove the sidecar meta. */
+export const clearMeta = (): void => {
+  localStorage.removeItem(META_KEY)
+}

--- a/src/composables/useAuth/session-storage.test.ts
+++ b/src/composables/useAuth/session-storage.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { GitHubSession } from './session'
+import { clearSession, loadSession, saveSession } from './session-storage'
+
+const FULL: GitHubSession = {
+  accessToken: 'gho_a',
+  refreshToken: 'ghr_a',
+  expiresAt: 1_000_000,
+  refreshTokenExpiresAt: 2_000_000,
+}
+
+describe('session-storage', () => {
+  beforeEach(() => localStorage.clear())
+  afterEach(() => localStorage.clear())
+
+  it('round-trips a full session through both keys', () => {
+    saveSession(FULL)
+    expect(localStorage.getItem('gh_token')).toBe('gho_a')
+    expect(loadSession()).toEqual(FULL)
+  })
+
+  it('reads a legacy token (no sidecar meta) as non-expiring', () => {
+    localStorage.setItem('gh_token', 'legacy')
+    expect(loadSession()).toEqual({ accessToken: 'legacy' })
+  })
+
+  it('overwrites stale refresh material when a bare token is saved', () => {
+    saveSession(FULL)
+    saveSession({ accessToken: 'plain' })
+    expect(loadSession()).toEqual({ accessToken: 'plain' })
+  })
+
+  it('survives corrupt meta JSON', () => {
+    localStorage.setItem('gh_token', 'tok')
+    localStorage.setItem('gh_session_meta', '{not json')
+    expect(loadSession()).toEqual({ accessToken: 'tok' })
+  })
+
+  it('clears both the token and its sidecar meta', () => {
+    saveSession(FULL)
+    clearSession()
+    expect(loadSession()).toBeUndefined()
+    expect(localStorage.getItem('gh_session_meta')).toBeNull()
+  })
+})

--- a/src/composables/useAuth/session-storage.ts
+++ b/src/composables/useAuth/session-storage.ts
@@ -1,0 +1,61 @@
+import { deleteCookie, readCookie } from './cookie-token'
+import type { GitHubSession } from './session'
+import { clearMeta, loadMeta, saveMeta } from './session-meta'
+
+/*
+ * The access token stays under the historical `gh_token` key so every
+ * existing reader (SW re-init, deploy status, RBAC calls, the route
+ * guard) keeps reading a plain string. The refresh material and expiry
+ * live in a sidecar meta key, so persisting a full session never changes
+ * the token key's contract.
+ */
+const TOKEN_KEY = 'gh_token'
+
+/**
+ * Persist a session: the access token under the legacy key, the refresh
+ * material alongside it. Overwrites any prior meta so a bare token
+ * (dev/mock/legacy) correctly clears stale refresh data.
+ * @param session - Session to store
+ */
+export const saveSession = (session: GitHubSession): void => {
+  localStorage.setItem(TOKEN_KEY, session.accessToken)
+  saveMeta({
+    refreshToken: session.refreshToken,
+    expiresAt: session.expiresAt,
+    refreshTokenExpiresAt: session.refreshTokenExpiresAt,
+  })
+}
+
+const adoptCookie = (token: string): string => {
+  localStorage.setItem(TOKEN_KEY, token)
+  deleteCookie(TOKEN_KEY)
+  return token
+}
+
+/*
+ * Legacy fallback: a token minted before the sidecar existed may live
+ * only in the parent-domain SSO cookie. Migrate it once into localStorage
+ * and expire the cookie (it is an XSS-exfiltration target).
+ */
+const loadRawToken = (): string | undefined => {
+  const stored = localStorage.getItem(TOKEN_KEY) ?? undefined
+  const fromCookie = stored ? undefined : (readCookie(TOKEN_KEY) ?? undefined)
+  return stored ?? (fromCookie ? adoptCookie(fromCookie) : undefined)
+}
+
+/**
+ * Reconstruct the stored session from the token key plus sidecar meta.
+ * A token with no meta reads back as a non-expiring session.
+ * @returns The session, or undefined when no token is stored
+ */
+export const loadSession = (): GitHubSession | undefined => {
+  const accessToken = loadRawToken()
+  return accessToken ? { accessToken, ...loadMeta() } : undefined
+}
+
+/** Remove the token, its sidecar meta, and the legacy cookie. */
+export const clearSession = (): void => {
+  localStorage.removeItem(TOKEN_KEY)
+  clearMeta()
+  deleteCookie(TOKEN_KEY)
+}

--- a/src/composables/useAuth/session.test.ts
+++ b/src/composables/useAuth/session.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canRefresh,
+  type GitHubSession,
+  needsRefresh,
+  sessionFromResponse,
+} from './session'
+
+const NOW = 1_000_000_000_000
+
+describe('sessionFromResponse', () => {
+  it('anchors relative lifetimes to now', () => {
+    const session = sessionFromResponse(
+      {
+        access_token: 'gho_a',
+        refresh_token: 'ghr_a',
+        expires_in: '28800',
+        refresh_token_expires_in: '15897600',
+      },
+      NOW
+    )
+    expect(session).toEqual<GitHubSession>({
+      accessToken: 'gho_a',
+      refreshToken: 'ghr_a',
+      expiresAt: NOW + 28_800 * 1000,
+      refreshTokenExpiresAt: NOW + 15_897_600 * 1000,
+    })
+  })
+
+  it('treats a token without expiry as non-expiring', () => {
+    const session = sessionFromResponse({ access_token: 'gho_a' }, NOW)
+    expect(session?.expiresAt).toBeUndefined()
+    expect(session?.refreshTokenExpiresAt).toBeUndefined()
+  })
+
+  it('returns undefined for an error payload', () => {
+    expect(
+      sessionFromResponse({ error: 'bad_verification_code' }, NOW)
+    ).toBeUndefined()
+  })
+})
+
+describe('needsRefresh', () => {
+  const base: GitHubSession = { accessToken: 'a', expiresAt: NOW + 60_000 }
+
+  it('is true inside the skew window', () => {
+    expect(needsRefresh(base, NOW, 120_000)).toBe(true)
+  })
+
+  it('is false with ample time left', () => {
+    expect(needsRefresh(base, NOW, 30_000)).toBe(false)
+  })
+
+  it('is false for a non-expiring session', () => {
+    expect(needsRefresh({ accessToken: 'a' }, NOW, 120_000)).toBe(false)
+  })
+})
+
+describe('canRefresh', () => {
+  it('requires a refresh token', () => {
+    expect(canRefresh({ accessToken: 'a' }, NOW)).toBe(false)
+  })
+
+  it('is true while the refresh token is alive', () => {
+    const session: GitHubSession = {
+      accessToken: 'a',
+      refreshToken: 'r',
+      refreshTokenExpiresAt: NOW + 1000,
+    }
+    expect(canRefresh(session, NOW)).toBe(true)
+  })
+
+  it('is false once the refresh token has expired', () => {
+    const session: GitHubSession = {
+      accessToken: 'a',
+      refreshToken: 'r',
+      refreshTokenExpiresAt: NOW - 1000,
+    }
+    expect(canRefresh(session, NOW)).toBe(false)
+  })
+})

--- a/src/composables/useAuth/session.ts
+++ b/src/composables/useAuth/session.ts
@@ -1,0 +1,88 @@
+/**
+ * A GitHub App user-to-server session. `accessToken` is the short-lived
+ * (~8h) token; `refreshToken` renews it; the `*ExpiresAt` fields are
+ * absolute epoch-ms deadlines. When the expiry fields are absent the
+ * token is treated as non-expiring (legacy tokens, or an App with token
+ * expiration opted out).
+ */
+export interface GitHubSession {
+  readonly accessToken: string
+  readonly refreshToken?: string
+  readonly expiresAt?: number
+  readonly refreshTokenExpiresAt?: number
+}
+
+/** The proxied `/api/oauth/token` response shape (scalars as strings). */
+export interface TokenResponse {
+  readonly access_token?: string
+  readonly refresh_token?: string
+  readonly expires_in?: string
+  readonly refresh_token_expires_in?: string
+  readonly error?: string
+}
+
+const deadline = (
+  seconds: string | undefined,
+  now: number
+): number | undefined =>
+  seconds === undefined ? undefined : now + Number(seconds) * 1000
+
+/**
+ * Build a session from a token response, anchoring relative lifetimes to
+ * `now`. Returns undefined when the response carries no access token
+ * (e.g. an error payload).
+ * @param response - Proxied token response
+ * @param now - Current epoch ms
+ * @returns The session, or undefined when unusable
+ */
+export const sessionFromResponse = (
+  response: TokenResponse,
+  now: number
+): GitHubSession | undefined =>
+  response.access_token
+    ? {
+        accessToken: response.access_token,
+        refreshToken: response.refresh_token,
+        expiresAt: deadline(response.expires_in, now),
+        refreshTokenExpiresAt: deadline(
+          response.refresh_token_expires_in,
+          now
+        ),
+      }
+    : undefined
+
+/**
+ * Whether the access token expires within `skewMs` and should be renewed
+ * proactively. Non-expiring sessions never need a refresh.
+ * @param session - Current session
+ * @param now - Current epoch ms
+ * @param skewMs - Renew-ahead window
+ * @returns True when a proactive refresh is due
+ */
+export const needsRefresh = (
+  session: GitHubSession,
+  now: number,
+  skewMs: number
+): boolean =>
+  session.expiresAt !== undefined && session.expiresAt - now <= skewMs
+
+/**
+ * Whether a refresh is still possible: a refresh token exists and has not
+ * itself expired.
+ * @param session - Current session
+ * @param now - Current epoch ms
+ * @returns True when the refresh token can be exchanged
+ */
+export const canRefresh = (session: GitHubSession, now: number): boolean =>
+  session.refreshToken !== undefined &&
+  (session.refreshTokenExpiresAt === undefined ||
+    session.refreshTokenExpiresAt > now)
+
+/**
+ * Whether the access token is already past its expiry (unusable now).
+ * @param session - Current session
+ * @param now - Current epoch ms
+ * @returns True when the access token has expired
+ */
+export const isExpired = (session: GitHubSession, now: number): boolean =>
+  session.expiresAt !== undefined && session.expiresAt <= now

--- a/src/composables/useAuth/token-storage.ts
+++ b/src/composables/useAuth/token-storage.ts
@@ -1,39 +1,23 @@
-import { deleteCookie, readCookie } from './cookie-token'
 import { clearProfile } from './profile-cache'
-
-const TOKEN_KEY = 'gh_token'
+import { clearSession, loadSession, saveSession } from './session-storage'
 
 /**
- * Save GitHub token to localStorage.
+ * Save a bare access token (dev/mock/legacy paths that have no refresh
+ * material). The OAuth flow persists a full session via saveSession.
  * @param token - GitHub access token
  */
 export const saveToken = (token: string): void => {
-  localStorage.setItem(TOKEN_KEY, token)
+  saveSession({ accessToken: token })
 }
 
 /**
- * Load GitHub token from localStorage or cookie fallback.
- * When found in cookie, persists to localStorage and expires the
- * cookie — the JS-readable copy must not linger as a second
- * exfiltration target after the one-time migration.
+ * Load the current access token.
  * @returns Token string or undefined
  */
-export const loadToken = (): string | undefined => {
-  const stored = localStorage.getItem(TOKEN_KEY) ?? undefined
-  if (stored) return stored
+export const loadToken = (): string | undefined => loadSession()?.accessToken
 
-  const fromCookie = readCookie(TOKEN_KEY)
-  if (fromCookie) {
-    saveToken(fromCookie)
-    deleteCookie(TOKEN_KEY)
-  }
-  return fromCookie
-}
-
-/**
- * Remove GitHub token from localStorage.
- */
+/** Remove the session (token + refresh material) and cached profile. */
 export const clearToken = (): void => {
-  localStorage.removeItem(TOKEN_KEY)
+  clearSession()
   clearProfile()
 }

--- a/src/stores/auth-refresh.test.ts
+++ b/src/stores/auth-refresh.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { startTokenRefresh } from '@/composables/useAuth/refresh-scheduler'
+import type { User } from '@/types/user'
+import { createRefreshManager } from './auth-refresh'
+
+vi.mock('@/composables/useAuth/refresh-scheduler', () => ({
+  startTokenRefresh: vi.fn(),
+}))
+
+const startMock = vi.mocked(startTokenRefresh)
+const user = (): User => ({
+  username: 'u',
+  name: 'U',
+  avatar: 'a',
+  accessToken: 't',
+})
+
+describe('createRefreshManager', () => {
+  const stop = vi.fn()
+
+  beforeEach(() => {
+    startMock.mockReset()
+    stop.mockReset()
+    startMock.mockReturnValue(stop)
+  })
+
+  it('starts the scheduler once across repeated logged-in updates', () => {
+    const manage = createRefreshManager({
+      onRefreshed: vi.fn(),
+      onDead: vi.fn(),
+    })
+    manage(user())
+    manage(user())
+    expect(startMock).toHaveBeenCalledOnce()
+  })
+
+  it('halts the scheduler on logout and can restart afterwards', () => {
+    const manage = createRefreshManager({
+      onRefreshed: vi.fn(),
+      onDead: vi.fn(),
+    })
+    manage(user())
+    manage(null)
+    expect(stop).toHaveBeenCalledOnce()
+    manage(user())
+    expect(startMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does nothing when logged out from the start', () => {
+    const manage = createRefreshManager({
+      onRefreshed: vi.fn(),
+      onDead: vi.fn(),
+    })
+    manage(null)
+    expect(startMock).not.toHaveBeenCalled()
+    expect(stop).not.toHaveBeenCalled()
+  })
+})

--- a/src/stores/auth-refresh.ts
+++ b/src/stores/auth-refresh.ts
@@ -1,0 +1,28 @@
+import {
+  type RefreshHooks,
+  startTokenRefresh,
+} from '@/composables/useAuth/refresh-scheduler'
+import type { User } from '@/types/user'
+
+/**
+ * Keep the proactive token-refresh scheduler running exactly while a user
+ * is authenticated. Starting on login and halting on logout avoids
+ * spurious refresh attempts — and logout loops — while signed out.
+ * @param hooks - Refresh/dead callbacks driven by the scheduler
+ * @returns A watcher to register against the user ref
+ */
+export const createRefreshManager = (
+  hooks: RefreshHooks
+): ((user: User | null) => void) => {
+  let stop: (() => void) | undefined
+  const start = (): void => {
+    stop ??= startTokenRefresh(hooks)
+  }
+  const halt = (): void => {
+    stop?.()
+    stop = undefined
+  }
+  return (user: User | null): void => {
+    void (user ? start() : halt())
+  }
+}

--- a/src/stores/auth-user-sync.ts
+++ b/src/stores/auth-user-sync.ts
@@ -1,0 +1,45 @@
+import { type Ref, watch } from 'vue'
+import type { User } from '@/types/user'
+import { createRefreshManager } from './auth-refresh'
+import { syncTokenToSW } from './auth-sync-sw'
+
+interface UserSyncDeps {
+  readonly user: Ref<User | null>
+  readonly setUser: (u: User | null) => void
+  readonly logout: () => void
+}
+
+/*
+ * A rotated token is applied through setUser so the user watcher re-inits
+ * the Service Worker with it; skip no-op updates to avoid a spurious SW
+ * re-init and audit record.
+ */
+const buildApplyToken =
+  (deps: UserSyncDeps) =>
+  (token: string): void => {
+    const current = deps.user.value
+    void (current && token !== current.accessToken
+      ? deps.setUser({ ...current, accessToken: token })
+      : undefined)
+  }
+
+/**
+ * Wire the authenticated-user side effects: mirror the token to the
+ * Service Worker on every change, and keep the proactive refresh scheduler
+ * running while signed in (renewed tokens flow back through setUser).
+ * @param deps - User ref plus setUser/logout actions
+ */
+export const installUserSync = (deps: UserSyncDeps): void => {
+  const manageRefresh = createRefreshManager({
+    onRefreshed: buildApplyToken(deps),
+    onDead: deps.logout,
+  })
+  watch(
+    deps.user,
+    u => {
+      syncTokenToSW(u)
+      manageRefresh(u)
+    },
+    { immediate: true }
+  )
+}

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,11 +1,11 @@
 import { defineStore } from 'pinia'
 import type { Ref } from 'vue'
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import { loadToken } from '@/composables/useAuth/token-storage'
 import type { User } from '@/types/user'
 import { createLogout, createSetUser } from './auth-actions'
 import { createCheckAuth } from './auth-check'
-import { syncTokenToSW } from './auth-sync-sw'
+import { installUserSync } from './auth-user-sync'
 import {
   clearSsoRolesStorage,
   loadSsoRoles,
@@ -34,12 +34,12 @@ export const useAuthStore = defineStore('auth', () => {
   const error = ref<string | null>(null)
   const ssoRoles = ref<readonly string[]>(loadSsoRoles())
 
-  watch(user, syncTokenToSW, { immediate: true })
-
   const logout = createLogout(user, loading)
   const checkAuth = createCheckAuth(user, loading, logout)
   const setUser = createSetUser(user)
   const ssoActions = buildSsoActions(ssoRoles)
+
+  installUserSync({ user, setUser, logout })
 
   return {
     user,


### PR DESCRIPTION
Promote to prod: the full GitHub App user-to-server **token refresh lifecycle** that stops editors' 8h tokens from dying (root cause: the App issues expiring tokens + a refresh_token, which the code discarded).

- **#378** — proxy relays/accepts the refresh grant; client stores a session with expiry in a sidecar key and renews it proactively (scheduler) + reactively, single-flight, honest re-login on a dead session.
- **#379** — regression fix: mock/dev init stays unauthenticated until a session exists.

Verified: `validate` green, 1264 unit tests green, full `e2e` suite green on the develop deploy, prod-bundle smoke green (after a flaky re-run). Dev (dev-admin.comprom.org) deployed for editor verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbzLcqvQ76TaBK2dEYsvhZ