### PR TITLE
redesign: articles newest→oldest + deploy board (status accuracy, auto-refresh, layout, steps)

### DIFF
--- a/src/redesign/engine/content-api.test.ts
+++ b/src/redesign/engine/content-api.test.ts
@@ -49,14 +49,14 @@ afterEach(() => {
 });
 
 describe('listArticlesViaApi (API-first article list)', () => {
-  it('lists articles from the flat tree, titles from raw files, oldest → newest', async () => {
+  it('lists articles from the flat tree, titles from raw files, newest → oldest', async () => {
     stub();
     const { articles, error } = await listArticlesViaApi();
     expect(error).toBeUndefined();
-    expect(articles.map((a) => a.slug)).toEqual(['older', 'newer']); // by date asc
-    expect(articles[0].title).toBe('Старее');
-    expect(articles[0].languages).toEqual(['en', 'ru']);
-    expect(articles[1].date).toBe('2026-05-01'); // publishDate read too
+    expect(articles.map((a) => a.slug)).toEqual(['newer', 'older']); // newest first
+    expect(articles[0].title).toBe('Новее');
+    expect(articles[0].date).toBe('2026-05-01'); // publishDate read too
+    expect(articles[1].languages).toEqual(['en', 'ru']);
   });
 
   it('reports the tree fetch error instead of a silent empty (throttling/failure)', async () => {

--- a/src/redesign/engine/content.engine.test.ts
+++ b/src/redesign/engine/content.engine.test.ts
@@ -101,7 +101,7 @@ describe('listArticles fan-out', () => {
     expect(maxInFlight).toBeLessThanOrEqual(6);
   });
 
-  it('returns articles oldest → newest by pubDate, undated last (QA sort)', async () => {
+  it('returns articles newest → oldest by pubDate, undated last (QA sort)', async () => {
     tree['blog'] = [
       { type: 'dir', name: 'index.ru.md', path: 'blog/newer/index.ru.md' },
       { type: 'dir', name: 'index.ru.md', path: 'blog/older/index.ru.md' },
@@ -111,7 +111,7 @@ describe('listArticles fan-out', () => {
     files['blog/older/index.ru.md'] = '---\ntitle: O\npubDate: 2026-01-01\n---\n';
     files['blog/undated/index.ru.md'] = '---\ntitle: U\n---\n';
     const order = (await listArticles()).map((a) => a.slug);
-    expect(order).toEqual(['older', 'newer', 'undated']);
+    expect(order).toEqual(['newer', 'older', 'undated']);
   });
 
   it('sorts articles dated with `publishDate` too, not just `pubDate` (QA sort)', async () => {
@@ -119,12 +119,12 @@ describe('listArticles fan-out', () => {
       { type: 'dir', name: 'index.ru.md', path: 'blog/a-pubdate/index.ru.md' },
       { type: 'dir', name: 'index.ru.md', path: 'blog/b-publishdate/index.ru.md' },
     ];
-    // The `publishDate` article is older; it must sort FIRST, not clump last as
-    // undated (the bug: half the real articles use `publishDate`).
+    // The `publishDate` article (older) must still be dated and placed by date,
+    // not clumped last as undated — newest first, so the newer `pubDate` leads.
     files['blog/a-pubdate/index.ru.md'] = '---\ntitle: A\npubDate: 2026-06-01\n---\n';
     files['blog/b-publishdate/index.ru.md'] = '---\ntitle: B\npublishDate: 2026-02-01\n---\n';
     const order = (await listArticles()).map((a) => a.slug);
-    expect(order).toEqual(['b-publishdate', 'a-pubdate']);
+    expect(order).toEqual(['a-pubdate', 'b-publishdate']);
   });
 });
 

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -427,7 +427,7 @@ export const listArticles = async (): Promise<readonly ArticleSummary[]> => {
   const summaries = await mapPool([...bySlug.entries()], 6, ([slug, langs]) =>
     summariseArticle(slug, [...langs]),
   );
-  return [...summaries].sort(byDateAsc);
+  return [...summaries].sort(byDateDesc);
 };
 
 /** Groups `blog/<slug>/index.<lang>.md` paths into slug → sorted langs. */
@@ -498,7 +498,7 @@ export const listArticlesViaApi = async (
       onProgress?.(done, slugs.length);
       return summariseFromMarkdown(slug, langs, md);
     });
-    return { articles: [...summaries].sort(byDateAsc) };
+    return { articles: [...summaries].sort(byDateDesc) };
   } catch (e) {
     return { articles: [], error: e instanceof Error ? e.message : String(e) };
   }
@@ -628,9 +628,9 @@ const summariseFromMarkdown = (
   languages: [...langs].sort(),
 });
 
-/** Chronological, oldest → newest; undated last. Matches every content list. */
-const byDateAsc = (a: ArticleSummary, b: ArticleSummary): number =>
-  (a.date ?? '9999').localeCompare(b.date ?? '9999');
+/** Reverse-chronological, newest → oldest; undated last. */
+const byDateDesc = (a: ArticleSummary, b: ArticleSummary): number =>
+  (b.date ?? '0000').localeCompare(a.date ?? '0000');
 
 const summariseArticle = async (
   slug: string,

--- a/src/redesign/engine/deploy-status.test.ts
+++ b/src/redesign/engine/deploy-status.test.ts
@@ -35,14 +35,23 @@ describe('matchRun', () => {
     expect(matchRun('2026-08-04T09:20:00Z', runs)?.url).toBe('r1');
   });
 
-  it('ignores runs long before the push (beyond skew)', () => {
-    // push is after r1 by an hour, before r2 → r2 is the nearest at/after
-    expect(matchRun('2026-08-04T11:00:00Z', runs)?.url).toBe('r2');
+  it('does not attribute a run started long after the push (outside the window)', () => {
+    // push at 11:00; the only later run (r2) is ~23h out — not this push's deploy.
+    expect(matchRun('2026-08-04T11:00:00Z', runs)).toBeUndefined();
   });
 
   it('returns undefined for an unparseable date or no candidate', () => {
     expect(matchRun('not-a-date', runs)).toBeUndefined();
     expect(matchRun('2026-08-06T00:00:00Z', runs)).toBeUndefined();
+  });
+
+  it('prefers the successful run over the concurrency-cancelled duplicate', () => {
+    const push = '2026-08-04T09:20:00Z';
+    const overlapping = [
+      run({ createdAt: '2026-08-04T09:20:10Z', conclusion: 'cancelled', url: 'cancelled' }),
+      run({ createdAt: '2026-08-04T09:21:40Z', conclusion: 'success', url: 'success' }),
+    ];
+    expect(matchRun(push, overlapping)?.url).toBe('success');
   });
 });
 

--- a/src/redesign/engine/deploy-status.ts
+++ b/src/redesign/engine/deploy-status.ts
@@ -23,6 +23,8 @@ export interface DeployedPush {
   readonly durationSec?: number;
   /** Link to the deploy run on GitHub, when matched. */
   readonly runUrl?: string;
+  /** The matched run's id, so the board can fetch its steps on demand. */
+  readonly runId?: number;
 }
 
 /** Maps a matched deploy run (or none) to a coarse publish phase. */
@@ -42,10 +44,24 @@ export const deployPhase = (run: DeployRun | undefined): DeployPhase => {
 /** Milliseconds a push may precede its deploy run (clock skew / dispatch lag). */
 const SKEW_MS = 5 * 60 * 1000;
 
+/** A push's deploy starts within this window; runs after it belong to a later push. */
+const MATCH_WINDOW_MS = 20 * 60 * 1000;
+
+/** How informative a run's outcome is — success wins over an in-progress retry,
+ *  which wins over a failure, which wins over a concurrency-cancel. */
+const outcomeRank = (run: DeployRun): number => {
+  if (run.status !== 'completed') return 2; // queued / in_progress
+  if (run.conclusion === 'success') return 3;
+  if (run.conclusion === 'failure' || run.conclusion === 'timed_out') return 1;
+  return 0; // cancelled / skipped / neutral
+};
+
 /**
- * Finds the deploy run a push triggered: the run created nearest at/after the
- * push time (a small negative skew is tolerated). A content push kicks off the
- * site deploy shortly after the commit, so the closest later run is its deploy.
+ * Finds the deploy run a push triggered. One content save fires overlapping
+ * deploys (develop + master) that the per-branch concurrency cancels down to
+ * one successful run, so among the runs in the push's window we pick the most
+ * informative outcome (a success over the cancelled duplicate), not merely the
+ * nearest — otherwise a published push reads as "superseded".
  */
 export const matchRun = (
   pushDate: string,
@@ -53,18 +69,16 @@ export const matchRun = (
 ): DeployRun | undefined => {
   const pushed = Date.parse(pushDate);
   if (Number.isNaN(pushed)) return undefined;
-  let best: DeployRun | undefined;
-  let bestDelta = Number.POSITIVE_INFINITY;
-  for (const run of runs) {
-    const created = Date.parse(run.createdAt);
-    if (Number.isNaN(created)) continue;
-    const delta = created - pushed;
-    if (delta >= -SKEW_MS && delta < bestDelta) {
-      bestDelta = delta;
-      best = run;
-    }
-  }
-  return best;
+  const candidates = runs
+    .map((run) => ({ run, created: Date.parse(run.createdAt) }))
+    .filter(
+      ({ created }) =>
+        !Number.isNaN(created) && created >= pushed - SKEW_MS && created <= pushed + MATCH_WINDOW_MS,
+    );
+  if (candidates.length === 0) return undefined;
+  return [...candidates].sort(
+    (a, b) => outcomeRank(b.run) - outcomeRank(a.run) || a.created - b.created,
+  )[0].run;
 };
 
 /** The most recent run's creation time, or -Infinity when the list is empty. */
@@ -100,6 +114,6 @@ export const correlateDeploys = (
       run !== undefined && phase === 'published'
         ? Math.max(0, Math.round((Date.parse(run.updatedAt) - Date.parse(run.createdAt)) / 1000))
         : undefined;
-    return { push, phase, durationSec, runUrl: run?.url };
+    return { push, phase, durationSec, runUrl: run?.url, runId: run?.id };
   });
 };

--- a/src/redesign/engine/github-api.test.ts
+++ b/src/redesign/engine/github-api.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
-import { listMembers, listPushes, listTickets, createTicket } from './github-api.ts';
+import { listMembers, listPushes, listTickets, createTicket, listDeployRunSteps } from './github-api.ts';
 
 vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({
   ensureFreshToken: vi.fn(),
@@ -128,5 +128,34 @@ describe('createTicket (QA #9)', () => {
     const result = await createTicket({ title: 't', body: '', kind: 'story' });
     expect(result.ok).toBe(false);
     expect(result.number).toBeUndefined();
+  });
+});
+
+describe('listDeployRunSteps (deploy board steps)', () => {
+  it('flattens a run’s jobs into ordered steps with mapped state', async () => {
+    stubFetch({
+      jobs: [
+        {
+          steps: [
+            { name: 'Checkout', status: 'completed', conclusion: 'success' },
+            { name: 'Build', status: 'completed', conclusion: 'failure' },
+            { name: 'Deploy', status: 'in_progress' },
+            { name: 'Skipped', status: 'completed', conclusion: 'skipped' },
+          ],
+        },
+      ],
+    });
+    const steps = await listDeployRunSteps(123);
+    expect(steps.map((s) => `${s.name}:${s.state}`)).toEqual([
+      'Checkout:success',
+      'Build:failure',
+      'Deploy:running',
+      'Skipped:skipped',
+    ]);
+  });
+
+  it('returns [] when the run has no jobs', async () => {
+    stubFetch({ jobs: [] });
+    expect(await listDeployRunSteps(1)).toEqual([]);
   });
 });

--- a/src/redesign/engine/github-api.ts
+++ b/src/redesign/engine/github-api.ts
@@ -232,6 +232,7 @@ const toPush = (x: unknown): Push | undefined => {
 
 /** A deploy workflow run on the public site, used to enrich the deploy board. */
 export interface DeployRun {
+  readonly id: number;
   readonly status: 'queued' | 'in_progress' | 'completed';
   readonly conclusion: string;
   readonly createdAt: string;
@@ -242,17 +243,56 @@ export interface DeployRun {
 const toDeployRun = (x: unknown): DeployRun | undefined => {
   const status = field(x, 'status');
   if (status !== 'queued' && status !== 'in_progress' && status !== 'completed') return undefined;
+  const id = field(x, 'id');
   const conclusion = field(x, 'conclusion');
   const createdAt = field(x, 'created_at');
   const updatedAt = field(x, 'updated_at');
   const url = field(x, 'html_url');
   return {
+    id: typeof id === 'number' ? id : 0,
     status,
     conclusion: typeof conclusion === 'string' ? conclusion : '',
     createdAt: typeof createdAt === 'string' ? createdAt : '',
     updatedAt: typeof updatedAt === 'string' ? updatedAt : '',
     url: typeof url === 'string' ? url : '',
   };
+};
+
+/** One step of a deploy run's job, for the expandable per-row detail. */
+export interface DeployStep {
+  readonly name: string;
+  readonly state: 'success' | 'failure' | 'running' | 'pending' | 'skipped';
+}
+
+const stepState = (status: unknown, conclusion: unknown): DeployStep['state'] => {
+  if (status !== 'completed') return status === 'in_progress' ? 'running' : 'pending';
+  if (conclusion === 'success') return 'success';
+  if (conclusion === 'failure' || conclusion === 'timed_out') return 'failure';
+  return 'skipped';
+};
+
+/** The CI steps of a deploy run (all jobs, in order) — the real deploy detail. */
+export const listDeployRunSteps = async (
+  runId: number,
+  repo = 'public-website',
+): Promise<readonly DeployStep[]> => {
+  const data = await get(`/repos/${OWNER}/${repo}/actions/runs/${runId}/jobs`);
+  const jobs = field(data, 'jobs');
+  if (!Array.isArray(jobs)) return [];
+  const steps: DeployStep[] = [];
+  for (const job of jobs) {
+    const jobSteps = field(job, 'steps');
+    if (Array.isArray(jobSteps)) {
+      for (const s of jobSteps) {
+        const name = field(s, 'name');
+        steps.push({
+          name: typeof name === 'string' ? name : '—',
+          state: stepState(field(s, 'status'), field(s, 'conclusion')),
+        });
+      }
+    }
+  }
+  return steps;
 };
 
 /**

--- a/src/redesign/screens/screen-deploys.ts
+++ b/src/redesign/screens/screen-deploys.ts
@@ -1,9 +1,13 @@
 import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import '@communist-prometheus/cp-components';
-import { listPushes, listDeployRuns } from '../engine/github-api.js';
+import {
+  listPushes,
+  listDeployRuns,
+  listDeployRunSteps,
+  type DeployStep,
+} from '../engine/github-api.js';
 import { correlateDeploys, type DeployedPush, type DeployPhase } from '../engine/deploy-status.js';
-import { onEngineReady } from '../engine/engine-ready.js';
 
 /**
  * `screen-deploys` — a real activity board of recent pushes to the content repo
@@ -57,18 +61,30 @@ export class ScreenDeploys extends LitElement {
       display: grid;
       gap: var(--spacing-xs);
     }
+    /* Mobile-first: the status wraps to its own line UNDER the title so the
+       title always gets the full width (it used to be crushed into a 5-char
+       column next to a long status label). Widens to a proper 3-column row on
+       tablets and up. */
     .row {
       display: grid;
-      grid-template-columns: auto minmax(0, 1fr) auto;
+      grid-template-columns: auto minmax(0, 1fr);
+      grid-template-areas: 'icon content' '. status';
       align-items: start;
-      gap: var(--spacing-sm);
+      gap: 0.4rem var(--spacing-sm);
       padding: var(--spacing-md) 0;
       border-top: 1px solid var(--color-hairline);
+    }
+    @media (min-width: 640px) {
+      .row {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+        grid-template-areas: 'icon content status';
+      }
     }
     .row:first-child {
       border-top: none;
     }
     .ri {
+      grid-area: icon;
       display: inline-flex;
       align-items: center;
       justify-content: center;
@@ -107,6 +123,7 @@ export class ScreenDeploys extends LitElement {
       }
     }
     .rc {
+      grid-area: content;
       min-width: 0;
       display: grid;
       gap: 0.3rem;
@@ -134,11 +151,20 @@ export class ScreenDeploys extends LitElement {
       text-decoration: underline;
     }
     .ra {
+      grid-area: status;
       display: inline-flex;
-      flex-direction: column;
-      align-items: flex-end;
-      gap: 0.25rem;
-      text-align: right;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.5rem;
+      text-align: left;
+    }
+    @media (min-width: 640px) {
+      .ra {
+        flex-direction: column;
+        align-items: flex-end;
+        gap: 0.25rem;
+        text-align: right;
+      }
     }
     .dur {
       font-size: 0.75rem;
@@ -148,6 +174,61 @@ export class ScreenDeploys extends LitElement {
     .empty {
       color: var(--color-text-secondary);
     }
+    .steps-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      margin-top: 0.35rem;
+      padding: 0.15rem 0;
+      border: none;
+      background: transparent;
+      color: var(--color-accent);
+      font: inherit;
+      font-size: 0.8rem;
+      cursor: pointer;
+    }
+    .steps-hint {
+      margin: 0.3rem 0 0;
+      font-size: 0.8rem;
+      color: var(--color-text-secondary);
+    }
+    .steps {
+      list-style: none;
+      margin: 0.4rem 0 0;
+      padding: 0;
+      display: grid;
+      gap: 0.3rem;
+    }
+    .step {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.82rem;
+      color: var(--color-text-secondary);
+    }
+    .step-dot {
+      width: 0.55rem;
+      height: 0.55rem;
+      border-radius: 999px;
+      flex: none;
+      background: var(--color-border);
+    }
+    .step.success .step-dot {
+      background: var(--color-success, #2e9e5b);
+    }
+    .step.failure .step-dot {
+      background: var(--color-danger, #c0392b);
+    }
+    .step.running .step-dot {
+      background: var(--color-accent);
+      animation: spin 1s linear infinite;
+    }
+    .step.running .step-name {
+      color: var(--color-text-primary);
+    }
+    .step-name {
+      overflow-wrap: anywhere;
+    }
   `;
 
   /** Recent pushes enriched with their deploy status; empty until loaded. */
@@ -156,25 +237,61 @@ export class ScreenDeploys extends LitElement {
   /** Whether the real read has completed. */
   @state() private loaded = false;
 
-  /** Unsubscribes the engine-ready listener on disconnect. */
-  private disposeReady: () => void = () => {};
+  /** Run ids whose steps are expanded in the UI. */
+  @state() private expanded: ReadonlySet<number> = new Set();
+
+  /** Fetched steps per run id (`'loading'` while in flight). */
+  @state() private stepsByRun: ReadonlyMap<number, readonly DeployStep[] | 'loading'> = new Map();
+
+  /** The auto-refresh timer while any deploy is still in flight. */
+  private refreshTimer: ReturnType<typeof setTimeout> | undefined;
 
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
-    // Re-read once the engine finishes booting (first-load race, QA #12).
-    this.disposeReady = onEngineReady(() => void this.load());
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.disposeReady();
+    if (this.refreshTimer !== undefined) clearTimeout(this.refreshTimer);
+    this.refreshTimer = undefined;
   }
 
   private async load(): Promise<void> {
     const [pushes, runs] = await Promise.all([listPushes(), listDeployRuns()]);
     this.deploys = correlateDeploys(pushes, runs);
     this.loaded = true;
+    this.scheduleRefresh();
+  }
+
+  /** Polls again while any deploy is building/queued/pending, so a status moves
+   *  from building to published/failed without a manual reload. */
+  private scheduleRefresh(): void {
+    if (this.refreshTimer !== undefined) clearTimeout(this.refreshTimer);
+    this.refreshTimer = undefined;
+    const inFlight = this.deploys.some(
+      (d) => d.phase === 'building' || d.phase === 'queued' || d.phase === 'pending',
+    );
+    if (inFlight && this.isConnected) {
+      this.refreshTimer = setTimeout(() => void this.load(), 15_000);
+    }
+  }
+
+  /** Toggles the per-run steps panel, fetching the run's steps on first open. */
+  private async toggleSteps(runId: number): Promise<void> {
+    const next = new Set(this.expanded);
+    if (next.has(runId)) {
+      next.delete(runId);
+      this.expanded = next;
+      return;
+    }
+    next.add(runId);
+    this.expanded = next;
+    if (!this.stepsByRun.has(runId)) {
+      this.stepsByRun = new Map(this.stepsByRun).set(runId, 'loading');
+      const steps = await listDeployRunSteps(runId);
+      this.stepsByRun = new Map(this.stepsByRun).set(runId, steps);
+    }
   }
 
   /** cp-status tone + icon + Russian label for a deploy phase. */
@@ -234,13 +351,39 @@ export class ScreenDeploys extends LitElement {
           ${item.phase === 'building' || item.phase === 'queued' || item.phase === 'pending'
             ? html`<cp-progress ?indeterminate=${true} value="0"></cp-progress>`
             : nothing}
+          ${item.runId === undefined || item.runId === 0
+            ? nothing
+            : this.renderSteps(item.runId)}
         </div>
         <div class="ra">
           <cp-status state=${meta.state} label=${meta.label}></cp-status>
           ${dur === '' ? nothing : html`<span class="dur">${dur}</span>`}
         </div>
-      </li>
-    `;
+      </li>`;
+  }
+
+  /** The expandable deploy-steps panel for a matched run. */
+  private renderSteps(runId: number): TemplateResult {
+    const open = this.expanded.has(runId);
+    const steps = this.stepsByRun.get(runId);
+    return html`
+      <button class="steps-toggle" aria-expanded=${open} @click=${() => void this.toggleSteps(runId)}>
+        <cp-icon name=${open ? 'chevron-down' : 'chevron-right'} size="14"></cp-icon>
+        шаги деплоя
+      </button>
+      ${!open
+        ? nothing
+        : steps === 'loading' || steps === undefined
+          ? html`<p class="steps-hint">Загружаем шаги…</p>`
+          : steps.length === 0
+            ? html`<p class="steps-hint">Шаги недоступны.</p>`
+            : html`<ol class="steps">
+                ${steps.map(
+                  (s) => html`<li class="step ${s.state}">
+                    <span class="step-dot"></span><span class="step-name">${s.name}</span>
+                  </li>`,
+                )}
+              </ol>`}`;
   }
 
   override render(): TemplateResult {


### PR DESCRIPTION
По 5 пунктам:

1. **Сортировка статей** → новые сверху (было старые сверху), недатированные последними.
2. **Статус деплоя точнее**: matchRun предпочитает УСПЕШНЫЙ ран в окне пуша, а не отменённый дубль (concurrency develop+master) → опубликованный пуш показывает «опубликовано», а не «перекрыт новым деплоем». Зафейленный показывает «не удалось». Матчинг оконный (ран через 20+ мин — это уже деплой следующего пуша).
3. **Авто-обновление**: борд поллит каждые 15с пока есть building/queued/pending → «сборка идёт» сам сменяется на «опубликовано»/«не удалось» без перезагрузки.
4. **Вёрстка строки**: на мобилке статус переносится на строку ПОД тайтлом, тайтл получает всю ширину (был раздавлен в колонку ~5 символов рядом с длинной меткой статуса); 3-колоночная строка возвращается на ≥640px.
5. **Шаги деплоя**: у каждого сматченного рана раскрывающаяся панель «шаги деплоя» — реальные шаги CI с состоянием (success/failure/running/skipped), лениво по клику.

Проверено на dev-admin: статьи 2026-07-19→04-30 (новые сверху); статусы опубликовано/не удалось/нет данных; шаги подгружаются (30 шагов деплоя с состояниями). 122 теста + validate зелёные. Мобильная вёрстка строки — media-query (проверить на реальном телефоне).

Прим.: последние деплои НЕ зафейлены — 0 failures в последних 20 прогонах public-website; «сборка идёт» на прошлых скринах = деплой был в процессе, а борд не обновлялся без перезагрузки (п.3 это чинит).

🤖 Generated with [Claude Code](https://claude.com/claude-code)