### PR TITLE
redesign QA follow-ups: deploy-board 'superseded' + description data-loss fix (#7,#10)

### DIFF
--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -144,6 +144,54 @@ export const upsertFrontmatterField = (markdown: string, key: string, value: str
   return `---\n${lines.join('\n')}${markdown.slice(end)}`;
 };
 
+/**
+ * Reads a frontmatter field that may be a YAML block scalar. An inline value
+ * (`key: text`) returns the unquoted text; a folded (`>` / `>-`) or literal
+ * (`|` / `|-`) block returns its indented continuation lines joined — folded
+ * with spaces, literal with newlines. Returns undefined when the key is absent.
+ * Needed because descriptions are stored as folded blocks that a naive
+ * single-line read would mangle to just the `>-` indicator.
+ */
+export const readFrontmatterField = (markdown: string, key: string): string | undefined => {
+  if (!markdown.startsWith('---')) return undefined;
+  const end = markdown.indexOf('\n---', 3);
+  const lines = (end < 0 ? markdown.slice(4) : markdown.slice(4, end)).split('\n');
+  const at = lines.findIndex((l) => l.startsWith(`${key}:`));
+  if (at < 0) return undefined;
+  const inline = lines[at].slice(key.length + 1).trim();
+  const block = inline.match(/^([|>])[+-]?$/);
+  if (!block) return inline.replace(/^["']|["']$/g, '');
+  const cont: string[] = [];
+  for (let i = at + 1; i < lines.length && /^\s/.test(lines[i]); i += 1) {
+    cont.push(lines[i].replace(/^\s+/, ''));
+  }
+  return block[1] === '>' ? cont.join(' ') : cont.join('\n');
+};
+
+/**
+ * Inserts or replaces a frontmatter field as a literal block scalar (`key: |-`),
+ * removing any prior continuation lines so replacing a block never orphans the
+ * old text. Used for prose fields (description) where inline quoting is fragile;
+ * pairs with {@link readFrontmatterField}. Pure — safe to unit test.
+ */
+export const upsertFrontmatterBlock = (markdown: string, key: string, value: string): string => {
+  const field = [`${key}: |-`, ...value.split('\n').map((l) => `  ${l}`)];
+  if (!markdown.startsWith('---')) return `---\n${field.join('\n')}\n---\n\n${markdown}`;
+  const end = markdown.indexOf('\n---', 3);
+  if (end < 0) return markdown;
+  const lines = markdown.slice(4, end).split('\n');
+  const at = lines.findIndex((l) => l.startsWith(`${key}:`));
+  if (at >= 0) {
+    let removeCount = 1;
+    for (let i = at + 1; i < lines.length && /^\s/.test(lines[i]); i += 1) removeCount += 1;
+    lines.splice(at, removeCount, ...field);
+  } else {
+    const langAt = lines.findIndex((l) => l.startsWith('lang:'));
+    lines.splice(langAt >= 0 ? langAt + 1 : lines.length, 0, ...field);
+  }
+  return `---\n${lines.join('\n')}${markdown.slice(end)}`;
+};
+
 /** Fields needed to render a magazine issue's `index.<lang>.md`. */
 export interface IssueIndexInput {
   readonly title: string;

--- a/src/redesign/engine/deploy-status.test.ts
+++ b/src/redesign/engine/deploy-status.test.ts
@@ -18,7 +18,10 @@ describe('deployPhase', () => {
     expect(deployPhase(run({ status: 'in_progress' }))).toBe('building');
     expect(deployPhase(run({ status: 'completed', conclusion: 'success' }))).toBe('published');
     expect(deployPhase(run({ status: 'completed', conclusion: 'failure' }))).toBe('failed');
-    expect(deployPhase(run({ status: 'completed', conclusion: 'cancelled' }))).toBe('unknown');
+    // A concurrency-cancelled run was superseded by a newer deploy, not "no data".
+    expect(deployPhase(run({ status: 'completed', conclusion: 'cancelled' }))).toBe('superseded');
+    expect(deployPhase(run({ status: 'completed', conclusion: 'skipped' }))).toBe('superseded');
+    expect(deployPhase(run({ status: 'completed', conclusion: 'neutral' }))).toBe('unknown');
   });
 });
 

--- a/src/redesign/engine/deploy-status.ts
+++ b/src/redesign/engine/deploy-status.ts
@@ -6,7 +6,14 @@ import type { Push, DeployRun } from './github-api.js';
  * per-step breakdown, so the board shows real states rather than invented
  * "step 3 of 5" numbers.
  */
-export type DeployPhase = 'pending' | 'queued' | 'building' | 'published' | 'failed' | 'unknown';
+export type DeployPhase =
+  | 'pending'
+  | 'queued'
+  | 'building'
+  | 'published'
+  | 'superseded'
+  | 'failed'
+  | 'unknown';
 
 /** A push enriched with its deploy outcome for the board. */
 export interface DeployedPush {
@@ -25,6 +32,10 @@ export const deployPhase = (run: DeployRun | undefined): DeployPhase => {
   if (run.status === 'in_progress') return 'building';
   if (run.conclusion === 'success') return 'published';
   if (run.conclusion === 'failure' || run.conclusion === 'timed_out') return 'failed';
+  // A content save fires overlapping deploys (develop + master); deploy.yml's
+  // per-branch concurrency cancels the older one, so a cancelled/skipped run
+  // was superseded by a newer deploy — not "no data".
+  if (run.conclusion === 'cancelled' || run.conclusion === 'skipped') return 'superseded';
   return 'unknown';
 };
 

--- a/src/redesign/screens/screen-deploys.ts
+++ b/src/redesign/screens/screen-deploys.ts
@@ -188,6 +188,8 @@ export class ScreenDeploys extends LitElement {
     if (phase === 'building') return { state: 'info', icon: 'refresh', label: 'сборка идёт', spin: true };
     if (phase === 'queued') return { state: 'info', icon: 'refresh', label: 'в очереди', spin: false };
     if (phase === 'pending') return { state: 'info', icon: 'refresh', label: 'ожидание деплоя', spin: true };
+    if (phase === 'superseded')
+      return { state: 'info', icon: 'refresh', label: 'перекрыт новым деплоем', spin: false };
     if (phase === 'failed') return { state: 'danger', icon: 'warning', label: 'не удалось', spin: false };
     return { state: 'neutral', icon: 'more', label: 'нет данных', spin: false };
   }

--- a/src/redesign/screens/screen-editor.props.test.ts
+++ b/src/redesign/screens/screen-editor.props.test.ts
@@ -19,6 +19,10 @@ import type { ScreenEditor } from './screen-editor.ts';
 const ARTICLE =
   '---\ntitle: "T"\ncategory: programme\npubDate: 2026-04-30\npublished: true\n---\n\nBody\n';
 
+/** An article whose description is a folded (`>-`) multi-line block scalar. */
+const ARTICLE_BLOCK_DESC =
+  '---\ntitle: "T"\ndescription: >-\n  First sentence of the summary.\n  Second sentence.\ncategory: programme\npubDate: 2026-04-30\npublished: true\nlang: ru\n---\n\nBody\n';
+
 interface EditorInternals {
   slug: string;
   live: boolean;
@@ -32,15 +36,17 @@ interface EditorInternals {
   applyMarkdown: (markdown: string, path: string, live: boolean) => void;
 }
 
-const seededEditor = (): EditorInternals => {
+const editorFrom = (markdown: string, lang = 'en'): EditorInternals => {
   const el = document.createElement('screen-editor') as ScreenEditor;
   const priv = el as unknown as EditorInternals;
   priv.slug = 'x';
   priv.live = true;
-  priv.activeLang = 'en';
-  priv.applyMarkdown(ARTICLE, 'blog/x/index.en.md', true);
+  priv.activeLang = lang;
+  priv.applyMarkdown(markdown, `blog/x/index.${lang}.md`, true);
   return priv;
 };
+
+const seededEditor = (): EditorInternals => editorFrom(ARTICLE);
 
 describe('screen-editor properties write-back (QA #4)', () => {
   beforeEach(() => {
@@ -66,10 +72,28 @@ describe('screen-editor properties write-back (QA #4)', () => {
     expect(el.editedMarkdown).toContain('pubDate: 2026-09-09');
   });
 
-  it('writes an edited description back into the published frontmatter', () => {
+  it('writes an edited description back as a literal block scalar', () => {
     const el = seededEditor();
     el.description = 'a new summary';
-    expect(el.editedMarkdown).toContain('description: a new summary');
+    expect(el.editedMarkdown).toContain('description: |-\n  a new summary');
+  });
+
+  it('leaves an untouched folded-block description byte-identical (no orphaning)', () => {
+    const el = editorFrom(ARTICLE_BLOCK_DESC, 'ru');
+    // The full folded text is seeded (not just the ">-" indicator)…
+    expect(el.description).toBe('First sentence of the summary. Second sentence.');
+    // …and, unedited, the frontmatter block survives verbatim on compose.
+    expect(el.editedMarkdown).toContain(
+      'description: >-\n  First sentence of the summary.\n  Second sentence.',
+    );
+  });
+
+  it('replaces a folded-block description without orphaning its old lines', () => {
+    const el = editorFrom(ARTICLE_BLOCK_DESC, 'ru');
+    el.description = 'brand new';
+    const out = el.editedMarkdown;
+    expect(out).toContain('description: |-\n  brand new');
+    expect(out).not.toContain('First sentence of the summary');
   });
 
   it('writes the published flag back into the published frontmatter', () => {

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -10,6 +10,8 @@ import {
   stageFile,
   commitAndPush,
   upsertFrontmatterField,
+  readFrontmatterField,
+  upsertFrontmatterBlock,
 } from '../engine/content.js';
 import { onEngineReady } from '../engine/engine-ready.js';
 
@@ -464,6 +466,9 @@ export class ScreenEditor extends LitElement {
   /** Article description frontmatter, seeded from the file + written back. */
   @state() private description = '';
 
+  /** The description as loaded, so writeback only fires when the user changed it. */
+  private descriptionSeed = '';
+
   /** Selected «Рубрика». */
   @state() private rubric = 'theory';
 
@@ -606,7 +611,11 @@ export class ScreenEditor extends LitElement {
     // article's `category`. Without this seed the required-field check below
     // always fired a false "заполните Тема" warning.
     this.topic = frontmatterValue(fm, 'category') ?? frontmatterValue(fm, 'topic') ?? '';
-    this.description = frontmatterValue(fm, 'description') ?? '';
+    // Block-scalar aware: descriptions are stored as folded (`>-`) blocks, so a
+    // naive single-line read would seed just ">-" and a publish would overwrite
+    // the real text. Seed the full text and remember it to only write on change.
+    this.description = readFrontmatterField(fm, 'description') ?? '';
+    this.descriptionSeed = this.description;
     const date = frontmatterValue(fm, 'pubDate') ?? frontmatterValue(fm, 'date');
     if (date !== undefined) this.pubDate = date;
     const published = frontmatterValue(fm, 'published');
@@ -623,8 +632,11 @@ export class ScreenEditor extends LitElement {
     let fm = this.frontmatter;
     if (fm !== '') {
       if (this.topic !== '') fm = upsertFrontmatterField(fm, 'category', this.topic);
-      if (this.description !== '')
-        fm = upsertFrontmatterField(fm, 'description', this.description);
+      // Only rewrite the description when the user actually edited it, so an
+      // untouched folded-block description is left byte-identical (no orphaned
+      // continuation lines); a real edit is re-emitted as a clean literal block.
+      if (this.description !== this.descriptionSeed)
+        fm = upsertFrontmatterBlock(fm, 'description', this.description);
       if (this.pubDate !== '') fm = upsertFrontmatterField(fm, 'pubDate', this.pubDate);
       fm = upsertFrontmatterField(fm, 'published', String(this.published));
     }


### PR DESCRIPTION
## Что это

Два follow-up к промоушену #410, найденные при живой проверке прода под andswew.

## Фиксы

- **#10 (деплой-борд).** Строки «нет данных» оказались сматченными ранами с `conclusion=cancelled` — их отменяет concurrency deploy.yml (дубль-деплой develop+master), а `deployPhase` мапил cancelled→unknown. Новая фаза `superseded` → «перекрыт новым деплоем» (проверено: отменённый 10:01:47 перекрыт успешным 10:03:12 — контент реально опубликован).
- **#7 (описание, потеря данных).** Поле показывало `>-`: описания хранятся folded-блок-скаляром (`description: >-` + отступ), а наивный ридер брал только индикатор. При публикации старый upsert затирал `description:`-строку, оставляя осиротевшие строки текста → порча frontmatter и потеря описания при любом редактировании поля. Теперь: block-scalar-aware чтение, re-emit литеральным блоком со снятием старых строк, writeback только при реальном изменении (нетронутый блок остаётся байт-в-байт).

## Проверки

- `test:unit:redesign` — 103/103 (добавлены тесты: cancelled→superseded, folded-read seeds full text, untouched block byte-identical, edit re-emits clean block).
- `bun run validate` — зелёный.
- Живая проверка прода под andswew подтвердила #1 (языки en/es/it/ru/uk родными именами), #3 (имя andswew), #4 (центровка), #5 (иконки), #6 (сортировка), #7 (поле «Описание»), #9 (форма «Новый тикет»).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
