### PR TITLE
redesign: no warning icon for journal issues; newest-first sort everywhere (+tests)

### DIFF
--- a/src/redesign/engine/github-api.test.ts
+++ b/src/redesign/engine/github-api.test.ts
@@ -33,6 +33,13 @@ describe('listTickets', () => {
     expect(urls[0]).not.toContain('admin-website');
   });
 
+  it('requests tickets newest-first (sort=created desc)', async () => {
+    const urls = stubFetch([]);
+    await listTickets();
+    expect(urls[0]).toContain('sort=created');
+    expect(urls[0]).toContain('direction=desc');
+  });
+
   it('surfaces real issues but excludes pull requests', async () => {
     stubFetch([
       {

--- a/src/redesign/engine/github-api.ts
+++ b/src/redesign/engine/github-api.ts
@@ -134,7 +134,10 @@ const toTicket = (x: unknown): Ticket | undefined => {
 /** Lists a repo's issues (default: the `tickets` repo) as tickets; PRs are
  * excluded so a code repo's pull requests never masquerade as tickets. */
 export const listTickets = async (repo = 'tickets'): Promise<readonly Ticket[]> => {
-  const data = await get(`/repos/${OWNER}/${repo}/issues?state=all&per_page=50`);
+  // Newest first, explicitly (not relying on the API default), like every list.
+  const data = await get(
+    `/repos/${OWNER}/${repo}/issues?state=all&sort=created&direction=desc&per_page=50`,
+  );
   return Array.isArray(data) ? data.map(toTicket).filter((t): t is Ticket => t !== undefined) : [];
 };
 

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -686,7 +686,9 @@ export class ScreenEditor extends LitElement {
 
   /** A required frontmatter field is empty. */
   private get incomplete(): boolean {
-    return this.topic === '';
+    // A journal issue has no topic, so it is never "incomplete" for that reason
+    // (this was still flagging the warning icon on the props button for issues).
+    return this.collection !== 'magazine' && this.topic === '';
   }
 
   private onLangChange = (event: Event): void => {

--- a/src/redesign/screens/screen-magazine.ts
+++ b/src/redesign/screens/screen-magazine.ts
@@ -17,6 +17,7 @@ import '../components/engine-loading.js';
 interface IssueFolder {
   readonly slug: string;
   readonly title: string;
+  readonly date: string;
 }
 
 /** The publish pipeline state surfaced in the result dialog. */
@@ -207,11 +208,15 @@ export class ScreenMagazine extends LitElement {
     const issues = await Promise.all(
       slugs.map(async (slug) => {
         const md = (await readFile(`magazine/${slug}/index.ru.md`)) ?? '';
-        const title = md.match(/^title:\s*(.+)$/m)?.[1]?.replace(/^["']|["']$/g, '') ?? slug;
-        return { slug: slug as string, title };
+        const fm = (key: string): string =>
+          md.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'))?.[1]?.replace(/^["']|["']$/g, '') ?? '';
+        const title = fm('title') || slug;
+        const date = fm('publishDate') || fm('pubDate') || fm('date');
+        return { slug: slug as string, title, date };
       }),
     );
-    this.issues = issues;
+    // Newest issue first (undated last), like every other content list.
+    this.issues = [...issues].sort((a, b) => (b.date || '0000').localeCompare(a.date || '0000'));
     this.articles = await listArticles();
     this.loaded = true;
   }


### PR DESCRIPTION
#3: убрал ⚠ в «Свойства» для номера журнала (у номера нет «Темы», required-гейт к нему не применяется). #4: журнальный список и тикеты сортируются новые→старые (журнал по publishDate/pubDate/date; тикеты sort=created desc явно), + тесты. 130 тестов + validate зелёные.