### PR TITLE
redesign: API-first editor (read+publish single file, no clone) + remove PAT login

### DIFF
--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -786,6 +786,20 @@ export class AppShell extends LitElement {
 
   /** Renders the login dialog (token bypass + GitHub OAuth). */
   private renderAuthDialog() {
+    // Machine-only auth in production: GitHub OAuth, no manual token entry. The
+    // PAT field survives ONLY in the local dev build (import.meta.env.DEV) for
+    // `dev:token` — it is compiled out of the deployed bundle entirely.
+    const devToken = import.meta.env.DEV
+      ? html`
+          <cp-input
+            label="GitHub-токен (PAT) — только локальная разработка"
+            type="password"
+            .value=${this.authToken}
+            @cp-input=${(event: CustomEvent<{ value: string }>) =>
+              (this.authToken = event.detail.value)}
+          ></cp-input>
+        `
+      : nothing;
     return html`
       <cp-dialog
         ?open=${this.authOpen}
@@ -794,24 +808,20 @@ export class AppShell extends LitElement {
         @cp-cancel=${() => (this.authOpen = false)}
       >
         <p class="auth-hint">
-          Вставьте GitHub-токен (fine-grained PAT с доступом Contents к репозиторию контента) —
-          самый стабильный способ. Или войдите через GitHub.
+          Войдите через GitHub — авторизация полностью машинная, вручную вводить токен не нужно.
         </p>
-        <cp-input
-          label="GitHub-токен (PAT)"
-          type="password"
-          .value=${this.authToken}
-          @cp-input=${(event: CustomEvent<{ value: string }>) =>
-            (this.authToken = event.detail.value)}
-        ></cp-input>
+        ${devToken}
         ${this.authError ? html`<p class="auth-error">${this.authError}</p>` : nothing}
         <div slot="footer" class="auth-actions">
-          <cp-button variant="secondary" @cp-click=${() => this.handleLogin()}
-            >Войти через GitHub</cp-button
-          >
-          <cp-button arrow ?loading=${this.loggingIn} @cp-click=${() => this.handleTokenLogin(this.authToken)}
-            >Войти по токену</cp-button
-          >
+          ${import.meta.env.DEV
+            ? html`<cp-button
+                variant="secondary"
+                ?loading=${this.loggingIn}
+                @cp-click=${() => this.handleTokenLogin(this.authToken)}
+                >Войти по токену (dev)</cp-button
+              >`
+            : nothing}
+          <cp-button arrow @cp-click=${() => this.handleLogin()}>Войти через GitHub</cp-button>
         </div>
       </cp-dialog>
     `;

--- a/src/redesign/engine/content-api.test.ts
+++ b/src/redesign/engine/content-api.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
-import { listArticlesViaApi } from './content.ts';
+import {
+  listArticlesViaApi,
+  readFileViaApi,
+  articleLangsViaApi,
+  publishFileViaApi,
+} from './content.ts';
 
 vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
 
@@ -82,5 +87,60 @@ describe('listArticlesViaApi (API-first article list)', () => {
     await listArticlesViaApi((done, total) => seen.push(`${done}/${total}`));
     expect(seen[0]).toBe('0/2');
     expect(seen.at(-1)).toBe('2/2');
+  });
+});
+
+describe('editor single-file API (read / langs / publish, no clone)', () => {
+  const decode = (b64: string): string =>
+    new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+
+  it('readFileViaApi returns the raw file body', async () => {
+    vi.stubGlobal('fetch', async () => new Response('# Заголовок', { status: 200 }));
+    expect(await readFileViaApi('blog/x/index.ru.md')).toBe('# Заголовок');
+  });
+
+  it('articleLangsViaApi lists only index.<lang>.md languages, sorted', async () => {
+    vi.stubGlobal(
+      'fetch',
+      async () =>
+        new Response(
+          JSON.stringify([{ name: 'index.ru.md' }, { name: 'index.en.md' }, { name: 'cover.jpg' }]),
+          { status: 200 },
+        ),
+    );
+    expect(await articleLangsViaApi('x')).toEqual(['en', 'ru']);
+  });
+
+  it('publishFileViaApi commits ONE file (UTF-8 base64) and returns the commit sha', async () => {
+    const calls: Array<{ method?: string; body?: Record<string, string> }> = [];
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {
+      calls.push({
+        method: init?.method,
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      });
+      if (init?.method === 'PUT') {
+        return new Response(JSON.stringify({ commit: { sha: 'commit1' } }), { status: 201 });
+      }
+      return new Response(JSON.stringify({ sha: 'blob1' }), { status: 200 });
+    });
+    const r = await publishFileViaApi('blog/x/index.ru.md', 'Привет, мир', 'msg');
+    expect(r).toEqual({ ok: true, sha: 'commit1' });
+    const put = calls.find((c) => c.method === 'PUT');
+    expect(put?.body?.sha).toBe('blob1'); // updates against the current blob
+    expect(put?.body?.message).toBe('msg');
+    expect(decode(String(put?.body?.content))).toBe('Привет, мир'); // Cyrillic survives
+  });
+
+  it('publishFileViaApi surfaces the GitHub error message on failure', async () => {
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) =>
+      init?.method === 'PUT'
+        ? new Response(JSON.stringify({ message: 'Resource not accessible by integration' }), {
+            status: 403,
+          })
+        : new Response(JSON.stringify({ sha: 'b' }), { status: 200 }),
+    );
+    const r = await publishFileViaApi('p', 'c', 'm');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('Resource not accessible');
   });
 });

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -525,7 +525,10 @@ export const readFileViaApi = async (path: string): Promise<string | undefined> 
   const t = await freshGhToken();
   if (t === undefined) return undefined;
   try {
+    // `no-store`: the same URL is fetched with a different Accept for the blob
+    // sha at publish time; a cache that ignores Accept must not cross the wires.
     const res = await fetch(`${REPO_BASE}/contents/${path}?ref=${contentBranch()}`, {
+      cache: 'no-store',
       headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github.raw' },
     });
     return res.ok ? await res.text() : undefined;
@@ -540,6 +543,7 @@ export const articleLangsViaApi = async (slug: string): Promise<readonly string[
   if (t === undefined) return [];
   try {
     const res = await fetch(`${REPO_BASE}/contents/blog/${slug}?ref=${contentBranch()}`, {
+      cache: 'no-store',
       headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github+json' },
     });
     if (!res.ok) return [];
@@ -574,6 +578,7 @@ export const publishFileViaApi = async (
   try {
     let sha: string | undefined;
     const cur = await fetch(`${REPO_BASE}/contents/${path}?ref=${branch}`, {
+      cache: 'no-store',
       headers: { ...auth, accept: 'application/vnd.github+json' },
     });
     if (cur.ok) {

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -504,6 +504,102 @@ export const listArticlesViaApi = async (
   }
 };
 
+/** Repo REST base + branch shared by the direct-API editor reads/writes. */
+const REPO_BASE = 'https://api.github.com/repos/communist-prometheus/public-website-content';
+const contentBranch = (): string => import.meta.env.VITE_GITHUB_BRANCH ?? 'develop';
+
+/** UTF-8 → base64 (btoa is latin1-only; article bodies are Cyrillic). */
+const toBase64 = (text: string): string => {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+};
+
+/**
+ * Reads ONE file straight from the GitHub API (raw body) — no Service-Worker
+ * clone. This is how the editor opens the single article the user asked for
+ * instead of waiting on the whole-repo clone to finish.
+ */
+export const readFileViaApi = async (path: string): Promise<string | undefined> => {
+  const t = await freshGhToken();
+  if (t === undefined) return undefined;
+  try {
+    const res = await fetch(`${REPO_BASE}/contents/${path}?ref=${contentBranch()}`, {
+      headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github.raw' },
+    });
+    return res.ok ? await res.text() : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/** The languages one article exists in (its `index.<lang>.md` files), via API. */
+export const articleLangsViaApi = async (slug: string): Promise<readonly string[]> => {
+  const t = await freshGhToken();
+  if (t === undefined) return [];
+  try {
+    const res = await fetch(`${REPO_BASE}/contents/blog/${slug}?ref=${contentBranch()}`, {
+      headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github+json' },
+    });
+    if (!res.ok) return [];
+    const data: unknown = await res.json();
+    const names = Array.isArray(data)
+      ? data.map((e) => (typeof e === 'object' && e && 'name' in e ? String(Reflect.get(e, 'name')) : ''))
+      : [];
+    return names
+      .map((n) => n.match(/^index\.([a-z]{2,3})\.md$/)?.[1])
+      .filter((l): l is string => l !== undefined)
+      .sort();
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Commits ONE edited file via the GitHub Contents API — a single-file commit,
+ * no clone and no whole-repo push. Fetches the file's current blob sha (an
+ * update needs it), then PUTs the new content. Returns the commit sha or the
+ * real error. This is the "push only what was opened" path.
+ */
+export const publishFileViaApi = async (
+  path: string,
+  content: string,
+  message: string,
+): Promise<{ ok: boolean; sha?: string; error?: string }> => {
+  const t = await freshGhToken();
+  if (t === undefined) return { ok: false, error: 'signed-out' };
+  const auth = { authorization: `Bearer ${t}` };
+  const branch = contentBranch();
+  try {
+    let sha: string | undefined;
+    const cur = await fetch(`${REPO_BASE}/contents/${path}?ref=${branch}`, {
+      headers: { ...auth, accept: 'application/vnd.github+json' },
+    });
+    if (cur.ok) {
+      const d: unknown = await cur.json();
+      sha = typeof d === 'object' && d && 'sha' in d ? String(Reflect.get(d, 'sha')) : undefined;
+    }
+    const put = await fetch(`${REPO_BASE}/contents/${path}`, {
+      method: 'PUT',
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ message, content: toBase64(content), branch, ...(sha ? { sha } : {}) }),
+    });
+    if (!put.ok) {
+      const e: unknown = await put.json().catch(() => undefined);
+      const msg = typeof e === 'object' && e && 'message' in e ? String(Reflect.get(e, 'message')) : undefined;
+      return { ok: false, error: msg ?? `Публикация не удалась (${put.status}).` };
+    }
+    const d: unknown = await put.json();
+    const commit = typeof d === 'object' && d && 'commit' in d ? Reflect.get(d, 'commit') : undefined;
+    const commitSha =
+      typeof commit === 'object' && commit && 'sha' in commit ? String(Reflect.get(commit, 'sha')) : undefined;
+    return { ok: true, sha: commitSha };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+};
+
 const preferredLang = (langs: readonly string[]): string =>
   langs.find((l) => l === 'ru') ?? langs.find((l) => l === 'en') ?? (langs[0] as string);
 

--- a/src/redesign/screens/screen-editor.lang.test.ts
+++ b/src/redesign/screens/screen-editor.lang.test.ts
@@ -13,7 +13,7 @@ vi.mock('../engine/content.js', async (importOriginal) => {
     'blog/x/index.ru.md': '---\ntitle: "RU"\ncategory: t\npublished: true\n---\n\nRU body\n',
     'blog/x/index.en.md': '---\ntitle: "EN"\ncategory: t\npublished: true\n---\n\nEN body\n',
   };
-  return { ...actual, readFile: async (path: string) => docs[path] };
+  return { ...actual, readFileViaApi: async (path: string) => docs[path] };
 });
 
 const RU = '---\ntitle: "RU"\ncategory: t\npublished: true\n---\n\nRU body\n';

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -5,15 +5,13 @@ import '@communist-prometheus/cp-components';
 import type { CpSelectOption, CpTab } from '@communist-prometheus/cp-components';
 import type { CpMarkdownEditor } from '../editor/cp-markdown-editor.js';
 import {
-  listArticles,
-  readFile,
-  stageFile,
-  commitAndPush,
+  readFileViaApi,
+  articleLangsViaApi,
+  publishFileViaApi,
   upsertFrontmatterField,
   readFrontmatterField,
   upsertFrontmatterBlock,
 } from '../engine/content.js';
-import { onEngineReady } from '../engine/engine-ready.js';
 
 /** One editable article block: a stable id plus its raw markdown source line(s).
  *  The rendered typography is derived from the raw text on every render, so the
@@ -86,8 +84,8 @@ const RUBRIC_OPTIONS: readonly CpSelectOption[] = [
   { value: 'critique', label: 'Критика' },
 ];
 
-/** The real publish pipeline stages, mapped to `stageFile` + `commitAndPush`. */
-const REAL_STAGES: readonly string[] = ['Стейдж', 'Коммит', 'Пуш'];
+/** Publish is now a single GitHub API commit of the one edited file. */
+const REAL_STAGES: readonly string[] = ['Публикация'];
 
 /** Reads a single frontmatter scalar (`key: value`) from a text block. */
 const frontmatterValue = (text: string, key: string): string | undefined => {
@@ -507,6 +505,9 @@ export class ScreenEditor extends LitElement {
   /** Error surfaced by a failed real push ('' otherwise); never swallowed. */
   @state() private publishError = '';
 
+  /** Set when the single-article API load fails (shown instead of a spinner). */
+  @state() private loadError = '';
+
   /** Set when a user click should move focus into the freshly-rendered textarea. */
   private pendingFocus = false;
 
@@ -521,9 +522,6 @@ export class ScreenEditor extends LitElement {
    */
   private readonly langBuffers = new Map<string, string>();
 
-  /** Unsubscribes the engine-ready listener on disconnect. */
-  private disposeReady: () => void = () => {};
-
   override connectedCallback(): void {
     super.connectedCallback();
     // Lazy-load the CodeMirror editor only when the editor screen mounts, so all
@@ -533,18 +531,13 @@ export class ScreenEditor extends LitElement {
     this.loadedSlug = this.routeSlug();
     void this.load();
     globalThis.addEventListener('hashchange', this.onHashChange);
-    // First-load race (QA #12): if the engine was still cloning the repo, our
-    // first read found no article. Re-read when it is ready — but never clobber
-    // an intentional new draft or an already-loaded article.
-    this.disposeReady = onEngineReady(() => {
-      if (this.slug === '' && this.routeSlug() !== 'new') void this.load();
-    });
+    // The article is read directly from the GitHub API, so there is no engine
+    // clone to wait on — no ready-gate re-read needed.
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     globalThis.removeEventListener('hashchange', this.onHashChange);
-    this.disposeReady();
   }
 
   // Re-load when the editor stays mounted but the requested slug changes
@@ -565,35 +558,37 @@ export class ScreenEditor extends LitElement {
   private async load(): Promise<void> {
     // A fresh article invalidates any per-language edits from the previous one.
     this.langBuffers.clear();
-    const articles = await listArticles();
-    // Open the article the route names — clicking a card must open THAT article,
-    // not always the first one. `new` starts a blank document; a missing/unknown
-    // slug falls back to the first article.
     const requested = this.routeSlug();
     if (requested === 'new') {
       this.startNewArticle();
       this.loaded = true;
       return;
     }
-    const target =
-      (requested !== '' ? articles.find((a) => a.slug === requested) : undefined) ?? articles.at(0);
-    if (target !== undefined) {
-      const lang = target.languages.includes('ru') ? 'ru' : (target.languages.at(0) ?? 'ru');
-      const path = `blog/${target.slug}/index.${lang}.md`;
-      const markdown = await readFile(path);
-      if (markdown !== undefined && markdown.trim() !== '') {
-        this.slug = target.slug;
-        this.availableLangs = target.languages;
-        // `lang` is already one of the article's real languages (line above),
-        // so use it directly instead of collapsing anything non-ru/en/it to ru.
-        this.activeLang = lang;
-        this.applyMarkdown(markdown, path, true);
-        this.loaded = true;
-        return;
-      }
+    if (requested === '') {
+      this.loaded = true;
+      return;
     }
-    // No real article (signed out or empty repo): stay empty and prompt sign-in
-    // rather than loading a fabricated demo document.
+    // Fetch ONLY the opened article via the GitHub API — its languages (one dir
+    // listing) then the preferred file — instead of cloning the whole repo. This
+    // is what the article-loading spinner used to wait on forever.
+    this.loadError = '';
+    const langs = await articleLangsViaApi(requested);
+    if (langs.length === 0) {
+      this.loadError = 'Не удалось загрузить статью (нет доступа или её нет в репозитории).';
+      this.loaded = true;
+      return;
+    }
+    const lang = langs.includes('ru') ? 'ru' : (langs[0] ?? 'ru');
+    const path = `blog/${requested}/index.${lang}.md`;
+    const markdown = await readFileViaApi(path);
+    if (markdown !== undefined && markdown.trim() !== '') {
+      this.slug = requested;
+      this.availableLangs = langs;
+      this.activeLang = lang;
+      this.applyMarkdown(markdown, path, true);
+    } else {
+      this.loadError = `Не удалось загрузить «${path}».`;
+    }
     this.loaded = true;
   }
 
@@ -607,7 +602,7 @@ export class ScreenEditor extends LitElement {
 
   private async loadLang(lang: string): Promise<void> {
     const path = `blog/${this.slug}/index.${lang}.md`;
-    const markdown = await readFile(path);
+    const markdown = await readFileViaApi(path);
     if (markdown !== undefined && markdown.trim() !== '') {
       this.applyMarkdown(markdown, path, true);
     }
@@ -776,28 +771,20 @@ export class ScreenEditor extends LitElement {
     void this.runRealPublish();
   };
 
-  /** Runs the REAL git cycle: stage the edited markdown, then commit + push. */
+  /** Publishes the ONE edited file via the GitHub API — a single-file commit,
+   *  no clone and no whole-repo push. */
   private async runRealPublish(): Promise<void> {
     this.publishBusy = true;
-    this.stageStates = ['running', 'pending', 'pending'];
-    const staged = await stageFile(this.articlePath, this.editedMarkdown);
-    if (!staged.ok) {
-      this.stageStates = ['failed', 'pending', 'pending'];
-      this.publishError =
-        staged.error ?? `Не удалось подготовить «${this.articlePath}» к коммиту.`;
-      this.publishBusy = false;
-      return;
-    }
-    this.stageStates = ['done', 'running', 'pending'];
+    this.stageStates = ['running'];
     const message = `${this.articleTitle === '' ? 'Материал' : this.articleTitle}: правка из редактора`;
-    const result = await commitAndPush(message);
-    if (result.ok && result.sha !== undefined) {
-      this.stageStates = ['done', 'done', 'done'];
-      this.publishSha = result.sha;
+    const result = await publishFileViaApi(this.articlePath, this.editedMarkdown, message);
+    if (result.ok) {
+      this.stageStates = ['done'];
+      this.publishSha = result.sha ?? 'ok';
       this.dirty = false;
     } else {
-      this.stageStates = ['done', 'failed', 'failed'];
-      this.publishError = result.error ?? 'Коммит или пуш не удался.';
+      this.stageStates = ['failed'];
+      this.publishError = result.error ?? 'Публикация не удалась.';
     }
     this.publishBusy = false;
   }
@@ -965,10 +952,17 @@ export class ScreenEditor extends LitElement {
             <h1 class="title" tabindex="-1">Редактор</h1>
           </div>
           <p class="hint">
-            ${this.loaded
-              ? 'Войдите через GitHub, чтобы открыть материалы репозитория для правки.'
-              : 'Загружаем материал…'}
+            ${!this.loaded
+              ? 'Загружаем материал…'
+              : this.loadError !== ''
+                ? this.loadError
+                : 'Войдите через GitHub, чтобы открыть материалы репозитория для правки.'}
           </p>
+          ${this.loaded && this.loadError !== ''
+            ? html`<cp-button variant="secondary" @cp-click=${() => void this.load()}
+                >Обновить</cp-button
+              >`
+            : nothing}
         </article>
       `;
     }


### PR DESCRIPTION
Продолжение API-first: открытие статьи больше не ждёт клон всего репо («Загружаем материал…» навсегда), а публикация не морозит на git-стейдже.

- **Открытие статьи**: readFileViaApi/articleLangsViaApi — редактор тянет ТОЛЬКО открытую статью через GitHub API (языки одним листингом папки, затем raw-тело preferred-lang). Без клона. Ошибка загрузки → реальная причина + «Обновить», не вечный спиннер.
- **Публикация**: publishFileViaApi — один файл коммитится через Contents API (текущий blob sha → PUT нового контента, UTF-8 base64). Без клона и пуша всего репо. Реальная ошибка GitHub сурфейсится. 3 шага Стейдж/Коммит/Пуш → один «Публикация».
- **no-store** на content-reads: тот же URL читается raw (открытие) и как JSON (sha при публикации); браузерный кэш игнорировал Accept и отдавал raw JSON-ридеру → падение публикации. Исправлено.
- **PAT-вход убран** из прод-бандла: поле токена и «Войти по токену» только за import.meta.env.DEV. Прод — только GitHub OAuth.

Проверено вживую на dev-admin: редактор по прямой ссылке за **1с**, PAT-поля нет, **реальная публикация прошла** (коммит 4df2ae2 на public-website-content develop, автор undeadliner), ошибка сурфейсится при сбое. 119 тестов + validate зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)