### PR TITLE
feat(tickets): role grants tickets-repo push; attach with caller token

### DIFF
--- a/src/api/authorize-and-write.ts
+++ b/src/api/authorize-and-write.ts
@@ -6,28 +6,28 @@ import {
 
 /**
  * Re-derive the caller's authorization (active org member, via their own
- * token) and, only on success, perform the pinned write with the service
- * token. The gate runs before the privileged write — a non-member never
- * reaches `doWrite`.
- * @param caller The caller's GitHub OAuth token (authorization only).
- * @param service The service token used for the write.
+ * token) and, only on success, write the attachment with the caller's own
+ * token. Role-holders receive `push` on the tickets repo at role
+ * assignment, so no service token is involved; a member without push is
+ * rejected by GitHub at the write. The gate runs before the write — a
+ * non-member never reaches `doWrite`.
+ * @param caller The caller's GitHub OAuth token (authorization + write).
  * @param body Validated attachment payload.
- * @returns The write response, or a 403 / 503.
+ * @returns The write response, or a 403 / 400.
  */
 export const authorizeAndWrite = async (
   caller: string,
-  service: string | undefined,
   body: Partial<AttachBody>
 ): Promise<Response> => {
   const denied = await requireOrgMember(caller)
   return (
     denied ??
-    (service && body.path && body.content !== undefined
-      ? doWrite(service, {
+    (body.path && body.content !== undefined
+      ? doWrite(caller, {
           path: body.path,
           content: body.content,
           message: body.message ?? '',
         })
-      : new Response('attachment service not configured', { status: 503 }))
+      : new Response('Bad attachment payload', { status: 400 }))
   )
 }

--- a/src/api/roles/collaborator-api.ts
+++ b/src/api/roles/collaborator-api.ts
@@ -1,6 +1,7 @@
 const GH = 'https://api.github.com'
 const ORG = 'communist-prometheus'
-const REPO = 'public-website-content'
+const CONTENT_REPO = 'public-website-content'
+const TICKETS_REPO = 'tickets'
 
 const headers = (token: string): Record<string, string> => ({
   Authorization: `Bearer ${token}`,
@@ -9,42 +10,75 @@ const headers = (token: string): Record<string, string> => ({
   'content-type': 'application/json',
 })
 
-const collabUrl = (login: string): string =>
-  `${GH}/repos/${ORG}/${REPO}/collaborators/${login}`
+const collabUrl = (repo: string, login: string): string =>
+  `${GH}/repos/${ORG}/${repo}/collaborators/${login}`
+
+const putCollab = (
+  token: string,
+  repo: string,
+  login: string
+): Promise<Response> =>
+  fetch(collabUrl(repo, login), {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify({ permission: 'push' }),
+  })
+
+const deleteCollab = (
+  token: string,
+  repo: string,
+  login: string
+): Promise<Response> =>
+  fetch(collabUrl(repo, login), { method: 'DELETE', headers: headers(token) })
 
 /**
  * PUT a direct collaborator on the content repo with `push` permission
  * (GitHub's name for read-write). 201 = new invite created (user not yet
  * a collaborator — accepting the invite is a one-click UI action), 204 =
  * permission already matches, 200 = permission updated.
- *
  * @param token Admin caller's OAuth token (repo scope required).
  * @param login GitHub login to grant push access.
  * @returns The raw fetch Response.
  */
-export const grantContentPush = async (
+export const grantContentPush = (
   token: string,
   login: string
-): Promise<Response> =>
-  fetch(collabUrl(login), {
-    method: 'PUT',
-    headers: headers(token),
-    body: JSON.stringify({ permission: 'push' }),
-  })
+): Promise<Response> => putCollab(token, CONTENT_REPO, login)
 
 /**
- * DELETE the direct collaborator record. 204 = removed, 404 = wasn't a
- * collaborator. Both are fine — the desired end state is "no write".
- *
+ * DELETE the content-repo collaborator record. 204 = removed, 404 = wasn't
+ * a collaborator. Both are fine — the desired end state is "no write".
  * @param token Admin caller's OAuth token (repo scope required).
  * @param login GitHub login to revoke access from.
  * @returns The raw fetch Response.
  */
-export const revokeContentAccess = async (
+export const revokeContentAccess = (
   token: string,
   login: string
-): Promise<Response> =>
-  fetch(collabUrl(login), {
-    method: 'DELETE',
-    headers: headers(token),
-  })
+): Promise<Response> => deleteCollab(token, CONTENT_REPO, login)
+
+/**
+ * PUT a direct collaborator on the tickets repo with `push` permission so
+ * role-holders can write ticket attachments with their OWN token (the
+ * attach endpoint no longer needs a service token). Same 201/204/200
+ * semantics as {@link grantContentPush}.
+ * @param token Admin caller's OAuth token (repo scope required).
+ * @param login GitHub login to grant push access.
+ * @returns The raw fetch Response.
+ */
+export const grantTicketsPush = (
+  token: string,
+  login: string
+): Promise<Response> => putCollab(token, TICKETS_REPO, login)
+
+/**
+ * DELETE the tickets-repo collaborator record. 204 = removed, 404 = wasn't
+ * a collaborator — both acceptable.
+ * @param token Admin caller's OAuth token (repo scope required).
+ * @param login GitHub login to revoke access from.
+ * @returns The raw fetch Response.
+ */
+export const revokeTicketsAccess = (
+  token: string,
+  login: string
+): Promise<Response> => deleteCollab(token, TICKETS_REPO, login)

--- a/src/api/roles/sync-content-access.test.ts
+++ b/src/api/roles/sync-content-access.test.ts
@@ -9,7 +9,9 @@ interface Call {
 
 const REPO =
   'https://api.github.com/repos/communist-prometheus/public-website-content'
+const TICKETS = 'https://api.github.com/repos/communist-prometheus/tickets'
 const COLLAB = (login: string) => `${REPO}/collaborators/${login}`
+const TICKETS_COLLAB = (login: string) => `${TICKETS}/collaborators/${login}`
 
 const stubFetch = (
   route: (call: Call) => Response
@@ -35,13 +37,18 @@ const forbidden = (): Response => new Response('forbidden', { status: 403 })
 describe('syncContentAccess', () => {
   afterEach(() => vi.unstubAllGlobals())
 
-  it('editor: PUT collaborator on the content repo with push permission', async () => {
+  it('editor: PUT push collaborator on BOTH the content and tickets repos', async () => {
     const { calls } = stubFetch(() => created())
     await syncContentAccess('tok', 'alice', 'editor')
-    expect(calls).toHaveLength(1)
-    expect(calls[0]?.method).toBe('PUT')
-    expect(calls[0]?.url).toBe(COLLAB('alice'))
-    expect(JSON.parse(calls[0]?.body ?? '{}')).toEqual({ permission: 'push' })
+    expect(calls).toHaveLength(2)
+    expect(calls.map(c => c.url)).toEqual([
+      COLLAB('alice'),
+      TICKETS_COLLAB('alice'),
+    ])
+    for (const c of calls) {
+      expect(c.method).toBe('PUT')
+      expect(JSON.parse(c.body ?? '{}')).toEqual({ permission: 'push' })
+    }
   })
 
   it('chief-editor: same PUT collaborator with push permission', async () => {
@@ -57,11 +64,15 @@ describe('syncContentAccess', () => {
     expect(calls[0]?.method).toBe('PUT')
   })
 
-  it('none: DELETE the collaborator record', async () => {
+  it('none: DELETE the collaborator record on BOTH repos', async () => {
     const { calls } = stubFetch(() => noContent())
     await syncContentAccess('tok', 'alice', 'none')
-    expect(calls[0]?.method).toBe('DELETE')
-    expect(calls[0]?.url).toBe(COLLAB('alice'))
+    expect(calls).toHaveLength(2)
+    expect(calls.map(c => c.method)).toEqual(['DELETE', 'DELETE'])
+    expect(calls.map(c => c.url)).toEqual([
+      COLLAB('alice'),
+      TICKETS_COLLAB('alice'),
+    ])
   })
 
   it('accepts DELETE 404 (login was not a collaborator)', async () => {

--- a/src/api/roles/sync-content-access.ts
+++ b/src/api/roles/sync-content-access.ts
@@ -19,17 +19,29 @@
  * from the same app path as editors do.
  */
 
-import { grantContentPush, revokeContentAccess } from './collaborator-api'
+import {
+  grantContentPush,
+  grantTicketsPush,
+  revokeContentAccess,
+  revokeTicketsAccess,
+} from './collaborator-api'
 import { requireDeleteCollab, requirePutCollab } from './collaborator-guards'
 import type { RoleAssignment } from './role-map'
 
 const grants = (role: RoleAssignment): boolean => role !== 'none'
 
-const applyGrant = async (token: string, login: string): Promise<void> =>
-  requirePutCollab(await grantContentPush(token, login))
+// Push on BOTH repos: the content repo (article edits push with the
+// caller's own token) and the tickets repo (ticket attachments upload
+// with the caller's own token — no service token needed).
+const applyGrant = async (token: string, login: string): Promise<void> => {
+  await requirePutCollab(await grantContentPush(token, login))
+  await requirePutCollab(await grantTicketsPush(token, login))
+}
 
-const applyRevoke = async (token: string, login: string): Promise<void> =>
-  requireDeleteCollab(await revokeContentAccess(token, login))
+const applyRevoke = async (token: string, login: string): Promise<void> => {
+  await requireDeleteCollab(await revokeContentAccess(token, login))
+  await requireDeleteCollab(await revokeTicketsAccess(token, login))
+}
 
 /**
  * Sync content-repo collaborator access to match a KV role assignment.

--- a/src/api/tickets-attach-write.ts
+++ b/src/api/tickets-attach-write.ts
@@ -9,9 +9,12 @@ export interface AttachBody {
   readonly message: string
 }
 
+// GitHub's REST API rejects requests without a User-Agent (403) — a
+// browser sets one automatically, but a Cloudflare Worker fetch does not.
 const ghHeaders = (token: string): HeadersInit => ({
   Authorization: `Bearer ${token}`,
   Accept: 'application/vnd.github+json',
+  'User-Agent': 'prometheus-admin',
 })
 
 const blobUrl = (path: string): string =>
@@ -38,19 +41,22 @@ export const requireOrgMember = async (
 }
 
 /**
- * Write one attachment to the pinned tickets-repo path using the service
- * token (never the caller's). Returns the blob URL on success.
- * @param service Service token with write on the tickets repo.
+ * Write one attachment to the pinned tickets-repo path using the CALLER's
+ * own token. Role-holders are granted `push` on the tickets repo at role
+ * assignment (see sync-content-access), so no service token is needed; a
+ * caller without push is rejected by GitHub (→ 502). Returns the blob URL
+ * on success.
+ * @param token The caller's OAuth token (needs push on the tickets repo).
  * @param body Validated path + base64 content + commit message.
  * @returns 200 `{ url }` on success, 502 on upstream failure.
  */
 export const doWrite = async (
-  service: string,
+  token: string,
   body: AttachBody
 ): Promise<Response> => {
   const res = await fetch(`${GH}/repos/${TICKETS}/contents/${body.path}`, {
     method: 'PUT',
-    headers: { ...ghHeaders(service), 'Content-Type': 'application/json' },
+    headers: { ...ghHeaders(token), 'Content-Type': 'application/json' },
     body: JSON.stringify({
       message: body.message,
       content: body.content,

--- a/src/api/tickets-attach.test.ts
+++ b/src/api/tickets-attach.test.ts
@@ -67,12 +67,6 @@ describe('ticketsAttach gates', () => {
     expect(mockDoWrite).not.toHaveBeenCalled()
   })
 
-  it('returns 503 when the service token is absent', async () => {
-    const res = await ticketsAttach(makeCtx({ ...good, service: undefined }))
-    expect(res.status).toBe(503)
-    expect(mockDoWrite).not.toHaveBeenCalled()
-  })
-
   it('rejects a path outside attachments/ before any upstream call', async () => {
     const res = await ticketsAttach(
       makeCtx({
@@ -95,8 +89,8 @@ describe('ticketsAttach gates', () => {
     expect(mockDoWrite).not.toHaveBeenCalled()
   })
 
-  it('writes via the service token for an authorized member', async () => {
+  it("writes with the caller's own token for an authorized member", async () => {
     await ticketsAttach(makeCtx(good))
-    expect(mockDoWrite).toHaveBeenCalledWith('svc', validBody)
+    expect(mockDoWrite).toHaveBeenCalledWith('usertoken', validBody)
   })
 })

--- a/src/api/tickets-attach.ts
+++ b/src/api/tickets-attach.ts
@@ -10,12 +10,13 @@ const forbidden = (reason: string): Response =>
   new Response(reason, { status: 403 })
 
 /**
- * POST /api/tickets/attach — write a ticket attachment with the service
- * token so an editor needs no direct tickets-repo access. Gates (before any
- * upstream call): Origin, bearer, service configured, `attachments/…` path,
- * then the caller's org-membership.
- * @param c Hono context (Env carries the TICKETS_TOKEN secret).
- * @returns 200 `{ url }`, or 403 / 503 / 502 per the failing gate.
+ * POST /api/tickets/attach — write a ticket attachment with the CALLER's
+ * own token. Role-holders are granted `push` on the tickets repo at role
+ * assignment, so no service token is needed. Gates (before any upstream
+ * call): Origin, bearer, `attachments/…` path, then the caller's
+ * org-membership.
+ * @param c Hono context.
+ * @returns 200 `{ url }`, or 403 / 400 / 502 per the failing gate.
  */
 export const ticketsAttach = async (
   c: Context<{ Bindings: Env }>
@@ -25,19 +26,15 @@ export const ticketsAttach = async (
     /^Bearer /i,
     ''
   )
-  const service = c.env.TICKETS_TOKEN
   const body: Partial<AttachBody> = await c.req.json().catch(() => ({}))
   return (
     (origin !== undefined && !isAllowedOrigin(origin)
       ? forbidden('Origin not allowed')
       : undefined) ??
     (caller ? undefined : forbidden('Missing token')) ??
-    (service
-      ? undefined
-      : new Response('attachment service not configured', { status: 503 })) ??
     (body.path && SAFE_PATH.test(body.path)
       ? undefined
       : forbidden('Bad attachment path')) ??
-    authorizeAndWrite(caller, service, body)
+    authorizeAndWrite(caller, body)
   )
 }


### PR DESCRIPTION
Ticket attachments failed on prod with **503 'attachment service not configured'** — the `TICKETS_TOKEN` service secret was never set. Per the chosen model (all role-holders get push to the tickets repo), attachments now upload with the editor's OWN token, no service token.

- `sync-content-access`: role assign/revoke now also PUT/DELETE the push collaborator on `communist-prometheus/tickets` (mirrors the content-repo grant). **All members, on role grant, get tickets-repo push.**
- attach: worker writes with the caller's token (they have push); dropped the service-token 503 path.
- fix: send `User-Agent` on the worker's GitHub fetches (GitHub 403s UA-less worker requests — was masked by the 503).

**Verified live** (deployed via `wrangler` — GitHub Actions is in a major_outage): andswew, freshly granted tickets push, uploaded a .png and a .docx through `/api/tickets/attach` → 200; files confirmed in the repo, test files cleaned up. Full unit suite 1267 green; `validate` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)