### PR TITLE
redesign: journal issues are editable (tap a magazine card opens the editor)

### DIFF
--- a/src/redesign/engine/content-api.test.ts
+++ b/src/redesign/engine/content-api.test.ts
@@ -111,6 +111,16 @@ describe('editor single-file API (read / langs / publish, no clone)', () => {
     expect(await articleLangsViaApi('x')).toEqual(['en', 'ru']);
   });
 
+  it('articleLangsViaApi reads the given collection folder (magazine issues too)', async () => {
+    let seen = '';
+    vi.stubGlobal('fetch', async (url: string) => {
+      seen = url;
+      return new Response(JSON.stringify([{ name: 'index.ru.md' }]), { status: 200 });
+    });
+    await articleLangsViaApi('nomer-1', 'magazine');
+    expect(seen).toContain('/contents/magazine/nomer-1');
+  });
+
   it('publishFileViaApi commits ONE file (UTF-8 base64) and returns the commit sha', async () => {
     const calls: Array<{ method?: string; body?: Record<string, string> }> = [];
     vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -537,12 +537,16 @@ export const readFileViaApi = async (path: string): Promise<string | undefined> 
   }
 };
 
-/** The languages one article exists in (its `index.<lang>.md` files), via API. */
-export const articleLangsViaApi = async (slug: string): Promise<readonly string[]> => {
+/** The languages one item exists in (its `index.<lang>.md` files), via API. The
+ *  collection is `blog` for articles, `magazine` for journal issues. */
+export const articleLangsViaApi = async (
+  slug: string,
+  collection = 'blog',
+): Promise<readonly string[]> => {
   const t = await freshGhToken();
   if (t === undefined) return [];
   try {
-    const res = await fetch(`${REPO_BASE}/contents/blog/${slug}?ref=${contentBranch()}`, {
+    const res = await fetch(`${REPO_BASE}/contents/${collection}/${slug}?ref=${contentBranch()}`, {
       cache: 'no-store',
       headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github+json' },
     });

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -514,6 +514,9 @@ export class ScreenEditor extends LitElement {
   /** Slug currently loaded, to detect same-screen route changes. */
   private loadedSlug = '';
 
+  /** Repo folder of the loaded item: `blog` (article) or `magazine` (issue). */
+  private collection = 'blog';
+
   /**
    * In-memory edits per language for the current article. Switching the language
    * tab stashes the active language's edited markdown here so switching back
@@ -550,15 +553,27 @@ export class ScreenEditor extends LitElement {
     }
   };
 
-  /** Slug requested via the route (`#/editor/<slug>`), '' for the default. */
+  /**
+   * The item the route names: `#/editor/<slug>` (a blog article, the default) or
+   * `#/editor/magazine/<slug>` (a journal issue). The collection selects the repo
+   * folder so the same editor edits both.
+   */
+  private routeTarget(): { collection: string; slug: string } {
+    const parts = window.location.hash.split('/');
+    if (parts[2] === 'magazine') return { collection: 'magazine', slug: parts[3] ?? '' };
+    return { collection: 'blog', slug: parts[2] ?? '' };
+  }
+
+  /** Slug requested via the route ('' for the default, 'new' for a blank doc). */
   private routeSlug(): string {
-    return window.location.hash.split('/')[2] ?? '';
+    return this.routeTarget().slug;
   }
 
   private async load(): Promise<void> {
     // A fresh article invalidates any per-language edits from the previous one.
     this.langBuffers.clear();
-    const requested = this.routeSlug();
+    const { collection, slug: requested } = this.routeTarget();
+    this.collection = collection;
     if (requested === 'new') {
       this.startNewArticle();
       this.loaded = true;
@@ -568,18 +583,19 @@ export class ScreenEditor extends LitElement {
       this.loaded = true;
       return;
     }
-    // Fetch ONLY the opened article via the GitHub API — its languages (one dir
+    // Fetch ONLY the opened item via the GitHub API — its languages (one dir
     // listing) then the preferred file — instead of cloning the whole repo. This
-    // is what the article-loading spinner used to wait on forever.
+    // is what the loading spinner used to wait on forever. Works for a blog
+    // article or a magazine issue via the collection folder.
     this.loadError = '';
-    const langs = await articleLangsViaApi(requested);
+    const langs = await articleLangsViaApi(requested, collection);
     if (langs.length === 0) {
-      this.loadError = 'Не удалось загрузить статью (нет доступа или её нет в репозитории).';
+      this.loadError = 'Не удалось загрузить материал (нет доступа или его нет в репозитории).';
       this.loaded = true;
       return;
     }
     const lang = langs.includes('ru') ? 'ru' : (langs[0] ?? 'ru');
-    const path = `blog/${requested}/index.${lang}.md`;
+    const path = `${collection}/${requested}/index.${lang}.md`;
     const markdown = await readFileViaApi(path);
     if (markdown !== undefined && markdown.trim() !== '') {
       this.slug = requested;
@@ -601,7 +617,7 @@ export class ScreenEditor extends LitElement {
   }
 
   private async loadLang(lang: string): Promise<void> {
-    const path = `blog/${this.slug}/index.${lang}.md`;
+    const path = `${this.collection}/${this.slug}/index.${lang}.md`;
     const markdown = await readFileViaApi(path);
     if (markdown !== undefined && markdown.trim() !== '') {
       this.applyMarkdown(markdown, path, true);

--- a/src/redesign/screens/screen-magazine.ts
+++ b/src/redesign/screens/screen-magazine.ts
@@ -430,7 +430,10 @@ export class ScreenMagazine extends LitElement {
         ? html`<div class="issues">
             ${this.issues.map(
               (issue) => html`
-                <cp-card>
+                <cp-card
+                  hoverable
+                  @cp-card-click=${() => (location.hash = `/editor/magazine/${issue.slug}`)}
+                >
                   <span slot="title" class="issue-title">${issue.title}</span>
                   <span slot="summary" class="issue-slug">${issue.slug}</span>
                 </cp-card>


### PR DESCRIPTION
Карточки журнала были некликабельны (тап ничего не делал), а пути редактора захардкожены на blog/ — редактировать номер было нельзя.

- Карточка журнала теперь hoverable и ведёт на #/editor/magazine/<slug>.
- Редактор парсит коллекцию из маршрута (blog по умолчанию, magazine для #/editor/magazine/<slug>) и читает/публикует под этой папкой. Тот же API-first: номер открывается за ~1с как статья.

Проверено на dev-admin: тап по карточке → #/editor/magazine/magazine-1-mai-2026; редактор загрузил номер (collection magazine, путь magazine/…/index.ru.md, заголовок «Журнал №1 — май 2026», языки en/es/it/ru, тело рендерится). 122 теста + validate зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)