### PR TITLE
fix: white frame + loading flash + table overflow

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -294,6 +294,13 @@ export class AppShell extends LitElement {
       padding: var(--spacing-lg) var(--spacing-md) var(--spacing-2xl);
       max-width: 60rem;
     }
+    /* main is focused programmatically on route change (for the aria-live
+       announcement); it must not paint the browser focus ring, which framed the
+       whole content area as a stray white border. */
+    main:focus,
+    main:focus-visible {
+      outline: none;
+    }
     header {
       min-width: 0;
     }
@@ -797,28 +804,36 @@ export class AppShell extends LitElement {
       <div class="body">
         ${this.renderRailNav()}
         <main tabindex="-1" aria-live="polite">
-          ${!this.authChecked
-            ? this.renderChecking()
-            : this.signedIn
-              ? screen
-                ? screen.render()
-                : nothing
-              : this.renderSignedOut()}
+          ${this.signedIn
+            ? screen
+              ? screen.render()
+              : nothing
+            : this.renderSignedOut()}
         </main>
       </div>
       ${this.signedIn ? this.renderFabMenu() : nothing} ${this.renderAuthDialog()}
     `;
   }
 
-  /** True only once the session is confirmed present. */
-  private get signedIn(): boolean {
-    return this.authChecked && this.account !== undefined;
+  /** A `gh_token` is persisted — used to render the signed-in shell optimistically. */
+  private get hasStoredToken(): boolean {
+    try {
+      return localStorage.getItem('gh_token') !== null;
+    } catch {
+      return false;
+    }
   }
 
-  /** Neutral placeholder shown while the session is being resolved (no flash). */
-  private renderChecking() {
-    return html`<p class="auth-hint" style="padding-top:var(--spacing-md)">Загрузка…</p>`;
+  /**
+   * Whether to render the signed-in shell. Once the session check has run, this
+   * is exact. Before it finishes, we render optimistically when a token is
+   * persisted — a reload of a logged-in page then paints the real layout
+   * immediately instead of flashing a "Загрузка…" placeholder and jumping.
+   */
+  private get signedIn(): boolean {
+    return this.account !== undefined || (!this.authChecked && this.hasStoredToken);
   }
+
 
   /** Content-area placeholder shown until a session exists (no repo data leaks). */
   private renderSignedOut() {

--- a/src/redesign/screens/screen-members.ts
+++ b/src/redesign/screens/screen-members.ts
@@ -127,12 +127,14 @@ export class ScreenMembers extends LitElement {
         <cp-button variant="primary" arrow>Пригласить</cp-button>
       </div>
       ${live
-        ? html`<cp-table
-            rowKey="login"
-            caption="Участники репозитория"
-            .columns=${[...ScreenMembers.columns]}
-            .rows=${rows}
-          ></cp-table>`
+        ? html`<div style="max-width:100%;overflow-x:auto">
+            <cp-table
+              rowKey="login"
+              caption="Участники репозитория"
+              .columns=${[...ScreenMembers.columns]}
+              .rows=${rows}
+            ></cp-table>
+          </div>`
         : html`<p class="note">
             ${this.loaded
               ? 'Войдите через GitHub токеном с доступом к коллабораторам репозитория, чтобы увидеть участников.'

--- a/src/redesign/screens/screen-newsletter.ts
+++ b/src/redesign/screens/screen-newsletter.ts
@@ -133,6 +133,13 @@ export class ScreenNewsletter extends LitElement {
       overflow-x: auto;
     }
 
+    /* Wide tables scroll inside their own gutter instead of pushing the whole
+       screen past the viewport (the horizontal-overflow "вёрстка" bug). */
+    .scroll-x {
+      max-width: 100%;
+      overflow-x: auto;
+    }
+
     section {
       display: grid;
       gap: var(--spacing-md);
@@ -304,11 +311,13 @@ export class ScreenNewsletter extends LitElement {
             Добавить
           </cp-button>
         </div>
-        <cp-table
-          caption="Список рассылки"
-          .columns=${SUBSCRIBER_COLUMNS}
-          .rows=${rows}
-        ></cp-table>
+        <div class="scroll-x">
+          <cp-table
+            caption="Список рассылки"
+            .columns=${SUBSCRIBER_COLUMNS}
+            .rows=${rows}
+          ></cp-table>
+        </div>
       </section>
     `;
   };

--- a/src/redesign/screens/screen-tickets.ts
+++ b/src/redesign/screens/screen-tickets.ts
@@ -185,7 +185,9 @@ export class ScreenTickets extends LitElement {
               </div>
             </div>
 
-            <cp-table caption="Тикеты и баг-репорты" .columns=${COLUMNS} .rows=${rows}></cp-table>
+            <div style="max-width:100%;overflow-x:auto">
+              <cp-table caption="Тикеты и баг-репорты" .columns=${COLUMNS} .rows=${rows}></cp-table>
+            </div>
           `
         : html`<p class="eyebrow">
             ${this.loaded


### PR DESCRIPTION
Prod-review fixes: main focus-ring white frame, logged-in reload flash (optimistic render), cp-table horizontal overflow (members/tickets/newsletter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)