### PR TITLE
fix(sw): commit author from pushing token + logout invalidates SW

### DIFF
--- a/src/stores/auth-actions.test.ts
+++ b/src/stores/auth-actions.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import type { User } from '@/types/user'
+
+const sendSWMessage = vi.fn()
+const clearToken = vi.fn()
+const clearSso = vi.fn()
+
+vi.mock('@/composables/useSWBridge/send-message', () => ({
+  sendSWMessage: (...args: readonly unknown[]) => sendSWMessage(...args),
+}))
+vi.mock('@/composables/useAuth/token-storage', () => ({
+  clearToken: () => clearToken(),
+}))
+vi.mock('@/composables/useAuth/profile-cache', () => ({
+  saveProfile: vi.fn(),
+}))
+vi.mock('@/features/action-history/recorder', () => ({
+  recordAction: () => Promise.resolve(),
+}))
+vi.mock('./sso-roles-storage', () => ({
+  clearSsoRolesStorage: () => clearSso(),
+}))
+
+const { createLogout } = await import('./auth-actions')
+
+const someUser: User = {
+  username: 'undeadliner',
+  name: 'undeadliner',
+  avatar: '',
+  accessToken: 'tok',
+}
+
+describe('createLogout', () => {
+  afterEach(() => vi.clearAllMocks())
+
+  it('invalidates the SW so the next account does not inherit the clone/identity', () => {
+    sendSWMessage.mockResolvedValue(undefined)
+    const user = ref<User | null>(someUser)
+    const loading = ref(true)
+
+    createLogout(user, loading)()
+
+    expect(clearToken).toHaveBeenCalledOnce()
+    expect(sendSWMessage).toHaveBeenCalledWith({ type: 'SW_INVALIDATE' })
+    expect(user.value).toBeNull()
+    expect(loading.value).toBe(false)
+  })
+})

--- a/src/stores/auth-actions.ts
+++ b/src/stores/auth-actions.ts
@@ -1,6 +1,7 @@
 import type { Ref } from 'vue'
 import { saveProfile } from '@/composables/useAuth/profile-cache'
 import { clearToken } from '@/composables/useAuth/token-storage'
+import { sendSWMessage } from '@/composables/useSWBridge/send-message'
 import { recordAction } from '@/features/action-history/recorder'
 import type { User } from '@/types/user'
 import { clearSsoRolesStorage } from './sso-roles-storage'
@@ -39,6 +40,10 @@ export const createLogout =
   () => {
     clearToken()
     clearSsoRolesStorage()
+    // Drop the SW's clone + persisted config so the next account starts
+    // clean — otherwise the previous user's token/identity linger in the
+    // worker and commits keep going out under the previous account.
+    void sendSWMessage({ type: 'SW_INVALIDATE' }).catch(() => undefined)
     user.value = null
     loading.value = false
     void recordAction({ kind: 'auth', action: 'logout' })

--- a/src/sw/core/auto-recover.ts
+++ b/src/sw/core/auto-recover.ts
@@ -1,6 +1,7 @@
 import { Effect, Option } from 'effect'
 import { loadConfig } from '../git/repo/persist-config'
 import { checkRepoAndSync } from '../git/sync/sync-repo'
+import { withTokenIdentity } from '../git/token-identity'
 import { log } from '../logging/logger'
 import { workerState } from '../state/state'
 
@@ -28,8 +29,11 @@ const recoverEffect: Effect.Effect<boolean, never> = Effect.tryPromise(() =>
       onNone: () => Effect.succeed(false),
       onSome: config =>
         Effect.tryPromise(async () => {
-          workerState.config = config
-          await checkRepoAndSync(config)
+          // Re-derive the author from the persisted token so a resurrected
+          // config never commits under a previous account's name.
+          const withAuthor = await withTokenIdentity(config)
+          workerState.config = withAuthor
+          await checkRepoAndSync(withAuthor)
           log('info', 'lifecycle', 'Auto-recovered after SW restart')
           if (workerState.state === 'ready') void drainAfterRecover()
           return workerState.state === 'ready'

--- a/src/sw/core/messaging/handle-init.ts
+++ b/src/sw/core/messaging/handle-init.ts
@@ -1,5 +1,6 @@
 import { saveConfig } from '../../git/repo/persist-config'
 import { checkRepoAndSync } from '../../git/sync/sync-repo'
+import { withTokenIdentity } from '../../git/token-identity'
 import { log } from '../../logging/logger'
 import type { SWGitConfig } from '../../protocol'
 import { workerState } from '../../state/state'
@@ -9,16 +10,13 @@ import { workerState } from '../../state/state'
  */
 let pending: Promise<void> | undefined
 
-/**
- * Handle SW_INIT: store config, initialize git repo, reply when ready.
- * Deduplicates concurrent init requests via a shared promise.
- * @param config - GitHub config with token
- * @param reply - Response callback (called after repo init)
- */
-export const handleInit = (
+const startInit = (
   config: SWGitConfig,
   reply: (data: unknown) => void
 ): void => {
+  // Author is derived from the token itself so it can never diverge from
+  // the account that pushes (see identity.ts) — even if the client passed
+  // a stale authorName/authorEmail.
   workerState.config = config
   log('info', 'auth', 'Config received', { owner: config.owner })
 
@@ -38,4 +36,19 @@ export const handleInit = (
       workerState.state = 'error'
       reply({ ok: false, error: msg })
     })
+}
+
+/**
+ * Handle SW_INIT: store config, initialize git repo, reply when ready.
+ * Deduplicates concurrent init requests via a shared promise.
+ * @param config - GitHub config with token
+ * @param reply - Response callback (called after repo init)
+ */
+export const handleInit = (
+  config: SWGitConfig,
+  reply: (data: unknown) => void
+): void => {
+  void withTokenIdentity(config).then(withAuthor =>
+    startInit(withAuthor, reply)
+  )
 }

--- a/src/sw/git/github-user.ts
+++ b/src/sw/git/github-user.ts
@@ -1,0 +1,40 @@
+/** Git author identity for a commit. */
+export interface CommitIdentity {
+  readonly name: string
+  readonly email: string
+}
+
+// Truthiness rejects the empty reference that `typeof x === 'object'`
+// admits; the predicate narrows to a real object for the compiler.
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && Boolean(value)
+
+const field = (value: unknown, key: string): unknown =>
+  isRecord(value) && key in value ? value[key] : undefined
+
+// GitHub attributes by author email; the id-prefixed noreply form links
+// for any account age, the legacy form only for pre-2017 accounts.
+const noreplyEmail = (id: unknown, login: string): string =>
+  typeof id === 'number'
+    ? `${id}+${login}@users.noreply.github.com`
+    : `${login}@users.noreply.github.com`
+
+const displayName = (user: unknown, login: string): string => {
+  const name = field(user, 'name')
+  return typeof name === 'string' && name.length > 0 ? name : login
+}
+
+/**
+ * Map a GitHub `/user` payload to a commit identity.
+ * @param user - Parsed `/user` response
+ * @returns Identity, or undefined when the payload lacks a login
+ */
+export const identityFrom = (user: unknown): CommitIdentity | undefined => {
+  const login = field(user, 'login')
+  return typeof login === 'string'
+    ? {
+        name: displayName(user, login),
+        email: noreplyEmail(field(user, 'id'), login),
+      }
+    : undefined
+}

--- a/src/sw/git/identity.test.ts
+++ b/src/sw/git/identity.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveCommitIdentity } from './identity'
+import { withTokenIdentity } from './token-identity'
+
+const userResponse = (body: unknown, status = 200): void => {
+  vi.stubGlobal(
+    'fetch',
+    async () => new Response(JSON.stringify(body), { status })
+  )
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('resolveCommitIdentity', () => {
+  it('builds the modern id-prefixed noreply email from /user', async () => {
+    userResponse({ login: 'andswew', id: 281177217, name: 'Andrew' })
+    expect(await resolveCommitIdentity('tok-A')).toEqual({
+      name: 'Andrew',
+      email: '281177217+andswew@users.noreply.github.com',
+    })
+  })
+
+  it('falls back to login when the profile name is empty', async () => {
+    userResponse({ login: 'undeadliner', id: 42, name: '' })
+    expect(await resolveCommitIdentity('tok-B')).toEqual({
+      name: 'undeadliner',
+      email: '42+undeadliner@users.noreply.github.com',
+    })
+  })
+
+  it('uses the legacy noreply form when id is absent', async () => {
+    userResponse({ login: 'legacyuser' })
+    expect(await resolveCommitIdentity('tok-C')).toEqual({
+      name: 'legacyuser',
+      email: 'legacyuser@users.noreply.github.com',
+    })
+  })
+
+  it('returns undefined on a non-ok response (keeps the caller falling back)', async () => {
+    userResponse({ message: 'Bad credentials' }, 401)
+    expect(await resolveCommitIdentity('tok-D')).toBeUndefined()
+  })
+
+  it('caches per token — a second call issues no request', async () => {
+    let calls = 0
+    vi.stubGlobal('fetch', async () => {
+      calls += 1
+      return new Response(JSON.stringify({ login: 'x', id: 1 }), {
+        status: 200,
+      })
+    })
+    await resolveCommitIdentity('tok-E')
+    await resolveCommitIdentity('tok-E')
+    expect(calls).toBe(1)
+  })
+})
+
+describe('withTokenIdentity', () => {
+  it('overrides authorName/authorEmail with the token-derived identity', async () => {
+    userResponse({ login: 'andswew', id: 281177217, name: 'Andrew' })
+    const out = await withTokenIdentity({
+      token: 'tok-F',
+      owner: 'o',
+      authorName: 'undeadliner',
+      authorEmail: 'undeadliner@users.noreply.github.com',
+    })
+    expect(out.authorName).toBe('Andrew')
+    expect(out.authorEmail).toBe('281177217+andswew@users.noreply.github.com')
+    expect(out.owner).toBe('o')
+  })
+
+  it('leaves the config untouched when identity cannot be resolved', async () => {
+    userResponse({}, 403)
+    const config = {
+      token: 'tok-G',
+      authorName: 'kept',
+      authorEmail: 'kept@example.com',
+    }
+    expect(await withTokenIdentity(config)).toEqual(config)
+  })
+})

--- a/src/sw/git/identity.ts
+++ b/src/sw/git/identity.ts
@@ -1,0 +1,51 @@
+/*
+ * Commit identity derived from the token that will push (not from a
+ * client-passed or stale-persisted authorName/authorEmail), so a commit
+ * can never be attributed to a different account than the one pushing it.
+ */
+
+import { type CommitIdentity, identityFrom } from './github-user'
+
+export type { CommitIdentity } from './github-user'
+
+const API = 'https://api.github.com'
+
+// Keyed by token: /user is stable for a token, so a tiny cache avoids a
+// round trip per commit.
+const cache = new Map<string, CommitIdentity>()
+
+const remember = (
+  token: string,
+  identity: CommitIdentity
+): CommitIdentity => {
+  cache.set(token, identity)
+  return identity
+}
+
+const fetchIdentity = async (
+  token: string
+): Promise<CommitIdentity | undefined> => {
+  try {
+    const res = await fetch(`${API}/user`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    })
+    const identity = res.ok ? identityFrom(await res.json()) : undefined
+    return identity === undefined ? undefined : remember(token, identity)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Resolve the git commit identity for a token from its GitHub user.
+ * @param token - The OAuth token that will author/push the commit
+ * @returns The identity, or undefined when it can't be resolved (caller
+ *   then keeps whatever author the config already carries)
+ */
+export const resolveCommitIdentity = async (
+  token: string
+): Promise<CommitIdentity | undefined> =>
+  cache.get(token) ?? (await fetchIdentity(token))

--- a/src/sw/git/token-identity.ts
+++ b/src/sw/git/token-identity.ts
@@ -1,0 +1,23 @@
+import { resolveCommitIdentity } from './identity'
+
+/**
+ * Return `config` with its author name/email overridden by the identity
+ * of its own token, so the commit author always matches the pusher.
+ * Leaves the config untouched when the identity can't be resolved.
+ * @param config - SW git config (carries the token)
+ * @returns Config with a token-derived author
+ */
+export const withTokenIdentity = async <
+  T extends {
+    readonly token: string
+    authorName?: string
+    authorEmail?: string
+  },
+>(
+  config: T
+): Promise<T> => {
+  const identity = await resolveCommitIdentity(config.token)
+  return identity === undefined
+    ? config
+    : { ...config, authorName: identity.name, authorEmail: identity.email }
+}


### PR DESCRIPTION
**Bug:** after switching accounts, commits kept the previous account's name (e.g. andswew logged in, commits authored `undeadliner`).

**Root cause:** commit author lives in the SW config (`authorName`/`authorEmail`), which is persisted to IndexedDB and resurrected by `auto-recover` on SW restart; logout never cleared it. So a stale identity outlived the account switch. Proof: prod admin commits are authored `undeadliner / igor.ganov@gmail.com` — an email the current `buildSWConfig` never generates (it uses `<username>@users.noreply`), i.e. a leftover persisted config from an old build.

**Fix (two layers):**
1. Derive the commit identity from the token that actually pushes (`sw/git/identity.ts` → `/user`), applied in `handleInit` **and** `auto-recover` — author can never diverge from the pusher, and it self-heals the existing stale state (no logout needed).
2. Logout sends `SW_INVALIDATE` (wipes the previous account's clone + persisted config) so the next login starts clean.

Shared SW engine → fixes old admin AND redesign. `validate` = 0; main unit suite 1275 green; new tests: `identity.test.ts` (id-prefixed noreply, cache, override, fallback) + `auth-actions.test.ts` (logout invalidates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)