### PR TITLE
redesign: structured, typed magazine issue page (no more flat file dump)

### DIFF
--- a/src/redesign/components/issue-files.logic.test.ts
+++ b/src/redesign/components/issue-files.logic.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { iconFor, fileLang, classifyUpload, plannedAssetPaths } from './issue-files.ts';
+import {
+  iconFor,
+  fileLang,
+  classifyUpload,
+  plannedAssetPaths,
+  classifyIssueAssets,
+} from './issue-files.ts';
+
+const file = (name: string, size = 100): { name: string; path: string; size: number; sha: string } => ({
+  name,
+  path: `magazine/nomer-2/assets/${name}`,
+  size,
+  sha: name,
+});
 
 describe('issue-files type icons', () => {
   it('maps extensions to pictograms', () => {
@@ -59,5 +72,46 @@ describe('issue-files planned asset paths', () => {
 
   it('a rejected upload plans no writes', () => {
     expect(plannedAssetPaths(dir, 'nomer-2', 'ru', 'reject')).toEqual([]);
+  });
+});
+
+describe('issue-files typed asset slots (structured, not a flat dump)', () => {
+  const slug = 'nomer-2';
+  const full = [
+    file('nomer-2.ru.pdf'),
+    file('nomer-2.ru.fb2'),
+    file('cover.ru.png'),
+    file('cover.png'),
+    file('nomer-2.en.pdf'),
+    file('cover.en.png'),
+    file('Magazine1 (3).pdf'), // stray leftover
+  ];
+
+  it('sorts the flat directory into the open language\'s typed slots', () => {
+    const a = classifyIssueAssets(full, slug, 'ru');
+    expect(a.pdf?.name).toBe('nomer-2.ru.pdf');
+    expect(a.fb2?.name).toBe('nomer-2.ru.fb2');
+    expect(a.cover?.name).toBe('cover.ru.png');
+    expect(a.coverShared).toBe(false);
+  });
+
+  it('falls back to the shared cover.png when a language has none', () => {
+    const a = classifyIssueAssets([file('cover.png'), file('nomer-2.es.fb2')], slug, 'es');
+    expect(a.cover?.name).toBe('cover.png');
+    expect(a.coverShared).toBe(true);
+    expect(a.pdf).toBeUndefined();
+    expect(a.fb2?.name).toBe('nomer-2.es.fb2');
+  });
+
+  it('reports empty slots when the language has no assets yet', () => {
+    const a = classifyIssueAssets([file('cover.en.png')], slug, 'ru');
+    expect(a.pdf).toBeUndefined();
+    expect(a.fb2).toBeUndefined();
+    expect(a.cover).toBeUndefined();
+  });
+
+  it('lists only genuinely stray files for cleanup (typed assets of any lang are not stray)', () => {
+    const names = classifyIssueAssets(full, slug, 'ru').other.map((f) => f.name);
+    expect(names).toEqual(['Magazine1 (3).pdf']);
   });
 });

--- a/src/redesign/components/issue-files.ts
+++ b/src/redesign/components/issue-files.ts
@@ -5,6 +5,7 @@ import {
   listDirViaApi,
   uploadBinaryViaApi,
   deleteFileViaApi,
+  rawContentUrl,
   type RepoFile,
 } from '../engine/content.js';
 
@@ -75,14 +76,57 @@ export const plannedAssetPaths = (
       ? [`${dir}/${slug}.${lang}.pdf`, `${dir}/cover.${lang}.png`]
       : [];
 
+/** The three typed slots of a magazine issue in one language, plus stray files. */
+export interface IssueAssets {
+  /** The per-language cover, or the shared `cover.png` fallback. */
+  readonly cover?: RepoFile;
+  /** True when only the shared `cover.png` exists (no per-language cover yet). */
+  readonly coverShared: boolean;
+  /** The newspaper PDF for this language. */
+  readonly pdf?: RepoFile;
+  /** The derived FB2 ebook for this language. */
+  readonly fb2?: RepoFile;
+  /** Anything that fits none of the typed slots of any language — for cleanup. */
+  readonly other: readonly RepoFile[];
+}
+
+/** Whether a filename is a recognised typed asset of some language (cover / pdf /
+ *  fb2), so the cleanup list can show only genuinely stray files. */
+const isTyped = (name: string, slug: string): boolean =>
+  name === 'cover.png' ||
+  /^cover\.[a-z]{2}\.png$/.test(name) ||
+  (name.startsWith(`${slug}.`) && (name.endsWith('.pdf') || name.endsWith('.fb2')));
+
+/** Sorts the flat assets directory into the issue's typed slots for one language. */
+export const classifyIssueAssets = (
+  files: readonly RepoFile[],
+  slug: string,
+  lang: string,
+): IssueAssets => {
+  const byName = (n: string): RepoFile | undefined => files.find((f) => f.name === n);
+  const pdf = byName(`${slug}.${lang}.pdf`);
+  const fb2 = byName(`${slug}.${lang}.fb2`);
+  const coverLang = byName(`cover.${lang}.png`);
+  const coverShared = byName('cover.png');
+  const other = files.filter((f) => !isTyped(f.name, slug));
+  return {
+    cover: coverLang ?? coverShared,
+    coverShared: coverLang === undefined && coverShared !== undefined,
+    pdf,
+    fb2,
+    other,
+  };
+};
+
 /**
- * The purpose-built file panel for one magazine issue's `assets/`, managed
- * entirely through the GitHub Contents API — no clone. It lists the issue's
- * files and accepts exactly ONE kind of upload: the newspaper itself, as PDF
- * or DOCX. A DOCX is converted client-side to FB2 (the docx is never
- * persisted); a PDF is stored and its first page is rendered into the cover.
- * Everything else (re-upload, manual delete of any derived asset) is the
- * customisation layer on top of that single use case.
+ * The purpose-built assets panel for one magazine issue's `assets/`, managed
+ * entirely through the GitHub Contents API — no clone. Instead of a flat file
+ * dump it presents the issue's three typed slots for the open language —
+ * **Обложка**, and the **Файл номера** (PDF + derived FB2) — with a single
+ * upload that accepts ONLY the newspaper as PDF or DOCX:
+ * - DOCX → converted client-side to FB2 (the docx is never persisted);
+ * - PDF → stored, and its first page is rendered into the cover.
+ * A collapsed cleanup list handles any stray leftovers.
  */
 @customElement('issue-files')
 export class IssueFiles extends LitElement {
@@ -90,112 +134,159 @@ export class IssueFiles extends LitElement {
     :host {
       display: block;
     }
-    .fhead {
-      display: flex;
-      align-items: baseline;
-      flex-wrap: wrap;
-      gap: 0.5rem var(--spacing-md);
-      margin: 0 0 var(--spacing-sm);
-    }
     h2 {
       font-size: 1.1rem;
+      margin: 0 0 var(--spacing-md);
+    }
+    .slots {
+      display: grid;
+      gap: var(--spacing-md);
+    }
+    section.slot {
+      border: 1px solid var(--color-hairline);
+      border-radius: var(--radius-md, 10px);
+      padding: var(--spacing-md);
+      display: grid;
+      gap: var(--spacing-sm);
+    }
+    .slot-head {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+    }
+    .slot-head h3 {
+      font-size: 0.95rem;
       margin: 0;
     }
-    .link {
-      border: none;
-      background: transparent;
-      color: var(--color-accent);
-      font: inherit;
-      font-size: 0.82rem;
-      cursor: pointer;
-      padding: 0;
+    .slot-head .spacer {
+      flex: 1;
     }
-    .ficon {
-      flex: none;
+    .cover-preview {
+      display: block;
+      max-width: 160px;
+      width: 100%;
+      height: auto;
+      border-radius: var(--radius-sm, 6px);
+      border: 1px solid var(--color-hairline);
+      background: var(--color-surface-sunken, rgba(0, 0, 0, 0.04));
+    }
+    .cover-none {
+      display: grid;
+      place-items: center;
+      width: 160px;
+      height: 110px;
+      border: 1px dashed var(--color-hairline);
+      border-radius: var(--radius-sm, 6px);
       color: var(--color-text-secondary);
+      font-size: 0.82rem;
     }
-    ul {
+    ul.rows {
       list-style: none;
-      margin: 0 0 var(--spacing-md);
+      margin: 0;
       padding: 0;
       display: grid;
       gap: var(--spacing-xs);
     }
-    li {
+    ul.rows li {
       display: flex;
       align-items: center;
       flex-wrap: wrap;
       gap: 0.5rem var(--spacing-sm);
-      padding: var(--spacing-sm) 0;
-      border-top: 1px solid var(--color-hairline);
     }
-    li:first-child {
-      border-top: none;
+    .kind {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--color-text-secondary);
+      min-width: 2.6rem;
     }
     .name {
       font-family: var(--font-mono);
-      font-size: 0.9rem;
+      font-size: 0.86rem;
       overflow-wrap: anywhere;
       min-width: 0;
     }
     .size {
-      font-size: 0.78rem;
+      font-size: 0.76rem;
       color: var(--color-text-secondary);
       font-variant-numeric: tabular-nums;
     }
     .spacer {
       flex: 1;
     }
-    a.dl {
+    a.open {
       color: var(--color-accent);
       text-decoration: none;
-      font-size: 0.82rem;
+      font-size: 0.8rem;
+      white-space: nowrap;
     }
-    .empty,
+    .missing {
+      color: var(--color-text-secondary);
+      font-size: 0.84rem;
+    }
+    .upload {
+      display: grid;
+      gap: 0.35rem;
+      margin-top: var(--spacing-xs);
+    }
+    .upload > span {
+      font-size: 0.85rem;
+      color: var(--color-text-secondary);
+    }
+    input[type='file'] {
+      color: var(--color-text-secondary);
+      font: inherit;
+      font-size: 0.82rem;
+      max-width: 100%;
+    }
+    .hint {
+      font-size: 0.8rem;
+      color: var(--color-text-secondary);
+      margin: 0;
+    }
     .msg {
       color: var(--color-text-secondary);
-      font-size: 0.88rem;
+      font-size: 0.86rem;
       margin: 0.2rem 0;
     }
     .msg.error {
       color: var(--color-danger, #c0392b);
     }
-    .upload {
-      display: inline-flex;
-      align-items: center;
-      gap: var(--spacing-sm);
-      margin-top: var(--spacing-sm);
+    details.cleanup {
+      border-top: 1px solid var(--color-hairline);
+      padding-top: var(--spacing-sm);
     }
-    input[type='file'] {
-      color: var(--color-text-secondary);
-      font: inherit;
+    details.cleanup summary {
+      cursor: pointer;
       font-size: 0.85rem;
-      max-width: 100%;
+      color: var(--color-text-secondary);
+    }
+    details.cleanup li {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem var(--spacing-sm);
+      flex-wrap: wrap;
+      padding: var(--spacing-xs) 0;
     }
     .confirm {
       display: inline-flex;
       gap: 0.35rem;
       align-items: center;
-      font-size: 0.8rem;
     }
   `;
 
   /** The repo directory whose files are managed, e.g. `magazine/<slug>/assets`. */
   @property() dir = '';
 
-  /** The language currently open in the editor — filters the list to it. */
+  /** The language currently open in the editor — the slots are per-language. */
   @property() lang = '';
 
-  /** All languages the item exists in — used to detect a file's language suffix. */
+  /** All languages the item exists in (reserved for cross-language hints). */
   @property({ attribute: false }) langs: readonly string[] = [];
 
   /** Issue slug + title + description — baked into the derived fb2 / asset names. */
   @property() slug = '';
   @property() title = '';
   @property() desc = '';
-
-  /** When true, show files of every language, not just the open one. */
-  @state() private showAll = false;
 
   @state() private files: readonly RepoFile[] = [];
   @state() private loading = false;
@@ -230,12 +321,12 @@ export class IssueFiles extends LitElement {
   }
 
   /**
-   * The purpose-built issue upload: ONLY the newspaper PDF or DOCX.
-   * - DOCX → converted client-side to FB2 (the docx itself is never persisted)
-   *   and uploaded as `<slug>.<lang>.fb2`.
-   * - PDF → uploaded as `<slug>.<lang>.pdf`, and its first page is rendered and
-   *   uploaded as `cover.<lang>.png`.
-   * The heavy converters (mammoth / mupdf-wasm) load lazily, only on use.
+   * The primary upload: ONLY the newspaper PDF or DOCX.
+   * - DOCX → converted client-side to FB2 (`docxFileToFb2`); the docx is never
+   *   persisted, only `<slug>.<lang>.fb2` is committed.
+   * - PDF → committed as `<slug>.<lang>.pdf`, and its first page is rendered
+   *   (`extractPdfCover`) and committed as `cover.<lang>.png`.
+   * Both converters load lazily so mammoth/mupdf stay out of the initial bundle.
    */
   private readonly onPick = async (event: Event): Promise<void> => {
     const input = event.target;
@@ -277,6 +368,35 @@ export class IssueFiles extends LitElement {
     }
   };
 
+  /** Replaces just the cover for the open language with a picked image. */
+  private readonly onPickCover = async (event: Event): Promise<void> => {
+    const input = event.target;
+    const file = input instanceof HTMLInputElement ? input.files?.[0] : undefined;
+    if (input instanceof HTMLInputElement) input.value = '';
+    if (file === undefined) return;
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+    if (!IMAGE_EXT.has(ext)) {
+      this.error = 'Обложка — это изображение (png, jpg, webp…).';
+      return;
+    }
+    this.busy = true;
+    this.message = '';
+    this.error = '';
+    try {
+      await this.commit(
+        `${this.dir}/cover.${this.lang}.png`,
+        file,
+        `assets: cover ${this.slug}.${this.lang}`,
+      );
+      this.message = `Обложка обновлена: cover.${this.lang}.png`;
+      await this.load();
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.busy = false;
+    }
+  };
+
   private readonly removeFile = async (file: RepoFile): Promise<void> => {
     this.confirmingPath = '';
     this.busy = true;
@@ -292,77 +412,72 @@ export class IssueFiles extends LitElement {
     }
   };
 
-  /** Files shown for the open language plus the shared (no-suffix) ones. */
-  private get visibleFiles(): readonly RepoFile[] {
-    if (this.showAll || this.lang === '') return this.files;
-    const set = new Set(this.langs);
-    return this.files.filter((f) => {
-      const fl = fileLang(f.name, set);
-      return fl === undefined || fl === this.lang;
-    });
-  }
-
-  private renderFile(file: RepoFile): TemplateResult {
-    const confirming = this.confirmingPath === file.path;
+  private renderFileRow(kind: string, file: RepoFile | undefined): TemplateResult {
     return html`
       <li>
-        <cp-icon class="ficon" name=${iconFor(file.name)} size="18"></cp-icon>
-        <span class="name">${file.name}</span>
-        <span class="size">${humanSize(file.size)}</span>
-        <span class="spacer"></span>
-        <a class="dl" href="https://github.com/communist-prometheus/public-website-content/raw/HEAD/${file.path}" target="_blank" rel="noopener">открыть ↗</a>
-        ${confirming
-          ? html`<span class="confirm">
-              <cp-button size="sm" variant="secondary" @cp-click=${() => (this.confirmingPath = '')}
-                >Отмена</cp-button
+        <span class="kind">${kind}</span>
+        ${file === undefined
+          ? html`<span class="missing">— не загружен</span>`
+          : html`
+              <cp-icon name=${iconFor(file.name)} size="16"></cp-icon>
+              <span class="name">${file.name}</span>
+              <span class="size">${humanSize(file.size)}</span>
+              <span class="spacer"></span>
+              <a class="open" href=${rawContentUrl(file.path)} target="_blank" rel="noopener"
+                >открыть ↗</a
               >
-              <cp-button size="sm" ?disabled=${this.busy} @cp-click=${() => void this.removeFile(file)}
-                >Удалить</cp-button
-              >
-            </span>`
-          : html`<cp-button
-              size="sm"
-              variant="ghost"
-              ?disabled=${this.busy}
-              @cp-click=${() => (this.confirmingPath = file.path)}
-              >Удалить</cp-button
-            >`}
+            `}
       </li>
     `;
   }
 
-  override render(): TemplateResult {
-    const visible = this.visibleFiles;
-    const hidden = this.files.length - visible.length;
+  private renderCover(assets: IssueAssets): TemplateResult {
     return html`
-      <div class="fhead">
-        <h2>Файлы номера</h2>
-        ${!this.showAll && hidden > 0
-          ? html`<button class="link" @click=${() => (this.showAll = true)}>
-              показать все языки (+${hidden})
-            </button>`
-          : this.showAll && this.lang !== ''
-            ? html`<button class="link" @click=${() => (this.showAll = false)}>
-                только «${this.lang}»
-              </button>`
-            : nothing}
-      </div>
-      ${this.loading
-        ? html`<p class="msg">Загружаем список файлов…</p>`
-        : visible.length === 0
-          ? html`<p class="empty">
-              ${this.files.length === 0
-                ? 'Файлов пока нет.'
-                : `Для языка «${this.lang}» файлов нет (есть у других языков).`}
-            </p>`
-          : html`<ul>
-              ${visible.map((f) => this.renderFile(f))}
-            </ul>`}
-      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
-      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
-      <div class="upload">
-        <label>
-          ${this.busy ? 'Обрабатываем файл газеты…' : 'Загрузить файл газеты (PDF или DOCX):'}
+      <section class="slot">
+        <div class="slot-head">
+          <h3>Обложка</h3>
+          <span class="spacer"></span>
+          ${assets.cover === undefined
+            ? html`<cp-tag tone="warning">нет</cp-tag>`
+            : assets.coverShared
+              ? html`<cp-tag>общая</cp-tag>`
+              : html`<cp-tag tone="success">есть</cp-tag>`}
+        </div>
+        ${assets.cover === undefined
+          ? html`<div class="cover-none">нет обложки</div>`
+          : html`<img
+              class="cover-preview"
+              src=${rawContentUrl(assets.cover.path)}
+              alt="Обложка номера (${this.lang})"
+              loading="lazy"
+            />`}
+        <label class="upload">
+          <span>${this.busy ? 'Обрабатываем…' : 'Заменить обложку (изображение):'}</span>
+          <input type="file" accept="image/*" ?disabled=${this.busy} @change=${this.onPickCover} />
+        </label>
+      </section>
+    `;
+  }
+
+  private renderNewspaper(assets: IssueAssets): TemplateResult {
+    return html`
+      <section class="slot">
+        <div class="slot-head">
+          <h3>Файл номера</h3>
+          <span class="spacer"></span>
+          ${assets.pdf !== undefined || assets.fb2 !== undefined
+            ? html`<cp-tag tone="success">готов</cp-tag>`
+            : html`<cp-tag tone="warning">пусто</cp-tag>`}
+        </div>
+        <ul class="rows">
+          ${this.renderFileRow('PDF', assets.pdf)}${this.renderFileRow('FB2', assets.fb2)}
+        </ul>
+        <label class="upload">
+          <span
+            >${this.busy
+              ? 'Обрабатываем файл газеты…'
+              : 'Загрузить файл газеты (PDF или DOCX):'}</span
+          >
           <input
             type="file"
             accept="application/pdf,.pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -370,11 +485,63 @@ export class IssueFiles extends LitElement {
             @change=${this.onPick}
           />
         </label>
+        <p class="hint">
+          DOCX → автоматически конвертируется в FB2. PDF → загружается, обложка берётся из
+          первой страницы. Другие файлы не принимаются.
+        </p>
+      </section>
+    `;
+  }
+
+  private renderCleanup(other: readonly RepoFile[]): TemplateResult {
+    return html`
+      <details class="cleanup">
+        <summary>Прочие файлы (${other.length}) — очистка</summary>
+        <ul class="rows">
+          ${other.map((file) => {
+            const confirming = this.confirmingPath === file.path;
+            return html`<li>
+              <cp-icon name=${iconFor(file.name)} size="16"></cp-icon>
+              <span class="name">${file.name}</span>
+              <span class="size">${humanSize(file.size)}</span>
+              <span class="spacer"></span>
+              <a class="open" href=${rawContentUrl(file.path)} target="_blank" rel="noopener"
+                >открыть ↗</a
+              >
+              ${confirming
+                ? html`<span class="confirm">
+                    <cp-button size="sm" variant="secondary" @cp-click=${() => (this.confirmingPath = '')}
+                      >Отмена</cp-button
+                    >
+                    <cp-button size="sm" ?disabled=${this.busy} @cp-click=${() => void this.removeFile(file)}
+                      >Удалить</cp-button
+                    >
+                  </span>`
+                : html`<cp-button
+                    size="sm"
+                    variant="ghost"
+                    ?disabled=${this.busy}
+                    @cp-click=${() => (this.confirmingPath = file.path)}
+                    >Удалить</cp-button
+                  >`}
+            </li>`;
+          })}
+        </ul>
+      </details>
+    `;
+  }
+
+  override render(): TemplateResult {
+    if (this.loading) return html`<h2>Материалы номера</h2><p class="msg">Загружаем…</p>`;
+    const assets = classifyIssueAssets(this.files, this.slug, this.lang);
+    return html`
+      <h2>Материалы номера</h2>
+      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
+      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
+      <div class="slots">
+        ${this.renderCover(assets)}${this.renderNewspaper(assets)}
+        ${assets.other.length > 0 ? this.renderCleanup(assets.other) : nothing}
       </div>
-      <p class="msg">
-        DOCX → автоматически конвертируется в FB2. PDF → загружается и из первой страницы
-        извлекается обложка. Другие файлы не загружаются.
-      </p>
     `;
   }
 }

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -571,6 +571,16 @@ export const listArticlesViaApi = async (
 const REPO_BASE = 'https://api.github.com/repos/communist-prometheus/public-website-content';
 const contentBranch = (): string => import.meta.env.VITE_GITHUB_BRANCH ?? 'develop';
 
+/**
+ * A browser-loadable raw URL for a content file on the current branch. The repo
+ * is public, so `<img src>` / download links work without an auth header. The
+ * path segments are encoded so spaces and Cyrillic filenames resolve.
+ */
+export const rawContentUrl = (path: string): string => {
+  const encoded = path.split('/').map(encodeURIComponent).join('/');
+  return `https://raw.githubusercontent.com/communist-prometheus/public-website-content/${contentBranch()}/${encoded}`;
+};
+
 /** UTF-8 → base64 (btoa is latin1-only; article bodies are Cyrillic). */
 const toBase64 = (text: string): string => {
   const bytes = new TextEncoder().encode(text);

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -435,10 +435,8 @@ export class ScreenEditor extends LitElement {
       min-width: 0;
       overflow-wrap: anywhere;
     }
-    .issue-files {
-      margin-top: var(--spacing-xl);
-      padding-top: var(--spacing-lg);
-      border-top: 1px solid var(--color-hairline);
+    .issue-panel {
+      margin-top: var(--spacing-lg);
       display: grid;
       gap: var(--spacing-xl);
     }
@@ -1012,6 +1010,28 @@ export class ScreenEditor extends LitElement {
     `;
   }
 
+  /**
+   * The primary body of a magazine issue: the structured, typed assets panel
+   * (cover + newspaper file + derived fb2) and the article-linking panel. A
+   * journal issue's `index.<lang>.md` carries no prose body, so it shows no
+   * markdown editor — the issue is assembled from its file, cover and articles.
+   */
+  private renderMagazineBody(): TemplateResult {
+    return html`
+      <div class="issue-panel">
+        <issue-files
+          .dir=${`magazine/${this.slug}/assets`}
+          .slug=${this.slug}
+          .title=${this.articleTitle}
+          .desc=${this.description}
+          .lang=${this.activeLang}
+          .langs=${this.availableLangs}
+        ></issue-files>
+        <issue-articles .issueSlug=${this.slug} .lang=${this.activeLang}></issue-articles>
+      </div>
+    `;
+  }
+
   private renderProps(): TemplateResult {
     // Topic/rubric are blog-article taxonomy; a journal issue has neither, so
     // those fields (and the required-topic gate) are hidden when editing one.
@@ -1153,18 +1173,22 @@ export class ScreenEditor extends LitElement {
             : nothing}
         </div>
         ${this.renderAddLangDialog()}
-        ${this.renderToolbar()}
-        <cp-markdown-editor
-          class="live"
-          .value=${this.body}
-          placeholder="Текст статьи в Markdown…"
-          @cp-change=${this.onBodyChange}
-        ></cp-markdown-editor>
-        <p class="hint">
-          Живой предпросмотр: форматирование отрендерено сразу, а разметку
-          <span class="kbd">#</span> <span class="kbd">**</span>
-          <span class="kbd">&gt;</span> видно только на строке с курсором.
-        </p>
+        ${this.collection === 'magazine'
+          ? this.renderMagazineBody()
+          : html`
+              ${this.renderToolbar()}
+              <cp-markdown-editor
+                class="live"
+                .value=${this.body}
+                placeholder="Текст статьи в Markdown…"
+                @cp-change=${this.onBodyChange}
+              ></cp-markdown-editor>
+              <p class="hint">
+                Живой предпросмотр: форматирование отрендерено сразу, а разметку
+                <span class="kbd">#</span> <span class="kbd">**</span>
+                <span class="kbd">&gt;</span> видно только на строке с курсором.
+              </p>
+            `}
         <p class="save-note">
           ${this.dirty
             ? html`<cp-icon name="warning" size="16"></cp-icon>
@@ -1175,22 +1199,6 @@ export class ScreenEditor extends LitElement {
           <span aria-hidden="true">·</span>
           <span class="path">${this.articlePath}</span>
         </p>
-        ${this.collection === 'magazine' && this.slug !== ''
-          ? html`<div class="issue-files">
-              <issue-files
-                .dir=${`magazine/${this.slug}/assets`}
-                .slug=${this.slug}
-                .title=${this.articleTitle}
-                .desc=${this.description}
-                .lang=${this.activeLang}
-                .langs=${this.availableLangs}
-              ></issue-files>
-              <issue-articles
-                .issueSlug=${this.slug}
-                .lang=${this.activeLang}
-              ></issue-articles>
-            </div>`
-          : nothing}
       </article>
       ${this.renderProps()}${this.renderPublishDialog()}
     `;


### PR DESCRIPTION
Follow-up to #422 addressing the editor's real objection: the magazine issue
page was still a **flat file dump** (`cover.png`, `cover.ru.png`, the docx, the
fb2 — each with its own Delete), not the **structured, section-divided** page
that was asked for.

**What changed**
- `classifyIssueAssets()` sorts the flat `assets/` directory into the issue's
  three **typed slots** for the open language:
  - **Обложка** — `cover.<lang>.png` (falls back to the shared `cover.png`),
    shown as a real image preview + a "replace cover" image upload.
  - **Файл номера** — the **PDF** (`<slug>.<lang>.pdf`) and the derived **FB2**
    (`<slug>.<lang>.fb2`), each with present/absent status; the single
    PDF/DOCX upload (docx→fb2, pdf→pdf+cover) lives here.
- Genuinely stray leftovers collapse into a **«Прочие файлы — очистка»**
  `<details>` instead of cluttering the page.
- A magazine issue's `index.<lang>.md` has no prose body, so the **markdown
  editor + toolbar are hidden** for issues — the structured assets panel and the
  article-linking panel are the primary body. Blog articles are unchanged.
- `rawContentUrl()` gives browser-loadable raw URLs (public repo) for the cover
  `<img>` / open links, path-encoded for spaces & Cyrillic filenames.

`classifyIssueAssets` is pure and unit-tested (typed slots, shared-cover
fallback, stray-file cleanup). 149 redesign specs green; `type-check:redesign`
+ `build:redesign` green.