### PR TITLE
Redesign becomes the dev admin root (/)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "validate": "bun run type-check && bun run check:ci && bun run lint:sonar && bun run lint:jsdoc && bun run lint:vue-depth && bun run lint:css",
     "build": "bun run validate && bun run build:client && bun run build:redesign && bun run build:sw",
     "build:client": "vite build --outDir dist/client",
-    "build:redesign": "vite build --config vite.redesign.config.ts",
+    "build:redesign": "vite build --config vite.redesign.config.ts && bun scripts/redesign-as-index.ts",
     "build:sw": "vite build --config vite.sw.config.ts && bun scripts/verify-sw-browser-safe.ts",
     "build:e2e": "cross-env VITE_MOCK_AUTH=true bun run build:client && cross-env MOCK_OAUTH=true bun run build:sw",
     "build:realmode": "cross-env VITE_GITHUB_OWNER=communist-prometheus VITE_GITHUB_REPO=admin-e2e-sandbox VITE_GITHUB_BRANCH=main bun run build:client && cross-env VITE_GITHUB_OWNER=communist-prometheus VITE_GITHUB_REPO=admin-e2e-sandbox VITE_GITHUB_BRANCH=main bun run build:sw",

--- a/redesign.html
+++ b/redesign.html
@@ -16,7 +16,6 @@
     </script>
   </head>
   <body>
-    <app-shell></app-shell>
     <script type="module" src="/src/redesign/main.ts"></script>
   </body>
 </html>

--- a/scripts/redesign-as-index.ts
+++ b/scripts/redesign-as-index.ts
@@ -1,0 +1,9 @@
+import { copyFileSync } from 'node:fs'
+
+/**
+ * Promote the redesigned app to the site root: overwrite dist/client/index.html
+ * with the redesign's HTML so `/` serves the new admin (the previous app's
+ * assets remain but nothing points at them). Runs after build:redesign.
+ */
+copyFileSync('dist/client/redesign.html', 'dist/client/index.html')
+console.log('redesign promoted to dist/client/index.html')

--- a/src/redesign/engine/oauth-callback.ts
+++ b/src/redesign/engine/oauth-callback.ts
@@ -1,0 +1,39 @@
+import { completeCallback } from '@/composables/useAuth/complete-callback';
+import { TRUSTED_ORIGINS } from '@/composables/useOAuthPopup/trusted-origins';
+
+/**
+ * OAuth popup-callback handler for the redesigned app (auth spec). When the
+ * redesign is the root app, GitHub redirects the login popup to
+ * `/auth/github/callback` — this must complete the PKCE exchange and post the
+ * token back to the opener, exactly as the previous Vue callback view did.
+ * Reuses the framework-agnostic `completeCallback` + trusted-origin allowlist.
+ */
+
+/** The registered OAuth callback path (matches config/auth.ts). */
+const CALLBACK_PATH = '/auth/github/callback';
+
+/** Posts the token to the opener across trusted origins, then closes the popup. */
+const notifyOpener = (token: string): void => {
+  const message = { type: 'github-oauth-success', token };
+  const targets = new Set([...TRUSTED_ORIGINS, globalThis.location.origin]);
+  for (const target of targets) globalThis.opener?.postMessage(message, target);
+  globalThis.close();
+};
+
+/**
+ * If the current page is the OAuth callback, completes it and returns true (the
+ * caller must NOT mount the app — this window is the popup). Otherwise false.
+ */
+export const handleOAuthCallbackIfPresent = async (): Promise<boolean> => {
+  if (globalThis.location.pathname !== CALLBACK_PATH) return false;
+  const params = new URLSearchParams(globalThis.location.search);
+  const code = params.get('code') ?? undefined;
+  const state = params.get('state') ?? undefined;
+  try {
+    const token = await completeCallback(code, state);
+    globalThis.opener ? notifyOpener(token) : globalThis.location.replace('/');
+  } catch {
+    globalThis.document.body.textContent = 'Ошибка авторизации. Закройте окно и попробуйте снова.';
+  }
+  return true;
+};

--- a/src/redesign/main.ts
+++ b/src/redesign/main.ts
@@ -1,18 +1,21 @@
 /**
- * Entry for the redesigned admin shell preview. Loads the generated theme layer,
- * registers the design-system primitives, resolves the initial theme
- * (localStorage → OS preference, explicit so the toggle is authoritative), and
- * boots the `app-shell` island. Runs alongside the current app without touching
- * it; the formal cutover replaces the old entry later.
+ * Entry for the redesigned admin. When served at the OAuth callback path this
+ * window is the login popup — it completes the exchange, posts the token to the
+ * opener, and closes without mounting the app. Otherwise it mounts the shell and
+ * boots the git engine from the dev token (local) or the OAuth session
+ * (deployed). The initial theme is set inline in the HTML <head> before this
+ * module so first paint is themed (no FOUC).
  */
 import '../styles/theme.css';
 import '@communist-prometheus/cp-components';
 import './app-shell.js';
 import { bootEngineIfTokenPresent } from './engine/engine-boot.js';
+import { handleOAuthCallbackIfPresent } from './engine/oauth-callback.js';
 
-// In local `dev:token` mode (VITE_DEV_TOKEN set), register + init the real
-// content engine so screens run against actual GitHub; a no-op otherwise.
-void bootEngineIfTokenPresent();
+const boot = async (): Promise<void> => {
+  if (await handleOAuthCallbackIfPresent()) return;
+  document.body.appendChild(document.createElement('app-shell'));
+  await bootEngineIfTokenPresent();
+};
 
-// The initial theme is set inline in redesign.html <head> before this module so
-// the shell mirrors it on connect and first paint is themed (no FOUC).
+void boot();


### PR DESCRIPTION
Makes the redesign the app served at `/` on dev, replacing the old admin. OAuth callback handled inside the redesign so login still works. Old Vue assets remain unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbzLcqvQ76TaBK2dEYsvhZ