### PR TITLE
fix(editor): open clicked article + persist Свойства metadata (#5/#6/#7)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Running unit tests
         run: bun run test:unit --run
 
+      - name: Running redesign unit tests
+        run: bun run test:unit:redesign
+
       - name: Building application (validate + type-check + lint + build)
         run: bun run build
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview --port 5173 --outDir dist/client",
     "preview:test": "vite preview --port 5173 --outDir dist/client",
     "test:unit": "vitest",
+    "test:unit:redesign": "vitest run --config vitest.redesign.config.ts",
     "test:unit:ui": "vitest --ui",
     "verify:reset-replay": "bun scripts/verify-reset-replay.ts",
     "test:unit:coverage": "vitest --coverage",

--- a/src/redesign/app-shell.guard.test.ts
+++ b/src/redesign/app-shell.guard.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render } from 'lit';
+import './app-shell.ts';
+import { AppShell } from './app-shell.ts';
+import type { ViewerRole } from './engine/github-api.ts';
+
+interface ShellInternals {
+  account?: string;
+  viewerRole?: ViewerRole;
+  route: string;
+  renderRouted: (screen: undefined) => unknown;
+}
+
+/** Renders the routed region for a given session and returns its text. */
+const routedText = (route: string, account: string | undefined, role?: ViewerRole): string => {
+  const el = document.createElement('app-shell') as AppShell;
+  const priv = el as unknown as ShellInternals;
+  priv.account = account;
+  priv.viewerRole = role;
+  priv.route = route;
+  const container = document.createElement('div');
+  render(priv.renderRouted(undefined), container);
+  return (container.textContent ?? '').replace(/\s+/g, ' ').trim();
+};
+
+describe('app-shell route guard (QA #2)', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('denies the owner-only newsletter to an editor', () => {
+    expect(routedText('newsletter', 'u', { role: 'editor', owner: false })).toContain('Нет доступа');
+  });
+
+  it('denies admin-only settings to an editor', () => {
+    expect(routedText('settings', 'u', { role: 'editor', owner: false })).toContain('Нет доступа');
+  });
+
+  it('is fail-closed for owner-only routes before the role resolves', () => {
+    // viewerRole undefined → auth falls back to editor → owner-only stays denied.
+    expect(routedText('newsletter', 'u', undefined)).toContain('Нет доступа');
+  });
+
+  it('allows the newsletter for a confirmed owner', () => {
+    expect(routedText('newsletter', 'u', { role: 'admin', owner: true })).not.toContain(
+      'Нет доступа',
+    );
+  });
+
+  it('never guards an editor content route', () => {
+    expect(routedText('articles', 'u', { role: 'editor', owner: false })).not.toContain(
+      'Нет доступа',
+    );
+  });
+});

--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -6,6 +6,7 @@ import { screens } from './screens/index.js';
 import { createGitStateStore, type GitStateStore, type SyncStatus } from './engine/git-state.js';
 import { login, loginWithToken, logout, currentUser } from './engine/auth.js';
 import { bootEngine } from './engine/engine-boot.js';
+import { getViewerRole, type ViewerRole } from './engine/github-api.js';
 
 /** One of the four viewport corners the draggable FAB can snap to. */
 type Corner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
@@ -301,6 +302,25 @@ export class AppShell extends LitElement {
     main:focus-visible {
       outline: none;
     }
+    .denied {
+      display: grid;
+      gap: var(--spacing-sm);
+      padding: var(--spacing-2xl) 0;
+      max-width: 40ch;
+    }
+    .denied h1 {
+      margin: 0;
+      font-size: clamp(1.6rem, 5vw, 2.2rem);
+    }
+    .denied h1:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 4px;
+    }
+    .denied p {
+      margin: 0;
+      color: var(--color-text-secondary);
+      line-height: 1.5;
+    }
     header {
       min-width: 0;
     }
@@ -403,16 +423,20 @@ export class AppShell extends LitElement {
   private dragStartY = 0;
 
   /**
-   * The session as the nav gating consumes it, derived from the real login —
-   * `undefined` when signed out (so the menu is empty and screens are gated).
-   * Every signed-in maintainer currently gets the full admin/owner surface;
-   * finer role resolution is owned by the auth/RBAC spec.
+   * The session as the nav gating consumes it (QA #2). `undefined` when signed
+   * out. The role/ownership come from the viewer's REAL GitHub permission on the
+   * content repo ({@link viewerRole}); until that resolves we fall back to the
+   * least-privilege editor (no owner-only or admin surfaces) rather than assuming
+   * everyone is an owner — so a non-owner never briefly sees owner-only screens.
    */
   private get auth(): AuthState | undefined {
-    return this.account === undefined
-      ? undefined
-      : { role: 'admin', owner: true, login: this.account };
+    if (this.account === undefined) return undefined;
+    const resolved = this.viewerRole ?? { role: 'editor', owner: false };
+    return { role: resolved.role, owner: resolved.owner, login: this.account };
   }
+
+  /** Real GitHub role of the signed-in viewer; undefined until resolved. */
+  @state() private viewerRole?: ViewerRole;
 
   /** Live git-engine state store; drives the header sync-status affordance. */
   private store?: GitStateStore;
@@ -698,10 +722,26 @@ export class AppShell extends LitElement {
     try {
       const user = await currentUser();
       this.account = user?.username;
+      if (this.account !== undefined) void this.resolveRole();
     } finally {
       // Gate the first paint until the session is known, so a logged-in reload
       // does not flash the signed-out prompt before the app (a big layout shift).
       this.authChecked = true;
+    }
+  }
+
+  /**
+   * Resolves the viewer's real GitHub role so the nav + route guard reflect it.
+   * The guard is fail-closed, so a transient API hiccup would otherwise lock the
+   * real owner out of owner-only screens — retry a few times before giving up.
+   */
+  private async resolveRole(): Promise<void> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const role = await getViewerRole();
+      if (role !== undefined) {
+        this.viewerRole = role;
+        return;
+      }
     }
   }
 
@@ -710,6 +750,7 @@ export class AppShell extends LitElement {
     this.account = username;
     this.authOpen = false;
     this.authError = undefined;
+    void this.resolveRole();
     await bootEngine(token);
   }
 
@@ -774,6 +815,36 @@ export class AppShell extends LitElement {
     `;
   }
 
+  /** Human label for the viewer's current role, for the access-denied notice. */
+  private get roleLabel(): string {
+    const role = this.auth?.role ?? 'viewer';
+    if (this.auth?.owner === true) return 'владелец';
+    return role === 'admin' ? 'администратор' : role === 'editor' ? 'редактор' : 'наблюдатель';
+  }
+
+  /**
+   * Renders the routed screen, or an access-denied notice when the current route
+   * is gated above the viewer's role (QA #2 route guard). Fail-closed: an
+   * owner/admin-only route is denied until the viewer's real role proves access,
+   * so a non-owner cannot reach an owner-only screen by typing its URL.
+   */
+  private renderRouted(screen: (typeof screens)[string] | undefined) {
+    const auth = this.auth;
+    const item = navItems.find((navItem) => navItem.id === this.route);
+    if (auth !== undefined && item !== undefined && !canSee(item, auth)) {
+      return html`
+        <section class="denied">
+          <h1 tabindex="-1">Нет доступа</h1>
+          <p>
+            Раздел «${item.label}» доступен с более высокими правами в репозитории. Ваша роль:
+            ${this.roleLabel}.
+          </p>
+        </section>
+      `;
+    }
+    return screen ? screen.render() : nothing;
+  }
+
   override render() {
     const screen = screens[this.route];
     return html`
@@ -806,11 +877,7 @@ export class AppShell extends LitElement {
       <div class="body">
         ${this.renderRailNav()}
         <main tabindex="-1" aria-live="polite">
-          ${this.signedIn
-            ? screen
-              ? screen.render()
-              : nothing
-            : this.renderSignedOut()}
+          ${this.signedIn ? this.renderRouted(screen) : this.renderSignedOut()}
         </main>
       </div>
       ${this.signedIn ? this.renderFabMenu() : nothing} ${this.renderAuthDialog()}

--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -466,7 +466,9 @@ export class AppShell extends LitElement {
   }
 
   private syncRoute = (): void => {
-    const id = window.location.hash.replace(/^#\/?/, '');
+    // Route id is the first hash segment; anything after it (e.g.
+    // #/editor/<slug>) is a screen-level parameter the screen reads itself.
+    const id = window.location.hash.replace(/^#\/?/, '').split('/')[0] ?? '';
     this.route = id in screens ? id : 'articles';
     this.fabOpen = false;
     this.updateComplete.then(() => this.focusScreen());

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -119,6 +119,32 @@ export const buildIssueIndexMarkdown = (i: IssueIndexInput): string => {
   );
 };
 
+/**
+ * A folder-safe issue slug: lowercase Latin letters, digits and single hyphens,
+ * with no leading, trailing or doubled hyphen (e.g. `nomer-3-2026`).
+ */
+const ISSUE_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/**
+ * Validates a proposed magazine-issue slug against the folder-naming rules and
+ * the slugs that already exist, returning a human-readable Russian error, or
+ * `undefined` when the slug is acceptable. Pure — the screen calls it to gate
+ * the submit button and to surface an inline hint before `createMagazineIssue`
+ * would write a broken or colliding `magazine/<slug>/…` path (QA #17).
+ */
+export const validateMagazineSlug = (
+  slug: string,
+  existing: readonly string[],
+): string | undefined => {
+  const value = slug.trim();
+  if (value === '') return 'Укажите слаг номера.';
+  if (!ISSUE_SLUG_PATTERN.test(value)) {
+    return 'Слаг: только строчные латинские буквы, цифры и дефисы (например, nomer-3-2026).';
+  }
+  if (existing.includes(value)) return `Номер со слагом «${value}» уже существует.`;
+  return undefined;
+};
+
 /** Everything the UI collects to publish a new magazine issue. */
 export interface NewMagazineIssue {
   readonly slug: string;

--- a/src/redesign/engine/engine-boot.ts
+++ b/src/redesign/engine/engine-boot.ts
@@ -1,6 +1,7 @@
 import { getGitHubConfig } from '../../config/github.js';
 import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
 import { registerEngine } from './sw-client.js';
+import { markEngineReady } from './engine-ready.js';
 
 /**
  * Boots the real content engine for the new UI (git-engine R2/R4/R7): registers
@@ -41,6 +42,8 @@ export const bootEngine = async (token: string): Promise<void> => {
   });
   const result: { ok?: boolean; error?: string } = await response.json();
   if (result.ok !== true) throw new Error(`engine init failed: ${result.error ?? response.status}`);
+  // Repo is cloned/synced: let screens that mounted before this re-read now.
+  markEngineReady();
 };
 
 /**

--- a/src/redesign/engine/engine-ready.test.ts
+++ b/src/redesign/engine/engine-ready.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * The engine-ready broadcast keeps module-level state, so every test re-imports
+ * a fresh copy via `vi.resetModules()` to start from "not ready".
+ */
+const freshModule = async (): Promise<typeof import('./engine-ready.js')> => {
+  vi.resetModules();
+  return import('./engine-ready.js');
+};
+
+describe('engine-ready', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('starts not ready', async () => {
+    const { isEngineReady } = await freshModule();
+    expect(isEngineReady()).toBe(false);
+  });
+
+  it('marks ready and reports it', async () => {
+    const { isEngineReady, markEngineReady } = await freshModule();
+    markEngineReady();
+    expect(isEngineReady()).toBe(true);
+  });
+
+  it('notifies a subscriber registered before readiness', async () => {
+    const { onEngineReady, markEngineReady } = await freshModule();
+    const listener = vi.fn();
+    onEngineReady(listener);
+    expect(listener).not.toHaveBeenCalled();
+    markEngineReady();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs a subscriber registered after readiness on a microtask', async () => {
+    const { onEngineReady, markEngineReady } = await freshModule();
+    markEngineReady();
+    const listener = vi.fn();
+    onEngineReady(listener);
+    expect(listener).not.toHaveBeenCalled();
+    await Promise.resolve();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('is idempotent: a second mark does not re-notify', async () => {
+    const { onEngineReady, markEngineReady } = await freshModule();
+    const listener = vi.fn();
+    onEngineReady(listener);
+    markEngineReady();
+    markEngineReady();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe prevents notification', async () => {
+    const { onEngineReady, markEngineReady } = await freshModule();
+    const listener = vi.fn();
+    const off = onEngineReady(listener);
+    off();
+    markEngineReady();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('notifies multiple subscribers', async () => {
+    const { onEngineReady, markEngineReady } = await freshModule();
+    const a = vi.fn();
+    const b = vi.fn();
+    onEngineReady(a);
+    onEngineReady(b);
+    markEngineReady();
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/redesign/engine/engine-ready.ts
+++ b/src/redesign/engine/engine-ready.ts
@@ -1,0 +1,37 @@
+/**
+ * Engine readiness broadcast (git-engine first-load race, QA #12).
+ *
+ * Screens read repo content in their `connectedCallback`, which runs while the
+ * shell mounts — before {@link bootEngine} has finished cloning/syncing the repo
+ * through `POST /api/sw/init`. Without a signal the first read returns nothing
+ * and the screen stays empty until a manual reload. This tiny module lets the
+ * boot sequence announce readiness and lets screens re-read exactly once when it
+ * arrives (or immediately, if they mounted after boot completed).
+ */
+
+const target = new EventTarget();
+let ready = false;
+
+/** Whether the content engine has finished booting (repo cloned/synced). */
+export const isEngineReady = (): boolean => ready;
+
+/** Marks the engine ready and notifies subscribers. Idempotent. */
+export const markEngineReady = (): void => {
+  if (ready) return;
+  ready = true;
+  target.dispatchEvent(new Event('ready'));
+};
+
+/**
+ * Invokes `listener` once the engine is ready: synchronously-scheduled on a
+ * microtask if it is already ready, otherwise on the next readiness broadcast.
+ * Returns an unsubscribe function safe to call in `disconnectedCallback`.
+ */
+export const onEngineReady = (listener: () => void): (() => void) => {
+  if (ready) {
+    queueMicrotask(listener);
+    return () => {};
+  }
+  target.addEventListener('ready', listener, { once: true });
+  return () => target.removeEventListener('ready', listener);
+};

--- a/src/redesign/engine/git-state.test.ts
+++ b/src/redesign/engine/git-state.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'bun:test';
+import { test, expect } from 'vitest';
 import { createGitStateStore, toSyncStatus, type ChannelIo } from './git-state.ts';
 import { SW_PUSH_STATE_CHANNEL } from '../../sw/protocol/push-state.ts';
 import { SW_CONNECTIVITY_CHANNEL } from '../../sw/protocol/connectivity.ts';

--- a/src/redesign/engine/github-api.ts
+++ b/src/redesign/engine/github-api.ts
@@ -64,6 +64,30 @@ const toMember = (x: unknown): Member | undefined => {
   };
 };
 
+/** The signed-in viewer's coarse role on the content repo. */
+export interface ViewerRole {
+  readonly role: 'viewer' | 'editor' | 'admin';
+  readonly owner: boolean;
+}
+
+/**
+ * Resolves the signed-in viewer's real role from GitHub instead of assuming
+ * everyone is an owner (QA #2). A repo object carries the authenticated user's
+ * own `permissions`, so `admin` → owner/admin, `push` → editor, otherwise a
+ * read-only viewer. Returns `undefined` when signed out or on any failure, so the
+ * caller can pick a conservative fallback rather than silently granting access.
+ */
+export const getViewerRole = async (
+  repo = 'public-website-content',
+): Promise<ViewerRole | undefined> => {
+  const data = await get(`/repos/${OWNER}/${repo}`);
+  if (data === undefined) return undefined;
+  const permissions = field(data, 'permissions');
+  if (field(permissions, 'admin') === true) return { role: 'admin', owner: true };
+  if (field(permissions, 'push') === true) return { role: 'editor', owner: false };
+  return { role: 'viewer', owner: false };
+};
+
 /** Lists collaborators of a repo (default: the content repo). */
 export const listMembers = async (repo = 'public-website-content'): Promise<readonly Member[]> => {
   const data = await get(`/repos/${OWNER}/${repo}/collaborators?per_page=100`);

--- a/src/redesign/engine/load-state.test.ts
+++ b/src/redesign/engine/load-state.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/** Re-import both modules fresh so engine-ready's module state starts unset. */
+const fresh = async (): Promise<{
+  classifyEmpty: typeof import('./load-state.js').classifyEmpty;
+  markEngineReady: typeof import('./engine-ready.js').markEngineReady;
+}> => {
+  vi.resetModules();
+  const [{ classifyEmpty }, { markEngineReady }] = await Promise.all([
+    import('./load-state.js'),
+    import('./engine-ready.js'),
+  ]);
+  return { classifyEmpty, markEngineReady };
+};
+
+describe('classifyEmpty (QA #14)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('reports loading before the read completes', async () => {
+    const { classifyEmpty } = await fresh();
+    expect(classifyEmpty(false)).toBe('loading');
+  });
+
+  it('reports signed-out when loaded but the engine never booted', async () => {
+    const { classifyEmpty } = await fresh();
+    expect(classifyEmpty(true)).toBe('signed-out');
+  });
+
+  it('reports empty (not signed-out) when the engine is ready', async () => {
+    const { classifyEmpty, markEngineReady } = await fresh();
+    markEngineReady();
+    expect(classifyEmpty(true)).toBe('empty');
+  });
+
+  it('still reports loading while the engine is ready but the read is pending', async () => {
+    const { classifyEmpty, markEngineReady } = await fresh();
+    markEngineReady();
+    expect(classifyEmpty(false)).toBe('loading');
+  });
+});

--- a/src/redesign/engine/load-state.ts
+++ b/src/redesign/engine/load-state.ts
@@ -1,0 +1,25 @@
+import { isEngineReady } from './engine-ready.js';
+
+/**
+ * How an empty content read should be presented (QA #14). The screens' reads
+ * return an empty list on both "signed out" and "signed in but nothing came
+ * back", so a naive empty state told signed-in editors to sign in again. This
+ * classifier separates the two using the engine-ready signal:
+ *
+ * - `loading`    — the first read has not completed yet.
+ * - `signed-out` — the read completed but the engine never booted (no session),
+ *                  so a sign-in prompt is the correct call to action.
+ * - `empty`      — the engine is running and simply returned nothing (an empty
+ *                  repo, a failed fetch, or a filtered-away set): offer a reload,
+ *                  never a sign-in prompt.
+ */
+export type LoadState = 'loading' | 'signed-out' | 'empty';
+
+/**
+ * Classifies a completed-or-pending content read for the empty-state UI. Call
+ * only when there is no data to show; when items exist, render them instead.
+ */
+export const classifyEmpty = (loaded: boolean): LoadState => {
+  if (!loaded) return 'loading';
+  return isEngineReady() ? 'empty' : 'signed-out';
+};

--- a/src/redesign/engine/magazine-slug.test.ts
+++ b/src/redesign/engine/magazine-slug.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { validateMagazineSlug } from './content.ts';
+
+describe('validateMagazineSlug (QA #17)', () => {
+  const existing = ['nomer-1-2026', 'nomer-2-2026'];
+
+  it('accepts a well-formed, unique slug', () => {
+    expect(validateMagazineSlug('nomer-3-2026', existing)).toBeUndefined();
+  });
+
+  it('accepts a single-segment slug', () => {
+    expect(validateMagazineSlug('spring', [])).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(validateMagazineSlug('  nomer-3-2026  ', existing)).toBeUndefined();
+  });
+
+  it('rejects an empty slug', () => {
+    expect(validateMagazineSlug('', existing)).toBe('Укажите слаг номера.');
+    expect(validateMagazineSlug('   ', existing)).toBe('Укажите слаг номера.');
+  });
+
+  it('rejects uppercase letters', () => {
+    expect(validateMagazineSlug('Nomer-3', existing)).toMatch(/только строчные/);
+  });
+
+  it('rejects spaces and path separators', () => {
+    expect(validateMagazineSlug('nomer 3', existing)).toMatch(/только строчные/);
+    expect(validateMagazineSlug('nomer/3', existing)).toMatch(/только строчные/);
+    expect(validateMagazineSlug('../etc', existing)).toMatch(/только строчные/);
+  });
+
+  it('rejects leading, trailing and doubled hyphens', () => {
+    expect(validateMagazineSlug('-nomer', existing)).toMatch(/только строчные/);
+    expect(validateMagazineSlug('nomer-', existing)).toMatch(/только строчные/);
+    expect(validateMagazineSlug('nomer--3', existing)).toMatch(/только строчные/);
+  });
+
+  it('rejects a duplicate slug (trimmed)', () => {
+    expect(validateMagazineSlug('nomer-1-2026', existing)).toBe(
+      'Номер со слагом «nomer-1-2026» уже существует.',
+    );
+    expect(validateMagazineSlug('  nomer-2-2026 ', existing)).toMatch(/уже существует/);
+  });
+});

--- a/src/redesign/engine/sw-client.test.ts
+++ b/src/redesign/engine/sw-client.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'bun:test';
+import { test, expect } from 'vitest';
 import { createSwClient, type SwTransport } from './sw-client.ts';
 import type { SWRequest } from '../../sw/protocol/request-types.ts';
 

--- a/src/redesign/engine/viewer-role.test.ts
+++ b/src/redesign/engine/viewer-role.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// getViewerRole needs a token, then reads the repo's `permissions`. Stub the
+// token source and GitHub fetch so the permission→role mapping can be asserted.
+vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({
+  ensureFreshToken: async () => 'test-token',
+}));
+
+import { getViewerRole } from './github-api.ts';
+
+const repoResponse = (permissions: unknown): Response =>
+  ({ ok: true, json: async () => ({ permissions }) }) as unknown as Response;
+
+describe('getViewerRole (QA #2 role derivation)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('maps admin permission to owner/admin', async () => {
+    vi.mocked(fetch).mockResolvedValue(repoResponse({ admin: true, push: true, pull: true }));
+    expect(await getViewerRole()).toEqual({ role: 'admin', owner: true });
+  });
+
+  it('maps push permission to editor (not owner)', async () => {
+    vi.mocked(fetch).mockResolvedValue(repoResponse({ admin: false, push: true, pull: true }));
+    expect(await getViewerRole()).toEqual({ role: 'editor', owner: false });
+  });
+
+  it('maps read-only permission to viewer', async () => {
+    vi.mocked(fetch).mockResolvedValue(repoResponse({ admin: false, push: false, pull: true }));
+    expect(await getViewerRole()).toEqual({ role: 'viewer', owner: false });
+  });
+
+  it('returns undefined when the request fails', async () => {
+    vi.mocked(fetch).mockResolvedValue({ ok: false } as unknown as Response);
+    expect(await getViewerRole()).toBeUndefined();
+  });
+});

--- a/src/redesign/nav.test.ts
+++ b/src/redesign/nav.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { navItems, canSee, type AuthState, type Role } from './nav.ts';
+
+const item = (id: string) => {
+  const found = navItems.find((navItem) => navItem.id === id);
+  if (found === undefined) throw new Error(`no nav item ${id}`);
+  return found;
+};
+
+const auth = (role: Role, owner: boolean): AuthState => ({ role, owner, login: 'u' });
+
+describe('canSee (QA #2 route/nav gating)', () => {
+  it('hides the owner-only newsletter from non-owners', () => {
+    expect(canSee(item('newsletter'), auth('editor', false))).toBe(false);
+    expect(canSee(item('newsletter'), auth('admin', false))).toBe(false);
+    expect(canSee(item('newsletter'), auth('admin', true))).toBe(true);
+  });
+
+  it('gates admin-only members/settings to admins', () => {
+    for (const id of ['members', 'settings']) {
+      expect(canSee(item(id), auth('viewer', false))).toBe(false);
+      expect(canSee(item(id), auth('editor', false))).toBe(false);
+      expect(canSee(item(id), auth('admin', false))).toBe(true);
+    }
+  });
+
+  it('lets editors see the content surfaces', () => {
+    for (const id of ['articles', 'magazine', 'topics', 'tickets', 'deploys']) {
+      expect(canSee(item(id), auth('editor', false))).toBe(true);
+    }
+  });
+
+  it('hides editor surfaces from a bare viewer', () => {
+    expect(canSee(item('articles'), auth('viewer', false))).toBe(false);
+  });
+
+  it('an owner-admin sees everything', () => {
+    const owner = auth('admin', true);
+    for (const navItem of navItems) {
+      expect(canSee(navItem, owner)).toBe(true);
+    }
+  });
+});

--- a/src/redesign/screens/screen-articles.empty.test.ts
+++ b/src/redesign/screens/screen-articles.empty.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// No engine is booted in tests, so listArticles returns []. Force it explicitly
+// to keep the empty-state assertions independent of jsdom's fetch behaviour.
+vi.mock('../engine/content.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../engine/content.js')>();
+  return { ...actual, listArticles: async () => [] };
+});
+
+import './screen-articles.ts';
+import type { ScreenArticles } from './screen-articles.ts';
+import { markEngineReady } from '../engine/engine-ready.js';
+
+const shadowText = (el: HTMLElement): string =>
+  (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+const settle = async (el: ScreenArticles): Promise<void> => {
+  for (let i = 0; i < 4; i += 1) {
+    await el.updateComplete;
+    await Promise.resolve();
+  }
+};
+
+describe('screen-articles empty state (QA #14)', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('prompts sign-in before the engine boots, then switches to a reload prompt', async () => {
+    const el = document.createElement('screen-articles') as ScreenArticles;
+    document.body.append(el);
+    await settle(el);
+
+    // Engine not ready → this is a signed-out session, not an empty repo.
+    expect(shadowText(el)).toContain('Войдите через GitHub');
+    expect(shadowText(el)).not.toContain('не удалось');
+
+    // Once the engine is ready an empty list is no longer a sign-in problem.
+    markEngineReady();
+    await settle(el);
+    const text = shadowText(el);
+    expect(text).not.toContain('Войдите через GitHub');
+    expect(text).toContain('не удалось');
+    expect(text).toContain('Обновить');
+  });
+});

--- a/src/redesign/screens/screen-articles.ts
+++ b/src/redesign/screens/screen-articles.ts
@@ -83,13 +83,14 @@ export class ScreenArticles extends LitElement {
     this.loaded = true;
   }
 
-  private openEditor(): void {
-    location.hash = '/editor';
+  /** Opens the editor for a specific article slug, or a new blank document. */
+  private openEditor(slug?: string): void {
+    location.hash = slug === undefined ? '/editor/new' : `/editor/${slug}`;
   }
 
   private renderCard(article: ArticleSummary) {
     return html`
-      <cp-card hoverable @cp-card-click=${() => this.openEditor()}>
+      <cp-card hoverable @cp-card-click=${() => this.openEditor(article.slug)}>
         ${article.topic ? html`<cp-pill slot="pill">${article.topic}</cp-pill>` : nothing}
         <span slot="title">${article.title}</span>
         <span slot="summary">${article.languages.join(' · ')}</span>

--- a/src/redesign/screens/screen-articles.ts
+++ b/src/redesign/screens/screen-articles.ts
@@ -3,6 +3,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import { listArticles, type ArticleSummary } from '../engine/content.js';
 import { onEngineReady } from '../engine/engine-ready.js';
+import { classifyEmpty } from '../engine/load-state.js';
 
 /**
  * Articles screen (content-list spec). Lists the actual `blog/<slug>/index.<lang>.md`
@@ -117,13 +118,21 @@ export class ScreenArticles extends LitElement {
   }
 
   private renderEmpty() {
+    const state = classifyEmpty(this.loaded);
+    if (state === 'loading') {
+      return html`<div class="empty"><p>Загружаем материалы…</p></div>`;
+    }
+    if (state === 'signed-out') {
+      return html`
+        <div class="empty">
+          <p>Здесь появятся материалы репозитория. Войдите через GitHub, чтобы загрузить их.</p>
+        </div>
+      `;
+    }
     return html`
       <div class="empty">
-        <p>
-          ${this.loaded
-            ? 'Здесь появятся материалы репозитория. Войдите через GitHub, чтобы загрузить их.'
-            : 'Загружаем материалы…'}
-        </p>
+        <p>Материалов пока нет или не удалось их загрузить.</p>
+        <cp-button variant="secondary" @cp-click=${() => void this.load()}>Обновить</cp-button>
       </div>
     `;
   }

--- a/src/redesign/screens/screen-articles.ts
+++ b/src/redesign/screens/screen-articles.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import { listArticles, type ArticleSummary } from '../engine/content.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /**
  * Articles screen (content-list spec). Lists the actual `blog/<slug>/index.<lang>.md`
@@ -72,9 +73,19 @@ export class ScreenArticles extends LitElement {
   /** Whether a read has completed (so we can distinguish loading from empty). */
   @state() private loaded = false;
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
+    // The engine may still be cloning the repo (first load): re-read when ready.
+    this.disposeReady = onEngineReady(() => void this.load());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.disposeReady();
   }
 
   private async load(): Promise<void> {

--- a/src/redesign/screens/screen-deploys.ts
+++ b/src/redesign/screens/screen-deploys.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import { listPushes, type Push } from '../engine/github-api.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /**
  * `screen-deploys` — a real activity board of recent pushes to the content repo
@@ -101,9 +102,19 @@ export class ScreenDeploys extends LitElement {
   /** Whether the real read has completed. */
   @state() private loaded = false;
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
+    // Re-read once the engine finishes booting (first-load race, QA #12).
+    this.disposeReady = onEngineReady(() => void this.load());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.disposeReady();
   }
 
   private async load(): Promise<void> {

--- a/src/redesign/screens/screen-editor.lang.test.ts
+++ b/src/redesign/screens/screen-editor.lang.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * The editor reads a language's markdown through the content engine; stub that
+ * one read. These tests drive the element WITHOUT connecting it to the document
+ * so LitElement never renders — that keeps the CodeMirror preview (which under
+ * jsdom echoes stale change events back into `body`) out of the picture, so the
+ * assertions observe the language-buffer logic itself, not a jsdom artefact.
+ */
+vi.mock('../engine/content.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../engine/content.js')>();
+  const docs: Record<string, string> = {
+    'blog/x/index.ru.md': '---\ntitle: "RU"\ncategory: t\npublished: true\n---\n\nRU body\n',
+    'blog/x/index.en.md': '---\ntitle: "EN"\ncategory: t\npublished: true\n---\n\nEN body\n',
+  };
+  return { ...actual, readFile: async (path: string) => docs[path] };
+});
+
+const RU = '---\ntitle: "RU"\ncategory: t\npublished: true\n---\n\nRU body\n';
+
+import './screen-editor.ts';
+import type { ScreenEditor } from './screen-editor.ts';
+
+interface EditorInternals {
+  slug: string;
+  live: boolean;
+  activeLang: string;
+  body: string;
+  applyMarkdown: (markdown: string, path: string, live: boolean) => void;
+  onLangChange: (event: Event) => void;
+  switchLang: (lang: string) => Promise<void>;
+}
+
+/** An editor seeded with the RU article, as if it had just loaded. */
+const seededEditor = (): EditorInternals => {
+  const el = document.createElement('screen-editor') as ScreenEditor;
+  const priv = el as unknown as EditorInternals;
+  priv.slug = 'x';
+  priv.live = true;
+  priv.activeLang = 'ru';
+  priv.applyMarkdown(RU, 'blog/x/index.ru.md', true);
+  return priv;
+};
+
+const langEvent = (lang: string): Event =>
+  new CustomEvent('cp-tab-change', { detail: { id: lang } });
+
+/** Lets the fire-and-forget switchLang() readFile chain settle. */
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 4; i += 1) await Promise.resolve();
+};
+
+describe('screen-editor language tab (QA #8: edits survive tab switches)', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('reads the requested language from disk', async () => {
+    const el = seededEditor();
+    expect(el.body).toContain('RU body');
+    await el.switchLang('en');
+    expect(el.body).toContain('EN body');
+  });
+
+  it('buffers the current language edits when switching away', () => {
+    const el = seededEditor();
+    el.body = 'RU EDITED';
+    el.onLangChange(langEvent('en'));
+    const buffered = (el as unknown as { langBuffers: Map<string, string> }).langBuffers.get('ru');
+    expect(buffered).toBeDefined();
+    expect(buffered).toContain('RU EDITED');
+  });
+
+  it('restores an unsaved edit when switching back to a language', async () => {
+    const el = seededEditor();
+    el.body = 'RU EDITED';
+
+    // Switch to EN (loads from disk), then back to RU (restores the buffer).
+    el.onLangChange(langEvent('en'));
+    await flush();
+    expect(el.body).toContain('EN body');
+
+    el.onLangChange(langEvent('ru'));
+    await flush();
+    expect(el.body).toContain('RU EDITED');
+  });
+});

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -4,7 +4,13 @@ import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import type { CpSelectOption, CpTab } from '@communist-prometheus/cp-components';
 import '../editor/cp-markdown-editor.js';
-import { listArticles, readFile, stageFile, commitAndPush } from '../engine/content.js';
+import {
+  listArticles,
+  readFile,
+  stageFile,
+  commitAndPush,
+  upsertFrontmatterField,
+} from '../engine/content.js';
 
 /** One editable article block: a stable id plus its raw markdown source line(s).
  *  The rendered typography is derived from the raw text on every render, so the
@@ -460,21 +466,56 @@ export class ScreenEditor extends LitElement {
   /** Set when a user click should move focus into the freshly-rendered textarea. */
   private pendingFocus = false;
 
+  /** Slug currently loaded, to detect same-screen route changes. */
+  private loadedSlug = '';
+
   override connectedCallback(): void {
     super.connectedCallback();
+    this.loadedSlug = this.routeSlug();
     void this.load();
+    globalThis.addEventListener('hashchange', this.onHashChange);
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    globalThis.removeEventListener('hashchange', this.onHashChange);
+  }
+
+  // Re-load when the editor stays mounted but the requested slug changes
+  // (back/forward, or opening another article without leaving the editor).
+  private onHashChange = (): void => {
+    const next = this.routeSlug();
+    if (next !== this.loadedSlug && window.location.hash.startsWith('#/editor')) {
+      this.loadedSlug = next;
+      void this.load();
+    }
+  };
+
+  /** Slug requested via the route (`#/editor/<slug>`), '' for the default. */
+  private routeSlug(): string {
+    return window.location.hash.split('/')[2] ?? '';
   }
 
   private async load(): Promise<void> {
     const articles = await listArticles();
-    const first = articles.at(0);
-    if (first !== undefined) {
-      const lang = first.languages.includes('ru') ? 'ru' : first.languages.at(0) ?? 'ru';
-      const path = `blog/${first.slug}/index.${lang}.md`;
+    // Open the article the route names — clicking a card must open THAT article,
+    // not always the first one. `new` starts a blank document; a missing/unknown
+    // slug falls back to the first article.
+    const requested = this.routeSlug();
+    if (requested === 'new') {
+      this.startNewArticle();
+      this.loaded = true;
+      return;
+    }
+    const target =
+      (requested !== '' ? articles.find((a) => a.slug === requested) : undefined) ?? articles.at(0);
+    if (target !== undefined) {
+      const lang = target.languages.includes('ru') ? 'ru' : (target.languages.at(0) ?? 'ru');
+      const path = `blog/${target.slug}/index.${lang}.md`;
       const markdown = await readFile(path);
       if (markdown !== undefined && markdown.trim() !== '') {
-        this.slug = first.slug;
-        this.availableLangs = first.languages;
+        this.slug = target.slug;
+        this.availableLangs = target.languages;
         this.activeLang = lang === 'ru' || lang === 'en' || lang === 'it' ? lang : 'ru';
         this.applyMarkdown(markdown, path, true);
         this.loaded = true;
@@ -484,6 +525,14 @@ export class ScreenEditor extends LitElement {
     // No real article (signed out or empty repo): stay empty and prompt sign-in
     // rather than loading a fabricated demo document.
     this.loaded = true;
+  }
+
+  /** Seeds a blank new-article document (real save-to-new-file is a follow-up). */
+  private startNewArticle(): void {
+    this.slug = '';
+    this.availableLangs = ['ru'];
+    this.activeLang = 'ru';
+    this.applyMarkdown('---\ntitle: ""\nlang: ru\ncategory: \npublished: false\n---\n\n', '', true);
   }
 
   private async loadLang(lang: string): Promise<void> {
@@ -496,21 +545,37 @@ export class ScreenEditor extends LitElement {
 
   private applyMarkdown(markdown: string, path: string, live: boolean): void {
     const parsed = parseArticle(markdown);
-    this.frontmatter = parsed.frontmatter;
+    const fm = parsed.frontmatter;
+    this.frontmatter = fm;
     this.articleTitle = parsed.title;
     this.body = parsed.body;
     this.articlePath = path;
     this.live = live;
-    const date =
-      frontmatterValue(parsed.frontmatter, 'pubDate') ?? frontmatterValue(parsed.frontmatter, 'date');
+    // Seed the Свойства fields from the real frontmatter — "Тема" maps to the
+    // article's `category`. Without this seed the required-field check below
+    // always fired a false "заполните Тема" warning.
+    this.topic = frontmatterValue(fm, 'category') ?? frontmatterValue(fm, 'topic') ?? '';
+    const date = frontmatterValue(fm, 'pubDate') ?? frontmatterValue(fm, 'date');
     if (date !== undefined) this.pubDate = date;
-    this.published = frontmatterValue(parsed.frontmatter, 'draft') !== 'true';
+    const published = frontmatterValue(fm, 'published');
+    this.published =
+      published !== undefined ? published === 'true' : frontmatterValue(fm, 'draft') !== 'true';
   }
 
-  /** Reconstructs the full markdown document from the frontmatter + edited body. */
+  /**
+   * Reconstructs the full markdown from the frontmatter + edited body, writing
+   * the Свойства edits (category/pubDate/published) back into the frontmatter so
+   * a publish actually persists them instead of silently discarding them.
+   */
   private get editedMarkdown(): string {
+    let fm = this.frontmatter;
+    if (fm !== '') {
+      if (this.topic !== '') fm = upsertFrontmatterField(fm, 'category', this.topic);
+      if (this.pubDate !== '') fm = upsertFrontmatterField(fm, 'pubDate', this.pubDate);
+      fm = upsertFrontmatterField(fm, 'published', String(this.published));
+    }
     const body = this.body.trimEnd();
-    return this.frontmatter === '' ? `${body}\n` : `${this.frontmatter}\n\n${body}\n`;
+    return fm === '' ? `${body}\n` : `${fm}\n\n${body}\n`;
   }
 
   /** A required frontmatter field is empty. */
@@ -576,6 +641,13 @@ export class ScreenEditor extends LitElement {
     this.publishOpen = true;
     this.publishSha = '';
     this.publishError = '';
+    if (this.articlePath === '') {
+      // New-article documents have no target file yet — saving to a new
+      // blog/<slug>/index.<lang>.md is a separate flow, not a silent no-op.
+      this.stageStates = ['failed', 'pending', 'pending'];
+      this.publishError = 'Новый материал: сохранение в новый файл пока в разработке.';
+      return;
+    }
     void this.runRealPublish();
   };
 

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -11,6 +11,7 @@ import {
   commitAndPush,
   upsertFrontmatterField,
 } from '../engine/content.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /** One editable article block: a stable id plus its raw markdown source line(s).
  *  The rendered typography is derived from the raw text on every render, so the
@@ -469,16 +470,26 @@ export class ScreenEditor extends LitElement {
   /** Slug currently loaded, to detect same-screen route changes. */
   private loadedSlug = '';
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     this.loadedSlug = this.routeSlug();
     void this.load();
     globalThis.addEventListener('hashchange', this.onHashChange);
+    // First-load race (QA #12): if the engine was still cloning the repo, our
+    // first read found no article. Re-read when it is ready — but never clobber
+    // an intentional new draft or an already-loaded article.
+    this.disposeReady = onEngineReady(() => {
+      if (this.slug === '' && this.routeSlug() !== 'new') void this.load();
+    });
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     globalThis.removeEventListener('hashchange', this.onHashChange);
+    this.disposeReady();
   }
 
   // Re-load when the editor stays mounted but the requested slug changes

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -470,6 +470,14 @@ export class ScreenEditor extends LitElement {
   /** Slug currently loaded, to detect same-screen route changes. */
   private loadedSlug = '';
 
+  /**
+   * In-memory edits per language for the current article. Switching the language
+   * tab stashes the active language's edited markdown here so switching back
+   * restores unsaved work instead of reloading the on-disk version (QA #8).
+   * Cleared whenever a different article loads.
+   */
+  private readonly langBuffers = new Map<string, string>();
+
   /** Unsubscribes the engine-ready listener on disconnect. */
   private disposeReady: () => void = () => {};
 
@@ -508,6 +516,8 @@ export class ScreenEditor extends LitElement {
   }
 
   private async load(): Promise<void> {
+    // A fresh article invalidates any per-language edits from the previous one.
+    this.langBuffers.clear();
     const articles = await listArticles();
     // Open the article the route names — clicking a card must open THAT article,
     // not always the first one. `new` starts a blank document; a missing/unknown
@@ -597,12 +607,27 @@ export class ScreenEditor extends LitElement {
   private onLangChange = (event: Event): void => {
     if (event instanceof CustomEvent) {
       const id: unknown = event.detail?.id;
-      if (id === 'ru' || id === 'en' || id === 'it') {
+      if ((id === 'ru' || id === 'en' || id === 'it') && id !== this.activeLang) {
+        // Stash the outgoing language's edits before swapping the buffers in.
+        if (this.slug !== '') this.langBuffers.set(this.activeLang, this.editedMarkdown);
         this.activeLang = id;
-        if (this.live && this.slug !== '') void this.loadLang(id);
+        if (this.live && this.slug !== '') void this.switchLang(id);
       }
     }
   };
+
+  /**
+   * Shows the requested language: restores an in-memory edit if one exists,
+   * otherwise reads the on-disk version. Keeps unsaved work across tab switches.
+   */
+  private async switchLang(lang: string): Promise<void> {
+    const buffered = this.langBuffers.get(lang);
+    if (buffered !== undefined) {
+      this.applyMarkdown(buffered, `blog/${this.slug}/index.${lang}.md`, true);
+      return;
+    }
+    await this.loadLang(lang);
+  }
 
   private onTopicChange = (event: Event): void => {
     if (event instanceof CustomEvent) {

--- a/src/redesign/screens/screen-magazine.test.ts
+++ b/src/redesign/screens/screen-magazine.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import './screen-magazine.ts';
+import type { ScreenMagazine } from './screen-magazine.ts';
+
+/** Mounts the magazine screen with the "new issue" form open. */
+const mountWithForm = async (): Promise<ScreenMagazine> => {
+  const el = document.createElement('screen-magazine') as ScreenMagazine;
+  document.body.append(el);
+  await el.updateComplete;
+  const priv = el as unknown as { formOpen: boolean; fSlug: string };
+  priv.formOpen = true;
+  return el;
+};
+
+const shadowText = (el: HTMLElement): string =>
+  (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+const setSlug = async (el: ScreenMagazine, slug: string): Promise<void> => {
+  (el as unknown as { fSlug: string }).fSlug = slug;
+  el.requestUpdate();
+  await el.updateComplete;
+};
+
+describe('screen-magazine slug validation (QA #17)', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('surfaces an inline error for an invalid slug', async () => {
+    const el = await mountWithForm();
+    await setSlug(el, 'Nomer 3');
+    expect(shadowText(el)).toContain('только строчные');
+  });
+
+  it('shows no error for a valid slug', async () => {
+    const el = await mountWithForm();
+    await setSlug(el, 'nomer-3-2026');
+    expect(shadowText(el)).not.toContain('только строчные');
+  });
+
+  it('does not shout before anything is typed', async () => {
+    const el = await mountWithForm();
+    await el.updateComplete;
+    expect(shadowText(el)).not.toContain('Укажите слаг');
+  });
+});

--- a/src/redesign/screens/screen-magazine.ts
+++ b/src/redesign/screens/screen-magazine.ts
@@ -8,6 +8,7 @@ import {
   createMagazineIssue,
   type ArticleSummary,
 } from '../engine/content.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /** One existing magazine issue discovered under `magazine/`. */
 interface IssueFolder {
@@ -171,9 +172,19 @@ export class ScreenMagazine extends LitElement {
   @state() private sha = '';
   @state() private error = '';
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
+    // Re-read when the engine finishes booting (first-load race, QA #12).
+    this.disposeReady = onEngineReady(() => void this.load());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.disposeReady();
   }
 
   private async load(): Promise<void> {

--- a/src/redesign/screens/screen-magazine.ts
+++ b/src/redesign/screens/screen-magazine.ts
@@ -10,6 +10,7 @@ import {
   type ArticleSummary,
 } from '../engine/content.js';
 import { onEngineReady } from '../engine/engine-ready.js';
+import { classifyEmpty } from '../engine/load-state.js';
 
 /** One existing magazine issue discovered under `magazine/`. */
 interface IssueFolder {
@@ -436,9 +437,11 @@ export class ScreenMagazine extends LitElement {
             )}
           </div>`
         : html`<p class="empty">
-            ${this.loaded
-              ? 'Номеров пока нет. Нажмите «Новый номер», чтобы загрузить первый.'
-              : 'Загружаем номера…'}
+            ${classifyEmpty(this.loaded) === 'loading'
+              ? 'Загружаем номера…'
+              : classifyEmpty(this.loaded) === 'signed-out'
+                ? 'Войдите через GitHub, чтобы увидеть и публиковать номера.'
+                : 'Номеров пока нет. Нажмите «Новый номер», чтобы загрузить первый.'}
           </p>`}
       ${this.renderForm()}
     `;

--- a/src/redesign/screens/screen-magazine.ts
+++ b/src/redesign/screens/screen-magazine.ts
@@ -6,6 +6,7 @@ import {
   listArticles,
   readFile,
   createMagazineIssue,
+  validateMagazineSlug,
   type ArticleSummary,
 } from '../engine/content.js';
 import { onEngineReady } from '../engine/engine-ready.js';
@@ -96,6 +97,15 @@ export class ScreenMagazine extends LitElement {
       display: flex;
       flex-direction: column;
       gap: var(--spacing-md);
+    }
+    .slug-field {
+      display: grid;
+      gap: 0.25rem;
+    }
+    .field-error {
+      margin: 0;
+      font-size: 0.78rem;
+      color: var(--color-danger, #c0392b);
     }
     .file label {
       display: block;
@@ -236,10 +246,15 @@ export class ScreenMagazine extends LitElement {
     this.fArticles = next;
   };
 
+  /** Slug validation error for the current input, or '' when the slug is fine. */
+  private get slugError(): string {
+    return validateMagazineSlug(this.fSlug, this.issues.map((i) => i.slug)) ?? '';
+  }
+
   private get canSubmit(): boolean {
     return (
       this.fTitle.trim() !== '' &&
-      this.fSlug.trim() !== '' &&
+      this.slugError === '' &&
       this.fDate.trim() !== '' &&
       this.pdf !== undefined &&
       this.phase !== 'running'
@@ -299,14 +314,20 @@ export class ScreenMagazine extends LitElement {
             @cp-input=${this.bind('fTitle')}
             @cp-change=${this.bind('fTitle')}
           ></cp-input>
-          <cp-input
-            label="Слаг (папка номера)"
-            required
-            placeholder="magazine-3-sentyabr-2026"
-            .value=${this.fSlug}
-            @cp-input=${this.bind('fSlug')}
-            @cp-change=${this.bind('fSlug')}
-          ></cp-input>
+          <div class="slug-field">
+            <cp-input
+              label="Слаг (папка номера)"
+              required
+              ?invalid=${this.fSlug.trim() !== '' && this.slugError !== ''}
+              placeholder="magazine-3-sentyabr-2026"
+              .value=${this.fSlug}
+              @cp-input=${this.bind('fSlug')}
+              @cp-change=${this.bind('fSlug')}
+            ></cp-input>
+            ${this.fSlug.trim() !== '' && this.slugError !== ''
+              ? html`<p class="field-error" role="alert">${this.slugError}</p>`
+              : nothing}
+          </div>
           <cp-select
             label="Язык"
             .value=${this.fLang}

--- a/src/redesign/screens/screen-members.ts
+++ b/src/redesign/screens/screen-members.ts
@@ -4,6 +4,7 @@ import '@communist-prometheus/cp-components';
 import type { CpTableColumn, CpTableRow } from '@communist-prometheus/cp-components';
 import { listMembers, type Member } from '../engine/github-api.js';
 import { onEngineReady } from '../engine/engine-ready.js';
+import { classifyEmpty } from '../engine/load-state.js';
 
 /** Semantic tag tones used for member roles (mirrors cp-tag's tone union). */
 type RoleTone = 'success' | 'info' | 'neutral';
@@ -149,9 +150,11 @@ export class ScreenMembers extends LitElement {
             ></cp-table>
           </div>`
         : html`<p class="note">
-            ${this.loaded
-              ? 'Войдите через GitHub токеном с доступом к коллабораторам репозитория, чтобы увидеть участников.'
-              : 'Загружаем участников…'}
+            ${classifyEmpty(this.loaded) === 'loading'
+              ? 'Загружаем участников…'
+              : classifyEmpty(this.loaded) === 'signed-out'
+                ? 'Войдите через GitHub токеном с доступом к коллабораторам репозитория, чтобы увидеть участников.'
+                : 'Участники не найдены: нужен токен с доступом к коллабораторам репозитория.'}
           </p>`}
     `;
   }

--- a/src/redesign/screens/screen-members.ts
+++ b/src/redesign/screens/screen-members.ts
@@ -3,6 +3,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import type { CpTableColumn, CpTableRow } from '@communist-prometheus/cp-components';
 import { listMembers, type Member } from '../engine/github-api.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /** Semantic tag tones used for member roles (mirrors cp-tag's tone union). */
 type RoleTone = 'success' | 'info' | 'neutral';
@@ -77,9 +78,19 @@ export class ScreenMembers extends LitElement {
   /** Whether the real read has completed. */
   @state() private loaded = false;
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
+    // Re-read once the engine finishes booting (first-load race, QA #12).
+    this.disposeReady = onEngineReady(() => void this.load());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.disposeReady();
   }
 
   private async load(): Promise<void> {
@@ -124,7 +135,9 @@ export class ScreenMembers extends LitElement {
       <div class="head">
         <p class="eyebrow">Сообщество · роли и доступ</p>
         <h1 tabindex="-1">Участники</h1>
-        <cp-button variant="primary" arrow>Пригласить</cp-button>
+        <cp-button variant="primary" disabled title="Приглашение участников появится позже">
+          Пригласить
+        </cp-button>
       </div>
       ${live
         ? html`<div style="max-width:100%;overflow-x:auto">

--- a/src/redesign/screens/screen-newsletter.test.ts
+++ b/src/redesign/screens/screen-newsletter.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import './screen-newsletter.ts';
+import type { ScreenNewsletter } from './screen-newsletter.ts';
+
+/** Mounts the newsletter screen and waits for its first render. */
+const mount = async (): Promise<ScreenNewsletter> => {
+  const el = document.createElement('screen-newsletter') as ScreenNewsletter;
+  document.body.append(el);
+  await el.updateComplete;
+  return el;
+};
+
+/** The full rendered text of the shadow root, whitespace-collapsed. */
+const shadowText = (el: HTMLElement): string =>
+  (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+describe('screen-newsletter (QA #9: no fake sends)', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('shows a "not connected" banner up front', async () => {
+    // The banner heading lives in cp-banner's own shadow root; assert on its
+    // slotted description text, which projects into this screen's shadow.
+    const el = await mount();
+    expect(shadowText(el)).toContain('реальная отправка не выполняется');
+  });
+
+  it('never claims delivery succeeded', async () => {
+    const el = await mount();
+    const text = shadowText(el);
+    expect(text).not.toContain('доставлено');
+    expect(text).not.toContain('Отправляется');
+  });
+
+  it('a confirmed send reports "not delivered", not success', async () => {
+    const el = await mount();
+    // Drive the same transition the danger button triggers, then re-render.
+    (el as unknown as { confirmSend: () => void }).confirmSend();
+    await el.updateComplete;
+    const text = shadowText(el);
+    expect(text).toContain('ни одно письмо не ушло');
+    expect(text).not.toContain('успешно');
+  });
+});

--- a/src/redesign/screens/screen-newsletter.ts
+++ b/src/redesign/screens/screen-newsletter.ts
@@ -127,6 +127,11 @@ export class ScreenNewsletter extends LitElement {
       color: var(--color-text-secondary);
     }
 
+    cp-banner {
+      display: block;
+      margin-bottom: var(--spacing-lg);
+    }
+
     cp-tabs {
       margin-bottom: var(--spacing-lg);
       max-width: 100%;
@@ -240,8 +245,13 @@ export class ScreenNewsletter extends LitElement {
   /** Whether the "send now" confirmation dialog is open. */
   @state() private confirmOpen = false;
 
-  /** Whether the issue is currently being sent (drives the dialog `busy` state). */
-  @state() private sending = false;
+  /**
+   * Whether a send was attempted. There is no mail transport wired to this
+   * console yet, so a confirmed "send" does NOT dispatch anything — it flips
+   * this flag to surface an honest "not delivered" notice instead of faking a
+   * successful delivery (QA #9: the previous mock pretended to send).
+   */
+  @state() private sendAttempted = false;
 
   /** Adopts the chosen tab from the `cp-tabs` change event. */
   private readonly onTabChange = (event: Event): void => {
@@ -256,24 +266,17 @@ export class ScreenNewsletter extends LitElement {
   };
 
   private readonly cancelConfirm = (): void => {
-    if (!this.sending) {
-      this.confirmOpen = false;
-    }
+    this.confirmOpen = false;
   };
 
   /**
-   * Simulates the irreversible send: flips the dialog into its `busy` state so
-   * dismissal is suppressed, then closes once the (mock) dispatch resolves.
+   * Confirms the "send" action. No email transport is connected, so this never
+   * dispatches a message: it records the attempt (surfacing a "not delivered"
+   * banner) and closes the dialog. It must not report success.
    */
   private readonly confirmSend = (): void => {
-    if (this.sending) {
-      return;
-    }
-    this.sending = true;
-    globalThis.setTimeout(() => {
-      this.sending = false;
-      this.confirmOpen = false;
-    }, 1600);
+    this.sendAttempted = true;
+    this.confirmOpen = false;
   };
 
   private readonly renderSchedule = (): TemplateResult => html`
@@ -290,7 +293,9 @@ export class ScreenNewsletter extends LitElement {
       </div>
       <div class="actions">
         <cp-button @cp-click=${this.openConfirm}>Отправить сейчас</cp-button>
-        <cp-button variant="secondary">Тест на свою почту</cp-button>
+        <cp-button variant="secondary" disabled title="Появится после подключения почтового сервиса">
+          Тест на свою почту
+        </cp-button>
       </div>
     </section>
   `;
@@ -360,20 +365,18 @@ export class ScreenNewsletter extends LitElement {
     return html`
       <cp-dialog
         open
-        tone="danger"
+        tone="warning"
         heading="Отправить выпуск ${ACTIVE_SUBSCRIBERS} подписчикам?"
-        ?busy=${this.sending}
         @cp-cancel=${this.cancelConfirm}
       >
         <p class="dialog-note">
-          Письмо уйдёт всем активным подписчикам немедленно и необратимо.
-          Рекомендуем сперва «Тест на свою почту».
+          Почтовый сервис ещё не подключён, поэтому письмо не будет отправлено —
+          рассылка появится в интерфейсе после интеграции доставки.
         </p>
         <button
           slot="footer"
           class="btn secondary"
           type="button"
-          ?disabled=${this.sending}
           @click=${this.cancelConfirm}
         >
           Отмена
@@ -382,10 +385,9 @@ export class ScreenNewsletter extends LitElement {
           slot="footer"
           class="btn danger"
           type="button"
-          ?disabled=${this.sending}
           @click=${this.confirmSend}
         >
-          ${this.sending ? 'Отправляется…' : '«Отправить всем»'}
+          Понятно
         </button>
       </cp-dialog>
     `;
@@ -398,6 +400,16 @@ export class ScreenNewsletter extends LitElement {
         <cp-tag tone="warning">только владелец</cp-tag>
       </header>
       <p class="eyebrow">Коммуникации · еженедельный дайджест для читателей</p>
+      <cp-banner
+        tone=${this.sendAttempted ? 'danger' : 'info'}
+        title=${this.sendAttempted
+          ? 'Письмо не отправлено'
+          : 'Рассылка ещё не подключена'}
+      >
+        ${this.sendAttempted
+          ? 'Почтовый сервис пока не интегрирован — ни одно письмо не ушло. Ниже демонстрационные данные.'
+          : 'Почтовый сервис ещё не интегрирован: расписание, список подписчиков и журнал ниже — демонстрационные, реальная отправка не выполняется.'}
+      </cp-banner>
       <cp-tabs
         .tabs=${TABS}
         active=${this.tab}

--- a/src/redesign/screens/screen-newsletter.ts
+++ b/src/redesign/screens/screen-newsletter.ts
@@ -311,7 +311,7 @@ export class ScreenNewsletter extends LitElement {
       <section aria-label="Подписчики">
         <div class="toolbar">
           <span class="meta">${ACTIVE_SUBSCRIBERS} активных · 4 отписались за неделю</span>
-          <cp-button variant="ghost" size="sm">
+          <cp-button variant="ghost" size="sm" disabled title="Появится после подключения почтового сервиса">
             <cp-icon name="plus" size="16"></cp-icon>
             Добавить
           </cp-button>
@@ -341,7 +341,9 @@ export class ScreenNewsletter extends LitElement {
                 state=${send.outcome}
                 label=${send.outcomeLabel}
               ></cp-status>
-              <cp-button slot="actions" variant="ghost" size="sm">Подробно</cp-button>
+              <cp-button slot="actions" variant="ghost" size="sm" disabled
+                >Подробно</cp-button
+              >
             </cp-list-row>
           `,
         )}

--- a/src/redesign/screens/screen-settings.ts
+++ b/src/redesign/screens/screen-settings.ts
@@ -3,6 +3,7 @@ import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import { readLanguages, type SiteLanguage } from '../engine/content.js';
 import { onEngineReady } from '../engine/engine-ready.js';
+import { classifyEmpty } from '../engine/load-state.js';
 
 /**
  * Settings screen (settings spec). When the real content engine is running
@@ -132,9 +133,11 @@ export class ScreenSettings extends LitElement {
           ? `Прочитано из settings/languages.json — ${this.languages.length} ${
               this.languages.length === 1 ? 'язык' : 'языков'
             } реального репозитория.`
-          : this.loaded
-            ? 'Войдите через GitHub, чтобы увидеть языки сайта из репозитория.'
-            : 'Загружаем настройки…'}
+          : classifyEmpty(this.loaded) === 'loading'
+            ? 'Загружаем настройки…'
+            : classifyEmpty(this.loaded) === 'signed-out'
+              ? 'Войдите через GitHub, чтобы увидеть языки сайта из репозитория.'
+              : 'Языки не найдены или не удалось их загрузить.'}
       </p>
     `;
   }

--- a/src/redesign/screens/screen-settings.ts
+++ b/src/redesign/screens/screen-settings.ts
@@ -2,6 +2,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
 import { readLanguages, type SiteLanguage } from '../engine/content.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /**
  * Settings screen (settings spec). When the real content engine is running
@@ -37,6 +38,10 @@ export class ScreenSettings extends LitElement {
       margin: 0;
       font-size: 0.8rem;
       color: var(--color-text-secondary);
+    }
+    cp-banner {
+      display: block;
+      margin-bottom: var(--spacing-md);
     }
     .langs {
       display: grid;
@@ -75,9 +80,19 @@ export class ScreenSettings extends LitElement {
   /** Whether the real read has completed. */
   @state() private loaded = false;
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
+    // Re-read once the engine finishes booting (first-load race, QA #12).
+    this.disposeReady = onEngineReady(() => void this.load());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.disposeReady();
   }
 
   private async load(): Promise<void> {
@@ -93,26 +108,24 @@ export class ScreenSettings extends LitElement {
         <p class="eyebrow">Администрирование · языки сайта</p>
         <h1 tabindex="-1">Настройки</h1>
       </div>
-      <cp-tabs
-        active="languages"
-        .tabs=${[
-          { id: 'languages', label: 'Языки' },
-          { id: 'links', label: 'Ссылки' },
-          { id: 'themes', label: 'Темы' },
-        ]}
-      ></cp-tabs>
       ${live
-        ? html`<div class="langs">
-            ${this.languages.map(
-              (lang) => html`
-                <div class="lang">
-                  <b>${lang.label}</b>
-                  <span class="code">${lang.code}</span>
-                  <cp-switch checked></cp-switch>
-                </div>
-              `,
-            )}
-          </div>`
+        ? html`
+            <cp-banner tone="info" title="Просмотр без редактирования">
+              Языки сайта настраиваются в settings/languages.json. Здесь — какие сейчас
+              включены в репозитории.
+            </cp-banner>
+            <div class="langs">
+              ${this.languages.map(
+                (lang) => html`
+                  <div class="lang">
+                    <b>${lang.label}</b>
+                    <span class="code">${lang.code}</span>
+                    <cp-status state="success" label="включён"></cp-status>
+                  </div>
+                `,
+              )}
+            </div>
+          `
         : nothing}
       <p class="note">
         ${live

--- a/src/redesign/screens/screen-tickets.ts
+++ b/src/redesign/screens/screen-tickets.ts
@@ -3,6 +3,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { CpTab, CpTableColumn, CpTableRow } from '@communist-prometheus/cp-components';
 import '@communist-prometheus/cp-components';
 import { listTickets, type Ticket } from '../engine/github-api.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /** The active list filter (`all` shows every ticket). */
 type TicketFilter = 'all' | 'bug' | 'story';
@@ -136,9 +137,19 @@ export class ScreenTickets extends LitElement {
   /** Active ticket-kind filter; `all` shows every ticket. */
   @state() private filter: TicketFilter = 'all';
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
+    // Re-read once the engine finishes booting (first-load race, QA #12).
+    this.disposeReady = onEngineReady(() => void this.load());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.disposeReady();
   }
 
   private async load(): Promise<void> {
@@ -167,7 +178,7 @@ export class ScreenTickets extends LitElement {
       <header class="head">
         <p class="eyebrow">Задачи${live ? html` · ${visible.length} на экране` : nothing}</p>
         <h1 tabindex="-1">Тикеты</h1>
-        <cp-button>
+        <cp-button disabled title="Создание тикетов появится позже">
           <cp-icon name="plus" size="18"></cp-icon>
           Новый тикет
         </cp-button>

--- a/src/redesign/screens/screen-tickets.ts
+++ b/src/redesign/screens/screen-tickets.ts
@@ -4,6 +4,7 @@ import type { CpTab, CpTableColumn, CpTableRow } from '@communist-prometheus/cp-
 import '@communist-prometheus/cp-components';
 import { listTickets, type Ticket } from '../engine/github-api.js';
 import { onEngineReady } from '../engine/engine-ready.js';
+import { classifyEmpty } from '../engine/load-state.js';
 
 /** The active list filter (`all` shows every ticket). */
 type TicketFilter = 'all' | 'bug' | 'story';
@@ -201,9 +202,11 @@ export class ScreenTickets extends LitElement {
             </div>
           `
         : html`<p class="eyebrow">
-            ${this.loaded
-              ? 'Войдите через GitHub, чтобы увидеть тикеты и баг-репорты репозитория.'
-              : 'Загружаем тикеты…'}
+            ${classifyEmpty(this.loaded) === 'loading'
+              ? 'Загружаем тикеты…'
+              : classifyEmpty(this.loaded) === 'signed-out'
+                ? 'Войдите через GitHub, чтобы увидеть тикеты и баг-репорты репозитория.'
+                : 'Тикеты не найдены или не удалось их загрузить.'}
           </p>`}
     `;
   }

--- a/src/redesign/screens/screen-topics.ts
+++ b/src/redesign/screens/screen-topics.ts
@@ -4,6 +4,7 @@ import type { CpTab } from '@communist-prometheus/cp-components';
 import '@communist-prometheus/cp-components';
 import { readTopics, type Topic } from '../engine/content.js';
 import { onEngineReady } from '../engine/engine-ready.js';
+import { classifyEmpty } from '../engine/load-state.js';
 
 /**
  * The seven publication languages, expressed as the keys used inside a topic's
@@ -292,9 +293,11 @@ export class ScreenTopics extends LitElement {
             </p>
           `
         : html`<p class="note">
-            ${this.loaded
-              ? 'Войдите через GitHub, чтобы увидеть темы из settings/topics.json.'
-              : 'Загружаем темы…'}
+            ${classifyEmpty(this.loaded) === 'loading'
+              ? 'Загружаем темы…'
+              : classifyEmpty(this.loaded) === 'signed-out'
+                ? 'Войдите через GitHub, чтобы увидеть темы из settings/topics.json.'
+                : 'Тем пока нет или не удалось их загрузить.'}
           </p>`}
     `;
   }

--- a/src/redesign/screens/screen-topics.ts
+++ b/src/redesign/screens/screen-topics.ts
@@ -138,16 +138,36 @@ export class ScreenTopics extends LitElement {
       color: var(--color-text-secondary);
     }
 
-    .grid {
+    .fields {
+      margin: 0;
       display: grid;
-      gap: var(--spacing-md);
+      gap: var(--spacing-sm);
     }
 
-    @media (min-width: 640px) {
-      .grid.two {
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-        align-items: end;
-      }
+    .field {
+      display: grid;
+      gap: 0.15rem;
+    }
+
+    .field dt {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--color-text-secondary);
+    }
+
+    .field dd {
+      margin: 0;
+      font-size: 1rem;
+    }
+
+    .missing {
+      color: var(--color-text-secondary);
+      font-style: italic;
+    }
+
+    cp-banner {
+      display: block;
+      margin-bottom: var(--spacing-lg);
     }
 
     .preview {
@@ -200,28 +220,27 @@ export class ScreenTopics extends LitElement {
 
   private renderTopic(topic: Topic) {
     const lang = this.activeLang;
-    const name = topic.name[lang] ?? topic.key;
+    const name = topic.name[lang] ?? '';
+    const hasName = name !== '';
     return html`
       <article class="topic" style="--tc:${topic.color}">
         <div class="thead">
           <span class="swatch" aria-hidden="true"></span>
-          <h2 class="name">${name}</h2>
+          <h2 class="name">${hasName ? name : topic.key}</h2>
           <span class="key">${topic.key}</span>
-          <cp-button variant="ghost" size="sm" aria-label="Удалить тему «${name}»">
-            <cp-icon name="trash" size="18"></cp-icon>
-          </cp-button>
+          <span class="key" aria-hidden="true">${topic.color}</span>
         </div>
 
-        <div class="grid two">
-          <cp-input label="Название · ${lang}" .value=${name}></cp-input>
-          <cp-input label="Приписка · ${lang}" .value=${name}></cp-input>
-        </div>
-
-        <cp-textarea label="Описание · ${lang}" rows="3" .value=${name}></cp-textarea>
+        <dl class="fields">
+          <div class="field">
+            <dt>Название · ${lang}</dt>
+            <dd>${hasName ? name : html`<span class="missing">нет перевода</span>`}</dd>
+          </div>
+        </dl>
 
         <div class="preview">
           <span class="preview-label">Плашка на сайте:</span>
-          <cp-pill style="--tc:${topic.color}">${name}</cp-pill>
+          <cp-pill style="--tc:${topic.color}">${hasName ? name : topic.key}</cp-pill>
         </div>
       </article>
     `;
@@ -235,12 +254,17 @@ export class ScreenTopics extends LitElement {
         <h1 tabindex="-1">Темы</h1>
       </header>
       <p class="intro">
-        Темы группируют статьи цветной плашкой и припиской. Название, приписка и описание — для
-        каждого из 7 языков.
+        Темы группируют статьи цветной плашкой. Название задаётся для каждого из 7 языков в
+        settings/topics.json.
       </p>
 
       ${live
         ? html`
+            <cp-banner tone="info" title="Просмотр без редактирования">
+              Темы пока правятся в settings/topics.json. Здесь — что сейчас в репозитории:
+              ключ, цвет и название на выбранном языке.
+            </cp-banner>
+
             <div class="tabs-scroll">
               <cp-tabs
                 .tabs=${LANGUAGES}

--- a/src/redesign/screens/screen-topics.ts
+++ b/src/redesign/screens/screen-topics.ts
@@ -3,6 +3,7 @@ import { customElement, state } from 'lit/decorators.js';
 import type { CpTab } from '@communist-prometheus/cp-components';
 import '@communist-prometheus/cp-components';
 import { readTopics, type Topic } from '../engine/content.js';
+import { onEngineReady } from '../engine/engine-ready.js';
 
 /**
  * The seven publication languages, expressed as the keys used inside a topic's
@@ -201,9 +202,19 @@ export class ScreenTopics extends LitElement {
   /** Currently edited language; drives which localised name the fields show. */
   @state() private activeLang: LangCode = 'ru';
 
+  /** Unsubscribes the engine-ready listener on disconnect. */
+  private disposeReady: () => void = () => {};
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
+    // Re-read when the engine finishes booting (first-load race, QA #12).
+    this.disposeReady = onEngineReady(() => void this.load());
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.disposeReady();
   }
 
   private async load(): Promise<void> {

--- a/src/redesign/test-setup.ts
+++ b/src/redesign/test-setup.ts
@@ -1,0 +1,17 @@
+/**
+ * jsdom implements `attachInternals()` but omits parts of the form-association
+ * API (`setFormValue`, validity setters) that the vendored form-control
+ * components call from their `updated()` lifecycle. Without these, mounting any
+ * screen that embeds a `cp-input`/`cp-select` throws. Stub them as no-ops so
+ * component tests can render real screens.
+ */
+const internals = (globalThis as { ElementInternals?: { prototype: Record<string, unknown> } })
+  .ElementInternals;
+
+if (internals !== undefined) {
+  const proto = internals.prototype;
+  proto['setFormValue'] ??= (): void => {};
+  proto['setValidity'] ??= (): void => {};
+  proto['checkValidity'] ??= (): boolean => true;
+  proto['reportValidity'] ??= (): boolean => true;
+}

--- a/src/redesign/tsconfig.json
+++ b/src/redesign/tsconfig.json
@@ -15,5 +15,5 @@
     }
   },
   "include": ["**/*.ts"],
-  "exclude": ["**/*.test.ts"]
+  "exclude": ["**/*.test.ts", "test-setup.ts"]
 }

--- a/vitest.redesign.config.ts
+++ b/vitest.redesign.config.ts
@@ -1,0 +1,30 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Test contour for the redesigned admin UI (`src/redesign`). The main
+ * `vitest.config.ts` excludes `src/redesign/**` because those modules import the
+ * vendored `@communist-prometheus/cp-components` build and register Lit custom
+ * elements, which the app's jsdom setup does not alias. This config mirrors the
+ * `vite.redesign.config.ts` aliases and runs the redesign specs under happy-dom
+ * (a DOM that Lit's `LitElement` boots cleanly in), so component behaviour and
+ * pure engine helpers are covered end-to-end.
+ */
+const cp = resolve(__dirname, 'vendor/cp-components/dist')
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      { find: /^@communist-prometheus\/cp-components$/, replacement: `${cp}/index.js` },
+      { find: /^@communist-prometheus\/cp-components\/(.*)$/, replacement: `${cp}/$1` },
+      { find: /^@\/(.*)$/, replacement: `${resolve(__dirname, 'src')}/$1` },
+    ],
+  },
+  test: {
+    environment: 'jsdom',
+    include: ['src/redesign/**/*.test.ts'],
+    setupFiles: ['src/redesign/test-setup.ts'],
+    root: fileURLToPath(new URL('./', import.meta.url)),
+  },
+})

--- a/vitest.redesign.config.ts
+++ b/vitest.redesign.config.ts
@@ -14,6 +14,18 @@ import { defineConfig } from 'vitest/config'
 const cp = resolve(__dirname, 'vendor/cp-components/dist')
 
 export default defineConfig({
+  // The redesign is authored for legacy decorators without class-field define
+  // semantics (see src/redesign/tsconfig.json). esbuild defaults to the opposite,
+  // which shadows Lit's reactive-property accessors and breaks @state in tests —
+  // pin the same semantics the app builds with.
+  esbuild: {
+    tsconfigRaw: {
+      compilerOptions: {
+        experimentalDecorators: true,
+        useDefineForClassFields: false,
+      },
+    },
+  },
   resolve: {
     alias: [
       { find: /^@communist-prometheus\/cp-components$/, replacement: `${cp}/index.js` },


### PR DESCRIPTION
Editor bugs from the QA audit: cards always opened article #1 (now route the slug), topic never seeded (permanent false warning), Свойства metadata discarded on publish (now written back, unit-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)