### PR TITLE
admin fixes: auth gating, sticky panels, real deploys board, OAuth logging

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -47,10 +47,12 @@ export class AppShell extends LitElement {
       position: sticky;
       top: 0;
       z-index: 10;
+      box-sizing: border-box;
+      height: var(--app-header-h);
       display: flex;
       align-items: center;
       gap: var(--spacing-md);
-      padding: 0.7rem var(--spacing-md);
+      padding: 0 var(--spacing-md);
       background: var(--color-background);
       border-bottom: 1px solid var(--color-hairline);
     }
@@ -390,8 +392,17 @@ export class AppShell extends LitElement {
   private dragStartX = 0;
   private dragStartY = 0;
 
-  /** Mock session for the local preview — replaced by real auth later. */
-  private auth: AuthState = { role: 'admin', owner: true, login: 'undeadliner' };
+  /**
+   * The session as the nav gating consumes it, derived from the real login —
+   * `undefined` when signed out (so the menu is empty and screens are gated).
+   * Every signed-in maintainer currently gets the full admin/owner surface;
+   * finer role resolution is owned by the auth/RBAC spec.
+   */
+  private get auth(): AuthState | undefined {
+    return this.account === undefined
+      ? undefined
+      : { role: 'admin', owner: true, login: this.account };
+  }
 
   /** Live git-engine state store; drives the header sync-status affordance. */
   private store?: GitStateStore;
@@ -590,7 +601,9 @@ export class AppShell extends LitElement {
 
   /** Grouped, role-gated nav items — shared by the desktop rail + FAB popup. */
   private renderNavItems() {
-    const visible = navItems.filter((item) => canSee(item, this.auth));
+    const auth = this.auth;
+    if (auth === undefined) return nothing;
+    const visible = navItems.filter((item) => canSee(item, auth));
     return groups.map(([key, label]) => {
       const items = visible.filter((item) => item.group === key);
       return items.length === 0
@@ -679,13 +692,15 @@ export class AppShell extends LitElement {
     await bootEngine(token);
   }
 
-  /** Runs the GitHub OAuth login. */
+  /** Runs the GitHub OAuth login, surfacing the concrete failure if any. */
   private async handleLogin(): Promise<void> {
     this.loggingIn = true;
-    const user = await login();
+    this.authError = undefined;
+    let concrete: string | undefined;
+    const user = await login((message) => (concrete = message));
     this.loggingIn = false;
     user === undefined
-      ? (this.authError = 'Вход через GitHub не завершён.')
+      ? (this.authError = concrete ?? 'Вход через GitHub не завершён (окно закрыто до ответа).')
       : void this.onSignedIn(user.username, user.accessToken);
   }
 
@@ -766,10 +781,33 @@ export class AppShell extends LitElement {
         </div>
       </header>
       <div class="body">
-        ${this.renderRailNav()}
-        <main tabindex="-1" aria-live="polite">${screen ? screen.render() : nothing}</main>
+        ${this.account === undefined ? nothing : this.renderRailNav()}
+        <main tabindex="-1" aria-live="polite">
+          ${this.account === undefined
+            ? this.renderSignedOut()
+            : screen
+              ? screen.render()
+              : nothing}
+        </main>
       </div>
-      ${this.renderFabMenu()} ${this.renderAuthDialog()}
+      ${this.account === undefined ? nothing : this.renderFabMenu()} ${this.renderAuthDialog()}
+    `;
+  }
+
+  /** Content-area placeholder shown until a session exists (no repo data leaks). */
+  private renderSignedOut() {
+    return html`
+      <div class="screen-head">
+        <p class="eyebrow">Доступ</p>
+        <h1 tabindex="-1">Войдите в админку</h1>
+      </div>
+      <p class="auth-hint">
+        Управление контентом доступно после входа через GitHub. До входа данные репозитория не
+        загружаются.
+      </p>
+      <div class="form-actions" style="justify-content:flex-start">
+        <cp-button arrow @cp-click=${() => (this.authOpen = true)}>Войти</cp-button>
+      </div>
     `;
   }
 }

--- a/src/redesign/engine/auth.ts
+++ b/src/redesign/engine/auth.ts
@@ -14,10 +14,17 @@ import { createPopupWindow } from '@/composables/useOAuthPopup/popup-window';
  * authenticated user; `currentUser()` resolves an existing session on load.
  */
 
-/** Runs the GitHub OAuth popup and resolves with the user, or undefined on cancel/error. */
-export const login = (): Promise<User | undefined> =>
+/**
+ * Runs the GitHub OAuth popup and resolves with the user, or undefined on
+ * cancel/error. `onError` receives the CONCRETE failure surfaced by the popup
+ * (GitHub error, token-exchange failure) so the UI can show the real cause
+ * instead of a generic message; every step is also logged to the console.
+ */
+export const login = (onError?: (message: string) => void): Promise<User | undefined> =>
   new Promise((resolve) => {
     void buildAuthorizeUrl().then((url) => {
+      // eslint-disable-next-line no-console
+      console.info('[oauth-login] opening popup', { authorize: url.split('?')[0] });
       const popup = createPopupWindow(url);
       const cleanup = (): void => {
         globalThis.removeEventListener('message', handleMessage);
@@ -25,14 +32,23 @@ export const login = (): Promise<User | undefined> =>
       };
       const handleMessage = createMessageHandler(
         (user) => {
+          // eslint-disable-next-line no-console
+          console.info('[oauth-login] success', { user: user.username });
           saveToken(user.accessToken);
           resolve(user);
         },
-        () => resolve(undefined),
+        (message) => {
+          // eslint-disable-next-line no-console
+          console.error('[oauth-login] error from popup:', message);
+          onError?.(message);
+          resolve(undefined);
+        },
         cleanup,
       );
       globalThis.addEventListener('message', handleMessage);
       createPopupMonitor(popup, () => {
+        // eslint-disable-next-line no-console
+        console.warn('[oauth-login] popup closed before completing');
         globalThis.removeEventListener('message', handleMessage);
         resolve(undefined);
       });

--- a/src/redesign/engine/github-api.ts
+++ b/src/redesign/engine/github-api.ts
@@ -6,16 +6,25 @@
  * to sample data with an honest badge.
  */
 
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+
 const OWNER = 'communist-prometheus';
 const API = 'https://api.github.com';
 
-const token = (): string | undefined => {
-  const t = import.meta.env.VITE_DEV_TOKEN;
-  return typeof t === 'string' && t.length > 0 ? t : undefined;
+/**
+ * The active GitHub token: the injected dev token locally, otherwise the
+ * signed-in user's session token (same one the engine pushes with). Using the
+ * session token is what makes members/tickets/pushes work on the deployed
+ * admin, not just in local `dev:token`.
+ */
+const token = async (): Promise<string | undefined> => {
+  const dev = import.meta.env.VITE_DEV_TOKEN;
+  if (typeof dev === 'string' && dev.length > 0) return dev;
+  return (await ensureFreshToken()) ?? undefined;
 };
 
 const get = async (path: string): Promise<unknown> => {
-  const t = token();
+  const t = await token();
   if (t === undefined) return undefined;
   try {
     const response = await fetch(`${API}${path}`, {
@@ -102,4 +111,43 @@ const toTicket = (x: unknown): Ticket | undefined => {
 export const listTickets = async (repo = 'admin-website'): Promise<readonly Ticket[]> => {
   const data = await get(`/repos/${OWNER}/${repo}/issues?state=all&per_page=50`);
   return Array.isArray(data) ? data.map(toTicket).filter((t): t is Ticket => t !== undefined) : [];
+};
+
+/** A recent push (commit) to the content repo, for the deploy board. */
+export interface Push {
+  readonly sha: string;
+  readonly title: string;
+  readonly author: string;
+  readonly date: string;
+  readonly url: string;
+}
+
+const toPush = (x: unknown): Push | undefined => {
+  const sha = field(x, 'sha');
+  if (typeof sha !== 'string') return undefined;
+  const commit = field(x, 'commit');
+  const message = field(commit, 'message');
+  const authorName = field(field(commit, 'author'), 'name');
+  const date = field(field(commit, 'author'), 'date');
+  const htmlUrl = field(x, 'html_url');
+  return {
+    sha: sha.slice(0, 7),
+    title: typeof message === 'string' ? (message.split('\n')[0] ?? sha) : sha,
+    author: typeof authorName === 'string' ? authorName : '—',
+    date: typeof date === 'string' ? date : '',
+    url: typeof htmlUrl === 'string' ? htmlUrl : '',
+  };
+};
+
+/**
+ * Recent commits (pushes) on a branch of the content repo — the real activity
+ * feed the deploy board shows. Branch defaults to the one the admin is wired to
+ * (build-time `VITE_GITHUB_BRANCH`), so prod and dev each show their own.
+ */
+export const listPushes = async (
+  branch = import.meta.env.VITE_GITHUB_BRANCH ?? 'develop',
+  repo = 'public-website-content',
+): Promise<readonly Push[]> => {
+  const data = await get(`/repos/${OWNER}/${repo}/commits?sha=${branch}&per_page=15`);
+  return Array.isArray(data) ? data.map(toPush).filter((p): p is Push => p !== undefined) : [];
 };

--- a/src/redesign/engine/oauth-callback.ts
+++ b/src/redesign/engine/oauth-callback.ts
@@ -20,6 +20,13 @@ const notifyOpener = (token: string): void => {
   globalThis.close();
 };
 
+/** Posts the CONCRETE failure back to the opener so it can show the real cause. */
+const notifyOpenerError = (error: string): void => {
+  const message = { type: 'github-oauth-error', error };
+  const targets = new Set([...TRUSTED_ORIGINS, globalThis.location.origin]);
+  for (const target of targets) globalThis.opener?.postMessage(message, target);
+};
+
 /**
  * If the current page is the OAuth callback, completes it and returns true (the
  * caller must NOT mount the app — this window is the popup). Otherwise false.
@@ -29,11 +36,37 @@ export const handleOAuthCallbackIfPresent = async (): Promise<boolean> => {
   const params = new URLSearchParams(globalThis.location.search);
   const code = params.get('code') ?? undefined;
   const state = params.get('state') ?? undefined;
+  const oauthError = params.get('error') ?? undefined;
+  const oauthErrorDesc = params.get('error_description') ?? undefined;
+  // eslint-disable-next-line no-console
+  console.info('[oauth-callback]', {
+    origin: globalThis.location.origin,
+    hasCode: code !== undefined,
+    hasState: state !== undefined,
+    hasOpener: globalThis.opener !== null,
+    githubError: oauthError,
+    githubErrorDesc: oauthErrorDesc,
+  });
+  // GitHub can bounce back with ?error=... (e.g. redirect_uri mismatch, access_denied).
+  if (oauthError !== undefined) {
+    const message = `GitHub: ${oauthError}${oauthErrorDesc ? ` — ${oauthErrorDesc}` : ''}`;
+    // eslint-disable-next-line no-console
+    console.error('[oauth-callback] GitHub returned an error', message);
+    notifyOpenerError(message);
+    globalThis.document.body.textContent = message;
+    return true;
+  }
   try {
     const token = await completeCallback(code, state);
+    // eslint-disable-next-line no-console
+    console.info('[oauth-callback] token exchange OK');
     globalThis.opener ? notifyOpener(token) : globalThis.location.replace('/');
-  } catch {
-    globalThis.document.body.textContent = 'Ошибка авторизации. Закройте окно и попробуйте снова.';
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    // eslint-disable-next-line no-console
+    console.error('[oauth-callback] token exchange FAILED:', message, e);
+    notifyOpenerError(message);
+    globalThis.document.body.textContent = `Ошибка авторизации: ${message}. Закройте окно и попробуйте снова.`;
   }
   return true;
 };

--- a/src/redesign/screens/screen-deploys.ts
+++ b/src/redesign/screens/screen-deploys.ts
@@ -1,245 +1,25 @@
-import { LitElement, html, css, nothing } from 'lit';
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
+import { listPushes, type Push } from '../engine/github-api.js';
 
 /**
- * `screen-deploys` — the push/deploy status board and the visual 3-way merge for
- * the admin redesign (deploy-status/git-engine, design.md R5).
- *
- * Two capabilities live on one screen:
- *
- * 1. A **status board** of recent pushes/deploys. Each entry is a purely
- *    presentational `cp-list-row` composing a `cp-status` (semantic tone), a
- *    staged `cp-steps` tracker (коммит → пуш → деплой → индексация) and a
- *    determinate `cp-progress`. A failed entry surfaces a danger `cp-banner`
- *    carrying an explicit retry and a "детали" affordance — colour is never the
- *    sole cue (status dot + shape + word; step markers + words), per design.md
- *    R5 / WCAG 1.4.1.
- * 2. A **visual 3-way merge** (deploy-status/git-engine, design.md R5). Every
- *    conflict hunk is shown as three read-only columns — ваша версия / база /
- *    удалённая — with a per-hunk "оставить" toggle that records an explicit
- *    choice. Nothing is auto-resolved and local work is never silently
- *    discarded: the merge stays blocked until every hunk has a chosen side, and
- *    only then does "Зафиксировать объединённое" enable.
- *
- * All interactive state (chosen sides, expanded failure details, retried and
- * committed flags) lives in reactive `@state`; the theme tokens on `:root`
- * inherit into this shadow root, so the surface re-themes with light/dark.
+ * `screen-deploys` — a real activity board of recent pushes to the content repo
+ * (the branch this admin is wired to). Each row is one commit with its author,
+ * short sha, message and a link to GitHub. No fabricated data and no mock
+ * conflict UI: it reads {@link listPushes} through the signed-in token and shows
+ * an honest empty/loading state otherwise.
  */
-
-/** Lifecycle state of a single pipeline stage (mirrors `cp-steps`' `Step`). */
-type StepState = 'pending' | 'running' | 'done' | 'failed';
-
-/** One pipeline stage: a human label plus its current lifecycle state. */
-interface Stage {
-  readonly label: string;
-  readonly state: StepState;
-}
-
-/** The lifecycle a push/deploy entry can be in. */
-type DeployStatus =
-  | 'queued'
-  | 'pushing'
-  | 'retrying'
-  | 'deploying'
-  | 'ok'
-  | 'failed';
-
-/** The semantic tones understood by `cp-status` / `cp-banner`. */
-type Tone = 'success' | 'warning' | 'info' | 'danger' | 'neutral';
-
-/** A registered `cp-icon` name (kept local to avoid a value import). */
-type Icon = 'refresh' | 'upload' | 'check' | 'warning' | 'chevron-right';
-
-/** One push/deploy entry on the status board. */
-interface Deploy {
-  readonly id: string;
-  readonly title: string;
-  readonly meta: string;
-  readonly status: DeployStatus;
-  readonly stages: readonly Stage[];
-  readonly progress: number;
-  readonly detail?: string;
-}
-
-/** The side of a 3-way conflict a hunk can be resolved to. */
-type MergeSide = 'ours' | 'base' | 'theirs';
-
-/** One conflicting region with its three candidate texts. */
-interface Hunk {
-  readonly id: string;
-  readonly title: string;
-  readonly ours: string;
-  readonly base: string;
-  readonly theirs: string;
-}
-
-/** Status → `cp-status`/`cp-banner` tone. Colour is one of several cues only. */
-const statusTone: Readonly<Record<DeployStatus, Tone>> = {
-  queued: 'info',
-  pushing: 'info',
-  retrying: 'warning',
-  deploying: 'info',
-  ok: 'success',
-  failed: 'danger',
-};
-
-/** Status → human label rendered next to the dot + shape. */
-const statusLabel: Readonly<Record<DeployStatus, string>> = {
-  queued: 'в очереди',
-  pushing: 'пушится',
-  retrying: 'повтор',
-  deploying: 'деплой',
-  ok: 'опубликовано',
-  failed: 'сбой',
-};
-
-/** Status → leading icon-circle shape (redundant with the tone). */
-const statusIcon: Readonly<Record<DeployStatus, Icon>> = {
-  queued: 'chevron-right',
-  pushing: 'upload',
-  retrying: 'refresh',
-  deploying: 'upload',
-  ok: 'check',
-  failed: 'warning',
-};
-
-/** Column headers for the 3-way merge, in reading order. */
-const sideLabel: Readonly<Record<MergeSide, string>> = {
-  ours: 'Ваша версия',
-  base: 'База · общий предок',
-  theirs: 'Удалённая · chief',
-};
-
-/** Representative board content for the local shell preview. */
-const deploys: readonly Deploy[] = [
-  {
-    id: 'd-deploying',
-    title: 'develop · «Иллюзия социализма…» (ru)',
-    meta: 'andswew · только что · шаг 3 из 4 — сборка',
-    status: 'deploying',
-    stages: [
-      { label: 'коммит', state: 'done' },
-      { label: 'пуш', state: 'done' },
-      { label: 'деплой', state: 'running' },
-      { label: 'индексация', state: 'pending' },
-    ],
-    progress: 0.58,
-  },
-  {
-    id: 'd-pushing',
-    title: 'develop · Публикация журнала №17 (обложка)',
-    meta: 'andswew · только что · отправка изменений',
-    status: 'pushing',
-    stages: [
-      { label: 'коммит', state: 'done' },
-      { label: 'пуш', state: 'running' },
-      { label: 'деплой', state: 'pending' },
-      { label: 'индексация', state: 'pending' },
-    ],
-    progress: 0.32,
-  },
-  {
-    id: 'd-retrying',
-    title: 'develop · Правки «К вопросу о партии» (ru)',
-    meta: 'andswew · 2 минуты назад · сеть недоступна, повтор через 0:06',
-    status: 'retrying',
-    stages: [
-      { label: 'коммит', state: 'done' },
-      { label: 'пуш', state: 'running' },
-      { label: 'деплой', state: 'pending' },
-      { label: 'индексация', state: 'pending' },
-    ],
-    progress: 0.34,
-  },
-  {
-    id: 'd-queued',
-    title: 'develop · Правки «Профсоюзы новой волны» (ru)',
-    meta: 'newcomer · только что · ждёт своей очереди на пуш',
-    status: 'queued',
-    stages: [
-      { label: 'коммит', state: 'done' },
-      { label: 'пуш', state: 'pending' },
-      { label: 'деплой', state: 'pending' },
-      { label: 'индексация', state: 'pending' },
-    ],
-    progress: 0.15,
-  },
-  {
-    id: 'd-ok',
-    title: 'master · Публикация журнала №17',
-    meta: 'chief · 12 минут назад · 4 из 4 · заняло 2м 41с',
-    status: 'ok',
-    stages: [
-      { label: 'коммит', state: 'done' },
-      { label: 'пуш', state: 'done' },
-      { label: 'деплой', state: 'done' },
-      { label: 'индексация', state: 'done' },
-    ],
-    progress: 1,
-  },
-  {
-    id: 'd-failed',
-    title: 'develop · Переиндексация (ru)',
-    meta: 'система · 1 час назад · упал на шаге 4 — индексация',
-    status: 'failed',
-    stages: [
-      { label: 'коммит', state: 'done' },
-      { label: 'пуш', state: 'done' },
-      { label: 'деплой', state: 'done' },
-      { label: 'индексация', state: 'failed' },
-    ],
-    progress: 0.8,
-    detail:
-      'Reindex ru упал: Vectorize вернул getByIds → 1101. Публикация не затронута — статья уже на сайте, обновится только поиск. Деплой и переиндексация — разные статусы, поэтому красный шаг не отменяет публикацию.',
-  },
-];
-
-/** The conflict opened for the visual 3-way merge (safe, explicit resolution). */
-const hunks: readonly Hunk[] = [
-  {
-    id: 'h1',
-    title: 'Конфликт 1 — абзац',
-    ours: '«Накопление богатства на одном полюсе есть накопление нищеты и деградации на противоположном».',
-    base: '«Накопление богатства на одном полюсе есть накопление нищеты на противоположном».',
-    theirs:
-      '«Накопление богатства на одном полюсе есть в то же время накопление нищеты, муки труда и рабства».',
-  },
-  {
-    id: 'h2',
-    title: 'Конфликт 2 — сноска',
-    ours: '[^24]: Маркс, «Капитал», т. I, гл. XXIII.',
-    base: '[^24]: Маркс, «Капитал», т. I.',
-    theirs: '[^24]: К. Маркс. Капитал. Том I, глава 23.',
-  },
-  {
-    id: 'h3',
-    title: 'Конфликт 3 — заголовок',
-    ours: '## Классовая динамика',
-    base: '## Классы',
-    theirs: '## Динамика классов',
-  },
-];
-
-/** Ordered sides so a hunk's three columns render deterministically. */
-const sides: readonly MergeSide[] = ['ours', 'base', 'theirs'];
-
 @customElement('screen-deploys')
 export class ScreenDeploys extends LitElement {
   static override styles = css`
     :host {
       display: block;
     }
-
     .head {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: var(--spacing-sm);
       margin-bottom: var(--spacing-lg);
     }
     .eyebrow {
-      flex-basis: 100%;
       margin: 0;
       font-size: 0.8rem;
       color: var(--color-text-secondary);
@@ -248,8 +28,7 @@ export class ScreenDeploys extends LitElement {
       font-size: clamp(1.9rem, 7vw, 2.6rem);
       line-height: 1.15;
       font-weight: 700;
-      margin: 0;
-      margin-right: auto;
+      margin: 0.2rem 0 0;
       background: linear-gradient(135deg, var(--color-accent), var(--color-text-primary));
       -webkit-background-clip: text;
       background-clip: text;
@@ -259,29 +38,16 @@ export class ScreenDeploys extends LitElement {
       outline: 2px solid var(--color-accent);
       outline-offset: 4px;
     }
-
-    section {
-      margin-top: var(--spacing-xl);
-    }
-    .section-label {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: baseline;
-      gap: var(--spacing-xs) var(--spacing-sm);
-      margin: 0 0 var(--spacing-sm);
-    }
-    .section-label h2 {
-      font-size: 1.2rem;
-      font-weight: 700;
-      margin: 0;
-    }
     .hint {
-      margin: 0;
-      max-width: 64ch;
+      margin: var(--spacing-sm) 0 var(--spacing-lg);
+      max-width: 60ch;
       font-size: 0.85rem;
       color: var(--color-text-secondary);
     }
-
+    .branch {
+      font-family: var(--font-mono);
+      color: var(--color-accent);
+    }
     ul {
       list-style: none;
       margin: 0;
@@ -289,376 +55,92 @@ export class ScreenDeploys extends LitElement {
       display: grid;
       gap: var(--spacing-sm);
     }
-
-    .body {
+    li {
       display: grid;
-      gap: var(--spacing-sm);
-      width: 100%;
-    }
-    .stage-line {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      align-items: baseline;
       gap: var(--spacing-xs) var(--spacing-sm);
+      padding: var(--spacing-sm) 0;
+      border-top: 1px solid var(--color-hairline);
     }
-    cp-steps {
-      flex: 1 1 18rem;
-      min-width: 12rem;
+    li:first-child {
+      border-top: none;
     }
-    .progress {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-sm);
-    }
-    cp-progress {
-      flex: 1 1 auto;
-    }
-    .pct {
+    .sha {
       font-family: var(--font-mono);
       font-size: 0.8rem;
       color: var(--color-text-secondary);
-      font-variant-numeric: tabular-nums;
-      flex: none;
     }
-    .actions {
-      display: inline-flex;
-      align-items: center;
-      gap: var(--spacing-xs);
+    .title {
+      min-width: 0;
+      overflow-wrap: anywhere;
+      font-weight: 600;
     }
-
-    .detail {
-      margin: var(--spacing-xs) 0 0;
-      padding: var(--spacing-sm);
-      border-radius: var(--radius-sm);
-      background: var(--color-surface);
-      border: 1px solid var(--color-hairline);
-      font-size: 0.85rem;
-      color: var(--color-text-secondary);
-      line-height: 1.5;
-    }
-
-    /* ---- 3-way merge ---- */
-    .merge-hint {
-      margin: 0 0 var(--spacing-md);
-    }
-    .hunk {
-      border: 1px solid var(--color-border);
-      border-radius: var(--radius-md);
-      overflow: hidden;
-      background: var(--color-surface-elevated);
-    }
-    .hunk.resolved {
-      border-color: var(--ok);
-    }
-    .hunk-head {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: var(--spacing-xs) var(--spacing-sm);
-      padding: var(--spacing-xs) var(--spacing-sm);
-      background: var(--color-surface);
-      border-bottom: 1px solid var(--color-hairline);
-      font-size: 0.78rem;
-      font-weight: 700;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
+    .meta {
+      grid-column: 2 / -1;
+      font-size: 0.8rem;
       color: var(--color-text-secondary);
     }
-    .hunk-head .grow {
-      margin-inline-start: auto;
-      text-transform: none;
-      letter-spacing: 0;
+    a.gh {
+      justify-self: end;
+      font-size: 0.8rem;
+      color: var(--color-accent);
+      text-decoration: none;
     }
-    .cols {
-      display: grid;
-      grid-template-columns: 1fr;
+    a.gh:hover {
+      text-decoration: underline;
     }
-    @media (min-width: 768px) {
-      .cols {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
-      }
-    }
-    .col {
-      display: flex;
-      flex-direction: column;
-      gap: var(--spacing-sm);
-      padding: var(--spacing-sm);
-      border-top: 1px solid var(--color-hairline);
-    }
-    @media (min-width: 768px) {
-      .col {
-        border-top: none;
-      }
-      .col + .col {
-        border-inline-start: 1px solid var(--color-hairline);
-      }
-    }
-    .col.ours {
-      background: var(--info-bg);
-    }
-    .col.theirs {
-      background: var(--draft-bg);
-    }
-    .col.chosen {
-      outline: 2px solid var(--ok);
-      outline-offset: -2px;
-    }
-    .col-head {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: var(--spacing-xs);
-    }
-    .col-name {
-      font-size: 0.74rem;
-      font-weight: 700;
-      letter-spacing: 0.04em;
-      text-transform: uppercase;
-      color: var(--color-text-secondary);
-    }
-    .col-text {
-      margin: 0;
-      font-size: 0.95rem;
-      line-height: 1.5;
-    }
-    .col.base .col-text {
-      font-family: var(--font-mono);
-      font-size: 0.85rem;
-      color: var(--color-text-secondary);
-    }
-    .take {
-      margin-top: auto;
-    }
-
-    .merge-bar {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: center;
-      gap: var(--spacing-sm);
-      margin-top: var(--spacing-md);
-      padding-top: var(--spacing-md);
-      border-top: 1px solid var(--color-border);
-    }
-    .merge-bar .grow {
-      margin-inline-start: auto;
-    }
-    .note {
-      margin: 0;
-      font-size: 0.85rem;
+    .empty {
       color: var(--color-text-secondary);
     }
   `;
 
-  /** Per-hunk chosen side; a missing key means the hunk is still unresolved. */
-  @state() private chosen: Readonly<Record<string, MergeSide>> = {};
+  /** Recent pushes read from the content repo; empty until loaded. */
+  @state() private pushes: readonly Push[] = [];
 
-  /** Ids of failed deploys whose detail panel is expanded. */
-  @state() private openDetails: ReadonlySet<string> = new Set();
+  /** Whether the real read has completed. */
+  @state() private loaded = false;
 
-  /** Ids of deploys whose retry the operator has already triggered. */
-  @state() private retried: ReadonlySet<string> = new Set();
-
-  /** Whether the merged result has been committed. */
-  @state() private committed = false;
-
-  private choose(hunkId: string, side: MergeSide): void {
-    this.chosen = { ...this.chosen, [hunkId]: side };
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.load();
   }
 
-  private toggleDetails(id: string): void {
-    const next = new Set(this.openDetails);
-    next.has(id) ? next.delete(id) : next.add(id);
-    this.openDetails = next;
+  private async load(): Promise<void> {
+    this.pushes = await listPushes();
+    this.loaded = true;
   }
 
-  private retry(id: string): void {
-    this.retried = new Set(this.retried).add(id);
-  }
-
-  private commitMerge(): void {
-    this.committed = true;
-  }
-
-  private get resolvedCount(): number {
-    return hunks.filter((hunk) => this.chosen[hunk.id] !== undefined).length;
-  }
-
-  private get allResolved(): boolean {
-    return this.resolvedCount === hunks.length;
-  }
-
-  private renderDeploy(deploy: Deploy) {
-    const tone = statusTone[deploy.status];
-    const failed = deploy.status === 'failed';
-    const isRetried = this.retried.has(deploy.id);
-    const open = this.openDetails.has(deploy.id);
+  private renderRow(push: Push): TemplateResult {
     return html`
       <li>
-        <cp-list-row icon=${statusIcon[deploy.status]} title=${deploy.title} meta=${deploy.meta}>
-          <div class="body" slot="content">
-            <cp-steps .steps=${deploy.stages}></cp-steps>
-            <div class="progress">
-              <cp-progress
-                .value=${deploy.progress}
-                label=${`Прогресс: ${deploy.title}`}
-              ></cp-progress>
-              <span class="pct">${Math.round(deploy.progress * 100)}%</span>
-            </div>
-          </div>
-          <cp-status
-            slot="actions"
-            state=${tone}
-            label=${statusLabel[deploy.status]}
-          ></cp-status>
-        </cp-list-row>
-        ${failed
-          ? html`
-              <cp-banner tone="danger" title="Индексация не обновлена" style="margin-top:var(--spacing-xs)">
-                ${isRetried
-                  ? 'Повтор запущен — переиндексация ru отправлена заново. Локальные правки в безопасности.'
-                  : 'Публикация прошла, но поиск не переиндексирован. Правки не потеряны — можно повторить только упавший шаг.'}
-                <span class="actions" slot="action">
-                  <cp-button
-                    variant="secondary"
-                    size="sm"
-                    ?disabled=${isRetried}
-                    @click=${() => this.retry(deploy.id)}
-                  >
-                    <cp-icon name="refresh" size="16"></cp-icon>
-                    ${isRetried ? 'Повтор идёт' : 'Повторить'}
-                  </cp-button>
-                  <cp-button
-                    variant="ghost"
-                    size="sm"
-                    aria-expanded=${open ? 'true' : 'false'}
-                    @click=${() => this.toggleDetails(deploy.id)}
-                  >
-                    Детали
-                  </cp-button>
-                </span>
-              </cp-banner>
-              ${open && deploy.detail !== undefined
-                ? html`<p class="detail">${deploy.detail}</p>`
-                : nothing}
-            `
-          : nothing}
+        <span class="sha">${push.sha}</span>
+        <span class="title">${push.title}</span>
+        ${push.url === ''
+          ? nothing
+          : html`<a class="gh" href=${push.url} target="_blank" rel="noopener">GitHub ↗</a>`}
+        <span class="meta">${push.author} · ${push.date.slice(0, 10)}</span>
       </li>
     `;
   }
 
-  private renderColumn(hunk: Hunk, side: MergeSide) {
-    const text = side === 'ours' ? hunk.ours : side === 'base' ? hunk.base : hunk.theirs;
-    const isChosen = this.chosen[hunk.id] === side;
-    return html`
-      <article class="col ${side} ${isChosen ? 'chosen' : ''}">
-        <header class="col-head">
-          <span class="col-name">${sideLabel[side]}</span>
-          ${isChosen ? html`<cp-tag tone="success">выбрано</cp-tag>` : nothing}
-        </header>
-        <p class="col-text">${text}</p>
-        <cp-button
-          class="take"
-          variant="secondary"
-          size="sm"
-          ?pressed=${isChosen}
-          aria-label=${`Оставить: ${sideLabel[side]} — ${hunk.title}`}
-          @click=${() => this.choose(hunk.id, side)}
-        >
-          ${isChosen ? 'Оставлено' : 'Оставить'}
-        </cp-button>
-      </article>
-    `;
-  }
-
-  private renderHunk(hunk: Hunk) {
-    const chosenSide = this.chosen[hunk.id];
-    const resolved = chosenSide !== undefined;
-    return html`
-      <li class="hunk ${resolved ? 'resolved' : ''}">
-        <header class="hunk-head">
-          <cp-icon name=${resolved ? 'check' : 'warning'} size="16"></cp-icon>
-          <span>${hunk.title}</span>
-          <span class="grow">
-            ${resolved
-              ? html`<cp-status
-                  state="success"
-                  label=${`оставлена: ${sideLabel[chosenSide]}`}
-                ></cp-status>`
-              : html`<cp-status state="warning" label="не выбрано"></cp-status>`}
-          </span>
-        </header>
-        <div class="cols">${sides.map((side) => this.renderColumn(hunk, side))}</div>
-      </li>
-    `;
-  }
-
-  private renderMerge() {
-    return html`
-      <section aria-labelledby="merge-title">
-        <div class="section-label">
-          <h2 id="merge-title">Разрешение конфликта</h2>
-          <span class="hint" style="font-family:var(--font-mono)">
-            blog/illuziya-socializma…/index.ru.md
-          </span>
-        </div>
-        <p class="hint merge-hint">
-          chief изменил те же строки, пока правки ждали пуша. Ничего не потеряно и ничего не
-          выбрано за вас — по каждому месту оставьте нужную версию. Слияние заблокировано, пока
-          выбор не сделан для всех мест.
-        </p>
-
-        <ul>${hunks.map((hunk) => this.renderHunk(hunk))}</ul>
-
-        ${this.committed
-          ? html`<cp-banner tone="success" title="Объединённое зафиксировано" style="margin-top:var(--spacing-md)">
-              Слияние собрано из выбранных версий и поставлено в очередь на пуш develop.
-            </cp-banner>`
-          : nothing}
-
-        <div class="merge-bar">
-          <cp-progress
-            .value=${this.resolvedCount / hunks.length}
-            label="Разрешено конфликтов"
-            style="max-width:12rem"
-          ></cp-progress>
-          <span class="note">${this.resolvedCount} из ${hunks.length} разрешено</span>
-          <span class="grow"></span>
-          <span class="note">
-            ${this.allResolved
-              ? 'Все места выбраны — можно фиксировать.'
-              : 'Выберите версию в оставшихся местах.'}
-          </span>
-          <cp-button
-            arrow
-            ?disabled=${!this.allResolved || this.committed}
-            @click=${() => this.commitMerge()}
-          >
-            Зафиксировать объединённое
-          </cp-button>
-        </div>
-      </section>
-    `;
-  }
-
-  override render() {
+  override render(): TemplateResult {
+    const branch = import.meta.env.VITE_GITHUB_BRANCH ?? 'develop';
     return html`
       <div class="head">
-        <p class="eyebrow">Публикации · пуш, деплой и переиндексация</p>
+        <p class="eyebrow">Публикации · недавние пуши</p>
         <h1 tabindex="-1">Деплои</h1>
       </div>
-
-      <section aria-labelledby="board-title">
-        <div class="section-label">
-          <h2 id="board-title">Статус пушей и деплоев</h2>
-          <p class="hint">
-            Публикация ≠ индекс: статья может быть на сайте, пока поиск обновляется отдельно.
-            Красный шаг индексации не отменяет успешный деплой.
-          </p>
-        </div>
-        <ul>${deploys.map((deploy) => this.renderDeploy(deploy))}</ul>
-      </section>
-
-      ${this.renderMerge()}
+      <p class="hint">
+        Недавние коммиты в контент-репозиторий (ветка <span class="branch">${branch}</span>). Каждый
+        пуш запускает сборку и деплой сайта. Публикация ≠ индекс: статья может быть на сайте, пока
+        поиск обновляется отдельно.
+      </p>
+      ${this.pushes.length > 0
+        ? html`<ul>${this.pushes.map((push) => this.renderRow(push))}</ul>`
+        : html`<p class="empty">
+            ${this.loaded ? 'Пушей не найдено (или нет доступа по токену).' : 'Загружаем историю…'}
+          </p>`}
     `;
   }
 }

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -200,7 +200,8 @@ export class ScreenEditor extends LitElement {
 
     .toolbar {
       position: sticky;
-      top: 0;
+      /* Stick just below the app header instead of colliding with it. */
+      top: var(--app-header-h, 3.75rem);
       z-index: 5;
       display: flex;
       flex-wrap: wrap;

--- a/src/redesign/styles/base.css
+++ b/src/redesign/styles/base.css
@@ -8,6 +8,9 @@
 html {
   background: var(--color-background);
   color-scheme: light dark;
+  /* Fixed app header height — shared so sticky in-screen toolbars (the editor)
+     can offset below the header instead of colliding with it. */
+  --app-header-h: 3.75rem;
 }
 
 body {


### PR DESCRIPTION
Prod-review fixes (Todoist Comprom):
- #6 auth gating — signed-out hides nav/FAB + shows sign-in prompt, no repo data leaks (was hardcoded admin/owner mock).
- #5 sticky panels — editor toolbar offsets below the fixed-height header (--app-header-h).
- #2 deploys — replace the fully-mock board + fake 3-way merge with a real recent-pushes list; fix mobile overflow.
- github-api uses the session token (works on deployed admin, not just dev:token).
- #8 OAuth — real logging + concrete error propagation to the login dialog. Diagnosed client_id/redirect valid; remaining cause is the code exchange (prod worker secret).

Verified on dev: signed-out gating, deploys layout, header height = --app-header-h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbzLcqvQ76TaBK2dEYsvhZ