### PR TITLE
fix: OAuth login race + first-paint CLS

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -124,7 +124,7 @@ export class AppShell extends LitElement {
       grid-template-columns: 1fr;
     }
     @media (min-width: 768px) {
-      .body {
+      .body.has-nav {
         grid-template-columns: 15rem minmax(0, 1fr);
       }
     }
@@ -413,6 +413,9 @@ export class AppShell extends LitElement {
   /** Signed-in GitHub login, or undefined when signed out. */
   @state() private account?: string;
 
+  /** True once the initial session check has completed (gates first paint). */
+  @state() private authChecked = false;
+
   /** True while a login attempt is in flight. */
   @state() private loggingIn = false;
 
@@ -680,8 +683,14 @@ export class AppShell extends LitElement {
 
   /** Resolves an existing session on load (populates the account name). */
   private async resolveAccount(): Promise<void> {
-    const user = await currentUser();
-    this.account = user?.username;
+    try {
+      const user = await currentUser();
+      this.account = user?.username;
+    } finally {
+      // Gate the first paint until the session is known, so a logged-in reload
+      // does not flash the signed-out prompt before the app (a big layout shift).
+      this.authChecked = true;
+    }
   }
 
   /** Finishes a successful login: records the account, boots the engine, closes. */
@@ -780,18 +789,30 @@ export class AppShell extends LitElement {
           </button>
         </div>
       </header>
-      <div class="body">
-        ${this.account === undefined ? nothing : this.renderRailNav()}
+      <div class="body ${this.signedIn ? 'has-nav' : ''}">
+        ${this.signedIn ? this.renderRailNav() : nothing}
         <main tabindex="-1" aria-live="polite">
-          ${this.account === undefined
-            ? this.renderSignedOut()
-            : screen
-              ? screen.render()
-              : nothing}
+          ${!this.authChecked
+            ? this.renderChecking()
+            : this.signedIn
+              ? screen
+                ? screen.render()
+                : nothing
+              : this.renderSignedOut()}
         </main>
       </div>
-      ${this.account === undefined ? nothing : this.renderFabMenu()} ${this.renderAuthDialog()}
+      ${this.signedIn ? this.renderFabMenu() : nothing} ${this.renderAuthDialog()}
     `;
+  }
+
+  /** True only once the session is confirmed present. */
+  private get signedIn(): boolean {
+    return this.authChecked && this.account !== undefined;
+  }
+
+  /** Neutral placeholder shown while the session is being resolved (no flash). */
+  private renderChecking() {
+    return html`<p class="auth-hint" style="padding-top:var(--spacing-md)">Загрузка…</p>`;
   }
 
   /** Content-area placeholder shown until a session exists (no repo data leaks). */

--- a/src/redesign/engine/auth.ts
+++ b/src/redesign/engine/auth.ts
@@ -22,6 +22,18 @@ import { createPopupWindow } from '@/composables/useOAuthPopup/popup-window';
  */
 export const login = (onError?: (message: string) => void): Promise<User | undefined> =>
   new Promise((resolve) => {
+    // The callback popup posts the token and then closes itself. The
+    // close-monitor polls every 500ms, but the success handler must first
+    // `fetchGitHubUser` (~1s) before it resolves — so the monitor used to win
+    // the race and report "closed before completing" even though the token had
+    // arrived and been saved. `settled` records the first real outcome; on a
+    // bare close we wait a grace period for a pending message before giving up.
+    let settled = false;
+    const finish = (user: User | undefined): void => {
+      if (settled) return;
+      settled = true;
+      resolve(user);
+    };
     void buildAuthorizeUrl().then((url) => {
       // eslint-disable-next-line no-console
       console.info('[oauth-login] opening popup', { authorize: url.split('?')[0] });
@@ -35,22 +47,28 @@ export const login = (onError?: (message: string) => void): Promise<User | undef
           // eslint-disable-next-line no-console
           console.info('[oauth-login] success', { user: user.username });
           saveToken(user.accessToken);
-          resolve(user);
+          finish(user);
         },
         (message) => {
           // eslint-disable-next-line no-console
           console.error('[oauth-login] error from popup:', message);
           onError?.(message);
-          resolve(undefined);
+          finish(undefined);
         },
         cleanup,
       );
       globalThis.addEventListener('message', handleMessage);
       createPopupMonitor(popup, () => {
-        // eslint-disable-next-line no-console
-        console.warn('[oauth-login] popup closed before completing');
-        globalThis.removeEventListener('message', handleMessage);
-        resolve(undefined);
+        // Popup closed: give an in-flight success/error message time to settle
+        // (the token may already be posted) before treating it as a cancel.
+        if (settled) return;
+        globalThis.setTimeout(() => {
+          if (settled) return;
+          // eslint-disable-next-line no-console
+          console.warn('[oauth-login] popup closed with no result — treating as cancel');
+          globalThis.removeEventListener('message', handleMessage);
+          finish(undefined);
+        }, 2500);
       });
     });
   });


### PR DESCRIPTION
OAuth success was lost to a popup-close race (token saved but UI showed 'не завершён'); fixed with a settled-guard + grace period. First-paint CLS from the signed-out→app flash + nav-column layout fixed via an authChecked gate and conditional grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)