### PR TITLE
redesign: unfreeze/de-trap publish + adaptive layout + surface stage error

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -295,9 +295,6 @@ export class AppShell extends LitElement {
       min-width: 0;
       padding: var(--spacing-lg) var(--spacing-md) var(--spacing-2xl);
       max-width: 60rem;
-      /* Safety net: no screen may push the page horizontally and clip content off
-         the left edge on mobile. clip (not hidden) keeps sticky toolbars working. */
-      overflow-x: clip;
     }
     /* main is focused programmatically on route change (for the aria-live
        announcement); it must not paint the browser focus ring, which framed the

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -75,28 +75,53 @@ export const listTree = async (path = ''): Promise<readonly TreeEntry[]> => {
 };
 
 /** Stages a file write in the local repo (no commit yet). Returns success. */
-export const stageFile = async (path: string, content: string): Promise<boolean> => {
+/** A local stage is fast; a network push is slower. Bound both so a hung SW git
+ * op fails gracefully instead of freezing the publish dialog forever. */
+const STAGE_TIMEOUT_MS = 30_000;
+const PUSH_TIMEOUT_MS = 90_000;
+
+export const stageFile = async (
+  path: string,
+  content: string,
+): Promise<{ ok: boolean; error?: string }> => {
   clearContentCache();
   try {
-    const response = await swFetch('/api/github/file/stage', {
-      method: 'PUT',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ path, content }),
-    });
-    return response.ok;
-  } catch {
-    return false;
+    const response = await swFetch(
+      '/api/github/file/stage',
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ path, content }),
+      },
+      STAGE_TIMEOUT_MS,
+    );
+    if (response.ok) return { ok: true };
+    // Surface the SW's real reason (e.g. an unsupported lang or a schema
+    // rejection) instead of a generic "could not prepare" so a failed publish
+    // is diagnosable rather than opaque.
+    const data: unknown = await response.json().catch(() => undefined);
+    const error =
+      typeof data === 'object' && data && 'error' in data
+        ? String(Reflect.get(data, 'error'))
+        : `stage failed (${response.status})`;
+    return { ok: false, error };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
 };
 
 /** Commits all staged changes and pushes to the remote. Returns the commit sha. */
 export const commitAndPush = async (message: string): Promise<{ ok: boolean; sha?: string; error?: string }> => {
   try {
-    const response = await swFetch('/api/github/commit', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ message }),
-    });
+    const response = await swFetch(
+      '/api/github/commit',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ message }),
+      },
+      PUSH_TIMEOUT_MS,
+    );
     const data: unknown = await response.json();
     const sha = typeof data === 'object' && data !== null && 'sha' in data ? String(data.sha) : undefined;
     const error =

--- a/src/redesign/engine/sw-fetch.ts
+++ b/src/redesign/engine/sw-fetch.ts
@@ -22,15 +22,38 @@ const isEngineNotReady = async (response: Response): Promise<boolean> => {
  * token exactly once (deduped across concurrent callers) and retries the
  * request; any other outcome passes through untouched.
  */
+/**
+ * fetch with an optional abort timeout. A hung SW handler (e.g. a git stage that
+ * never resolves) must not freeze the caller forever — with a timeout the fetch
+ * rejects so the publish flow can surface an error instead of an infinite
+ * "publishing…" spinner. Without a timeout it behaves exactly like native fetch
+ * (reads during a slow first clone stay untimed).
+ */
+const fetchWithTimeout = async (
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  timeoutMs: number | undefined,
+): Promise<Response> => {
+  if (timeoutMs === undefined) return fetch(input, init);
+  const controller = new AbortController();
+  const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    globalThis.clearTimeout(timer);
+  }
+};
+
 export const swFetch = async (
   input: RequestInfo | URL,
   init?: RequestInit,
+  timeoutMs?: number,
 ): Promise<Response> => {
-  const response = await fetch(input, init);
+  const response = await fetchWithTimeout(input, init, timeoutMs);
   if (!(await isEngineNotReady(response))) return response;
   healing ??= reinitEngine().finally(() => {
     healing = undefined;
   });
   const healed = await healing;
-  return healed ? fetch(input, init) : response;
+  return healed ? fetchWithTimeout(input, init, timeoutMs) : response;
 };

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -189,10 +189,9 @@ export class ScreenEditor extends LitElement {
     .ed {
       max-width: 44rem;
       margin-inline: auto;
-      /* Never let a wide child (e.g. the 5-language tab strip) push the page
-         sideways and clip content off the left edge on mobile. */
+      /* Wide children (the language tabs) must adapt inside their own scroll
+         strip, not push the column — so no clipping is needed here. */
       min-width: 0;
-      overflow-x: clip;
     }
 
     .head {
@@ -782,9 +781,10 @@ export class ScreenEditor extends LitElement {
     this.publishBusy = true;
     this.stageStates = ['running', 'pending', 'pending'];
     const staged = await stageFile(this.articlePath, this.editedMarkdown);
-    if (!staged) {
+    if (!staged.ok) {
       this.stageStates = ['failed', 'pending', 'pending'];
-      this.publishError = `Не удалось подготовить «${this.articlePath}» к коммиту.`;
+      this.publishError =
+        staged.error ?? `Не удалось подготовить «${this.articlePath}» к коммиту.`;
       this.publishBusy = false;
       return;
     }
@@ -803,7 +803,10 @@ export class ScreenEditor extends LitElement {
   }
 
   private closePublish = (): void => {
-    if (this.publishBusy) return;
+    // Always allow closing — a hung publish must never trap the user in the
+    // dialog. Abandoning it clears the busy flag; the timed-out SW op resolves
+    // to a no-op (the file is already staged locally, so a re-publish is safe).
+    this.publishBusy = false;
     this.publishOpen = false;
     this.stageStates = [];
     this.publishSha = '';


### PR DESCRIPTION
Правка описания → публикация зависла на «Стейдж», крестик не работал; после reload générique «Не удалось подготовить к коммиту». Repro доказал: контент и блок-скаляр правка проходят YAML+схему — падение на стороне SW (зависший git stage). Фиксы: swFetch abort-таймаут (stage 30с/push 90с); closePublish работает всегда; stageFile отдаёт реальную ошибку SW; убран overflow-x:clip костыль (обрезал крестик), вкладки адаптивны через .tabs-scroll. tsc+109 тестов+validate зелёные. Корневая SW-нестабильность — отдельная задача.

🤖 Generated with [Claude Code](https://claude.com/claude-code)