### PR TITLE
redesign: fix editor that never rendered (&light crash) + false-dirty + publishDate sort

### DIFF
--- a/src/redesign/editor/cp-markdown-editor.test.ts
+++ b/src/redesign/editor/cp-markdown-editor.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+/**
+ * Regression guard for the editor that renders every article. A caret-colour
+ * tweak once added an `&light` selector to `EditorView.theme()`; that selector
+ * is only valid in `baseTheme`, so `theme()` threw "Unsupported selector" inside
+ * `firstUpdated()` — the CodeMirror view was never created and NO article body
+ * rendered. These tests mount the real component and assert the view exists and
+ * shows the value, so a broken theme can never ship silently again.
+ */
+import './cp-markdown-editor.ts';
+
+const mount = async (value: string): Promise<HTMLElement> => {
+  // The tag map gives this the CpMarkdownEditor type; `value` is public.
+  const el = document.createElement('cp-markdown-editor');
+  el.value = value;
+  document.body.append(el);
+  await el.updateComplete;
+  return el;
+};
+
+describe('cp-markdown-editor', () => {
+  beforeEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it('creates the CodeMirror view during firstUpdated (theme must not throw)', async () => {
+    const el = await mount('# Title\n\nHello body');
+    expect(Reflect.get(el, 'view')).toBeDefined();
+    expect(el.shadowRoot?.querySelector('.cm-editor')).not.toBeNull();
+  });
+
+  it('renders the supplied markdown into the editor content', async () => {
+    const el = await mount('# Title\n\nHello body');
+    const content = el.shadowRoot?.querySelector('.cm-content')?.textContent ?? '';
+    expect(content).toContain('Hello body');
+  });
+});

--- a/src/redesign/editor/cp-markdown-editor.ts
+++ b/src/redesign/editor/cp-markdown-editor.ts
@@ -36,7 +36,12 @@ export class CpMarkdownEditor extends LitElement {
     }
     .cm-content {
       padding: 0;
-      caret-color: var(--color-accent);
+      /* CodeMirror's baseTheme forces the native caret black via
+         '.cm-light .cm-content' (specificity 0,2,0). Override with !important so
+         the caret is the accent colour on the dark ground — cheaper and, unlike
+         an '&light' theme rule, valid (that selector throws in EditorView.theme
+         and killed the whole editor init). */
+      caret-color: var(--color-accent) !important;
     }
     .cm-line {
       padding: 0;
@@ -72,7 +77,11 @@ export class CpMarkdownEditor extends LitElement {
           placeholder(this.placeholder),
           this.appTheme(),
           EditorView.updateListener.of((update) => {
-            if (update.docChanged) this.emit();
+            // Emit only for user edits, never for the programmatic `value` sync in
+            // updated(): after a sync the doc equals `this.value`; a user edit
+            // leaves the doc diverged from the (stale) prop. Emitting on the sync
+            // made the host mark every freshly-opened article as dirty.
+            if (update.docChanged && update.state.doc.toString() !== this.value) this.emit();
           }),
         ],
       }),
@@ -107,14 +116,10 @@ export class CpMarkdownEditor extends LitElement {
       '.cm-selectionBackground, ::selection': {
         backgroundColor: 'var(--accent-bg) !important',
       },
-      // CodeMirror's baseTheme forces the native caret black via
-      // `.cm-light .cm-content` (the view always carries `cm-light` since the
-      // theme is built without {dark:true}), which is invisible on the dark
-      // ground. Match that specificity from this user theme so the caret is the
-      // accent colour in both app themes.
-      '&light .cm-content, &dark .cm-content': {
-        caretColor: 'var(--color-accent)',
-      },
+      // NB: the caret colour is handled by the static `.cm-content` rule with
+      // `!important` (see styles above). Do NOT add an `&light`/`&dark` selector
+      // here — those are only valid in `baseTheme`; in `theme()` they throw
+      // "Unsupported selector" and abort editor initialisation entirely.
       '.cm-activeLine': { backgroundColor: 'transparent' },
       '.cm-placeholder': { color: 'var(--color-text-secondary)' },
     });

--- a/src/redesign/engine/content.engine.test.ts
+++ b/src/redesign/engine/content.engine.test.ts
@@ -113,6 +113,19 @@ describe('listArticles fan-out', () => {
     const order = (await listArticles()).map((a) => a.slug);
     expect(order).toEqual(['older', 'newer', 'undated']);
   });
+
+  it('sorts articles dated with `publishDate` too, not just `pubDate` (QA sort)', async () => {
+    tree['blog'] = [
+      { type: 'dir', name: 'index.ru.md', path: 'blog/a-pubdate/index.ru.md' },
+      { type: 'dir', name: 'index.ru.md', path: 'blog/b-publishdate/index.ru.md' },
+    ];
+    // The `publishDate` article is older; it must sort FIRST, not clump last as
+    // undated (the bug: half the real articles use `publishDate`).
+    files['blog/a-pubdate/index.ru.md'] = '---\ntitle: A\npubDate: 2026-06-01\n---\n';
+    files['blog/b-publishdate/index.ru.md'] = '---\ntitle: B\npublishDate: 2026-02-01\n---\n';
+    const order = (await listArticles()).map((a) => a.slug);
+    expect(order).toEqual(['b-publishdate', 'a-pubdate']);
+  });
 });
 
 describe('createMagazineIssue count (QA #17)', () => {

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -412,7 +412,13 @@ const summariseArticle = async (
     slug,
     title: frontmatterValue(markdown, 'title') ?? slug.replace(/-/g, ' '),
     topic: frontmatterValue(markdown, 'topic'),
-    date: frontmatterValue(markdown, 'pubDate') ?? frontmatterValue(markdown, 'date'),
+    // Articles are inconsistent: `pubDate`, `publishDate` (magazine-era) or
+    // `date`. Read all three so every article has a real date to sort by,
+    // otherwise the `publishDate` ones fall to '9999' and clump at the end.
+    date:
+      frontmatterValue(markdown, 'pubDate') ??
+      frontmatterValue(markdown, 'publishDate') ??
+      frontmatterValue(markdown, 'date'),
     published: frontmatterValue(markdown, 'draft') !== 'true',
     languages: [...langs].sort(),
   };

--- a/src/redesign/screens/screen-editor.props.test.ts
+++ b/src/redesign/screens/screen-editor.props.test.ts
@@ -31,6 +31,8 @@ interface EditorInternals {
   description: string;
   pubDate: string;
   published: boolean;
+  dirty: boolean;
+  onDescriptionChange: (event: Event) => void;
   readonly editedMarkdown: string;
   readonly incomplete: boolean;
   applyMarkdown: (markdown: string, path: string, live: boolean) => void;
@@ -70,6 +72,27 @@ describe('screen-editor properties write-back (QA #4)', () => {
     const el = seededEditor();
     el.pubDate = '2026-09-09';
     expect(el.editedMarkdown).toContain('pubDate: 2026-09-09');
+  });
+
+  it('seeds pubDate from a `publishDate` article (magazine-era field)', () => {
+    const el = editorFrom(
+      '---\ntitle: "T"\npublishDate: 2026-07-06\npublished: true\nlang: it\n---\n\nBody\n',
+      'it',
+    );
+    expect(el.pubDate).toBe('2026-07-06');
+  });
+
+  it('is not dirty right after loading (save note stays hidden)', () => {
+    // Regression: the save note was hardcoded on, so every opened article read
+    // as having "unsaved changes".
+    const el = seededEditor();
+    expect(el.dirty).toBe(false);
+  });
+
+  it('becomes dirty once a property is edited', () => {
+    const el = seededEditor();
+    el.onDescriptionChange(new CustomEvent('cp-change', { detail: { value: 'edited' } }));
+    expect(el.dirty).toBe(true);
   });
 
   it('writes an edited description back as a literal block scalar', () => {

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -454,6 +454,9 @@ export class ScreenEditor extends LitElement {
   /** Whether the initial read has completed (gates the demo `cp-tag`). */
   @state() private loaded = false;
 
+  /** True once the user edits the body or a property; drives the save note. */
+  @state() private dirty = false;
+
   /** Active language variant driving the `cp-tabs`. */
   @state() private activeLang = 'ru';
 
@@ -616,11 +619,20 @@ export class ScreenEditor extends LitElement {
     // the real text. Seed the full text and remember it to only write on change.
     this.description = readFrontmatterField(fm, 'description') ?? '';
     this.descriptionSeed = this.description;
-    const date = frontmatterValue(fm, 'pubDate') ?? frontmatterValue(fm, 'date');
+    // Content is inconsistent: some articles use `pubDate`, some `publishDate`
+    // (magazine-era), some `date`. Read all three so every article carries a real
+    // date (else half the list has no date and clumps at the end when sorted).
+    const date =
+      frontmatterValue(fm, 'pubDate') ??
+      frontmatterValue(fm, 'publishDate') ??
+      frontmatterValue(fm, 'date');
     if (date !== undefined) this.pubDate = date;
     const published = frontmatterValue(fm, 'published');
     this.published =
       published !== undefined ? published === 'true' : frontmatterValue(fm, 'draft') !== 'true';
+    // Freshly loaded content is not "unsaved" — clear the dirty flag the save
+    // note reads (it used to be hardcoded on, flagging every article).
+    this.dirty = false;
   }
 
   /**
@@ -674,11 +686,19 @@ export class ScreenEditor extends LitElement {
     await this.loadLang(lang);
   }
 
+  // The editor's cp-change only fires for real user edits (the component
+  // suppresses the programmatic value sync), so marking dirty here is safe.
+  private onBodyChange = (event: CustomEvent<{ value: string }>): void => {
+    this.body = event.detail.value;
+    this.dirty = true;
+  };
+
   private onTopicChange = (event: Event): void => {
     if (event instanceof CustomEvent) {
       const value: unknown = event.detail?.value;
       if (typeof value === 'string') {
         this.topic = value;
+        this.dirty = true;
       }
     }
   };
@@ -688,6 +708,7 @@ export class ScreenEditor extends LitElement {
       const value: unknown = event.detail?.value;
       if (typeof value === 'string') {
         this.rubric = value;
+        this.dirty = true;
       }
     }
   };
@@ -697,6 +718,7 @@ export class ScreenEditor extends LitElement {
       const value: unknown = event.detail?.value;
       if (typeof value === 'string') {
         this.pubDate = value;
+        this.dirty = true;
       }
     }
   };
@@ -706,6 +728,7 @@ export class ScreenEditor extends LitElement {
       const value: unknown = event.detail?.value;
       if (typeof value === 'string') {
         this.description = value;
+        this.dirty = true;
       }
     }
   };
@@ -715,6 +738,7 @@ export class ScreenEditor extends LitElement {
       const checked: unknown = event.detail?.checked;
       if (typeof checked === 'boolean') {
         this.published = checked;
+        this.dirty = true;
       }
     }
   };
@@ -758,6 +782,7 @@ export class ScreenEditor extends LitElement {
     if (result.ok && result.sha !== undefined) {
       this.stageStates = ['done', 'done', 'done'];
       this.publishSha = result.sha;
+      this.dirty = false;
     } else {
       this.stageStates = ['done', 'failed', 'failed'];
       this.publishError = result.error ?? 'Коммит или пуш не удался.';
@@ -951,8 +976,7 @@ export class ScreenEditor extends LitElement {
           class="live"
           .value=${this.body}
           placeholder="Текст статьи в Markdown…"
-          @cp-change=${(event: CustomEvent<{ value: string }>) =>
-            (this.body = event.detail.value)}
+          @cp-change=${this.onBodyChange}
         ></cp-markdown-editor>
         <p class="hint">
           Живой предпросмотр: форматирование отрендерено сразу, а разметку
@@ -960,9 +984,11 @@ export class ScreenEditor extends LitElement {
           <span class="kbd">&gt;</span> видно только на строке с курсором.
         </p>
         <p class="save-note">
-          <cp-icon name="warning" size="16"></cp-icon>
-          <span class="draft">несохранённые правки</span>
-          <span aria-hidden="true">·</span>
+          ${this.dirty
+            ? html`<cp-icon name="warning" size="16"></cp-icon>
+                <span class="draft">несохранённые правки</span>
+                <span aria-hidden="true">·</span>`
+            : nothing}
           <span>${this.activeLang}</span>
           <span aria-hidden="true">·</span>
           <span class="path">${this.articlePath}</span>


### PR DESCRIPTION
## Критический фикс — редактор не рендерился

Найдено на проде: мой ранний фикс курсора (#2) добавил селектор `&light .cm-content` в `EditorView.theme()`. Он валиден только в `baseTheme`; в `theme()` бросает `RangeError: Unsupported selector: &light` прямо в `firstUpdated()` → `EditorView` **не создавался**, тело **ни одной** статьи не рендерилось (виден только футер с путём). Ушло на прод дважды, потому что я проверял внутреннее состояние (`el.body`, вкладки), но не смотрел на реально отрендеренный CodeMirror.

## Что чинит

1. **Редактор не инициализируется** — убран `&light`/`&dark` из `theme()`; акцентный курсор через статический `.cm-content { caret-color: … !important }` (валидно, нужная специфичность).
2. **Ложные «несохранённые правки» в каждой статье** — заметка была захардкожена. Теперь: cp-markdown-editor эмитит `cp-change` только на реальные правки (не на программную синхронизацию `.value`), а screen-editor гейтит заметку реальным `dirty`-флагом (ставится на правках, сбрасывается на загрузке и после публикации).
3. **Сортировка** — читаю `publishDate` тоже, не только `pubDate`/`date`. ~половина статей на magazine-era `publishDate` валилась в конец без даты — это и выглядело как «сортировка сломана».

## Проверки

- **Тест `cp-markdown-editor.test.ts`** маунтит компонент и проверяет, что view создаётся и рендерит value — **доказано, что падает** при возврате селектора `&light`.
- Тесты: свежая статья не dirty; правка ставит dirty; pubDate сидится из `publishDate`; listArticles сортирует `publishDate`-статьи. 109 тестов зелёные, validate зелёный.
- **Проверено вживую на dev-admin (DOM):** редактор рендерит тело (высота 13956px), dirty=false, заметка скрыта, описание — реальный текст; список — все 21 с датами, порядок 2026-04-30 → 07-19 по возрастанию.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
