### PR TITLE
redesign: white side-lines fix + remove demo data everywhere

### DIFF
--- a/src/redesign/main.ts
+++ b/src/redesign/main.ts
@@ -7,6 +7,7 @@
  * module so first paint is themed (no FOUC).
  */
 import '../styles/theme.css';
+import './styles/base.css';
 import './styles/view-transition.css';
 import '@communist-prometheus/cp-components';
 import './app-shell.js';

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -66,31 +66,6 @@ const RUBRIC_OPTIONS: readonly CpSelectOption[] = [
 /** The real publish pipeline stages, mapped to `stageFile` + `commitAndPush`. */
 const REAL_STAGES: readonly string[] = ['Стейдж', 'Коммит', 'Пуш'];
 
-/**
- * Demo article used when the git engine is off (no `dev:token`): a complete
- * markdown document (frontmatter + body) so the live-preview still renders and
- * the publish dialog can simulate the staged pipeline without any real call.
- */
-const DEMO_MARKDOWN = `---
-title: "Иллюзия социализма и реальность капитала в СССР"
-topic: theory
-pubDate: 2026-07-24
-draft: true
----
-
-Отношение к средствам производства определяет класс. Но на макроуровне динамика производства неизбежно ведёт к концентрации богатства и обнажает пределы «планового» хозяйства.
-
-Хотя уровень дохода — необходимый критерий классовой принадлежности **больших социальных групп**, его нельзя напрямую применять к отдельному индивиду: класс определяется местом в системе производства, а не размером зарплаты.
-
-## Государство как совокупный капиталист
-
-Национализация средств производства не отменяет капитала как отношения. Пока сохраняются наёмный труд, товарная форма продукта и накопление ради накопления, «общенародная собственность» остаётся коллективной собственностью бюрократии.
-
-> «Накопление богатства на одном полюсе есть в то же время накопление нищеты, муки труда и моральной деградации на противоположном полюсе».
-
-Именно поэтому мы публикуем этот перевод: он принадлежит к теоретическому наследию марксизма[^24], а не к его апологетическим подделкам.
-`;
-
 /** Reads a single frontmatter scalar (`key: value`) from a text block. */
 const frontmatterValue = (text: string, key: string): string | undefined => {
   const match = text.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
@@ -504,7 +479,8 @@ export class ScreenEditor extends LitElement {
         return;
       }
     }
-    this.applyMarkdown(DEMO_MARKDOWN, '', false);
+    // No real article (signed out or empty repo): stay empty and prompt sign-in
+    // rather than loading a fabricated demo document.
     this.loaded = true;
   }
 
@@ -632,11 +608,7 @@ export class ScreenEditor extends LitElement {
     this.publishOpen = true;
     this.publishSha = '';
     this.publishError = '';
-    if (this.live && this.articlePath !== '') {
-      void this.runRealPublish();
-    } else {
-      this.runDemoPublish();
-    }
+    void this.runRealPublish();
   };
 
   /** Runs the REAL git cycle: stage the edited markdown, then commit + push. */
@@ -662,23 +634,6 @@ export class ScreenEditor extends LitElement {
     }
     this.publishBusy = false;
   }
-
-  /** Demo mode: simulate the staged pipeline with no real calls. */
-  private runDemoPublish(): void {
-    this.publishBusy = true;
-    this.simulateStage(0);
-  }
-
-  private simulateStage = (index: number): void => {
-    this.stageStates = REAL_STAGES.map((_label, position) =>
-      position < index ? 'done' : position === index ? 'running' : 'pending',
-    );
-    if (index >= REAL_STAGES.length) {
-      this.publishBusy = false;
-      return;
-    }
-    globalThis.setTimeout(() => this.simulateStage(index + 1), 900);
-  };
 
   private closePublish = (): void => {
     if (this.publishBusy) return;
@@ -834,11 +789,7 @@ export class ScreenEditor extends LitElement {
       >`;
     }
     return html`<p class="dialog-note">
-      ${this.live
-        ? html`Файл <code>${this.articlePath}</code> будет застейджен, закоммичен и запушен через
-            git-движок.`
-        : html`Демо-режим: шаги имитируются без реальных вызовов. Запустите dev:token с токеном,
-            чтобы публиковать по-настоящему.`}
+      Файл <code>${this.articlePath}</code> будет застейджен, закоммичен и запушен через git-движок.
     </p>`;
   }
 
@@ -864,18 +815,29 @@ export class ScreenEditor extends LitElement {
   }
 
   override render(): TemplateResult {
+    if (!this.live) {
+      return html`
+        <article class="ed">
+          <div class="head">
+            <p class="eyebrow">Контент · редактор</p>
+            <h1 class="title" tabindex="-1">Редактор</h1>
+          </div>
+          <p class="hint">
+            ${this.loaded
+              ? 'Войдите через GitHub, чтобы открыть материалы репозитория для правки.'
+              : 'Загружаем материал…'}
+          </p>
+        </article>
+      `;
+    }
     return html`
       <article class="ed">
         <div class="head">
-          <p class="eyebrow">Контент · ${this.live ? this.slug : 'демо-материал'} · черновик</p>
+          <p class="eyebrow">Контент · ${this.slug} · черновик</p>
           <h1 class="title" tabindex="-1">
             ${this.articleTitle === '' ? 'Без названия' : this.articleTitle}
           </h1>
-          ${this.live
-            ? html`<cp-tag tone="success">данные из репозитория</cp-tag>`
-            : this.loaded
-              ? html`<cp-tag tone="neutral">демо-данные</cp-tag>`
-              : nothing}
+          <cp-tag tone="success">данные из репозитория</cp-tag>
         </div>
         <cp-tabs
           .tabs=${LANG_TABS}
@@ -894,10 +856,8 @@ export class ScreenEditor extends LitElement {
           <span class="draft">несохранённые правки</span>
           <span aria-hidden="true">·</span>
           <span>${this.activeLang}</span>
-          ${this.live
-            ? html`<span aria-hidden="true">·</span>
-                <span class="path">${this.articlePath}</span>`
-            : nothing}
+          <span aria-hidden="true">·</span>
+          <span class="path">${this.articlePath}</span>
         </p>
       </article>
       ${this.renderProps()}${this.renderPublishDialog()}

--- a/src/redesign/screens/screen-magazine.ts
+++ b/src/redesign/screens/screen-magazine.ts
@@ -115,29 +115,6 @@ const readLangCode = (detail: unknown): LangCode | undefined => {
   return isLangCode(detail.id) ? detail.id : undefined;
 };
 
-/** Representative seed content shown when the content engine is not running. */
-const SAMPLE_LANGUAGES: readonly LangSources[] = [
-  {
-    code: 'ru',
-    name: 'Русский',
-    files: [
-      { name: 'magazine-1-mai-2026.ru.pdf', path: 'magazine/magazine-1-mai-2026.ru.pdf', kind: 'pdf' },
-      { name: 'magazine-1-mai-2026.ru.fb2', path: 'magazine/magazine-1-mai-2026.ru.fb2', kind: 'fb2' },
-      { name: 'cover.ru.png', path: 'magazine/cover.ru.png', kind: 'cover' },
-      { name: 'index.ru.md', path: 'magazine/index.ru.md', kind: 'index' },
-    ],
-  },
-  {
-    code: 'en',
-    name: 'English',
-    files: [
-      { name: 'magazine-1-mai-2026.en.pdf', path: 'magazine/magazine-1-mai-2026.en.pdf', kind: 'pdf' },
-    ],
-  },
-  { code: 'es', name: 'Español', files: [] },
-  { code: 'it', name: 'Italiano', files: [] },
-];
-
 /**
  * The "Загрузка журнала" screen (content-editor (magazine), design.md R5),
  * driven by the REAL cloned content repo. On connect it lists `magazine/` via
@@ -286,14 +263,14 @@ export class ScreenMagazine extends LitElement {
     this.loaded = true;
   }
 
-  /** True when the panel reflects real repo files rather than the sample. */
+  /** True when the panel reflects real repo files. */
   private get live(): boolean {
     return this.languages.length > 0;
   }
 
-  /** The effective list: real repo data when live, otherwise the sample. */
+  /** The real repo data (empty until the engine has loaded the listing). */
   private get list(): readonly LangSources[] {
-    return this.live ? this.languages : SAMPLE_LANGUAGES;
+    return this.languages;
   }
 
   /** The currently selected language row (falls back to the first). */
@@ -366,31 +343,34 @@ export class ScreenMagazine extends LitElement {
     const slug = issueSlug(this.list);
     return html`
       <header class="head">
-        <p class="eyebrow">magazine · ${slug ?? 'новый выпуск'}</p>
+        <p class="eyebrow">magazine · ${this.live ? (slug ?? 'новый выпуск') : ''}</p>
         <h1 tabindex="-1">Загрузка журнала</h1>
-        ${this.live
-          ? html`<cp-tag tone="success">данные из репозитория</cp-tag>`
-          : this.loaded
-            ? html`<cp-tag tone="neutral">демо-данные</cp-tag>`
-            : nothing}
       </header>
 
-      <h2 class="section-label">Источники по языкам</h2>
-      <cp-tabs
-        .tabs=${this.tabs}
-        active=${this.selected}
-        aria-label="Язык источника"
-        @cp-tab-change=${this.onTabChange}
-      ></cp-tabs>
+      ${this.live
+        ? html`
+            <h2 class="section-label">Источники по языкам</h2>
+            <cp-tabs
+              .tabs=${this.tabs}
+              active=${this.selected}
+              aria-label="Язык источника"
+              @cp-tab-change=${this.onTabChange}
+            ></cp-tabs>
 
-      ${this.renderSource(this.current)}
+            ${this.renderSource(this.current)}
 
-      <div class="actions">
-        <p class="status-line">${this.statusLine}</p>
-        <span class="spacer"></span>
-        <cp-button variant="secondary">Сохранить черновик</cp-button>
-        <cp-button arrow>Опубликовать готовые</cp-button>
-      </div>
+            <div class="actions">
+              <p class="status-line">${this.statusLine}</p>
+              <span class="spacer"></span>
+              <cp-button variant="secondary">Сохранить черновик</cp-button>
+              <cp-button arrow>Опубликовать готовые</cp-button>
+            </div>
+          `
+        : html`<p class="empty">
+            ${this.loaded
+              ? 'Войдите через GitHub, чтобы загрузить файлы выпусков из репозитория.'
+              : 'Загружаем выпуски…'}
+          </p>`}
     `;
   }
 }

--- a/src/redesign/screens/screen-members.ts
+++ b/src/redesign/screens/screen-members.ts
@@ -88,14 +88,6 @@ export class ScreenMembers extends LitElement {
     this.loaded = true;
   }
 
-  private sample(): readonly Member[] {
-    return [
-      { login: 'red-october', role: 'Владелец', avatar: '' },
-      { login: 'praxis-editor', role: 'Редактор', avatar: '' },
-      { login: 'observer-13', role: 'Наблюдатель', avatar: '' },
-    ];
-  }
-
   private static readonly columns: readonly CpTableColumn[] = [
     { key: 'login', label: 'Логин' },
     { key: 'role', label: 'Роль' },
@@ -127,32 +119,25 @@ export class ScreenMembers extends LitElement {
 
   override render() {
     const live = this.members.length > 0;
-    const list = live ? this.members : this.sample();
-    const rows = list.map((member) => this.toRow(member));
+    const rows = this.members.map((member) => this.toRow(member));
     return html`
       <div class="head">
         <p class="eyebrow">Сообщество · роли и доступ</p>
         <h1 tabindex="-1">Участники</h1>
         <cp-button variant="primary" arrow>Пригласить</cp-button>
-        ${live
-          ? html`<cp-tag tone="success">данные из репозитория</cp-tag>`
-          : this.loaded
-            ? html`<cp-tag tone="neutral">демо-данные</cp-tag>`
-            : nothing}
       </div>
-      <cp-table
-        rowKey="login"
-        caption="Участники репозитория"
-        .columns=${[...ScreenMembers.columns]}
-        .rows=${rows}
-      ></cp-table>
-      <p class="note">
-        ${live
-          ? `Прочитано из GitHub — ${list.length} ${
-              list.length === 1 ? 'участник' : 'участников'
-            } реального репозитория.`
-          : 'Запустите dev:token с токеном, дающим доступ к коллабораторам, чтобы увидеть реальных участников.'}
-      </p>
+      ${live
+        ? html`<cp-table
+            rowKey="login"
+            caption="Участники репозитория"
+            .columns=${[...ScreenMembers.columns]}
+            .rows=${rows}
+          ></cp-table>`
+        : html`<p class="note">
+            ${this.loaded
+              ? 'Войдите через GitHub токеном с доступом к коллабораторам репозитория, чтобы увидеть участников.'
+              : 'Загружаем участников…'}
+          </p>`}
     `;
   }
 }

--- a/src/redesign/screens/screen-settings.ts
+++ b/src/redesign/screens/screen-settings.ts
@@ -86,26 +86,12 @@ export class ScreenSettings extends LitElement {
     this.loaded = true;
   }
 
-  private sample(): readonly SiteLanguage[] {
-    return [
-      { code: 'ru', label: 'Русский' },
-      { code: 'en', label: 'English' },
-      { code: 'it', label: 'Italiano' },
-    ];
-  }
-
   override render() {
     const live = this.languages.length > 0;
-    const list = live ? this.languages : this.sample();
     return html`
       <div class="head">
         <p class="eyebrow">Администрирование · языки сайта</p>
         <h1 tabindex="-1">Настройки</h1>
-        ${live
-          ? html`<cp-tag tone="success">данные из репозитория</cp-tag>`
-          : this.loaded
-            ? html`<cp-tag tone="neutral">демо-данные</cp-tag>`
-            : nothing}
       </div>
       <cp-tabs
         active="languages"
@@ -115,23 +101,27 @@ export class ScreenSettings extends LitElement {
           { id: 'themes', label: 'Темы' },
         ]}
       ></cp-tabs>
-      <div class="langs">
-        ${list.map(
-          (lang) => html`
-            <div class="lang">
-              <b>${lang.label}</b>
-              <span class="code">${lang.code}</span>
-              <cp-switch checked></cp-switch>
-            </div>
-          `,
-        )}
-      </div>
+      ${live
+        ? html`<div class="langs">
+            ${this.languages.map(
+              (lang) => html`
+                <div class="lang">
+                  <b>${lang.label}</b>
+                  <span class="code">${lang.code}</span>
+                  <cp-switch checked></cp-switch>
+                </div>
+              `,
+            )}
+          </div>`
+        : nothing}
       <p class="note">
         ${live
-          ? `Прочитано из settings/languages.json — ${list.length} ${
-              list.length === 1 ? 'язык' : 'языков'
+          ? `Прочитано из settings/languages.json — ${this.languages.length} ${
+              this.languages.length === 1 ? 'язык' : 'языков'
             } реального репозитория.`
-          : 'Запустите dev:token с токеном, чтобы увидеть реальные языки репозитория.'}
+          : this.loaded
+            ? 'Войдите через GitHub, чтобы увидеть языки сайта из репозитория.'
+            : 'Загружаем настройки…'}
       </p>
     `;
   }

--- a/src/redesign/screens/screen-tickets.ts
+++ b/src/redesign/screens/screen-tickets.ts
@@ -52,58 +52,6 @@ const toRow = (ticket: Ticket): CpTableRow => ({
   date: ticket.date,
 });
 
-/** Representative backlog for the local shell preview (no live issues). */
-const SAMPLE: readonly Ticket[] = [
-  {
-    number: 341,
-    title: 'Битые ссылки в архиве журнала за 2024 год',
-    state: 'open',
-    author: 'andswew',
-    date: '2026-07-29',
-    kind: 'bug',
-  },
-  {
-    number: 338,
-    title: 'Ошибка 500 при загрузке FB2 больше 10 МБ',
-    state: 'open',
-    author: 'undeadliner',
-    date: '2026-07-27',
-    kind: 'bug',
-  },
-  {
-    number: 335,
-    title: 'Планировщик отложенной публикации рассылки',
-    state: 'open',
-    author: 'undeadliner',
-    date: '2026-07-25',
-    kind: 'story',
-  },
-  {
-    number: 330,
-    title: 'Автосохранение черновиков каждые 30 секунд',
-    state: 'open',
-    author: 'newcomer',
-    date: '2026-07-18',
-    kind: 'story',
-  },
-  {
-    number: 322,
-    title: 'Тёмная тема: контраст плашек тем ниже AAA',
-    state: 'closed',
-    author: 'andswew',
-    date: '2026-07-21',
-    kind: 'bug',
-  },
-  {
-    number: 318,
-    title: 'Экспорт статьи в PDF для печати',
-    state: 'closed',
-    author: 'andswew',
-    date: '2026-07-10',
-    kind: 'other',
-  },
-];
-
 /**
  * Ticket tracker screen (tickets spec: tasks and bug-reports). When the dev
  * token is present (local dev:token), it reads the repo's real GitHub issues
@@ -213,39 +161,37 @@ export class ScreenTickets extends LitElement {
 
   override render() {
     const live = this.tickets.length > 0;
-    const source = live ? this.tickets : SAMPLE;
-    const visible = this.visible(source);
+    const visible = this.visible(this.tickets);
     const rows = visible.map(toRow);
     return html`
       <header class="head">
-        <p class="eyebrow">Задачи · ${visible.length} на экране</p>
+        <p class="eyebrow">Задачи${live ? html` · ${visible.length} на экране` : nothing}</p>
         <h1 tabindex="-1">Тикеты</h1>
         <cp-button>
           <cp-icon name="plus" size="18"></cp-icon>
           Новый тикет
         </cp-button>
-        ${live
-          ? html`<cp-tag tone="success">данные из репозитория</cp-tag>`
-          : this.loaded
-            ? html`<cp-tag tone="neutral">демо-данные</cp-tag>`
-            : nothing}
       </header>
 
-      <div class="toolbar">
-        <div class="tabs-scroll">
-          <cp-tabs
-            .tabs=${FILTERS}
-            active=${this.filter}
-            @cp-tab-change=${this.onFilterChange}
-          ></cp-tabs>
-        </div>
-      </div>
+      ${live
+        ? html`
+            <div class="toolbar">
+              <div class="tabs-scroll">
+                <cp-tabs
+                  .tabs=${FILTERS}
+                  active=${this.filter}
+                  @cp-tab-change=${this.onFilterChange}
+                ></cp-tabs>
+              </div>
+            </div>
 
-      <cp-table
-        caption="Тикеты и баг-репорты"
-        .columns=${COLUMNS}
-        .rows=${rows}
-      ></cp-table>
+            <cp-table caption="Тикеты и баг-репорты" .columns=${COLUMNS} .rows=${rows}></cp-table>
+          `
+        : html`<p class="eyebrow">
+            ${this.loaded
+              ? 'Войдите через GitHub, чтобы увидеть тикеты и баг-репорты репозитория.'
+              : 'Загружаем тикеты…'}
+          </p>`}
     `;
   }
 }

--- a/src/redesign/screens/screen-topics.ts
+++ b/src/redesign/screens/screen-topics.ts
@@ -29,39 +29,6 @@ const LANG_CODES: ReadonlySet<string> = new Set(LANGUAGES.map((tab) => tab.id));
 const isLangCode = (value: string): value is LangCode => LANG_CODES.has(value);
 
 /**
- * A small representative sample used only when the real content engine is off
- * (no `dev:token`), so the preview still renders instead of showing nothing.
- */
-const SAMPLE_TOPICS: readonly Topic[] = [
-  {
-    key: 'editorial',
-    color: '#b03a2e',
-    name: {
-      ru: 'От редакции',
-      en: 'Editorial',
-      it: 'Dalla redazione',
-      es: 'De la redacción',
-      bl: 'От редакцията',
-      pl: 'Od redakcji',
-      uk: 'Від редакції',
-    },
-  },
-  {
-    key: 'translation',
-    color: '#2563eb',
-    name: {
-      ru: 'Наш перевод',
-      en: 'Our translation',
-      it: 'La nostra traduzione',
-      es: 'Nuestra traducción',
-      bl: 'Наш превод',
-      pl: 'Nasze tłumaczenie',
-      uk: 'Наш переклад',
-    },
-  },
-];
-
-/**
  * Topics screen (settings spec: the "Темы" subpanel). When the real content
  * engine is running (local `dev:token`), it reads the repo's
  * `settings/topics.json` and lists the ACTUAL topics — colour, per-language name
@@ -141,7 +108,6 @@ export class ScreenTopics extends LitElement {
       border: 1px solid var(--color-hairline);
       border-inline-start: 4px solid var(--tc, var(--color-accent));
       border-radius: var(--radius-md);
-      box-shadow: var(--shadow-sm);
     }
 
     .thead {

--- a/src/redesign/styles/base.css
+++ b/src/redesign/styles/base.css
@@ -1,0 +1,20 @@
+/*
+ * Base reset for the redesigned admin. The browser's default 8px body margin,
+ * combined with a transparent html/body background, leaked the white page
+ * backdrop as vertical strips down both sides of the dark app. Kill the margin
+ * and paint the themed background across the whole viewport so the shell reaches
+ * edge to edge in every theme.
+ */
+html {
+  background: var(--color-background);
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-background);
+  color: var(--color-text-primary);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}


### PR DESCRIPTION
- base.css resets the default 8px body margin + paints the themed background — kills the white vertical strips leaking down both sides of the dark app.
- Removes the sample/demo fallback from every screen (members, topics, magazine, tickets, settings, editor); signed out shows a sign-in prompt, never fabricated data.

Verified locally on mobile dark: no side lines, real repo data, subtle site-matched cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbzLcqvQ76TaBK2dEYsvhZ