### PR TITLE
redesign: fix mobile horizontal overflow (content clipped off the left)

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -295,6 +295,9 @@ export class AppShell extends LitElement {
       min-width: 0;
       padding: var(--spacing-lg) var(--spacing-md) var(--spacing-2xl);
       max-width: 60rem;
+      /* Safety net: no screen may push the page horizontally and clip content off
+         the left edge on mobile. clip (not hidden) keeps sticky toolbars working. */
+      overflow-x: clip;
     }
     /* main is focused programmatically on route change (for the aria-live
        announcement); it must not paint the browser focus ring, which framed the

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -189,6 +189,10 @@ export class ScreenEditor extends LitElement {
     .ed {
       max-width: 44rem;
       margin-inline: auto;
+      /* Never let a wide child (e.g. the 5-language tab strip) push the page
+         sideways and clip content off the left edge on mobile. */
+      min-width: 0;
+      overflow-x: clip;
     }
 
     .head {
@@ -216,9 +220,15 @@ export class ScreenEditor extends LitElement {
       color: transparent;
     }
 
+    /* The language tabs can be wider than a phone (5 native names); let them
+       scroll horizontally inside their own strip instead of widening the page. */
+    .tabs-scroll {
+      max-width: 100%;
+      overflow-x: auto;
+      margin-bottom: var(--spacing-md);
+    }
     cp-tabs {
       display: block;
-      margin-bottom: var(--spacing-md);
     }
 
     .toolbar {
@@ -390,6 +400,8 @@ export class ScreenEditor extends LitElement {
     .save-note .path {
       font-family: var(--font-mono);
       font-size: 0.82rem;
+      min-width: 0;
+      overflow-wrap: anywhere;
     }
 
     .sheet-form {
@@ -966,11 +978,13 @@ export class ScreenEditor extends LitElement {
           </h1>
           <cp-tag tone="success">данные из репозитория</cp-tag>
         </div>
-        <cp-tabs
-          .tabs=${langTabs(this.availableLangs)}
-          active=${this.activeLang}
-          @cp-tab-change=${this.onLangChange}
-        ></cp-tabs>
+        <div class="tabs-scroll">
+          <cp-tabs
+            .tabs=${langTabs(this.availableLangs)}
+            active=${this.activeLang}
+            @cp-tab-change=${this.onLangChange}
+          ></cp-tabs>
+        </div>
         ${this.renderToolbar()}
         <cp-markdown-editor
           class="live"


### PR DESCRIPTION
На мобилке контент редактора (заголовок, тело статьи, лист свойств, вкладки языков) обрезался слева — горизонтальный оверфлоу. Причина: полоса из 5 языковых вкладок с родными именами (после фикса #1) шире вьюпорта и без скролл-контейнера распирала страницу вбок.

- Вкладки редактора обёрнуты в `.tabs-scroll { overflow-x:auto; max-width:100% }` — скроллятся в своей полосе, не расширяя страницу.
- `main` (app-shell) и `.ed` (редактор) получили `overflow-x: clip` (не hidden — sticky-тулбар продолжает работать) как глобальный предохранитель: ни один экран не может распереть страницу.
- Длинный путь в 'несохранённые правки' переносится.

tsc + 109 тестов зелёные. Мобильный визуал требует подтверждения на устройстве (залогиненного мобильного сеанса у меня нет).

🤖 Generated with [Claude Code](https://claude.com/claude-code)