### PR TITLE
fix(sw): publish via GitHub REST Git Data API (fix month-long 'Push failed')

### DIFF
--- a/src/sw/git/remote/changed-files-between.ts
+++ b/src/sw/git/remote/changed-files-between.ts
@@ -1,0 +1,33 @@
+import {
+  collectChange,
+  type FileChange,
+} from '../../push-queue/collect-change'
+import { fs, REPO_DIR } from '../fs'
+import { loadGit } from '../load-git'
+
+/**
+ * Diff two local trees and return the paths that differ, each carrying
+ * its `headRef`-side bytes (or a deletion marker). Unlike
+ * {@link changedFilesOfCommit} (which diffs a commit against its own
+ * parent), this compares two arbitrary refs — used by the REST push to
+ * compute the cumulative change set from the current remote tip to the
+ * local HEAD, so a linear stack of local commits replays as one commit.
+ * Both refs must be present in the local (shallow) clone.
+ * @param baseRef Oid/ref of the base tree (e.g. the remote branch tip).
+ * @param headRef Oid/ref of the target tree (e.g. local HEAD).
+ * @returns The changed paths with their post-change bytes.
+ */
+export const changedFilesBetween = async (
+  baseRef: string,
+  headRef: string
+): Promise<ReadonlyArray<FileChange>> => {
+  const git = await loadGit()
+  const changes: FileChange[] = []
+  await git.walk({
+    fs,
+    dir: REPO_DIR,
+    trees: [git.TREE({ ref: baseRef }), git.TREE({ ref: headRef })],
+    map: (filepath, entries) => collectChange(changes, filepath, entries),
+  })
+  return changes
+}

--- a/src/sw/git/remote/push-to-remote.ts
+++ b/src/sw/git/remote/push-to-remote.ts
@@ -1,54 +1,22 @@
 import { log } from '../../logging/logger'
 import type { SWGitConfig } from '../../protocol'
-import { loadGit } from '../load-git'
-import { buildAuthOpts } from './build-auth-opts'
-import { pushRejection } from './push-rejection'
-
-type Git = Awaited<ReturnType<typeof loadGit>>
-type AuthOpts = ReturnType<typeof buildAuthOpts>
-
-/*
- * Best-effort pre-pull keeps the push fast-forward. A failure here is NOT
- * fatal — the real NFF recovery (handle-failure → tryMergeAfterNff) handles
- * merges and the reset-onto-remote replay — but the error MUST be logged,
- * not swallowed, or "save said OK but nothing reached the remote" is the
- * only observable symptom.
- */
-const prePull = (
-  git: Git,
-  opts: AuthOpts,
-  config: SWGitConfig
-): Promise<void> =>
-  git
-    .pull({
-      ...opts,
-      ref: config.branch,
-      singleBranch: true,
-      author: {
-        name: config.authorName ?? 'Admin',
-        email: config.authorEmail ?? 'admin@prometheus.org',
-      },
-    })
-    .catch((err: unknown) =>
-      log(
-        'warn',
-        'git',
-        `pull before push failed: ${err instanceof Error ? err.message : String(err)}`
-      )
-    )
+import { restPush } from './rest-push'
 
 /**
- * Pull latest then push local commits to remote. Throws on push rejection —
- * including a per-ref `ng` that leaves `result.error` empty (see
- * {@link pushRejection}), which used to be read as success.
+ * Publish local commits to the remote branch.
+ *
+ * Writes through the GitHub REST Git Data API (see {@link restPush})
+ * rather than a git smart-HTTP push. The `/api/cors` proxy's forward to
+ * `github.com/.../git-receive-pack` stalls indefinitely (git-upload-pack
+ * reads are unaffected), which reached editors as the recurring
+ * "Push failed: Network unreachable" and blocked publishing entirely.
+ * REST writes go straight to api.github.com (CORS-enabled) and keep
+ * fast-forward safety: the new commit's parent is the current remote tip
+ * and the ref is updated with `force: false`, so a genuine divergence is
+ * rejected and routed to the existing merge/replay recovery.
  * @param config - SW git configuration with token
  */
 export const pushToRemote = async (config: SWGitConfig): Promise<void> => {
-  const git = await loadGit()
-  const { default: http } = await import('isomorphic-git/http/web')
-  const opts = buildAuthOpts(config, http)
-  await prePull(git, opts, config)
-  const rejection = pushRejection(await git.push(opts))
-  if (rejection) throw new Error(`Push rejected: ${rejection}`)
+  await restPush(config)
   log('info', 'git', 'pushed to remote')
 }

--- a/src/sw/git/remote/rest-push.test.ts
+++ b/src/sw/git/remote/rest-push.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FileChange } from '../../push-queue/collect-change'
+import { workerState } from '../../state/state'
+import { loadGit } from './../load-git'
+import { changedFilesBetween } from './changed-files-between'
+import { restPush } from './rest-push'
+
+vi.mock('./../load-git', () => ({ loadGit: vi.fn() }))
+vi.mock('./changed-files-between', () => ({ changedFilesBetween: vi.fn() }))
+vi.mock('../fs', () => ({ fs: {}, REPO_DIR: '/repo' }))
+vi.mock('../../logging/logger', () => ({ log: vi.fn() }))
+vi.mock('../../state/state', () => ({
+  workerState: { commitSha: 'HEADSHA' },
+}))
+
+const config = {
+  owner: 'o',
+  repo: 'r',
+  branch: 'develop',
+  contentPath: '',
+  corsProxy: '',
+  token: 'tok',
+}
+
+const localCommit = {
+  commit: {
+    message: 'note: edit',
+    tree: 'BASETREE',
+    author: { name: 'Ed', email: 'ed@x.org', timestamp: 1_700_000_000 },
+  },
+}
+
+interface Call {
+  readonly url: string
+  readonly method: string
+  readonly body: unknown
+}
+
+const routeReply = (url: string): Record<string, unknown> =>
+  url.endsWith('/git/ref/heads/develop')
+    ? { object: { sha: 'REMOTE' } }
+    : url.endsWith('/git/blobs')
+      ? { sha: 'BLOB' }
+      : url.endsWith('/git/trees')
+        ? { sha: 'NEWTREE' }
+        : url.endsWith('/git/commits')
+          ? { sha: 'NEWCOMMIT' }
+          : {}
+
+const stubFetch = (patch: () => Response): Call[] => {
+  const calls: Call[] = []
+  vi.stubGlobal('fetch', async (url: string, init: RequestInit = {}) => {
+    const method = init.method ?? 'GET'
+    calls.push({
+      url,
+      method,
+      body: init.body ? JSON.parse(String(init.body)) : undefined,
+    })
+    return method === 'PATCH'
+      ? patch()
+      : new Response(JSON.stringify(routeReply(url)), { status: 200 })
+  })
+  return calls
+}
+
+const okPatch = (): Response => new Response('{}', { status: 200 })
+
+beforeEach(() => {
+  workerState.commitSha = 'HEADSHA'
+  vi.mocked(loadGit).mockResolvedValue({
+    readCommit: vi.fn(async ({ oid }: { oid: string }) =>
+      oid === 'MISSING' ? Promise.reject(new Error('not found')) : localCommit
+    ),
+  } as unknown as Awaited<ReturnType<typeof loadGit>>)
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('restPush', () => {
+  it('creates blob → tree → commit → ref update with fast-forward safety', async () => {
+    const changes: FileChange[] = [
+      { path: 'blog/a.md', data: new Uint8Array([104, 105]) },
+      { path: 'blog/old.md', deleted: true },
+    ]
+    vi.mocked(changedFilesBetween).mockResolvedValue(changes)
+    const calls = stubFetch(okPatch)
+
+    await restPush(config)
+
+    const steps = calls.map(c => `${c.method} ${c.url.split('/git/')[1]}`)
+    expect(steps).toEqual([
+      'GET ref/heads/develop',
+      'POST blobs',
+      'POST trees',
+      'POST commits',
+      'PATCH refs/heads/develop',
+    ])
+    const tree = calls.find(c => c.url.endsWith('/git/trees'))?.body
+    expect(tree).toMatchObject({
+      base_tree: 'BASETREE',
+      tree: [
+        { path: 'blog/a.md', sha: 'BLOB', type: 'blob' },
+        { path: 'blog/old.md', sha: null, type: 'blob' },
+      ],
+    })
+    const commit = calls.find(c => c.url.endsWith('/git/commits'))?.body
+    expect(commit).toMatchObject({ tree: 'NEWTREE', parents: ['REMOTE'] })
+    const ref = calls.find(c => c.method === 'PATCH')?.body
+    expect(ref).toEqual({ sha: 'NEWCOMMIT', force: false })
+    expect(workerState.commitSha).toBe('NEWCOMMIT')
+  })
+
+  it('is a no-op when the local commit is identical to the remote', async () => {
+    vi.mocked(changedFilesBetween).mockResolvedValue([])
+    const calls = stubFetch(okPatch)
+
+    await restPush(config)
+
+    expect(calls.map(c => c.method)).toEqual(['GET'])
+    expect(workerState.commitSha).toBe('HEADSHA')
+  })
+
+  it('raises a non-fast-forward when the remote tip is not in the local clone', async () => {
+    vi.mocked(loadGit).mockResolvedValue({
+      readCommit: vi.fn(async ({ oid }: { oid: string }) =>
+        oid === 'REMOTE'
+          ? Promise.reject(new Error('object not found'))
+          : localCommit
+      ),
+    } as unknown as Awaited<ReturnType<typeof loadGit>>)
+    stubFetch(okPatch)
+
+    await expect(restPush(config)).rejects.toThrow(/not a fast-forward/i)
+  })
+
+  it('surfaces a 422 fast-forward rejection so recovery can merge', async () => {
+    vi.mocked(changedFilesBetween).mockResolvedValue([
+      { path: 'blog/a.md', data: new Uint8Array([1]) },
+    ])
+    stubFetch(
+      () =>
+        new Response('{"message":"Update is not a fast forward"}', {
+          status: 422,
+        })
+    )
+
+    await expect(restPush(config)).rejects.toThrow(/not a fast forward/i)
+  })
+})

--- a/src/sw/git/remote/rest-push.ts
+++ b/src/sw/git/remote/rest-push.ts
@@ -1,0 +1,45 @@
+import { log } from '../../logging/logger'
+import type { SWGitConfig } from '../../protocol'
+import { workerState } from '../../state/state'
+import { fs, REPO_DIR } from '../fs'
+import { loadGit } from '../load-git'
+import { changedFilesBetween } from './changed-files-between'
+import { fail } from './rest/fail'
+import { publishTree } from './rest/publish'
+import { baseTreeSha, remoteTipSha } from './rest/push-reads'
+import { buildTree } from './rest/push-tree'
+
+/**
+ * Publish the local HEAD commit to the remote branch WITHOUT git
+ * smart-HTTP: blobs → tree → commit → update-ref through the GitHub REST
+ * Git Data API (api.github.com, CORS-enabled). This bypasses the
+ * `/api/cors` git-receive-pack proxy, whose forward to
+ * `github.com/.../git-receive-pack` stalls (git-upload-pack reads are
+ * unaffected) — the recurring "Push failed: Network unreachable".
+ *
+ * Fast-forward safety is preserved: the commit's parent is the current
+ * remote tip and the ref is updated with `force: false`, so a concurrent
+ * push is rejected (422 → non-fast-forward → merge/replay recovery). An
+ * identical re-save is a no-op, never an empty commit.
+ * @param config - SW git configuration with token + remote coordinates
+ */
+export const restPush = async (config: SWGitConfig): Promise<void> => {
+  const git = await loadGit()
+  const head = workerState.commitSha ?? fail('rest push: no local commit')
+  const local = await git.readCommit({ fs, dir: REPO_DIR, oid: head })
+  const remoteTip = await remoteTipSha(config)
+  const baseTree = await baseTreeSha(git, remoteTip)
+  const changes = await changedFilesBetween(remoteTip, head)
+  await (changes.length === 0
+    ? Promise.resolve(
+        log('info', 'git', 'rest push: nothing to push (identical to remote)')
+      )
+    : buildTree(config, baseTree, changes).then(tree =>
+        publishTree(config, {
+          message: local.commit.message,
+          author: local.commit.author,
+          parent: remoteTip,
+          tree,
+        })
+      ))
+}

--- a/src/sw/git/remote/rest/fail.ts
+++ b/src/sw/git/remote/rest/fail.ts
@@ -1,0 +1,9 @@
+/**
+ * Throw an Error from an expression position (e.g. `value ?? fail(msg)` or
+ * a ternary's else branch), keeping call sites free of `if` statements.
+ * @param message - Error message
+ * @returns Never — always throws
+ */
+export const fail = (message: string): never => {
+  throw new Error(message)
+}

--- a/src/sw/git/remote/rest/gh-send.ts
+++ b/src/sw/git/remote/rest/gh-send.ts
@@ -1,0 +1,54 @@
+import { API, ghHeaders } from '../../../rbac/github-api'
+import { fail } from './fail'
+
+/**
+ * Base64-encode bytes in chunks so large binary assets (images, PDFs)
+ * never overflow the argument stack of a single `String.fromCharCode`.
+ * @param bytes - Raw file bytes
+ * @returns Base64 string
+ */
+export const toBase64 = (bytes: Uint8Array): string => {
+  const CHUNK = 0x8000
+  let binary = ''
+  for (let offset = 0; offset < bytes.length; offset += CHUNK)
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + CHUNK))
+  return btoa(binary)
+}
+
+const bodyHeaders = (token: string): HeadersInit => ({
+  ...ghHeaders(token),
+  'content-type': 'application/json',
+})
+
+const onError = async (
+  res: Response,
+  method: string,
+  path: string
+): Promise<never> =>
+  fail(
+    `github ${res.status} ${method} ${path}: ${(await res.text().catch(() => '')).slice(0, 300)}`
+  )
+
+/**
+ * One GitHub REST call. Throws on non-2xx with the status and a slice of
+ * the body so `classifyPushError` can route the failure — a 422 "not a
+ * fast forward" becomes an NFF recovery, 401/403 an auth prompt.
+ * @param method - HTTP method
+ * @param path - Path under api.github.com
+ * @param token - OAuth bearer
+ * @param body - JSON body for writes; omit for GET
+ * @returns Parsed JSON response body
+ */
+export const ghSend = async (
+  method: string,
+  path: string,
+  token: string,
+  body?: unknown
+): Promise<unknown> => {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: body === undefined ? ghHeaders(token) : bodyHeaders(token),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  return res.ok ? res.json() : onError(res, method, path)
+}

--- a/src/sw/git/remote/rest/narrow.ts
+++ b/src/sw/git/remote/rest/narrow.ts
@@ -1,0 +1,28 @@
+import { fail } from './fail'
+
+// `typeof x === 'object'` also admits the empty reference; truthiness
+// rejects it so callers get a real record.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && Boolean(value)
+
+/**
+ * Read the `sha` of a blob/tree/commit response without a type assertion.
+ * @param value - Parsed GitHub JSON body
+ * @returns The object sha
+ */
+export const shaOf = (value: unknown): string =>
+  isRecord(value) && typeof value.sha === 'string'
+    ? value.sha
+    : fail('github response missing sha')
+
+/**
+ * Read `object.sha` of a ref response without a type assertion.
+ * @param value - Parsed GitHub ref JSON body
+ * @returns The referenced commit sha
+ */
+export const refShaOf = (value: unknown): string =>
+  isRecord(value) &&
+  isRecord(value.object) &&
+  typeof value.object.sha === 'string'
+    ? value.object.sha
+    : fail('github ref response missing object.sha')

--- a/src/sw/git/remote/rest/publish.ts
+++ b/src/sw/git/remote/rest/publish.ts
@@ -1,0 +1,52 @@
+import { log } from '../../../logging/logger'
+import type { SWGitConfig } from '../../../protocol'
+import { workerState } from '../../../state/state'
+import { createCommit, updateRef } from './push-commit'
+
+interface CommitAuthor {
+  readonly name: string
+  readonly email: string
+  readonly timestamp: number
+}
+
+/** Local commit metadata plus where it lands on the remote. */
+export interface PublishSpec {
+  readonly message: string
+  readonly author: CommitAuthor
+  readonly parent: string
+  readonly tree: string
+}
+
+const authorOf = (
+  config: SWGitConfig,
+  author: CommitAuthor
+): { name: string; email: string; date: string } => ({
+  name: config.authorName ?? author.name,
+  email: config.authorEmail ?? author.email,
+  date: new Date(author.timestamp * 1000).toISOString(),
+})
+
+/**
+ * Commit `spec.tree` onto the remote tip and fast-forward the branch ref,
+ * mirroring the local commit's message + author, then record the new sha.
+ * @param config - SW git configuration
+ * @param spec - Local commit metadata, remote parent, and new tree sha
+ */
+export const publishTree = async (
+  config: SWGitConfig,
+  spec: PublishSpec
+): Promise<void> => {
+  const commitSha = await createCommit(config, {
+    message: spec.message,
+    tree: spec.tree,
+    parent: spec.parent,
+    author: authorOf(config, spec.author),
+  })
+  await updateRef(config, commitSha)
+  workerState.commitSha = commitSha
+  log(
+    'info',
+    'git',
+    `rest push: ${config.branch} -> ${commitSha.slice(0, 7)}`
+  )
+}

--- a/src/sw/git/remote/rest/push-commit.ts
+++ b/src/sw/git/remote/rest/push-commit.ts
@@ -1,0 +1,48 @@
+import type { SWGitConfig } from '../../../protocol'
+import { ghSend } from './gh-send'
+import { shaOf } from './narrow'
+import { repoPath } from './repo-path'
+
+interface CommitSpec {
+  readonly message: string
+  readonly tree: string
+  readonly parent: string
+  readonly author: { name: string; email: string; date: string }
+}
+
+/**
+ * Create a commit object pointing at `spec.tree` with `spec.parent`.
+ * @param config - SW git configuration
+ * @param spec - Message, tree sha, parent sha, and author
+ * @returns The new commit sha
+ */
+export const createCommit = async (
+  config: SWGitConfig,
+  spec: CommitSpec
+): Promise<string> =>
+  shaOf(
+    await ghSend('POST', `${repoPath(config)}/git/commits`, config.token, {
+      message: spec.message,
+      tree: spec.tree,
+      parents: [spec.parent],
+      author: spec.author,
+    })
+  )
+
+/**
+ * Fast-forward the branch ref to `sha` (never force) so a diverged remote
+ * is rejected with 422 → non-fast-forward recovery.
+ * @param config - SW git configuration
+ * @param sha - New commit sha for the branch head
+ */
+export const updateRef = async (
+  config: SWGitConfig,
+  sha: string
+): Promise<void> => {
+  await ghSend(
+    'PATCH',
+    `${repoPath(config)}/git/refs/heads/${config.branch}`,
+    config.token,
+    { sha, force: false }
+  )
+}

--- a/src/sw/git/remote/rest/push-reads.ts
+++ b/src/sw/git/remote/rest/push-reads.ts
@@ -1,0 +1,43 @@
+import type { SWGitConfig } from '../../../protocol'
+import { fs, REPO_DIR } from '../../fs'
+import type { loadGit } from '../../load-git'
+import { ghSend } from './gh-send'
+import { refShaOf } from './narrow'
+
+type Git = Awaited<ReturnType<typeof loadGit>>
+
+/**
+ * Current commit sha of the remote branch head.
+ * @param config - SW git configuration
+ * @returns The remote tip sha
+ */
+export const remoteTipSha = async (config: SWGitConfig): Promise<string> =>
+  refShaOf(
+    await ghSend(
+      'GET',
+      `/repos/${config.owner}/${config.repo}/git/ref/heads/${config.branch}`,
+      config.token
+    )
+  )
+
+/**
+ * Tree sha of the remote base, read from the LOCAL clone. A remote tip
+ * absent locally means the branch advanced beyond our shallow clone —
+ * surfaced as a non-fast-forward so the merge/replay recovery re-pulls.
+ * @param git - Loaded isomorphic-git instance
+ * @param remoteTip - Remote branch head sha
+ * @returns The base tree sha
+ */
+export const baseTreeSha = async (
+  git: Git,
+  remoteTip: string
+): Promise<string> => {
+  const commit = await git
+    .readCommit({ fs, dir: REPO_DIR, oid: remoteTip })
+    .catch(() => {
+      throw new Error(
+        `not a fast-forward: remote advanced to ${remoteTip.slice(0, 7)}`
+      )
+    })
+  return commit.commit.tree
+}

--- a/src/sw/git/remote/rest/push-tree.ts
+++ b/src/sw/git/remote/rest/push-tree.ts
@@ -1,0 +1,60 @@
+import type { SWGitConfig } from '../../../protocol'
+import type { FileChange } from '../../../push-queue/collect-change'
+import { ghSend, toBase64 } from './gh-send'
+import { shaOf } from './narrow'
+import { repoPath } from './repo-path'
+
+const BLOB_MODE = '100644'
+
+interface TreeEntry {
+  readonly path: string
+  readonly mode: string
+  readonly type: 'blob'
+  readonly sha: string | null
+}
+
+const blobSha = async (
+  config: SWGitConfig,
+  data: Uint8Array
+): Promise<string> =>
+  shaOf(
+    await ghSend('POST', `${repoPath(config)}/git/blobs`, config.token, {
+      content: toBase64(data),
+      encoding: 'base64',
+    })
+  )
+
+const treeEntry = async (
+  config: SWGitConfig,
+  change: FileChange
+): Promise<TreeEntry> =>
+  'deleted' in change
+    ? { path: change.path, mode: BLOB_MODE, type: 'blob', sha: null }
+    : {
+        path: change.path,
+        mode: BLOB_MODE,
+        type: 'blob',
+        sha: await blobSha(config, change.data),
+      }
+
+/**
+ * Create a tree from `changes` layered on `baseTree` (a deletion carries a
+ * null sha per the GitHub Git Data contract).
+ * @param config - SW git configuration
+ * @param baseTree - Base tree sha to layer onto
+ * @param changes - Files added/modified/deleted
+ * @returns The new tree sha
+ */
+export const buildTree = async (
+  config: SWGitConfig,
+  baseTree: string,
+  changes: ReadonlyArray<FileChange>
+): Promise<string> => {
+  const tree = await Promise.all(changes.map(c => treeEntry(config, c)))
+  return shaOf(
+    await ghSend('POST', `${repoPath(config)}/git/trees`, config.token, {
+      base_tree: baseTree,
+      tree,
+    })
+  )
+}

--- a/src/sw/git/remote/rest/repo-path.ts
+++ b/src/sw/git/remote/rest/repo-path.ts
@@ -1,0 +1,9 @@
+import type { SWGitConfig } from '../../../protocol'
+
+/**
+ * The `/repos/{owner}/{repo}` prefix for GitHub REST calls.
+ * @param config - SW git configuration
+ * @returns Repo path prefix
+ */
+export const repoPath = (config: SWGitConfig): string =>
+  `/repos/${config.owner}/${config.repo}`


### PR DESCRIPTION
## Problem
Every publish from the admin failed with **'Push failed: Network unreachable (develop)'** for ~a month. Diagnosed live in the browser as andswew:
- Token valid (`/user` 200), `repo` scope, **push:true** on the content repo, REST blob write **201** — token is fully healthy.
- Role `chief-editor` (`/api/roles/me` 200) — RBAC healthy.
- **Root cause:** the `/api/cors` proxy's forward to `github.com/.../git-receive-pack` **stalls indefinitely** (verified: hangs even unauthenticated; the same request direct to github.com returns in 875ms; `git-upload-pack` reads through the proxy work fine). isomorphic-git surfaces the stall as 'Network unreachable'. Not account/token/role specific.

## Fix
Replace the smart-HTTP push in `pushToRemote` with a REST push (blob → tree → commit → update-ref) straight to **api.github.com** (CORS-enabled, no proxy). Fast-forward safety preserved: parent = remote tip, ref `force:false` → 422 maps to the existing non-fast-forward merge/replay recovery. Identical re-save is a no-op.

## Verify
- `bun run validate` exit 0; `bun run build` OK (sw.js browser-safe); full unit suite **1268 passed**; new `rest-push.test.ts` covers happy-path sequence, no-op, NFF-when-remote-advanced, and 422 fast-forward.
- Post-deploy: publish as andswew must land a commit on `develop` (no 'Network unreachable').

🤖 Generated with [Claude Code](https://claude.com/claude-code)