### PR TITLE
deploy: prod admin reads+writes content master, not develop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,15 +59,18 @@ jobs:
             echo "GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
             echo "WRANGLER_COMMAND=deploy --env develop" >> "$GITHUB_ENV"
           else
-            # Prod editors push to `develop` on the content repo, not
-            # `master` — master is protected by `guard` status checks
-            # and rejects direct pushes as GH006 (isomorphic-git surfaces
-            # this as "Unexpected error", which read like a client bug
-            # to editors). Content-repo Actions ff-merges develop into
-            # master via the CONTENT_MERGE_TOKEN admin PAT, so from the
-            # editor's point of view "save" still lands in production —
-            # just through an unprotected staging branch.
-            echo "VITE_GITHUB_BRANCH=develop" >> "$GITHUB_ENV"
+            # Prod admin reads AND writes the content `master` branch
+            # directly. The develop→master auto-merge that used to promote
+            # editor saves to production was removed (it caused duplicate
+            # deploys), so routing prod through `develop` left the prod
+            # site (master) stale and showed dev content in the admin.
+            # Writing `master` keeps prod self-consistent. `master`
+            # protection has enforce_admins:false, so admin-role editors
+            # push directly; the only required check (`guard`) runs on PRs,
+            # not pushes. Non-admin editors still hit GH006 on direct
+            # pushes — if they must publish, drop `guard` from master's
+            # required status checks.
+            echo "VITE_GITHUB_BRANCH=master" >> "$GITHUB_ENV"
             echo "VITE_OAUTH_REDIRECT_URI=$OAUTH_REDIRECT_URI_MASTER" >> "$GITHUB_ENV"
             echo "VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID_MASTER" >> "$GITHUB_ENV"
             echo "VITE_COMMS_BASE=https://lists.comprom.org" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Проблема
Prod-админка (admin.comprom.org) была нацелена на content-ветку `develop`, а не `master`. Раньше сейвы доезжали до прода через auto-merge develop→master в контент-репе; этот auto-merge был удалён (он давал дубли деплоя), после чего правки редактора застревали на `develop` и на comprom.org (=master) не попадали.

## Фикс
Сборка prod-воркера теперь с `VITE_GITHUB_BRANCH=master` → сейв в prod-админке пишется прямо в production-ветку контента.

dev-админка и admin-v2 остаются на `develop` (превью).

🤖 Generated with [Claude Code](https://claude.com/claude-code)