### PR TITLE
redesign QA: language switcher, caret, icons, sort, description, ticket create, deploy board (10 fixes)

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -100,7 +100,8 @@ export class AppShell extends LitElement {
     }
     .account {
       font-size: 0.9rem;
-      color: var(--color-text-secondary);
+      color: var(--color-text-primary);
+      font-weight: 500;
     }
     .auth-hint {
       margin: 0 0 var(--spacing-md);
@@ -132,10 +133,10 @@ export class AppShell extends LitElement {
         grid-template-columns: 15rem minmax(0, 1fr);
       }
     }
-    /* Compact header on mobile: keep the sync dot, drop the long label + login. */
+    /* Compact header on mobile: drop the long sync-status label, but keep the
+       logged-in username visible (it was hidden before, leaving a lone Logout). */
     @media (max-width: 767px) {
-      .header-right cp-status,
-      .account {
+      .header-right cp-status {
         display: none;
       }
     }

--- a/src/redesign/components/engine-loading.ts
+++ b/src/redesign/components/engine-loading.ts
@@ -16,11 +16,18 @@ export class EngineLoading extends LitElement {
   static override styles = css`
     :host {
       display: block;
+      /* Fill the cell even when a parent grid uses justify-items:start, so the
+         centred .wrap below is centred against the full width (mobile included). */
+      justify-self: stretch;
     }
     .wrap {
       display: grid;
       gap: var(--spacing-sm);
       max-width: 30rem;
+      width: 100%;
+      margin-inline: auto;
+      justify-items: center;
+      text-align: center;
       padding: var(--spacing-md) 0;
     }
     .label {

--- a/src/redesign/editor/cp-markdown-editor.ts
+++ b/src/redesign/editor/cp-markdown-editor.ts
@@ -107,6 +107,14 @@ export class CpMarkdownEditor extends LitElement {
       '.cm-selectionBackground, ::selection': {
         backgroundColor: 'var(--accent-bg) !important',
       },
+      // CodeMirror's baseTheme forces the native caret black via
+      // `.cm-light .cm-content` (the view always carries `cm-light` since the
+      // theme is built without {dark:true}), which is invisible on the dark
+      // ground. Match that specificity from this user theme so the caret is the
+      // accent colour in both app themes.
+      '&light .cm-content, &dark .cm-content': {
+        caretColor: 'var(--color-accent)',
+      },
       '.cm-activeLine': { backgroundColor: 'transparent' },
       '.cm-placeholder': { color: 'var(--color-text-secondary)' },
     });

--- a/src/redesign/engine/content.engine.test.ts
+++ b/src/redesign/engine/content.engine.test.ts
@@ -100,6 +100,19 @@ describe('listArticles fan-out', () => {
     expect(list).toHaveLength(20);
     expect(maxInFlight).toBeLessThanOrEqual(6);
   });
+
+  it('returns articles oldest → newest by pubDate, undated last (QA sort)', async () => {
+    tree['blog'] = [
+      { type: 'dir', name: 'index.ru.md', path: 'blog/newer/index.ru.md' },
+      { type: 'dir', name: 'index.ru.md', path: 'blog/older/index.ru.md' },
+      { type: 'dir', name: 'index.ru.md', path: 'blog/undated/index.ru.md' },
+    ];
+    files['blog/newer/index.ru.md'] = '---\ntitle: N\npubDate: 2026-05-01\n---\n';
+    files['blog/older/index.ru.md'] = '---\ntitle: O\npubDate: 2026-01-01\n---\n';
+    files['blog/undated/index.ru.md'] = '---\ntitle: U\n---\n';
+    const order = (await listArticles()).map((a) => a.slug);
+    expect(order).toEqual(['older', 'newer', 'undated']);
+  });
 });
 
 describe('createMagazineIssue count (QA #17)', () => {

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -341,8 +341,13 @@ export const listArticles = async (): Promise<readonly ArticleSummary[]> => {
       bySlug.set(slug, set);
     }
   }
-  return mapPool([...bySlug.entries()], 6, ([slug, langs]) =>
+  const summaries = await mapPool([...bySlug.entries()], 6, ([slug, langs]) =>
     summariseArticle(slug, [...langs]),
+  );
+  // Chronological, oldest → newest (ISO YYYY-MM-DD sorts lexicographically);
+  // undated articles sort last. Matches every content list's ordering.
+  return [...summaries].sort((a, b) =>
+    (a.date ?? '9999').localeCompare(b.date ?? '9999'),
   );
 };
 

--- a/src/redesign/engine/deploy-status.test.ts
+++ b/src/redesign/engine/deploy-status.test.ts
@@ -63,9 +63,20 @@ describe('correlateDeploys', () => {
     expect(d.runUrl).toBe('r1');
   });
 
-  it('reports unknown when no run matches', () => {
+  it('reports unknown when there are no runs at all', () => {
     const [d] = correlateDeploys([push({ date: '2020-01-01T00:00:00Z' })], []);
     expect(d.phase).toBe('unknown');
     expect(d.durationSec).toBeUndefined();
+  });
+
+  it('reports pending for a fresh push newer than every known run', () => {
+    // The just-committed push has not triggered its deploy yet: awaiting, not
+    // missing data (QA #10 — no more grey no-data dot right after a commit).
+    const [d] = correlateDeploys(
+      [push({ date: '2026-08-04T12:00:00Z' })],
+      [run({ createdAt: '2026-08-04T09:20:35Z', url: 'r-old' })],
+    );
+    expect(d.phase).toBe('pending');
+    expect(d.runUrl).toBeUndefined();
   });
 });

--- a/src/redesign/engine/deploy-status.ts
+++ b/src/redesign/engine/deploy-status.ts
@@ -6,7 +6,7 @@ import type { Push, DeployRun } from './github-api.js';
  * per-step breakdown, so the board shows real states rather than invented
  * "step 3 of 5" numbers.
  */
-export type DeployPhase = 'queued' | 'building' | 'published' | 'failed' | 'unknown';
+export type DeployPhase = 'pending' | 'queued' | 'building' | 'published' | 'failed' | 'unknown';
 
 /** A push enriched with its deploy outcome for the board. */
 export interface DeployedPush {
@@ -56,17 +56,39 @@ export const matchRun = (
   return best;
 };
 
+/** The most recent run's creation time, or -Infinity when the list is empty. */
+const newestRunTime = (runs: readonly DeployRun[]): number =>
+  runs.reduce((max, run) => {
+    const created = Date.parse(run.createdAt);
+    return Number.isNaN(created) ? max : Math.max(max, created);
+  }, Number.NEGATIVE_INFINITY);
+
+/**
+ * Phase of a push with no matched run. A push newer than every known run has
+ * simply not triggered its deploy yet — that is "awaiting deploy", not missing
+ * data. Only a push that predates the newest run (so its run has aged out of the
+ * fetched window) is genuinely unknown.
+ */
+const unmatchedPhase = (pushDate: string, newestRun: number): DeployPhase => {
+  const pushed = Date.parse(pushDate);
+  // No runs at all (fetch failure / no history) — can't tell pending from data.
+  if (Number.isNaN(pushed) || !Number.isFinite(newestRun)) return 'unknown';
+  return pushed >= newestRun - SKEW_MS ? 'pending' : 'unknown';
+};
+
 /** Enriches each push with the deploy status of the run it triggered. */
 export const correlateDeploys = (
   pushes: readonly Push[],
   runs: readonly DeployRun[],
-): readonly DeployedPush[] =>
-  pushes.map((push) => {
+): readonly DeployedPush[] => {
+  const newest = newestRunTime(runs);
+  return pushes.map((push) => {
     const run = matchRun(push.date, runs);
-    const phase = deployPhase(run);
+    const phase = run === undefined ? unmatchedPhase(push.date, newest) : deployPhase(run);
     const durationSec =
       run !== undefined && phase === 'published'
         ? Math.max(0, Math.round((Date.parse(run.updatedAt) - Date.parse(run.createdAt)) / 1000))
         : undefined;
     return { push, phase, durationSec, runUrl: run?.url };
   });
+};

--- a/src/redesign/engine/github-api.test.ts
+++ b/src/redesign/engine/github-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
-import { listMembers, listPushes, listTickets } from './github-api.ts';
+import { listMembers, listPushes, listTickets, createTicket } from './github-api.ts';
 
 vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({
   ensureFreshToken: vi.fn(),
@@ -84,5 +84,49 @@ describe('list* repo targeting (regression: each list reads its own repo)', () =
     expect(urls[0]).toContain(
       '/repos/communist-prometheus/public-website-content/commits'
     );
+  });
+});
+
+describe('createTicket (QA #9)', () => {
+  interface Call {
+    readonly url: string;
+    readonly method?: string;
+    readonly body: unknown;
+  }
+
+  const stubCreate = (payload: unknown, status = 201): Call[] => {
+    const calls: Call[] = [];
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      calls.push({
+        url,
+        method: init?.method,
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      });
+      return new Response(JSON.stringify(payload), { status });
+    });
+    return calls;
+  };
+
+  it('POSTs a new issue to the tickets repo with the kind label', async () => {
+    const calls = stubCreate({ number: 42, html_url: 'https://gh/tickets/42' });
+    const result = await createTicket({ title: 'broken', body: 'steps', kind: 'bug' });
+
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.url).toContain('/repos/communist-prometheus/tickets/issues');
+    expect(calls[0]?.body).toEqual({ title: 'broken', body: 'steps', labels: ['bug'] });
+    expect(result).toEqual({ ok: true, number: 42, url: 'https://gh/tickets/42' });
+  });
+
+  it('sends no label for an "other" ticket', async () => {
+    const calls = stubCreate({ number: 7, html_url: 'u' });
+    await createTicket({ title: 't', body: '', kind: 'other' });
+    expect(calls[0]?.body).toMatchObject({ labels: [] });
+  });
+
+  it('reports failure (no throw) when GitHub rejects the create', async () => {
+    stubCreate({ message: 'Forbidden' }, 403);
+    const result = await createTicket({ title: 't', body: '', kind: 'story' });
+    expect(result.ok).toBe(false);
+    expect(result.number).toBeUndefined();
   });
 });

--- a/src/redesign/engine/github-api.ts
+++ b/src/redesign/engine/github-api.ts
@@ -138,6 +138,72 @@ export const listTickets = async (repo = 'tickets'): Promise<readonly Ticket[]> 
   return Array.isArray(data) ? data.map(toTicket).filter((t): t is Ticket => t !== undefined) : [];
 };
 
+/** POST with the active token; returns ok + parsed body (undefined on failure). */
+const post = async (path: string, body: unknown): Promise<{ ok: boolean; data: unknown }> => {
+  const t = await token();
+  if (t === undefined) return { ok: false, data: undefined };
+  try {
+    const response = await fetch(`${API}${path}`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${t}`,
+        accept: 'application/vnd.github+json',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    return { ok: response.ok, data: response.ok ? await response.json() : undefined };
+  } catch {
+    return { ok: false, data: undefined };
+  }
+};
+
+/** Fields a new ticket carries; `kind` maps to a GitHub label {@link kindOf} reads back. */
+export interface NewTicket {
+  readonly title: string;
+  readonly body: string;
+  readonly kind: Ticket['kind'];
+}
+
+/** The outcome of a create attempt — number/url on success, message on failure. */
+export interface CreateResult {
+  readonly ok: boolean;
+  readonly number?: number;
+  readonly url?: string;
+}
+
+/** Labels applied per kind so the created issue reads back as the same kind. */
+const LABELS_OF: Readonly<Record<Ticket['kind'], readonly string[]>> = {
+  bug: ['bug'],
+  story: ['story'],
+  other: [],
+};
+
+/**
+ * Opens a new issue in the `tickets` repo as the signed-in member. Every org
+ * member has at least read on that repo, and GitHub's read role already permits
+ * opening issues, so any member can file a ticket with their own token — the
+ * author is the real person, not a bot.
+ */
+export const createTicket = async (
+  ticket: NewTicket,
+  repo = 'tickets',
+): Promise<CreateResult> => {
+  const { ok, data } = await post(`/repos/${OWNER}/${repo}/issues`, {
+    title: ticket.title,
+    body: ticket.body,
+    labels: LABELS_OF[ticket.kind],
+  });
+  if (!ok) return { ok: false };
+  const number = field(data, 'number');
+  const url = field(data, 'html_url');
+  return {
+    ok: true,
+    number: typeof number === 'number' ? number : undefined,
+    url: typeof url === 'string' ? url : undefined,
+  };
+};
+
 /** A recent push (commit) to the content repo, for the deploy board. */
 export interface Push {
   readonly sha: string;

--- a/src/redesign/nav.ts
+++ b/src/redesign/nav.ts
@@ -37,14 +37,14 @@ export const groups: ReadonlyArray<readonly [NavItem['group'], string]> = [
 
 /** The admin's primary navigation (roles per the inventory; refined in auth). */
 export const navItems: readonly NavItem[] = [
-  { id: 'articles', label: 'Статьи', icon: 'check', group: 'content', role: 'editor' },
-  { id: 'magazine', label: 'Журнал', icon: 'upload', group: 'content', role: 'editor' },
-  { id: 'topics', label: 'Темы', icon: 'more', group: 'content', role: 'editor' },
-  { id: 'members', label: 'Участники', icon: 'plus', group: 'community', role: 'admin' },
-  { id: 'tickets', label: 'Тикеты', icon: 'warning', group: 'community', role: 'editor' },
-  { id: 'newsletter', label: 'Рассылка', icon: 'chevron-right', group: 'distribution', ownerOnly: true },
-  { id: 'deploys', label: 'Деплои', icon: 'refresh', group: 'distribution', role: 'editor' },
-  { id: 'settings', label: 'Настройки', icon: 'more', group: 'admin', role: 'admin' },
+  { id: 'articles', label: 'Статьи', icon: 'file-text', group: 'content', role: 'editor' },
+  { id: 'magazine', label: 'Журнал', icon: 'book', group: 'content', role: 'editor' },
+  { id: 'topics', label: 'Темы', icon: 'hash', group: 'content', role: 'editor' },
+  { id: 'members', label: 'Участники', icon: 'users', group: 'community', role: 'admin' },
+  { id: 'tickets', label: 'Тикеты', icon: 'ticket', group: 'community', role: 'editor' },
+  { id: 'newsletter', label: 'Рассылка', icon: 'mail', group: 'distribution', ownerOnly: true },
+  { id: 'deploys', label: 'Деплои', icon: 'rocket', group: 'distribution', role: 'editor' },
+  { id: 'settings', label: 'Настройки', icon: 'settings', group: 'admin', role: 'admin' },
 ];
 
 const rank: Record<Role, number> = { viewer: 0, editor: 1, admin: 2 };

--- a/src/redesign/screens/screen-deploys.ts
+++ b/src/redesign/screens/screen-deploys.ts
@@ -187,6 +187,7 @@ export class ScreenDeploys extends LitElement {
     if (phase === 'published') return { state: 'success', icon: 'check', label: 'опубликовано', spin: false };
     if (phase === 'building') return { state: 'info', icon: 'refresh', label: 'сборка идёт', spin: true };
     if (phase === 'queued') return { state: 'info', icon: 'refresh', label: 'в очереди', spin: false };
+    if (phase === 'pending') return { state: 'info', icon: 'refresh', label: 'ожидание деплоя', spin: true };
     if (phase === 'failed') return { state: 'danger', icon: 'warning', label: 'не удалось', spin: false };
     return { state: 'neutral', icon: 'more', label: 'нет данных', spin: false };
   }
@@ -228,7 +229,7 @@ export class ScreenDeploys extends LitElement {
               : html`<span aria-hidden="true">·</span
                   ><a class="gh" href=${item.runUrl} target="_blank" rel="noopener">лог ↗</a>`}
           </div>
-          ${item.phase === 'building' || item.phase === 'queued'
+          ${item.phase === 'building' || item.phase === 'queued' || item.phase === 'pending'
             ? html`<cp-progress ?indeterminate=${true} value="0"></cp-progress>`
             : nothing}
         </div>

--- a/src/redesign/screens/screen-editor.lang.test.ts
+++ b/src/redesign/screens/screen-editor.lang.test.ts
@@ -25,6 +25,7 @@ interface EditorInternals {
   slug: string;
   live: boolean;
   activeLang: string;
+  availableLangs: readonly string[];
   body: string;
   applyMarkdown: (markdown: string, path: string, live: boolean) => void;
   onLangChange: (event: Event) => void;
@@ -38,6 +39,9 @@ const seededEditor = (): EditorInternals => {
   priv.slug = 'x';
   priv.live = true;
   priv.activeLang = 'ru';
+  // `load()` populates this from the article's real languages; the tests drive
+  // applyMarkdown directly, so seed it so a switch to 'en' is accepted.
+  priv.availableLangs = ['ru', 'en'];
   priv.applyMarkdown(RU, 'blog/x/index.ru.md', true);
   return priv;
 };

--- a/src/redesign/screens/screen-editor.props.test.ts
+++ b/src/redesign/screens/screen-editor.props.test.ts
@@ -24,6 +24,7 @@ interface EditorInternals {
   live: boolean;
   activeLang: string;
   topic: string;
+  description: string;
   pubDate: string;
   published: boolean;
   readonly editedMarkdown: string;
@@ -63,6 +64,12 @@ describe('screen-editor properties write-back (QA #4)', () => {
     const el = seededEditor();
     el.pubDate = '2026-09-09';
     expect(el.editedMarkdown).toContain('pubDate: 2026-09-09');
+  });
+
+  it('writes an edited description back into the published frontmatter', () => {
+    const el = seededEditor();
+    el.description = 'a new summary';
+    expect(el.editedMarkdown).toContain('description: a new summary');
   });
 
   it('writes the published flag back into the published frontmatter', () => {

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -44,12 +44,21 @@ interface PublishStage {
   readonly state: StageState;
 }
 
-/** Language variants, surfaced as `cp-tabs`. */
-const LANG_TABS: readonly CpTab[] = [
-  { id: 'ru', label: 'Русский' },
-  { id: 'en', label: 'English' },
-  { id: 'it', label: 'Italiano' },
-];
+/** Display labels for known language codes; any other code falls back to its
+ * uppercased code, so an article in es/uk/pl/… still gets a usable tab. */
+const LANG_LABELS: Readonly<Record<string, string>> = {
+  ru: 'Русский',
+  en: 'English',
+  it: 'Italiano',
+  es: 'Español',
+  uk: 'Українська',
+  pl: 'Polski',
+  bl: 'Беларуская',
+};
+
+/** Builds the language tabs from the codes an article actually has. */
+const langTabs = (codes: readonly string[]): readonly CpTab[] =>
+  codes.map((code) => ({ id: code, label: LANG_LABELS[code] ?? code.toUpperCase() }));
 
 /** Presentational toolbar affordances (block/inline formatting placeholders). */
 const FORMAT_TOOLS: readonly FormatTool[] = [
@@ -394,6 +403,14 @@ export class ScreenEditor extends LitElement {
     }
     cp-banner {
       margin-top: var(--spacing-md);
+      max-width: 100%;
+    }
+    /* A commit sha / long path in a monospace code span can't line-break and
+       would push the dialog past a phone's viewport — force it to wrap. */
+    cp-banner code,
+    .dialog-note code {
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     .dialog-foot {
       display: flex;
@@ -443,6 +460,9 @@ export class ScreenEditor extends LitElement {
 
   /** Selected «Тема»; empty keeps the material incomplete. */
   @state() private topic = '';
+
+  /** Article description frontmatter, seeded from the file + written back. */
+  @state() private description = '';
 
   /** Selected «Рубрика». */
   @state() private rubric = 'theory';
@@ -545,7 +565,9 @@ export class ScreenEditor extends LitElement {
       if (markdown !== undefined && markdown.trim() !== '') {
         this.slug = target.slug;
         this.availableLangs = target.languages;
-        this.activeLang = lang === 'ru' || lang === 'en' || lang === 'it' ? lang : 'ru';
+        // `lang` is already one of the article's real languages (line above),
+        // so use it directly instead of collapsing anything non-ru/en/it to ru.
+        this.activeLang = lang;
         this.applyMarkdown(markdown, path, true);
         this.loaded = true;
         return;
@@ -584,6 +606,7 @@ export class ScreenEditor extends LitElement {
     // article's `category`. Without this seed the required-field check below
     // always fired a false "заполните Тема" warning.
     this.topic = frontmatterValue(fm, 'category') ?? frontmatterValue(fm, 'topic') ?? '';
+    this.description = frontmatterValue(fm, 'description') ?? '';
     const date = frontmatterValue(fm, 'pubDate') ?? frontmatterValue(fm, 'date');
     if (date !== undefined) this.pubDate = date;
     const published = frontmatterValue(fm, 'published');
@@ -600,6 +623,8 @@ export class ScreenEditor extends LitElement {
     let fm = this.frontmatter;
     if (fm !== '') {
       if (this.topic !== '') fm = upsertFrontmatterField(fm, 'category', this.topic);
+      if (this.description !== '')
+        fm = upsertFrontmatterField(fm, 'description', this.description);
       if (this.pubDate !== '') fm = upsertFrontmatterField(fm, 'pubDate', this.pubDate);
       fm = upsertFrontmatterField(fm, 'published', String(this.published));
     }
@@ -615,7 +640,7 @@ export class ScreenEditor extends LitElement {
   private onLangChange = (event: Event): void => {
     if (event instanceof CustomEvent) {
       const id: unknown = event.detail?.id;
-      if ((id === 'ru' || id === 'en' || id === 'it') && id !== this.activeLang) {
+      if (typeof id === 'string' && this.availableLangs.includes(id) && id !== this.activeLang) {
         // Stash the outgoing language's edits before swapping the buffers in.
         if (this.slug !== '') this.langBuffers.set(this.activeLang, this.editedMarkdown);
         this.activeLang = id;
@@ -660,6 +685,15 @@ export class ScreenEditor extends LitElement {
       const value: unknown = event.detail?.value;
       if (typeof value === 'string') {
         this.pubDate = value;
+      }
+    }
+  };
+
+  private onDescriptionChange = (event: Event): void => {
+    if (event instanceof CustomEvent) {
+      const value: unknown = event.detail?.value;
+      if (typeof value === 'string') {
+        this.description = value;
       }
     }
   };
@@ -804,6 +838,12 @@ export class ScreenEditor extends LitElement {
             .options=${TOPIC_OPTIONS}
             @cp-change=${this.onTopicChange}
           ></cp-select>
+          <cp-textarea
+            label="Описание"
+            rows="3"
+            .value=${this.description}
+            @cp-change=${this.onDescriptionChange}
+          ></cp-textarea>
           <cp-select
             label="Рубрика"
             .value=${this.rubric}
@@ -834,7 +874,8 @@ export class ScreenEditor extends LitElement {
     }
     if (this.publishSha !== '') {
       return html`<cp-banner tone="success" title="Отправлено в репозиторий"
-        >Коммит <code>${this.publishSha}</code> запушен в контент-репозиторий.</cp-banner
+        >Коммит <code>${this.publishSha.slice(0, 7)}</code> запушен в
+        контент-репозиторий.</cp-banner
       >`;
     }
     return html`<p class="dialog-note">
@@ -889,7 +930,7 @@ export class ScreenEditor extends LitElement {
           <cp-tag tone="success">данные из репозитория</cp-tag>
         </div>
         <cp-tabs
-          .tabs=${LANG_TABS}
+          .tabs=${langTabs(this.availableLangs)}
           active=${this.activeLang}
           @cp-tab-change=${this.onLangChange}
         ></cp-tabs>

--- a/src/redesign/screens/screen-tickets.ts
+++ b/src/redesign/screens/screen-tickets.ts
@@ -1,10 +1,33 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { CpTab, CpTableColumn, CpTableRow } from '@communist-prometheus/cp-components';
+import type {
+  CpTab,
+  CpTableColumn,
+  CpTableRow,
+  CpSelectOption,
+} from '@communist-prometheus/cp-components';
 import '@communist-prometheus/cp-components';
-import { listTickets, type Ticket } from '../engine/github-api.js';
+import { listTickets, createTicket, type Ticket } from '../engine/github-api.js';
 import { onEngineReady } from '../engine/engine-ready.js';
 import { classifyEmpty } from '../engine/load-state.js';
+
+/** Lifecycle of the create-ticket form. */
+type CreatePhase = 'idle' | 'running' | 'done' | 'failed';
+
+/** Kind options for the create form; values match the labels {@link kindOf} reads. */
+const KIND_OPTIONS: readonly CpSelectOption[] = [
+  { value: 'bug', label: 'Баг' },
+  { value: 'story', label: 'История' },
+  { value: 'other', label: 'Задача' },
+];
+
+/** Reads `event.detail.value` off a `cp-*` change event without a cast. */
+const detailValue = (event: Event): unknown => {
+  const detail = 'detail' in event ? Reflect.get(event, 'detail') : undefined;
+  return typeof detail === 'object' && detail && 'value' in detail
+    ? Reflect.get(detail, 'value')
+    : undefined;
+};
 
 /** The active list filter (`all` shows every ticket). */
 type TicketFilter = 'all' | 'bug' | 'story';
@@ -127,6 +150,23 @@ export class ScreenTickets extends LitElement {
       overflow: hidden;
       background: var(--color-surface);
     }
+
+    .form {
+      display: grid;
+      gap: var(--spacing-md);
+    }
+
+    .foot {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      gap: var(--spacing-sm);
+      margin-top: var(--spacing-sm);
+    }
+
+    a.gh {
+      color: var(--color-accent);
+    }
   `;
 
   /** Tickets read from GitHub; empty until loaded (or if the token is absent). */
@@ -137,6 +177,19 @@ export class ScreenTickets extends LitElement {
 
   /** Active ticket-kind filter; `all` shows every ticket. */
   @state() private filter: TicketFilter = 'all';
+
+  /** Whether the create-ticket sheet is open. */
+  @state() private formOpen = false;
+
+  /** Create-form fields. */
+  @state() private fTitle = '';
+  @state() private fKind: Ticket['kind'] = 'bug';
+  @state() private fBody = '';
+
+  /** Create-form lifecycle + result. */
+  @state() private phase: CreatePhase = 'idle';
+  @state() private createdNumber?: number;
+  @state() private createdUrl?: string;
 
   /** Unsubscribes the engine-ready listener on disconnect. */
   private disposeReady: () => void = () => {};
@@ -165,10 +218,119 @@ export class ScreenTickets extends LitElement {
     }
   };
 
+  private readonly openForm = (): void => {
+    this.formOpen = true;
+    this.phase = 'idle';
+    this.fTitle = '';
+    this.fKind = 'bug';
+    this.fBody = '';
+    this.createdNumber = undefined;
+    this.createdUrl = undefined;
+  };
+
+  private readonly closeForm = (): void => {
+    this.formOpen = false;
+  };
+
+  /** Reads a `cp-input`/`cp-select`/`cp-textarea` value into a string field. */
+  private readonly bindText =
+    (field: 'fTitle' | 'fBody') =>
+    (event: Event): void => {
+      const value = detailValue(event);
+      if (typeof value === 'string') this[field] = value;
+    };
+
+  private readonly onKindChange = (event: Event): void => {
+    const value = detailValue(event);
+    if (value === 'bug' || value === 'story' || value === 'other') this.fKind = value;
+  };
+
+  /** True once the title carries content — the only required field. */
+  private get canSubmit(): boolean {
+    return this.fTitle.trim() !== '' && this.phase !== 'running';
+  }
+
+  private readonly submit = async (): Promise<void> => {
+    if (!this.canSubmit) return;
+    this.phase = 'running';
+    const result = await createTicket({
+      title: this.fTitle.trim(),
+      body: this.fBody,
+      kind: this.fKind,
+    });
+    if (result.ok) {
+      this.phase = 'done';
+      this.createdNumber = result.number;
+      this.createdUrl = result.url;
+      await this.load();
+    } else {
+      this.phase = 'failed';
+    }
+  };
+
   private visible(source: readonly Ticket[]): readonly Ticket[] {
     return this.filter === 'all'
       ? source
       : source.filter((ticket) => ticket.kind === this.filter);
+  }
+
+  private renderCreateResult(): TemplateResult | typeof nothing {
+    if (this.phase === 'done') {
+      const ref = this.createdNumber !== undefined ? `#${this.createdNumber}` : 'тикет';
+      return html`<cp-banner tone="success" title="Тикет создан">
+        Создан ${ref}.${this.createdUrl !== undefined
+          ? html` <a class="gh" href=${this.createdUrl} target="_blank" rel="noopener">Открыть ↗</a>`
+          : nothing}
+      </cp-banner>`;
+    }
+    if (this.phase === 'failed') {
+      return html`<cp-banner tone="danger" title="Не удалось создать тикет"
+        >Проверьте вход через GitHub и доступ к репозиторию.</cp-banner
+      >`;
+    }
+    return nothing;
+  }
+
+  private renderForm(): TemplateResult {
+    return html`
+      <cp-sheet ?open=${this.formOpen} heading="Новый тикет" @cp-close=${this.closeForm}>
+        <div class="form">
+          <cp-input
+            label="Заголовок"
+            required
+            .value=${this.fTitle}
+            @cp-input=${this.bindText('fTitle')}
+            @cp-change=${this.bindText('fTitle')}
+          ></cp-input>
+          <cp-select
+            label="Тип"
+            .value=${this.fKind}
+            .options=${KIND_OPTIONS}
+            @cp-change=${this.onKindChange}
+          ></cp-select>
+          <cp-textarea
+            label="Описание"
+            rows="6"
+            .value=${this.fBody}
+            @cp-input=${this.bindText('fBody')}
+            @cp-change=${this.bindText('fBody')}
+          ></cp-textarea>
+
+          ${this.renderCreateResult()}
+
+          <div class="foot">
+            <cp-button variant="secondary" @cp-click=${this.closeForm}>
+              ${this.phase === 'done' ? 'Закрыть' : 'Отмена'}
+            </cp-button>
+            ${this.phase === 'done'
+              ? nothing
+              : html`<cp-button arrow ?disabled=${!this.canSubmit} @cp-click=${this.submit}>
+                  ${this.phase === 'running' ? 'Создаётся…' : 'Создать тикет'}
+                </cp-button>`}
+          </div>
+        </div>
+      </cp-sheet>
+    `;
   }
 
   override render() {
@@ -179,11 +341,13 @@ export class ScreenTickets extends LitElement {
       <header class="head">
         <p class="eyebrow">Задачи${live ? html` · ${visible.length} на экране` : nothing}</p>
         <h1 tabindex="-1">Тикеты</h1>
-        <cp-button disabled title="Создание тикетов появится позже">
+        <cp-button @cp-click=${this.openForm}>
           <cp-icon name="plus" size="18"></cp-icon>
           Новый тикет
         </cp-button>
       </header>
+
+      ${this.renderForm()}
 
       ${live
         ? html`

--- a/vendor/cp-components/dist/icons/registry.d.ts
+++ b/vendor/cp-components/dist/icons/registry.d.ts
@@ -23,6 +23,14 @@ export declare const icons: {
     readonly more: "<circle cx=\"12\" cy=\"5\" r=\"1.6\" fill=\"currentColor\" stroke=\"none\" /><circle cx=\"12\" cy=\"12\" r=\"1.6\" fill=\"currentColor\" stroke=\"none\" /><circle cx=\"12\" cy=\"19\" r=\"1.6\" fill=\"currentColor\" stroke=\"none\" />";
     readonly refresh: "<path d=\"M21 12a9 9 0 1 1-2.6-6.4M21 3v6h-6\" />";
     readonly upload: "<path d=\"M12 16V4M7 9l5-5 5 5M4 20h16\" />";
+    readonly 'file-text': "<path d=\"M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z\" /><path d=\"M14 3v5h5M8.5 13h7M8.5 17h7\" />";
+    readonly book: "<path d=\"M5 4a1 1 0 0 1 1-1h13v16H6a1 1 0 0 0-1 1z\" /><path d=\"M5 20a1 1 0 0 1 1-1h13M9 7h6\" />";
+    readonly hash: "<path d=\"M4 9h16M4 15h16M10 3L8 21M16 3l-2 18\" />";
+    readonly users: "<circle cx=\"9\" cy=\"8\" r=\"3.2\" /><path d=\"M2.5 20a6.5 6.5 0 0 1 13 0M16 4.7a3.2 3.2 0 0 1 0 6.2M18 14.4a6.5 6.5 0 0 1 3.5 5.6\" />";
+    readonly ticket: "<path d=\"M4 7a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3a2 2 0 0 0 0 4v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-3a2 2 0 0 0 0-4z\" /><path d=\"M15 6v12\" />";
+    readonly mail: "<rect x=\"3\" y=\"5\" width=\"18\" height=\"14\" rx=\"2\" /><path d=\"M3.5 7l8.5 6 8.5-6\" />";
+    readonly rocket: "<path d=\"M12 2.5c2.4 2 3.8 4.8 3.8 7.7v3.3l-1.8 1.8h-4l-1.8-1.8V10.2C8.2 7.3 9.6 4.5 12 2.5z\" /><circle cx=\"12\" cy=\"9\" r=\"1.3\" /><path d=\"M8.2 15.3l-2.2 3.7 3.7-2.2M15.8 15.3l2.2 3.7-3.7-2.2\" />";
+    readonly settings: "<path d=\"M4 7h9M17 7h3M4 12h3M11 12h9M4 17h13M21 17h-1\" /><circle cx=\"15\" cy=\"7\" r=\"2.2\" /><circle cx=\"9\" cy=\"12\" r=\"2.2\" /><circle cx=\"19\" cy=\"17\" r=\"2.2\" />";
 };
 /** A registered icon name. */
 export type IconName = keyof typeof icons;

--- a/vendor/cp-components/dist/icons/registry.js
+++ b/vendor/cp-components/dist/icons/registry.js
@@ -23,5 +23,13 @@ export const icons = {
     more: '<circle cx="12" cy="5" r="1.6" fill="currentColor" stroke="none" /><circle cx="12" cy="12" r="1.6" fill="currentColor" stroke="none" /><circle cx="12" cy="19" r="1.6" fill="currentColor" stroke="none" />',
     refresh: '<path d="M21 12a9 9 0 1 1-2.6-6.4M21 3v6h-6" />',
     upload: '<path d="M12 16V4M7 9l5-5 5 5M4 20h16" />',
+    'file-text': '<path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" /><path d="M14 3v5h5M8.5 13h7M8.5 17h7" />',
+    book: '<path d="M5 4a1 1 0 0 1 1-1h13v16H6a1 1 0 0 0-1 1z" /><path d="M5 20a1 1 0 0 1 1-1h13M9 7h6" />',
+    hash: '<path d="M4 9h16M4 15h16M10 3L8 21M16 3l-2 18" />',
+    users: '<circle cx="9" cy="8" r="3.2" /><path d="M2.5 20a6.5 6.5 0 0 1 13 0M16 4.7a3.2 3.2 0 0 1 0 6.2M18 14.4a6.5 6.5 0 0 1 3.5 5.6" />',
+    ticket: '<path d="M4 7a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v3a2 2 0 0 0 0 4v3a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-3a2 2 0 0 0 0-4z" /><path d="M15 6v12" />',
+    mail: '<rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3.5 7l8.5 6 8.5-6" />',
+    rocket: '<path d="M12 2.5c2.4 2 3.8 4.8 3.8 7.7v3.3l-1.8 1.8h-4l-1.8-1.8V10.2C8.2 7.3 9.6 4.5 12 2.5z" /><circle cx="12" cy="9" r="1.3" /><path d="M8.2 15.3l-2.2 3.7 3.7-2.2M15.8 15.3l2.2 3.7-3.7-2.2" />',
+    settings: '<path d="M4 7h9M17 7h3M4 12h3M11 12h9M4 17h13M21 17h-1" /><circle cx="15" cy="7" r="2.2" /><circle cx="9" cy="12" r="2.2" /><circle cx="19" cy="17" r="2.2" />',
 };
 //# sourceMappingURL=registry.js.map


### PR DESCRIPTION
## Что это

Промоушен на прод 10 фиксов из ревью редизайна под andswew на проде. Каждый заведён тикетом в Todoist (Development/Comprom) и проведён по циклу fix → test → validate → deploy(dev green).

## Фиксы

1. **Переключатель языка контента** — вкладки строятся из реальных языков статьи (ru/en/it/es/uk/pl/bl), а не хардкод ru/en/it; переключение принимает любой из них.
2. **Курсор при редактировании** — акцентный `caret-color` в обеих темах CodeMirror (был чёрный на тёмном = невидим).
3. **Имя пользователя на мобилке** — больше не скрывается в шапке.
4. **Центрирование загрузки** — индикатор центрирован на телефоне.
5. **Иконки меню** — 8 осмысленных 24×24 `currentColor` SVG (file-text/book/hash/users/ticket/mail/rocket/settings) вместо случайных глифов.
6. **Сортировка статей** — от старых к новым по `pubDate` (недатированные последними).
7. **Редактирование описания** — поле «Описание» в свойствах, пишется во frontmatter.
8. **Баннер коммита на мобилке** — перенос SHA + `max-width`, больше не выезжает за экран.
9. **Создание тикетов** — кнопка «Новый тикет» была навсегда задизейблена; теперь `createTicket` POST-ит issue в репо `tickets` токеном самого пользователя (автор = реальный человек). Право уже есть у всех членов орги (≥read → GitHub разрешает открывать issues).
10. **Деплой-борд «нет данных»** — свежий коммит новее всех известных ранов → новая фаза `pending` «ожидание деплоя» вместо серой «нет данных».

## Проверки

- `test:unit:redesign` — 101/101 зелёные (добавлены тесты: сортировка, description-writeback, createTicket, pending-фаза).
- `bun run validate` — зелёный (vue-tsc, type-check:redesign, biome, oxlint sonar, jsdoc).
- dev-admin деплой `e0a0998` — зелёный; realmode E2E — зелёный.
- Иконки — визуально проверены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
