### PR TITLE
Redesign: real OAuth login in the new UI

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -3,6 +3,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { navItems, groups, canSee, type AuthState } from './nav.js';
 import { screens } from './screens/index.js';
 import { createGitStateStore, type GitStateStore, type SyncStatus } from './engine/git-state.js';
+import { login, currentUser } from './engine/auth.js';
+import { bootEngine } from './engine/engine-boot.js';
 
 /**
  * The admin app shell (app-shell spec R1–R7): a client-side SPA island that owns
@@ -256,6 +258,12 @@ export class AppShell extends LitElement {
   /** Derived sync-status descriptor (design-system tone + label). */
   @state() private sync: SyncStatus = { tone: 'success', label: 'синхронизировано' };
 
+  /** Signed-in GitHub login, or undefined when signed out. */
+  @state() private account?: string;
+
+  /** True while an OAuth login popup is in flight. */
+  @state() private loggingIn = false;
+
   override connectedCallback(): void {
     super.connectedCallback();
     const theme = document.documentElement.getAttribute('data-theme');
@@ -263,6 +271,7 @@ export class AppShell extends LitElement {
     this.store = createGitStateStore();
     this.store.subscribe(() => (this.sync = this.store?.syncStatus() ?? this.sync));
     this.sync = this.store.syncStatus();
+    void this.resolveAccount();
     this.syncRoute();
     window.addEventListener('hashchange', this.syncRoute);
   }
@@ -343,6 +352,22 @@ export class AppShell extends LitElement {
     `;
   }
 
+  /** Resolves an existing session on load (populates the account name). */
+  private async resolveAccount(): Promise<void> {
+    const user = await currentUser();
+    this.account = user?.username;
+  }
+
+  /** Runs the OAuth login, then boots the engine with the fresh token. */
+  private async handleLogin(): Promise<void> {
+    this.loggingIn = true;
+    const user = await login();
+    this.loggingIn = false;
+    if (user === undefined) return;
+    this.account = user.username;
+    await bootEngine(user.accessToken);
+  }
+
   override render() {
     const screen = screens[this.route];
     return html`
@@ -361,7 +386,14 @@ export class AppShell extends LitElement {
         </a>
         <div class="header-right">
           <cp-status state=${this.sync.tone} label=${this.sync.label}></cp-status>
-          <span class="account">${this.auth.login}</span>
+          ${this.account
+            ? html`<span class="account">${this.account}</span>`
+            : html`<cp-button
+                size="sm"
+                ?loading=${this.loggingIn}
+                @cp-click=${() => this.handleLogin()}
+                >Войти</cp-button
+              >`}
           <button class="icon-btn" aria-label="Переключить тему" @click=${() => this.toggleTheme()}>
             <cp-icon name="sun"></cp-icon>
           </button>

--- a/src/redesign/engine/auth.ts
+++ b/src/redesign/engine/auth.ts
@@ -1,0 +1,51 @@
+import type { User } from '@/types/user';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+import { fetchGitHubUser } from '@/composables/useAuth/fetch-github-user';
+import { saveToken } from '@/composables/useAuth/token-storage';
+import { buildAuthorizeUrl } from '@/composables/useOAuthPopup/authorize-url';
+import { createMessageHandler } from '@/composables/useOAuthPopup/handlers';
+import { createPopupMonitor } from '@/composables/useOAuthPopup/popup-monitor';
+import { createPopupWindow } from '@/composables/useOAuthPopup/popup-window';
+
+/**
+ * Real authentication for the redesigned UI (auth spec), reusing the current
+ * admin's proven OAuth building blocks (same GitHub App, same registered
+ * callback) — no Vue. `login()` runs the popup flow and resolves with the
+ * authenticated user; `currentUser()` resolves an existing session on load.
+ */
+
+/** Runs the GitHub OAuth popup and resolves with the user, or undefined on cancel/error. */
+export const login = (): Promise<User | undefined> =>
+  new Promise((resolve) => {
+    void buildAuthorizeUrl().then((url) => {
+      const popup = createPopupWindow(url);
+      const cleanup = (): void => {
+        globalThis.removeEventListener('message', handleMessage);
+        popup?.close();
+      };
+      const handleMessage = createMessageHandler(
+        (user) => {
+          saveToken(user.accessToken);
+          resolve(user);
+        },
+        () => resolve(undefined),
+        cleanup,
+      );
+      globalThis.addEventListener('message', handleMessage);
+      createPopupMonitor(popup, () => {
+        globalThis.removeEventListener('message', handleMessage);
+        resolve(undefined);
+      });
+    });
+  });
+
+/** Resolves the current session's user (fresh token), or undefined if signed out. */
+export const currentUser = async (): Promise<User | undefined> => {
+  const token = await ensureFreshToken();
+  if (token === null || token === undefined) return undefined;
+  try {
+    return await fetchGitHubUser(token);
+  } catch {
+    return undefined;
+  }
+};

--- a/src/redesign/tsconfig.json
+++ b/src/redesign/tsconfig.json
@@ -7,7 +7,12 @@
     "useDefineForClassFields": false,
     "strict": true,
     "verbatimModuleSyntax": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "@/*": ["../*"],
+      "@communist-prometheus/cp-components": ["../../vendor/cp-components/dist/index.d.ts"],
+      "@communist-prometheus/cp-components/*": ["../../vendor/cp-components/dist/*"]
+    }
   },
   "include": ["**/*.ts"],
   "exclude": ["**/*.test.ts"]


### PR DESCRIPTION
Adds a real «Войти» login to the deployed /redesign so it runs on real repo data (reuses the current admin's OAuth flow). Signed out shows a login button; signed in boots the git engine with the session token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbzLcqvQ76TaBK2dEYsvhZ