### PR TITLE
redesign: issue files — type pictograms + filter to the open language

### DIFF
--- a/src/redesign/components/issue-files.logic.test.ts
+++ b/src/redesign/components/issue-files.logic.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { iconFor, fileLang } from './issue-files.ts';
+
+describe('issue-files type icons', () => {
+  it('maps extensions to pictograms', () => {
+    expect(iconFor('cover.ru.png')).toBe('image');
+    expect(iconFor('shot.JPEG')).toBe('image');
+    expect(iconFor('nomer-1.ru.fb2')).toBe('book');
+    expect(iconFor('book.epub')).toBe('book');
+    expect(iconFor('nomer-1.ru.pdf')).toBe('file-text');
+    expect(iconFor('notes.txt')).toBe('file-generic');
+  });
+});
+
+describe('issue-files language detection', () => {
+  const langs = new Set(['en', 'es', 'it', 'ru', 'uk']);
+
+  it('reads a known-language suffix', () => {
+    expect(fileLang('cover.ru.png', langs)).toBe('ru');
+    expect(fileLang('magazine-1-mai-2026.en.fb2', langs)).toBe('en');
+  });
+
+  it('treats a no-suffix / unknown-token file as shared (undefined)', () => {
+    expect(fileLang('cover.png', langs)).toBeUndefined(); // no lang segment
+    expect(fileLang('Magazine1 (3).pdf', langs)).toBeUndefined();
+    expect(fileLang('cover.xx.png', langs)).toBeUndefined(); // xx not a known lang
+  });
+});

--- a/src/redesign/components/issue-files.ts
+++ b/src/redesign/components/issue-files.ts
@@ -28,6 +28,26 @@ const humanSize = (bytes: number): string =>
       ? `${(bytes / 1024).toFixed(0)} КБ`
       : `${(bytes / (1024 * 1024)).toFixed(1)} МБ`;
 
+const IMAGE_EXT = new Set(['png', 'jpg', 'jpeg', 'webp', 'gif', 'svg', 'avif']);
+
+/** A type pictogram for a filename by its extension. */
+export const iconFor = (name: string): string => {
+  const ext = name.split('.').pop()?.toLowerCase() ?? '';
+  if (IMAGE_EXT.has(ext)) return 'image';
+  if (ext === 'fb2' || ext === 'epub') return 'book';
+  if (ext === 'pdf') return 'file-text';
+  return 'file-generic';
+};
+
+/** The language a file belongs to (`cover.ru.png` → `ru`), or undefined when it
+ *  carries no known-language suffix (`cover.png` is shared across languages). */
+export const fileLang = (name: string, langs: ReadonlySet<string>): string | undefined => {
+  const parts = name.split('.');
+  if (parts.length < 3) return undefined;
+  const candidate = parts[parts.length - 2];
+  return langs.has(candidate) ? candidate : undefined;
+};
+
 /**
  * Files of one content directory (a magazine issue's `assets/`), managed
  * entirely through the GitHub Contents API — no clone. Lists what is uploaded,
@@ -40,9 +60,29 @@ export class IssueFiles extends LitElement {
     :host {
       display: block;
     }
+    .fhead {
+      display: flex;
+      align-items: baseline;
+      flex-wrap: wrap;
+      gap: 0.5rem var(--spacing-md);
+      margin: 0 0 var(--spacing-sm);
+    }
     h2 {
       font-size: 1.1rem;
-      margin: 0 0 var(--spacing-sm);
+      margin: 0;
+    }
+    .link {
+      border: none;
+      background: transparent;
+      color: var(--color-accent);
+      font: inherit;
+      font-size: 0.82rem;
+      cursor: pointer;
+      padding: 0;
+    }
+    .ficon {
+      flex: none;
+      color: var(--color-text-secondary);
     }
     ul {
       list-style: none;
@@ -113,6 +153,15 @@ export class IssueFiles extends LitElement {
   /** The repo directory whose files are managed, e.g. `magazine/<slug>/assets`. */
   @property() dir = '';
 
+  /** The language currently open in the editor — filters the list to it. */
+  @property() lang = '';
+
+  /** All languages the item exists in — used to detect a file's language suffix. */
+  @property({ attribute: false }) langs: readonly string[] = [];
+
+  /** When true, show files of every language, not just the open one. */
+  @state() private showAll = false;
+
   @state() private files: readonly RepoFile[] = [];
   @state() private loading = false;
   @state() private busy = false;
@@ -172,10 +221,21 @@ export class IssueFiles extends LitElement {
     }
   };
 
+  /** Files shown for the open language plus the shared (no-suffix) ones. */
+  private get visibleFiles(): readonly RepoFile[] {
+    if (this.showAll || this.lang === '') return this.files;
+    const set = new Set(this.langs);
+    return this.files.filter((f) => {
+      const fl = fileLang(f.name, set);
+      return fl === undefined || fl === this.lang;
+    });
+  }
+
   private renderFile(file: RepoFile): TemplateResult {
     const confirming = this.confirmingPath === file.path;
     return html`
       <li>
+        <cp-icon class="ficon" name=${iconFor(file.name)} size="18"></cp-icon>
         <span class="name">${file.name}</span>
         <span class="size">${humanSize(file.size)}</span>
         <span class="spacer"></span>
@@ -201,14 +261,31 @@ export class IssueFiles extends LitElement {
   }
 
   override render(): TemplateResult {
+    const visible = this.visibleFiles;
+    const hidden = this.files.length - visible.length;
     return html`
-      <h2>Файлы номера</h2>
+      <div class="fhead">
+        <h2>Файлы номера</h2>
+        ${!this.showAll && hidden > 0
+          ? html`<button class="link" @click=${() => (this.showAll = true)}>
+              показать все языки (+${hidden})
+            </button>`
+          : this.showAll && this.lang !== ''
+            ? html`<button class="link" @click=${() => (this.showAll = false)}>
+                только «${this.lang}»
+              </button>`
+            : nothing}
+      </div>
       ${this.loading
         ? html`<p class="msg">Загружаем список файлов…</p>`
-        : this.files.length === 0
-          ? html`<p class="empty">Файлов пока нет.</p>`
+        : visible.length === 0
+          ? html`<p class="empty">
+              ${this.files.length === 0
+                ? 'Файлов пока нет.'
+                : `Для языка «${this.lang}» файлов нет (есть у других языков).`}
+            </p>`
           : html`<ul>
-              ${this.files.map((f) => this.renderFile(f))}
+              ${visible.map((f) => this.renderFile(f))}
             </ul>`}
       ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
       ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -1035,7 +1035,11 @@ export class ScreenEditor extends LitElement {
         </p>
         ${this.collection === 'magazine' && this.slug !== ''
           ? html`<div class="issue-files">
-              <issue-files .dir=${`magazine/${this.slug}/assets`}></issue-files>
+              <issue-files
+                .dir=${`magazine/${this.slug}/assets`}
+                .lang=${this.activeLang}
+                .langs=${this.availableLangs}
+              ></issue-files>
             </div>`
           : nothing}
       </article>

--- a/vendor/cp-components/dist/icons/registry.d.ts
+++ b/vendor/cp-components/dist/icons/registry.d.ts
@@ -31,6 +31,8 @@ export declare const icons: {
     readonly mail: "<rect x=\"3\" y=\"5\" width=\"18\" height=\"14\" rx=\"2\" /><path d=\"M3.5 7l8.5 6 8.5-6\" />";
     readonly rocket: "<path d=\"M12 2.5c2.4 2 3.8 4.8 3.8 7.7v3.3l-1.8 1.8h-4l-1.8-1.8V10.2C8.2 7.3 9.6 4.5 12 2.5z\" /><circle cx=\"12\" cy=\"9\" r=\"1.3\" /><path d=\"M8.2 15.3l-2.2 3.7 3.7-2.2M15.8 15.3l2.2 3.7-3.7-2.2\" />";
     readonly settings: "<path d=\"M4 7h9M17 7h3M4 12h3M11 12h9M4 17h13M21 17h-1\" /><circle cx=\"15\" cy=\"7\" r=\"2.2\" /><circle cx=\"9\" cy=\"12\" r=\"2.2\" /><circle cx=\"19\" cy=\"17\" r=\"2.2\" />";
+    readonly image: "<rect x=\"3\" y=\"3\" width=\"18\" height=\"18\" rx=\"2\" /><circle cx=\"8.5\" cy=\"8.5\" r=\"1.6\" /><path d=\"M21 15l-5-5L5 21\" />";
+    readonly 'file-generic': "<path d=\"M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z\" /><path d=\"M14 3v5h5\" />";
 };
 /** A registered icon name. */
 export type IconName = keyof typeof icons;

--- a/vendor/cp-components/dist/icons/registry.js
+++ b/vendor/cp-components/dist/icons/registry.js
@@ -31,5 +31,7 @@ export const icons = {
     mail: '<rect x="3" y="5" width="18" height="14" rx="2" /><path d="M3.5 7l8.5 6 8.5-6" />',
     rocket: '<path d="M12 2.5c2.4 2 3.8 4.8 3.8 7.7v3.3l-1.8 1.8h-4l-1.8-1.8V10.2C8.2 7.3 9.6 4.5 12 2.5z" /><circle cx="12" cy="9" r="1.3" /><path d="M8.2 15.3l-2.2 3.7 3.7-2.2M15.8 15.3l2.2 3.7-3.7-2.2" />',
     settings: '<path d="M4 7h9M17 7h3M4 12h3M11 12h9M4 17h13M21 17h-1" /><circle cx="15" cy="7" r="2.2" /><circle cx="9" cy="12" r="2.2" /><circle cx="19" cy="17" r="2.2" />',
+    image: '<rect x="3" y="3" width="18" height="18" rx="2" /><circle cx="8.5" cy="8.5" r="1.6" /><path d="M21 15l-5-5L5 21" />',
+    'file-generic': '<path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z" /><path d="M14 3v5h5" />',
 };
 //# sourceMappingURL=registry.js.map


### PR DESCRIPTION
По просьбе: отображать вложения номера с пиктограммами и только по открытому языку.

- **Пиктограммы** по типу: image (png/jpg…), book (fb2/epub), file-text (pdf), generic. Новые иконки image/file-generic в реестре.
- **Фильтр по языку**: показываются файлы текущего языка редактора + общие (без языкового суффикса). Правишь ru → видишь cover.ru.png, <slug>.ru.pdf, <slug>.ru.fb2 и cover.png; en/es/it скрыты. Переключатель «показать все языки (+N)» ↔ «только «<lang>»».

Проверено на dev-admin: язык ru → 5 файлов из 14 (en/es/it скрыты), иконки image/book/file-text; тоггл раскрывает 14 и обратно. 129 тестов + validate зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)