### PR TITLE
deploy: prod admin operates on content master (#3)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,15 +59,16 @@ jobs:
             echo "GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy --env develop" >> "$GITHUB_ENV"
           else
-            # Prod editors push to `develop` on the content repo, not
-            # `master` — master is protected by `guard` status checks
-            # and rejects direct pushes as GH006 (isomorphic-git surfaces
-            # this as "Unexpected error", which read like a client bug
-            # to editors). Content-repo Actions ff-merges develop into
-            # master via the CONTENT_MERGE_TOKEN admin PAT, so from the
-            # editor's point of view "save" still lands in production —
-            # just through an unprotected staging branch.
-            echo "VITE_GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
+            # Prod admin reads AND writes `master` directly (chosen model):
+            # the develop→master auto-merge that used to promote saves was
+            # removed, so routing prod through develop left the prod site
+            # (master) stale and showed dev data in the admin. Writing master
+            # keeps prod self-consistent. `master` protection has
+            # enforce_admins:false, so admin-role editors push directly; the
+            # only required check (`guard`) runs on PRs, not pushes. Non-admin
+            # editors still hit GH006 on direct pushes — if they must publish,
+            # drop `guard` from master's required status checks.
+            echo "VITE_GITHUB_BRANCH=master" >> "$GITHUB_ENV"
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_MASTER" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_MASTER" >> "$GITHUB_ENV"
             echo "VITE_COMMS_BASE=https://lists.comprom.org" >> "$GITHUB_ENV"

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,14 @@
     "": {
       "name": "admin-website",
       "dependencies": {
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-markdown": "^6.5.1",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.7",
         "@isomorphic-git/lightning-fs": "^4.6.2",
+        "@lezer/highlight": "^1.2.3",
+        "@lezer/markdown": "^1.7.2",
         "@types/turndown": "^5.0.6",
         "buffer": "^6.0.3",
         "dompurify": "^3.4.9",
@@ -198,6 +205,26 @@
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260603.1", "", {}, "sha512-TLeVHoBbcYv35S5TdRWUoj3IJ56BhHtrsuci+O7ithU8yz7ttNdCk6rAl1QUSGNVEWSIp54bWOuV/xmX1zu79g=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.4", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.7.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-6re5avCNfyRMIoi3XNjbEfQM1vTeVD3JS3g/Fyegyso/eoANFM71Cyvbb66LDyYtQLMEcRFlzioywCqDo9SlLA=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.4", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.7", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg=="],
+
+    "@codemirror/state": ["@codemirror/state@6.7.1", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A=="],
+
+    "@codemirror/view": ["@codemirror/view@6.43.7", "", { "dependencies": { "@codemirror/state": "^6.7.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g=="],
+
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@3.1.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ=="],
@@ -334,9 +361,25 @@
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/css": ["@lezer/css@1.3.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-PrlQ8glBdWS5UOqgnFCmPxAJbhuOhb0WoDnSAXiNQPjivlDujhuUQ1K/fxyk2vFoq4VTBgFtFZOc8sOpiYjz5g=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.7.2", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ=="],
+
     "@lit-labs/ssr-dom-shim": ["@lit-labs/ssr-dom-shim@1.6.0", "", {}, "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ=="],
 
     "@lit/reactive-element": ["@lit/reactive-element@2.1.2", "", { "dependencies": { "@lit-labs/ssr-dom-shim": "^1.5.0" } }, "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.3", "", {}, "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
 
@@ -863,6 +906,8 @@
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" } }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
 
     "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
+
+    "crelt": ["crelt@1.0.7", "", {}, "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA=="],
 
     "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
 
@@ -1810,6 +1855,8 @@
 
     "stubborn-utils": ["stubborn-utils@1.0.2", "", {}, "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "stylelint": ["stylelint@17.7.0", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-syntax-patches-for-csstree": "^1.1.2", "@csstools/css-tokenizer": "^4.0.0", "@csstools/media-query-list-parser": "^5.0.0", "@csstools/selector-resolve-nested": "^4.0.0", "@csstools/selector-specificity": "^6.0.0", "colord": "^2.9.3", "cosmiconfig": "^9.0.1", "css-functions-list": "^3.3.3", "css-tree": "^3.2.1", "debug": "^4.4.3", "fast-glob": "^3.3.3", "fastest-levenshtein": "^1.0.16", "file-entry-cache": "^11.1.2", "global-modules": "^2.0.0", "globby": "^16.2.0", "globjoin": "^0.1.4", "html-tags": "^5.1.0", "ignore": "^7.0.5", "import-meta-resolve": "^4.2.0", "is-plain-object": "^5.0.0", "mathml-tag-names": "^4.0.0", "meow": "^14.1.0", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.5.8", "postcss-safe-parser": "^7.0.1", "postcss-selector-parser": "^7.1.1", "postcss-value-parser": "^4.2.0", "string-width": "^8.2.0", "supports-hyperlinks": "^4.4.0", "svg-tags": "^1.0.0", "table": "^6.9.0", "write-file-atomic": "^7.0.1" }, "bin": "bin/stylelint.mjs" }, "sha512-n/+4RheCRl+cecGnF+S/Adz59iCRaK9BVznJYB+a7GOksfwNzjiOPnYv17pTO0HgRse9IiqbMtekGNhOb2tVYQ=="],
 
     "stylelint-config-html": ["stylelint-config-html@1.1.0", "", { "peerDependencies": { "postcss-html": "^1.0.0", "stylelint": ">=14.0.0" } }, "sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ=="],
@@ -1969,6 +2016,8 @@
     "vue-router": ["vue-router@5.0.4", "", { "dependencies": { "@babel/generator": "^7.28.6", "@vue-macros/common": "^3.1.1", "@vue/devtools-api": "^8.0.6", "ast-walker-scope": "^0.8.3", "chokidar": "^5.0.0", "json5": "^2.2.3", "local-pkg": "^1.1.2", "magic-string": "^0.30.21", "mlly": "^1.8.0", "muggle-string": "^0.4.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "scule": "^1.3.0", "tinyglobby": "^0.2.15", "unplugin": "^3.0.0", "unplugin-utils": "^0.3.1", "yaml": "^2.8.2" }, "peerDependencies": { "@pinia/colada": ">=0.21.2", "@vue/compiler-sfc": "^3.5.17", "pinia": "^3.0.4", "vue": "^3.5.0" }, "optionalPeers": ["@pinia/colada"] }, "sha512-lCqDLCI2+fKVRl2OzXuzdSWmxXFLQRxQbmHugnRpTMyYiT+hNaycV0faqG5FBHDXoYrZ6MQcX87BvbY8mQ20Bg=="],
 
     "vue-tsc": ["vue-tsc@3.2.6", "", { "dependencies": { "@volar/typescript": "2.4.28", "@vue/language-core": "3.2.6" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": "bin/vue-tsc.js" }, "sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,14 @@
     "deploy": "CLOUDFLARE_API_TOKEN=$VITE_CF_API_TOKEN npx wrangler deploy --config wrangler.jsonc"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-markdown": "^6.5.1",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.7",
     "@isomorphic-git/lightning-fs": "^4.6.2",
+    "@lezer/highlight": "^1.2.3",
+    "@lezer/markdown": "^1.7.2",
     "@types/turndown": "^5.0.6",
     "buffer": "^6.0.3",
     "dompurify": "^3.4.9",

--- a/src/redesign/editor/cp-markdown-editor.ts
+++ b/src/redesign/editor/cp-markdown-editor.ts
@@ -1,0 +1,135 @@
+import { LitElement, html, css, type PropertyValues } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { markdown } from '@codemirror/lang-markdown';
+import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
+import { EditorState } from '@codemirror/state';
+import { EditorView, keymap, placeholder } from '@codemirror/view';
+import { livePreview } from './live-preview.js';
+
+/**
+ * `cp-markdown-editor` — a self-contained Obsidian-style live-preview markdown
+ * editor built on CodeMirror 6. Formatting renders inline and the raw syntax
+ * reveals itself only on the caret's line (see {@link livePreview}). It takes a
+ * `value` (the markdown) and emits `cp-change` with the edited text — no engine
+ * coupling, so it can be tested and reused in isolation.
+ */
+@customElement('cp-markdown-editor')
+export class CpMarkdownEditor extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+    .host {
+      font-size: 1.05rem;
+    }
+    .cm-editor {
+      background: transparent;
+      color: var(--color-text-primary);
+    }
+    .cm-editor.cm-focused {
+      outline: none;
+    }
+    .cm-scroller {
+      font-family: var(--font-sans);
+      line-height: 1.7;
+    }
+    .cm-content {
+      padding: 0;
+      caret-color: var(--color-accent);
+    }
+    .cm-line {
+      padding: 0;
+    }
+    .cm-cursor {
+      border-left-color: var(--color-accent);
+      border-left-width: 2px;
+    }
+  `;
+
+  /** The markdown document. Two-way: external changes push into the editor. */
+  @property({ type: String }) value = '';
+
+  /** Placeholder shown when the document is empty. */
+  @property({ type: String }) placeholder = '';
+
+  private view?: EditorView;
+
+  override firstUpdated(): void {
+    const parent = this.renderRoot.querySelector<HTMLElement>('.host');
+    if (parent === null) return;
+    this.view = new EditorView({
+      parent,
+      root: this.shadowRoot ?? undefined,
+      state: EditorState.create({
+        doc: this.value,
+        extensions: [
+          history(),
+          keymap.of([...defaultKeymap, ...historyKeymap]),
+          markdown(),
+          livePreview(),
+          EditorView.lineWrapping,
+          placeholder(this.placeholder),
+          this.appTheme(),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) this.emit();
+          }),
+        ],
+      }),
+    });
+  }
+
+  override updated(changed: PropertyValues): void {
+    if (!changed.has('value') || this.view === undefined) return;
+    const current = this.view.state.doc.toString();
+    if (this.value === current) return;
+    this.view.dispatch({
+      changes: { from: 0, to: current.length, insert: this.value },
+    });
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.view?.destroy();
+  }
+
+  /** CodeMirror theme wired to the app's design tokens (light + dark). */
+  private appTheme() {
+    return EditorView.theme({
+      '&': { backgroundColor: 'transparent', color: 'var(--color-text-primary)' },
+      // CodeMirror defaults the content to a monospace font; the article editor
+      // must read in the site's sans like the rendered page.
+      '.cm-content, .cm-scroller, .cm-line': {
+        fontFamily: 'var(--font-sans)',
+        fontSize: '1.05rem',
+        lineHeight: '1.75',
+      },
+      '.cm-selectionBackground, ::selection': {
+        backgroundColor: 'var(--accent-bg) !important',
+      },
+      '.cm-activeLine': { backgroundColor: 'transparent' },
+      '.cm-placeholder': { color: 'var(--color-text-secondary)' },
+    });
+  }
+
+  private emit(): void {
+    const value = this.view?.state.doc.toString() ?? '';
+    this.dispatchEvent(
+      new CustomEvent('cp-change', { detail: { value }, bubbles: true, composed: true }),
+    );
+  }
+
+  /** Focuses the editor (used when opening a document). */
+  focus(): void {
+    this.view?.focus();
+  }
+
+  override render() {
+    return html`<div class="host"></div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cp-markdown-editor': CpMarkdownEditor;
+  }
+}

--- a/src/redesign/editor/live-preview.ts
+++ b/src/redesign/editor/live-preview.ts
@@ -1,0 +1,94 @@
+import { syntaxTree, HighlightStyle, syntaxHighlighting } from '@codemirror/language';
+import { RangeSetBuilder, type Extension } from '@codemirror/state';
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from '@codemirror/view';
+import { tags } from '@lezer/highlight';
+
+/**
+ * Obsidian-style live preview for a CodeMirror 6 markdown editor. Two pieces
+ * working together:
+ *
+ * 1. {@link markdownHighlight} renders the formatting itself — headings grow,
+ *    `**bold**` is bold, `_italic_` is italic, quotes and inline code get their
+ *    own look — straight off the Lezer markdown tree, so it is always on.
+ * 2. {@link hideMarkersPlugin} hides the raw syntax markers (`#`, `**`, `>`, …)
+ *    on every line EXCEPT the one the caret is on, so the source reveals itself
+ *    only where you are editing. This is exactly Obsidian's live-preview model.
+ */
+
+/** Formatting rendered from the markdown syntax tree (always visible). */
+const markdownHighlight = HighlightStyle.define([
+  { tag: tags.heading1, fontSize: '1.9rem', fontWeight: '700', lineHeight: '1.25' },
+  { tag: tags.heading2, fontSize: '1.5rem', fontWeight: '700', lineHeight: '1.3' },
+  { tag: tags.heading3, fontSize: '1.25rem', fontWeight: '700' },
+  { tag: [tags.heading4, tags.heading5, tags.heading6], fontWeight: '700' },
+  { tag: tags.strong, fontWeight: '700' },
+  { tag: tags.emphasis, fontStyle: 'italic' },
+  { tag: tags.strikethrough, textDecoration: 'line-through' },
+  { tag: tags.quote, color: 'var(--color-text-secondary)', fontStyle: 'italic' },
+  { tag: tags.monospace, fontFamily: 'var(--font-mono)', fontSize: '0.9em' },
+  { tag: tags.link, color: 'var(--color-accent)' },
+  { tag: tags.url, color: 'var(--color-text-secondary)' },
+  { tag: [tags.processingInstruction, tags.meta], color: 'var(--color-text-secondary)' },
+]);
+
+/** Lezer node names for the raw syntax markers we hide off the active line. */
+const MARKER_NODES = new Set([
+  'HeaderMark',
+  'EmphasisMark',
+  'StrongMark',
+  'StrikethroughMark',
+  'QuoteMark',
+  'CodeMark',
+  'LinkMark',
+  'URL',
+]);
+
+const hide = Decoration.replace({});
+
+/** Builds the "hide markers except on the caret's line" decoration set. */
+const buildMarkerDecorations = (view: EditorView): DecorationSet => {
+  const builder = new RangeSetBuilder<Decoration>();
+  const { head } = view.state.selection.main;
+  const activeLine = view.state.doc.lineAt(head).number;
+  for (const { from, to } of view.visibleRanges) {
+    syntaxTree(view.state).iterate({
+      from,
+      to,
+      enter: (node) => {
+        if (!MARKER_NODES.has(node.name)) return;
+        if (node.from === node.to) return;
+        if (view.state.doc.lineAt(node.from).number === activeLine) return;
+        builder.add(node.from, node.to, hide);
+      },
+    });
+  }
+  return builder.finish();
+};
+
+/** Re-hides markers on every doc/selection/viewport change. */
+const hideMarkersPlugin = ViewPlugin.fromClass(
+  class {
+    decorations: DecorationSet;
+    constructor(view: EditorView) {
+      this.decorations = buildMarkerDecorations(view);
+    }
+    update(update: ViewUpdate): void {
+      if (update.docChanged || update.selectionSet || update.viewportChanged) {
+        this.decorations = buildMarkerDecorations(update.view);
+      }
+    }
+  },
+  { decorations: (plugin) => plugin.decorations },
+);
+
+/** The full live-preview extension bundle (highlight + marker hiding). */
+export const livePreview = (): Extension => [
+  syntaxHighlighting(markdownHighlight),
+  hideMarkersPlugin,
+];

--- a/src/redesign/main.ts
+++ b/src/redesign/main.ts
@@ -10,6 +10,7 @@ import '../styles/theme.css';
 import './styles/base.css';
 import './styles/view-transition.css';
 import '@communist-prometheus/cp-components';
+import './editor/cp-markdown-editor.js';
 import './app-shell.js';
 import { bootEngineIfTokenPresent } from './engine/engine-boot.js';
 import { handleOAuthCallbackIfPresent } from './engine/oauth-callback.js';

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -3,6 +3,7 @@ import type { TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import type { CpSelectOption, CpTab } from '@communist-prometheus/cp-components';
+import '../editor/cp-markdown-editor.js';
 import { listArticles, readFile, stageFile, commitAndPush } from '../engine/content.js';
 
 /** One editable article block: a stable id plus its raw markdown source line(s).
@@ -402,8 +403,8 @@ export class ScreenEditor extends LitElement {
   /** Frontmatter `title`, shown in the gradient H1. */
   @state() private articleTitle = '';
 
-  /** The article body as editable blocks — the in-memory source of truth. */
-  @state() private blocks: readonly EditorBlock[] = [];
+  /** The article body markdown — the in-memory source of truth for the editor. */
+  @state() private body = '';
 
   /** Id of the block currently revealing/editing its raw markdown; '' reveals none. */
   @state() private focusedBlock = '';
@@ -497,19 +498,18 @@ export class ScreenEditor extends LitElement {
     const parsed = parseArticle(markdown);
     this.frontmatter = parsed.frontmatter;
     this.articleTitle = parsed.title;
-    this.blocks = splitBlocks(parsed.body).map((raw, index) => ({ id: `blk-${index}`, raw }));
+    this.body = parsed.body;
     this.articlePath = path;
     this.live = live;
-    this.focusedBlock = '';
     const date =
       frontmatterValue(parsed.frontmatter, 'pubDate') ?? frontmatterValue(parsed.frontmatter, 'date');
     if (date !== undefined) this.pubDate = date;
     this.published = frontmatterValue(parsed.frontmatter, 'draft') !== 'true';
   }
 
-  /** Reconstructs the full markdown document from the edited in-memory blocks. */
+  /** Reconstructs the full markdown document from the frontmatter + edited body. */
   private get editedMarkdown(): string {
-    const body = this.blocks.map((block) => block.raw).join('\n\n');
+    const body = this.body.trimEnd();
     return this.frontmatter === '' ? `${body}\n` : `${this.frontmatter}\n\n${body}\n`;
   }
 
@@ -846,11 +846,17 @@ export class ScreenEditor extends LitElement {
           @cp-tab-change=${this.onLangChange}
         ></cp-tabs>
         ${this.renderToolbar()}
-        <div class="live">${this.blocks.map((block, index) => this.renderBlock(block, index))}</div>
+        <cp-markdown-editor
+          class="live"
+          .value=${this.body}
+          placeholder="Текст статьи в Markdown…"
+          @cp-change=${(event: CustomEvent<{ value: string }>) =>
+            (this.body = event.detail.value)}
+        ></cp-markdown-editor>
         <p class="hint">
-          Кликни в абзац — раскроется только он и покажет разметку
+          Живой предпросмотр: форматирование отрендерено сразу, а разметку
           <span class="kbd">#</span> <span class="kbd">**</span>
-          <span class="kbd">&gt;</span> <span class="kbd">[^24]</span>. Остальное — вёрстка статьи.
+          <span class="kbd">&gt;</span> видно только на строке с курсором.
         </p>
         <p class="save-note">
           <cp-icon name="warning" size="16"></cp-icon>


### PR DESCRIPTION
Points the master build VITE_GITHUB_BRANCH at master so the prod admin reads+writes prod content instead of develop. See commit for the protection tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)