### PR TITLE
redesign: file manager for journal issues (view / upload any file incl. fb2 / delete)

### DIFF
--- a/src/redesign/components/issue-files.ts
+++ b/src/redesign/components/issue-files.ts
@@ -1,0 +1,229 @@
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import '@communist-prometheus/cp-components';
+import {
+  listDirViaApi,
+  uploadBinaryViaApi,
+  deleteFileViaApi,
+  type RepoFile,
+} from '../engine/content.js';
+
+/** Reads a File as base64 (without the data-URL prefix) for the Contents API. */
+const fileToBase64 = (file: File): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (): void => {
+      const result = String(reader.result);
+      resolve(result.slice(result.indexOf(',') + 1));
+    };
+    reader.onerror = (): void => reject(reader.error ?? new Error('read failed'));
+    reader.readAsDataURL(file);
+  });
+
+/** Human file size. */
+const humanSize = (bytes: number): string =>
+  bytes < 1024
+    ? `${bytes} Б`
+    : bytes < 1024 * 1024
+      ? `${(bytes / 1024).toFixed(0)} КБ`
+      : `${(bytes / (1024 * 1024)).toFixed(1)} МБ`;
+
+/**
+ * Files of one content directory (a magazine issue's `assets/`), managed
+ * entirely through the GitHub Contents API — no clone. Lists what is uploaded,
+ * uploads ANY file type (pdf, fb2, doc, images…) and deletes files. This is the
+ * "where are the files / upload mine / delete" panel the journal workflow needs.
+ */
+@customElement('issue-files')
+export class IssueFiles extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+    h2 {
+      font-size: 1.1rem;
+      margin: 0 0 var(--spacing-sm);
+    }
+    ul {
+      list-style: none;
+      margin: 0 0 var(--spacing-md);
+      padding: 0;
+      display: grid;
+      gap: var(--spacing-xs);
+    }
+    li {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5rem var(--spacing-sm);
+      padding: var(--spacing-sm) 0;
+      border-top: 1px solid var(--color-hairline);
+    }
+    li:first-child {
+      border-top: none;
+    }
+    .name {
+      font-family: var(--font-mono);
+      font-size: 0.9rem;
+      overflow-wrap: anywhere;
+      min-width: 0;
+    }
+    .size {
+      font-size: 0.78rem;
+      color: var(--color-text-secondary);
+      font-variant-numeric: tabular-nums;
+    }
+    .spacer {
+      flex: 1;
+    }
+    a.dl {
+      color: var(--color-accent);
+      text-decoration: none;
+      font-size: 0.82rem;
+    }
+    .empty,
+    .msg {
+      color: var(--color-text-secondary);
+      font-size: 0.88rem;
+      margin: 0.2rem 0;
+    }
+    .msg.error {
+      color: var(--color-danger, #c0392b);
+    }
+    .upload {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+      margin-top: var(--spacing-sm);
+    }
+    input[type='file'] {
+      color: var(--color-text-secondary);
+      font: inherit;
+      font-size: 0.85rem;
+      max-width: 100%;
+    }
+    .confirm {
+      display: inline-flex;
+      gap: 0.35rem;
+      align-items: center;
+      font-size: 0.8rem;
+    }
+  `;
+
+  /** The repo directory whose files are managed, e.g. `magazine/<slug>/assets`. */
+  @property() dir = '';
+
+  @state() private files: readonly RepoFile[] = [];
+  @state() private loading = false;
+  @state() private busy = false;
+  @state() private message = '';
+  @state() private error = '';
+  /** Path awaiting a delete confirmation (two-step, so a tap can't wipe a file). */
+  @state() private confirmingPath = '';
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.load();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has('dir')) void this.load();
+  }
+
+  private async load(): Promise<void> {
+    if (this.dir === '') return;
+    this.loading = true;
+    this.error = '';
+    this.files = await listDirViaApi(this.dir);
+    this.loading = false;
+  }
+
+  private readonly onPick = async (event: Event): Promise<void> => {
+    const input = event.target;
+    const file = input instanceof HTMLInputElement ? input.files?.[0] : undefined;
+    if (input instanceof HTMLInputElement) input.value = '';
+    if (file === undefined) return;
+    this.busy = true;
+    this.message = '';
+    this.error = '';
+    const base64 = await fileToBase64(file);
+    const result = await uploadBinaryViaApi(`${this.dir}/${file.name}`, base64, `assets: add ${file.name}`);
+    this.busy = false;
+    if (result.ok) {
+      this.message = `Загружен файл «${file.name}».`;
+      await this.load();
+    } else {
+      this.error = result.error ?? 'Загрузка не удалась.';
+    }
+  };
+
+  private readonly removeFile = async (file: RepoFile): Promise<void> => {
+    this.confirmingPath = '';
+    this.busy = true;
+    this.message = '';
+    this.error = '';
+    const result = await deleteFileViaApi(file.path, `assets: remove ${file.name}`);
+    this.busy = false;
+    if (result.ok) {
+      this.message = `Удалён файл «${file.name}».`;
+      await this.load();
+    } else {
+      this.error = result.error ?? 'Удаление не удалось.';
+    }
+  };
+
+  private renderFile(file: RepoFile): TemplateResult {
+    const confirming = this.confirmingPath === file.path;
+    return html`
+      <li>
+        <span class="name">${file.name}</span>
+        <span class="size">${humanSize(file.size)}</span>
+        <span class="spacer"></span>
+        <a class="dl" href="https://github.com/communist-prometheus/public-website-content/raw/HEAD/${file.path}" target="_blank" rel="noopener">открыть ↗</a>
+        ${confirming
+          ? html`<span class="confirm">
+              <cp-button size="sm" variant="secondary" @cp-click=${() => (this.confirmingPath = '')}
+                >Отмена</cp-button
+              >
+              <cp-button size="sm" ?disabled=${this.busy} @cp-click=${() => void this.removeFile(file)}
+                >Удалить</cp-button
+              >
+            </span>`
+          : html`<cp-button
+              size="sm"
+              variant="ghost"
+              ?disabled=${this.busy}
+              @cp-click=${() => (this.confirmingPath = file.path)}
+              >Удалить</cp-button
+            >`}
+      </li>
+    `;
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <h2>Файлы номера</h2>
+      ${this.loading
+        ? html`<p class="msg">Загружаем список файлов…</p>`
+        : this.files.length === 0
+          ? html`<p class="empty">Файлов пока нет.</p>`
+          : html`<ul>
+              ${this.files.map((f) => this.renderFile(f))}
+            </ul>`}
+      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
+      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
+      <div class="upload">
+        <label>
+          ${this.busy ? 'Обрабатываем…' : 'Загрузить файл (pdf, fb2, любой):'}
+          <input type="file" ?disabled=${this.busy} @change=${this.onPick} />
+        </label>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'issue-files': IssueFiles;
+  }
+}

--- a/src/redesign/engine/content-api.test.ts
+++ b/src/redesign/engine/content-api.test.ts
@@ -5,6 +5,9 @@ import {
   readFileViaApi,
   articleLangsViaApi,
   publishFileViaApi,
+  listDirViaApi,
+  uploadBinaryViaApi,
+  deleteFileViaApi,
 } from './content.ts';
 
 vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
@@ -139,6 +142,55 @@ describe('editor single-file API (read / langs / publish, no clone)', () => {
     expect(put?.body?.sha).toBe('blob1'); // updates against the current blob
     expect(put?.body?.message).toBe('msg');
     expect(decode(String(put?.body?.content))).toBe('Привет, мир'); // Cyrillic survives
+  });
+
+  it('listDirViaApi returns only files (not sub-dirs), with size and sha', async () => {
+    vi.stubGlobal(
+      'fetch',
+      async () =>
+        new Response(
+          JSON.stringify([
+            { type: 'file', name: 'issue.ru.pdf', path: 'magazine/x/assets/issue.ru.pdf', size: 2048, sha: 'a' },
+            { type: 'file', name: 'book.fb2', path: 'magazine/x/assets/book.fb2', size: 500, sha: 'b' },
+            { type: 'dir', name: 'nested', path: 'magazine/x/assets/nested', size: 0, sha: 'c' },
+          ]),
+          { status: 200 },
+        ),
+    );
+    const files = await listDirViaApi('magazine/x/assets');
+    expect(files.map((f) => f.name)).toEqual(['issue.ru.pdf', 'book.fb2']);
+    expect(files[1]).toMatchObject({ path: 'magazine/x/assets/book.fb2', size: 500, sha: 'b' });
+  });
+
+  it('uploadBinaryViaApi PUTs base64 content, overwriting via the current sha', async () => {
+    const calls: Array<{ method?: string; body?: Record<string, string> }> = [];
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {
+      calls.push({
+        method: init?.method,
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      });
+      if (init?.method === 'PUT') return new Response('{}', { status: 200 });
+      return new Response(JSON.stringify({ sha: 'existing' }), { status: 200 });
+    });
+    const r = await uploadBinaryViaApi('magazine/x/assets/book.fb2', 'QkFTRTY0', 'add fb2');
+    expect(r.ok).toBe(true);
+    const put = calls.find((c) => c.method === 'PUT');
+    expect(put?.body).toMatchObject({ content: 'QkFTRTY0', sha: 'existing', message: 'add fb2' });
+  });
+
+  it('deleteFileViaApi DELETEs with the file sha', async () => {
+    const calls: Array<{ method?: string; body?: Record<string, string> }> = [];
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) => {
+      calls.push({
+        method: init?.method,
+        body: typeof init?.body === 'string' ? JSON.parse(init.body) : undefined,
+      });
+      if (init?.method === 'DELETE') return new Response('{}', { status: 200 });
+      return new Response(JSON.stringify({ sha: 'todelete' }), { status: 200 });
+    });
+    const r = await deleteFileViaApi('magazine/x/assets/old.pdf', 'remove');
+    expect(r.ok).toBe(true);
+    expect(calls.find((c) => c.method === 'DELETE')?.body).toMatchObject({ sha: 'todelete' });
   });
 
   it('publishFileViaApi surfaces the GitHub error message on failure', async () => {

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -609,6 +609,110 @@ export const publishFileViaApi = async (
   }
 };
 
+/** One file in a repo directory (a magazine issue's asset, etc.). */
+export interface RepoFile {
+  readonly name: string;
+  readonly path: string;
+  readonly size: number;
+  readonly sha: string;
+}
+
+/** Lists the files in a repo directory via the API (e.g. an issue's assets). */
+export const listDirViaApi = async (dir: string): Promise<readonly RepoFile[]> => {
+  const t = await freshGhToken();
+  if (t === undefined) return [];
+  try {
+    const res = await fetch(`${REPO_BASE}/contents/${dir}?ref=${contentBranch()}`, {
+      cache: 'no-store',
+      headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github+json' },
+    });
+    if (!res.ok) return [];
+    const data: unknown = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data
+      .filter((e) => typeof e === 'object' && e && Reflect.get(e, 'type') === 'file')
+      .map((e) => ({
+        name: String(Reflect.get(e, 'name')),
+        path: String(Reflect.get(e, 'path')),
+        size: typeof Reflect.get(e, 'size') === 'number' ? Number(Reflect.get(e, 'size')) : 0,
+        sha: String(Reflect.get(e, 'sha')),
+      }));
+  } catch {
+    return [];
+  }
+};
+
+/** The current blob sha of a file, or undefined when it does not exist. */
+const blobShaViaApi = async (
+  path: string,
+  auth: Record<string, string>,
+  branch: string,
+): Promise<string | undefined> => {
+  const res = await fetch(`${REPO_BASE}/contents/${path}?ref=${branch}`, {
+    cache: 'no-store',
+    headers: { ...auth, accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) return undefined;
+  const d: unknown = await res.json();
+  return typeof d === 'object' && d && 'sha' in d ? String(Reflect.get(d, 'sha')) : undefined;
+};
+
+const apiError = async (res: Response, fallback: string): Promise<string> => {
+  const e: unknown = await res.json().catch(() => undefined);
+  return typeof e === 'object' && e && 'message' in e ? String(Reflect.get(e, 'message')) : fallback;
+};
+
+/** Uploads a file (already base64-encoded) via the Contents API — ANY type,
+ *  including fb2/doc/pdf. Overwrites in place when the path already exists. */
+export const uploadBinaryViaApi = async (
+  path: string,
+  base64: string,
+  message: string,
+): Promise<{ ok: boolean; error?: string }> => {
+  const t = await freshGhToken();
+  if (t === undefined) return { ok: false, error: 'signed-out' };
+  const auth = { authorization: `Bearer ${t}` };
+  const branch = contentBranch();
+  try {
+    const sha = await blobShaViaApi(path, auth, branch);
+    const put = await fetch(`${REPO_BASE}/contents/${path}`, {
+      method: 'PUT',
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ message, content: base64, branch, ...(sha ? { sha } : {}) }),
+    });
+    return put.ok
+      ? { ok: true }
+      : { ok: false, error: await apiError(put, `Загрузка не удалась (${put.status}).`) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+};
+
+/** Deletes a file via the Contents API (needs its current blob sha). */
+export const deleteFileViaApi = async (
+  path: string,
+  message: string,
+): Promise<{ ok: boolean; error?: string }> => {
+  const t = await freshGhToken();
+  if (t === undefined) return { ok: false, error: 'signed-out' };
+  const auth = { authorization: `Bearer ${t}` };
+  const branch = contentBranch();
+  try {
+    const sha = await blobShaViaApi(path, auth, branch);
+    if (sha === undefined) return { ok: false, error: 'Файл не найден.' };
+    const res = await fetch(`${REPO_BASE}/contents/${path}`, {
+      method: 'DELETE',
+      headers: { ...auth, 'content-type': 'application/json' },
+      body: JSON.stringify({ message, sha, branch }),
+    });
+    return res.ok
+      ? { ok: true }
+      : { ok: false, error: await apiError(res, `Удаление не удалось (${res.status}).`) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+};
+
 const preferredLang = (langs: readonly string[]): string =>
   langs.find((l) => l === 'ru') ?? langs.find((l) => l === 'en') ?? (langs[0] as string);
 

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -12,6 +12,7 @@ import {
   readFrontmatterField,
   upsertFrontmatterBlock,
 } from '../engine/content.js';
+import '../components/issue-files.js';
 
 /** One editable article block: a stable id plus its raw markdown source line(s).
  *  The rendered typography is derived from the raw text on every render, so the
@@ -399,6 +400,11 @@ export class ScreenEditor extends LitElement {
       font-size: 0.82rem;
       min-width: 0;
       overflow-wrap: anywhere;
+    }
+    .issue-files {
+      margin-top: var(--spacing-xl);
+      padding-top: var(--spacing-lg);
+      border-top: 1px solid var(--color-hairline);
     }
 
     .sheet-form {
@@ -876,6 +882,9 @@ export class ScreenEditor extends LitElement {
   }
 
   private renderProps(): TemplateResult {
+    // Topic/rubric are blog-article taxonomy; a journal issue has neither, so
+    // those fields (and the required-topic gate) are hidden when editing one.
+    const isArticle = this.collection !== 'magazine';
     return html`
       <cp-sheet
         ?open=${this.propsOpen}
@@ -883,28 +892,32 @@ export class ScreenEditor extends LitElement {
         @cp-close=${this.closeProps}
       >
         <div class="sheet-form">
-          ${this.incomplete
+          ${isArticle && this.incomplete
             ? html`<cp-tag tone="warning">заполните обязательное поле «Тема»</cp-tag>`
             : nothing}
-          <cp-select
-            label="Тема"
-            required
-            .value=${this.topic}
-            .options=${TOPIC_OPTIONS}
-            @cp-change=${this.onTopicChange}
-          ></cp-select>
+          ${isArticle
+            ? html`<cp-select
+                label="Тема"
+                required
+                .value=${this.topic}
+                .options=${TOPIC_OPTIONS}
+                @cp-change=${this.onTopicChange}
+              ></cp-select>`
+            : nothing}
           <cp-textarea
             label="Описание"
             rows="3"
             .value=${this.description}
             @cp-change=${this.onDescriptionChange}
           ></cp-textarea>
-          <cp-select
-            label="Рубрика"
-            .value=${this.rubric}
-            .options=${RUBRIC_OPTIONS}
-            @cp-change=${this.onRubricChange}
-          ></cp-select>
+          ${isArticle
+            ? html`<cp-select
+                label="Рубрика"
+                .value=${this.rubric}
+                .options=${RUBRIC_OPTIONS}
+                @cp-change=${this.onRubricChange}
+              ></cp-select>`
+            : nothing}
           <cp-date-input
             label="Дата публикации"
             type="date"
@@ -1020,6 +1033,11 @@ export class ScreenEditor extends LitElement {
           <span aria-hidden="true">·</span>
           <span class="path">${this.articlePath}</span>
         </p>
+        ${this.collection === 'magazine' && this.slug !== ''
+          ? html`<div class="issue-files">
+              <issue-files .dir=${`magazine/${this.slug}/assets`}></issue-files>
+            </div>`
+          : nothing}
       </article>
       ${this.renderProps()}${this.renderPublishDialog()}
     `;


### PR DESCRIPTION
По юзкейсам файлов журнала (прошёл сам, проверил end-to-end):

**Было (пробелы):** посмотреть загруженные файлы номера негде; загрузка только PDF+PNG (fb2/док/произвольный — нельзя); удаления нет; в свойствах номера показывалась чужая «Тема».

**Стало:**
- Панель **«Файлы номера»** в редакторе номера: список файлов из magazine/<slug>/assets через GitHub API; загрузка **любого** файла (pdf, fb2, док, картинки) одним PUT Contents API; удаление файла (2-шаговое подтверждение) через DELETE. Всё API, без клона.
- content.ts: listDirViaApi / uploadBinaryViaApi / deleteFileViaApi.
- «Тема» и «Рубрика» (и required-гейт) скрыты для номера — это таксономия статей.

**Проверено вживую на dev-admin end-to-end:** открыл номер → 14 файлов в списке; загрузил admin-upload-test.fb2 → появился (14→15); удалил → пропал (15→14), dev-контент чист; свойства номера — только Описание/Дата/Опубликовано, без «Тема». 126 тестов + validate зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)