### PR TITLE
redesign: load article list from GitHub API (kills the clone-hang loading failure)

### DIFF
--- a/src/redesign/engine/content-api.test.ts
+++ b/src/redesign/engine/content-api.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+import { listArticlesViaApi } from './content.ts';
+
+vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
+
+/** A tree with two articles: `older` (ru+en) and `newer` (ru). */
+const TREE = {
+  tree: [
+    { path: 'blog/older/index.ru.md' },
+    { path: 'blog/older/index.en.md' },
+    { path: 'blog/newer/index.ru.md' },
+    { path: 'README.md' },
+    { path: 'blog/older/cover.jpg' },
+  ],
+};
+
+const FILES: Record<string, string> = {
+  'blog/older/index.ru.md': '---\ntitle: Старее\npubDate: 2026-01-01\n---\n\nBody\n',
+  'blog/newer/index.ru.md': '---\ntitle: Новее\npublishDate: 2026-05-01\n---\n\nBody\n',
+};
+
+/** Stubs global fetch: tree endpoint returns TREE, contents return raw md. */
+const stub = (opts: { treeStatus?: number; failFile?: string } = {}): void => {
+  vi.stubGlobal('fetch', async (url: string) => {
+    if (url.includes('/git/trees/')) {
+      return new Response(JSON.stringify(TREE), { status: opts.treeStatus ?? 200 });
+    }
+    const m = url.match(/contents\/(blog\/[^?]+)/);
+    const path = m ? decodeURIComponent(m[1]) : '';
+    if (opts.failFile !== undefined && path === opts.failFile) throw new Error('throttled');
+    return new Response(FILES[path] ?? '', { status: FILES[path] ? 200 : 404 });
+  });
+};
+
+beforeEach(() => {
+  vi.stubEnv('VITE_DEV_TOKEN', '');
+  vi.stubEnv('VITE_GITHUB_BRANCH', 'master');
+  vi.mocked(ensureFreshToken).mockResolvedValue('tok');
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('listArticlesViaApi (API-first article list)', () => {
+  it('lists articles from the flat tree, titles from raw files, oldest → newest', async () => {
+    stub();
+    const { articles, error } = await listArticlesViaApi();
+    expect(error).toBeUndefined();
+    expect(articles.map((a) => a.slug)).toEqual(['older', 'newer']); // by date asc
+    expect(articles[0].title).toBe('Старее');
+    expect(articles[0].languages).toEqual(['en', 'ru']);
+    expect(articles[1].date).toBe('2026-05-01'); // publishDate read too
+  });
+
+  it('reports the tree fetch error instead of a silent empty (throttling/failure)', async () => {
+    stub({ treeStatus: 502 });
+    const { articles, error } = await listArticlesViaApi();
+    expect(articles).toEqual([]);
+    expect(error).toContain('502');
+  });
+
+  it('is signed-out when no token is available', async () => {
+    vi.mocked(ensureFreshToken).mockResolvedValue(undefined);
+    stub();
+    const { error } = await listArticlesViaApi();
+    expect(error).toBe('signed-out');
+  });
+
+  it('survives a single title fetch failing (falls back to the slug, no error)', async () => {
+    stub({ failFile: 'blog/newer/index.ru.md' });
+    const { articles, error } = await listArticlesViaApi();
+    expect(error).toBeUndefined();
+    expect(articles).toHaveLength(2);
+    expect(articles.find((a) => a.slug === 'newer')?.title).toBe('newer');
+  });
+
+  it('reports title-fetch progress from 0 to total', async () => {
+    stub();
+    const seen: string[] = [];
+    await listArticlesViaApi((done, total) => seen.push(`${done}/${total}`));
+    expect(seen[0]).toBe('0/2');
+    expect(seen.at(-1)).toBe('2/2');
+  });
+});

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -8,6 +8,16 @@
  * eviction or a post-deploy SW version bump.
  */
 import { swFetch } from './sw-fetch.js';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+
+/** The active GitHub token for direct REST reads: the injected dev token, else
+ * the signed-in session token. Mirrors github-api.ts so the API-first article
+ * list works both in local dev:token and on the deployed admin. */
+const freshGhToken = async (): Promise<string | undefined> => {
+  const dev = import.meta.env.VITE_DEV_TOKEN;
+  if (typeof dev === 'string' && dev.length > 0) return dev;
+  return (await ensureFreshToken()) ?? undefined;
+};
 
 /** One entry in a repo directory listing. */
 export interface TreeEntry {
@@ -417,15 +427,109 @@ export const listArticles = async (): Promise<readonly ArticleSummary[]> => {
   const summaries = await mapPool([...bySlug.entries()], 6, ([slug, langs]) =>
     summariseArticle(slug, [...langs]),
   );
-  // Chronological, oldest → newest (ISO YYYY-MM-DD sorts lexicographically);
-  // undated articles sort last. Matches every content list's ordering.
-  return [...summaries].sort((a, b) =>
-    (a.date ?? '9999').localeCompare(b.date ?? '9999'),
-  );
+  return [...summaries].sort(byDateAsc);
+};
+
+/** Groups `blog/<slug>/index.<lang>.md` paths into slug → sorted langs. */
+const groupArticlePaths = (paths: readonly string[]): Map<string, string[]> => {
+  const bySlug = new Map<string, string[]>();
+  for (const p of paths) {
+    const m = p.match(/^blog\/([^/]+)\/index\.([a-z]{2,3})\.md$/);
+    if (m) {
+      const slug = m[1] as string;
+      const langs = bySlug.get(slug) ?? [];
+      langs.push(m[2] as string);
+      bySlug.set(slug, langs);
+    }
+  }
+  return bySlug;
+};
+
+/** Outcome of the API-first article load: the list plus an optional real error. */
+export interface ArticleListResult {
+  readonly articles: readonly ArticleSummary[];
+  readonly error?: string;
+}
+
+/**
+ * Lists articles straight from the GitHub REST API — the flat git tree in one
+ * request for the slugs + languages, then each preferred-language file's raw
+ * body (parallel, capped) for the title/date. This is the fast, reliable path
+ * the list uses: it does NOT wait for the Service-Worker git clone (that heavy
+ * clone is only needed to *edit*), so the list appears in seconds and surfaces
+ * a real error instead of hanging on "compressing objects". `onProgress`
+ * reports title-fetch progress so the UI shows "N of M", not an opaque spinner.
+ */
+export const listArticlesViaApi = async (
+  onProgress?: (loaded: number, total: number) => void,
+): Promise<ArticleListResult> => {
+  const branch = import.meta.env.VITE_GITHUB_BRANCH ?? 'develop';
+  const base = `https://api.github.com/repos/communist-prometheus/public-website-content`;
+  const t = await freshGhToken();
+  if (t === undefined) return { articles: [], error: 'signed-out' };
+  const auth = { authorization: `Bearer ${t}` };
+  try {
+    const treeRes = await fetch(`${base}/git/trees/${branch}?recursive=1`, {
+      headers: { ...auth, accept: 'application/vnd.github+json' },
+    });
+    if (!treeRes.ok) {
+      return { articles: [], error: `Не удалось получить список файлов из репозитория (${treeRes.status}).` };
+    }
+    const data: unknown = await treeRes.json();
+    const tree = typeof data === 'object' && data && 'tree' in data ? Reflect.get(data, 'tree') : undefined;
+    const paths = Array.isArray(tree)
+      ? tree.map((e) => (typeof e === 'object' && e && 'path' in e ? String(Reflect.get(e, 'path')) : '')).filter(Boolean)
+      : [];
+    const slugs = [...groupArticlePaths(paths).entries()];
+    onProgress?.(0, slugs.length);
+    let done = 0;
+    const summaries = await mapPool(slugs, 6, async ([slug, langs]) => {
+      const lang = preferredLang(langs);
+      let md = '';
+      try {
+        const fileRes = await fetch(`${base}/contents/blog/${slug}/index.${lang}.md?ref=${branch}`, {
+          headers: { ...auth, accept: 'application/vnd.github.raw' },
+        });
+        if (fileRes.ok) md = await fileRes.text();
+      } catch {
+        /* a single title failing must not sink the whole list */
+      }
+      done += 1;
+      onProgress?.(done, slugs.length);
+      return summariseFromMarkdown(slug, langs, md);
+    });
+    return { articles: [...summaries].sort(byDateAsc) };
+  } catch (e) {
+    return { articles: [], error: e instanceof Error ? e.message : String(e) };
+  }
 };
 
 const preferredLang = (langs: readonly string[]): string =>
   langs.find((l) => l === 'ru') ?? langs.find((l) => l === 'en') ?? (langs[0] as string);
+
+/** Builds an article summary from an already-fetched markdown body (pure). */
+const summariseFromMarkdown = (
+  slug: string,
+  langs: readonly string[],
+  markdown: string,
+): ArticleSummary => ({
+  slug,
+  title: frontmatterValue(markdown, 'title') ?? slug.replace(/-/g, ' '),
+  topic: frontmatterValue(markdown, 'topic'),
+  // Articles are inconsistent: `pubDate`, `publishDate` (magazine-era) or
+  // `date`. Read all three so every article has a real date to sort by,
+  // otherwise the `publishDate` ones fall to '9999' and clump at the end.
+  date:
+    frontmatterValue(markdown, 'pubDate') ??
+    frontmatterValue(markdown, 'publishDate') ??
+    frontmatterValue(markdown, 'date'),
+  published: frontmatterValue(markdown, 'draft') !== 'true',
+  languages: [...langs].sort(),
+});
+
+/** Chronological, oldest → newest; undated last. Matches every content list. */
+const byDateAsc = (a: ArticleSummary, b: ArticleSummary): number =>
+  (a.date ?? '9999').localeCompare(b.date ?? '9999');
 
 const summariseArticle = async (
   slug: string,
@@ -433,18 +537,5 @@ const summariseArticle = async (
 ): Promise<ArticleSummary> => {
   const lang = preferredLang(langs);
   const markdown = (await readFile(`blog/${slug}/index.${lang}.md`)) ?? '';
-  return {
-    slug,
-    title: frontmatterValue(markdown, 'title') ?? slug.replace(/-/g, ' '),
-    topic: frontmatterValue(markdown, 'topic'),
-    // Articles are inconsistent: `pubDate`, `publishDate` (magazine-era) or
-    // `date`. Read all three so every article has a real date to sort by,
-    // otherwise the `publishDate` ones fall to '9999' and clump at the end.
-    date:
-      frontmatterValue(markdown, 'pubDate') ??
-      frontmatterValue(markdown, 'publishDate') ??
-      frontmatterValue(markdown, 'date'),
-    published: frontmatterValue(markdown, 'draft') !== 'true',
-    languages: [...langs].sort(),
-  };
+  return summariseFromMarkdown(slug, langs, markdown);
 };

--- a/src/redesign/screens/screen-articles.empty.test.ts
+++ b/src/redesign/screens/screen-articles.empty.test.ts
@@ -1,46 +1,51 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
-// No engine is booted in tests, so listArticles returns []. Force it explicitly
-// to keep the empty-state assertions independent of jsdom's fetch behaviour.
+// The article list now loads via the GitHub REST API (no SW clone). Mock that
+// one call so the empty/error states are asserted independently of fetch.
 vi.mock('../engine/content.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../engine/content.js')>();
-  return { ...actual, listArticles: async () => [] };
+  return { ...actual, listArticlesViaApi: vi.fn() };
 });
 
 import './screen-articles.ts';
 import type { ScreenArticles } from './screen-articles.ts';
-import { markEngineReady } from '../engine/engine-ready.js';
+import { listArticlesViaApi } from '../engine/content.js';
 
 const shadowText = (el: HTMLElement): string =>
   (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
 
-const settle = async (el: ScreenArticles): Promise<void> => {
-  for (let i = 0; i < 4; i += 1) {
+const mount = async (): Promise<ScreenArticles> => {
+  const el = document.createElement('screen-articles');
+  document.body.append(el);
+  for (let i = 0; i < 5; i += 1) {
     await el.updateComplete;
     await Promise.resolve();
   }
+  return el;
 };
 
-describe('screen-articles empty state (QA #14)', () => {
+describe('screen-articles empty + error states (QA #14)', () => {
   beforeEach(() => {
     document.body.replaceChildren();
   });
 
-  it('prompts sign-in before the engine boots, then switches to a reload prompt', async () => {
-    const el = document.createElement('screen-articles') as ScreenArticles;
-    document.body.append(el);
-    await settle(el);
-
-    // Engine not ready → this is a signed-out session, not an empty repo.
+  it('prompts sign-in when the session is signed out', async () => {
+    vi.mocked(listArticlesViaApi).mockResolvedValue({ articles: [], error: 'signed-out' });
+    const el = await mount();
     expect(shadowText(el)).toContain('Войдите через GitHub');
-    expect(shadowText(el)).not.toContain('не удалось');
+    expect(shadowText(el)).not.toContain('Не удалось');
+  });
 
-    // Once the engine is ready an empty list is no longer a sign-in problem.
-    markEngineReady();
-    await settle(el);
+  it('surfaces the real load error (not a silent empty) with a reload prompt', async () => {
+    vi.mocked(listArticlesViaApi).mockResolvedValue({
+      articles: [],
+      error: 'Не удалось получить список файлов из репозитория (502).',
+    });
+    const el = await mount();
     const text = shadowText(el);
-    expect(text).not.toContain('Войдите через GitHub');
-    expect(text).toContain('не удалось');
+    expect(text).toContain('Не удалось загрузить статьи');
+    expect(text).toContain('502');
     expect(text).toContain('Обновить');
+    expect(text).not.toContain('Войдите через GitHub');
   });
 });

--- a/src/redesign/screens/screen-articles.ts
+++ b/src/redesign/screens/screen-articles.ts
@@ -1,10 +1,7 @@
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
-import { listArticles, type ArticleSummary } from '../engine/content.js';
-import { onEngineReady } from '../engine/engine-ready.js';
-import { classifyEmpty } from '../engine/load-state.js';
-import '../components/engine-loading.js';
+import { listArticlesViaApi, type ArticleSummary } from '../engine/content.js';
 
 /**
  * Articles screen (content-list spec). Lists the actual `blog/<slug>/index.<lang>.md`
@@ -69,30 +66,39 @@ export class ScreenArticles extends LitElement {
     }
   `;
 
-  /** Articles read from the repo; empty until the engine has loaded them. */
+  /** Articles read straight from the GitHub API; empty until loaded. */
   @state() private articles: readonly ArticleSummary[] = [];
 
   /** Whether a read has completed (so we can distinguish loading from empty). */
   @state() private loaded = false;
 
-  /** Unsubscribes the engine-ready listener on disconnect. */
-  private disposeReady: () => void = () => {};
+  /** Whether a load is in flight (drives the progress indicator). */
+  @state() private loading = false;
+
+  /** Title-fetch progress: how many of how many articles have their title. */
+  @state() private progress: { readonly done: number; readonly total: number } = {
+    done: 0,
+    total: 0,
+  };
+
+  /** The real load error, when the tree/title fetch failed (empty otherwise). */
+  @state() private error = '';
 
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
-    // The engine may still be cloning the repo (first load): re-read when ready.
-    this.disposeReady = onEngineReady(() => void this.load());
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.disposeReady();
   }
 
   private async load(): Promise<void> {
-    const articles = await listArticles();
-    this.articles = articles;
+    this.loading = true;
+    this.error = '';
+    this.progress = { done: 0, total: 0 };
+    const result = await listArticlesViaApi((done, total) => {
+      this.progress = { done, total };
+    });
+    this.articles = result.articles;
+    this.error = result.error ?? '';
+    this.loading = false;
     this.loaded = true;
   }
 
@@ -119,13 +125,19 @@ export class ScreenArticles extends LitElement {
   }
 
   private renderEmpty() {
-    const state = classifyEmpty(this.loaded);
-    if (state === 'loading') {
+    if (this.loading) {
+      const { done, total } = this.progress;
+      const label =
+        total > 0 ? `Загружаем заголовки: ${done} из ${total}` : 'Получаем список статей…';
       return html`<div class="empty">
-        <engine-loading label="Загружаем материалы…"></engine-loading>
+        <cp-progress
+          ?indeterminate=${total === 0}
+          value=${total > 0 ? done / total : 0}
+        ></cp-progress>
+        <p>${label}</p>
       </div>`;
     }
-    if (state === 'signed-out') {
+    if (this.error === 'signed-out') {
       return html`
         <div class="empty">
           <p>Здесь появятся материалы репозитория. Войдите через GitHub, чтобы загрузить их.</p>
@@ -134,7 +146,7 @@ export class ScreenArticles extends LitElement {
     }
     return html`
       <div class="empty">
-        <p>Материалов пока нет или не удалось их загрузить.</p>
+        <p>${this.error !== '' ? `Не удалось загрузить статьи: ${this.error}` : 'Материалов пока нет.'}</p>
         <cp-button variant="secondary" @cp-click=${() => void this.load()}>Обновить</cp-button>
       </div>
     `;


### PR DESCRIPTION
Список статей грузился через SW-git-движок, который сначала shallow-клонирует весь 84MB контент-репо. На мобилке этот клон виснет на «Сжимаем объекты 100%» или падает в «материалы не удалось загрузить», а каждая перезагрузка стартует его заново — это и есть повторяющиеся сбои загрузки.

Для показа списка клон не нужен (он нужен только для редактирования/пуша). Новый listArticlesViaApi ходит в GitHub REST напрямую (как участники/тикеты): плоское git-дерево ОДНИМ запросом → слаги+языки, затем raw-тело preferred-lang файла параллельно (с лимитом) → заголовок и дата. Показывает реальную ошибку вместо тихого пустого, прогресс «N из M», и переживает падение одного заголовка.

Проверено вживую на dev-admin (холодная + повторная загрузка): список из 21 статьи за **2 секунды**, реальные заголовки/языки/даты, порядок 2026-04-30 → 07-19, без «Сжимаем объекты». Клон остаётся для редактора, лениво.

Тесты: happy path, surface ошибки дерева (тротлинг/сбой), signed-out, устойчивость к падению заголовка, прогресс. 115 тестов + validate зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)