### PR TITLE
redesign → prod: structured magazine issue page, docx→fb2/pdf→cover, translations, sections, lead

### DIFF
--- a/src/redesign/components/issue-articles.ts
+++ b/src/redesign/components/issue-articles.ts
@@ -1,0 +1,209 @@
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import '@communist-prometheus/cp-components';
+import {
+  listArticlesViaApi,
+  readFileViaApi,
+  readSequenceField,
+  linkIssueArticlesViaApi,
+  type ArticleSummary,
+} from '../engine/content.js';
+
+/**
+ * The article-linking panel of a magazine issue. Lists every blog article that
+ * exists in the issue's open language, shows which are currently part of the
+ * issue (its `articles:` table of contents), and lets the editor tick articles
+ * in or out — the manual "reassign articles" the journal workflow needs. Saving
+ * reconciles both sides of the link (the issue TOC and each article's
+ * `magazine:` back-link) via the Contents API, no clone.
+ */
+@customElement('issue-articles')
+export class IssueArticles extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+    h2 {
+      font-size: 1.1rem;
+      margin: 0 0 var(--spacing-sm);
+    }
+    ul {
+      list-style: none;
+      margin: 0 0 var(--spacing-md);
+      padding: 0;
+      display: grid;
+      gap: var(--spacing-xs);
+    }
+    li {
+      display: flex;
+      align-items: baseline;
+      gap: var(--spacing-sm);
+      padding: var(--spacing-xs) 0;
+      border-top: 1px solid var(--color-hairline);
+    }
+    li:first-child {
+      border-top: none;
+    }
+    label {
+      display: flex;
+      align-items: baseline;
+      gap: var(--spacing-sm);
+      cursor: pointer;
+      min-width: 0;
+    }
+    .title {
+      overflow-wrap: anywhere;
+    }
+    .date {
+      font-size: 0.78rem;
+      color: var(--color-text-secondary);
+      font-variant-numeric: tabular-nums;
+      margin-left: auto;
+      white-space: nowrap;
+    }
+    .actions {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-md);
+      flex-wrap: wrap;
+    }
+    .empty,
+    .msg {
+      color: var(--color-text-secondary);
+      font-size: 0.88rem;
+      margin: 0.2rem 0;
+    }
+    .msg.error {
+      color: var(--color-danger, #c0392b);
+    }
+    .count {
+      font-size: 0.82rem;
+      color: var(--color-text-secondary);
+    }
+  `;
+
+  /** The issue slug whose table of contents is edited. */
+  @property() issueSlug = '';
+
+  /** The language currently open — articles and links are per-language. */
+  @property() lang = '';
+
+  @state() private articles: readonly ArticleSummary[] = [];
+  @state() private selected: ReadonlySet<string> = new Set();
+  @state() private linkedAtLoad: ReadonlySet<string> = new Set();
+  @state() private loading = false;
+  @state() private busy = false;
+  @state() private message = '';
+  @state() private error = '';
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.load();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has('issueSlug') || changed.has('lang')) void this.load();
+  }
+
+  private async load(): Promise<void> {
+    if (this.issueSlug === '' || this.lang === '') return;
+    this.loading = true;
+    this.error = '';
+    this.message = '';
+    const [list, indexMd] = await Promise.all([
+      listArticlesViaApi(),
+      readFileViaApi(`magazine/${this.issueSlug}/index.${this.lang}.md`),
+    ]);
+    if (list.error !== undefined) {
+      this.error = list.error === 'signed-out' ? 'Войдите, чтобы редактировать связи.' : list.error;
+      this.loading = false;
+      return;
+    }
+    // Only articles that actually exist in this language can be linked.
+    this.articles = list.articles.filter((a) => a.languages.includes(this.lang));
+    const linked = new Set(indexMd === undefined ? [] : readSequenceField(indexMd, 'articles'));
+    this.linkedAtLoad = linked;
+    this.selected = new Set(linked);
+    this.loading = false;
+  }
+
+  private readonly toggle = (slug: string): void => {
+    const next = new Set(this.selected);
+    if (next.has(slug)) next.delete(slug);
+    else next.add(slug);
+    this.selected = next;
+  };
+
+  /** True once the selection differs from what was loaded — enables Save. */
+  private get changed(): boolean {
+    if (this.selected.size !== this.linkedAtLoad.size) return true;
+    for (const s of this.selected) if (!this.linkedAtLoad.has(s)) return true;
+    return false;
+  }
+
+  private readonly save = async (): Promise<void> => {
+    this.busy = true;
+    this.error = '';
+    this.message = '';
+    const result = await linkIssueArticlesViaApi(this.issueSlug, this.lang, [...this.selected]);
+    this.busy = false;
+    if (result.ok) {
+      this.linkedAtLoad = new Set(this.selected);
+      this.message = `Связи обновлены: +${result.linked}, −${result.unlinked}.`;
+    } else {
+      this.error = result.error ?? 'Не удалось обновить связи.';
+    }
+  };
+
+  private renderArticle(a: ArticleSummary): TemplateResult {
+    return html`
+      <li>
+        <label>
+          <input
+            type="checkbox"
+            .checked=${this.selected.has(a.slug)}
+            ?disabled=${this.busy}
+            @change=${() => this.toggle(a.slug)}
+          />
+          <span class="title">${a.title === '' ? a.slug : a.title}</span>
+        </label>
+        ${a.date !== undefined ? html`<span class="date">${a.date}</span>` : nothing}
+      </li>
+    `;
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <h2>Статьи номера</h2>
+      ${this.loading
+        ? html`<p class="msg">Загружаем статьи…</p>`
+        : this.articles.length === 0
+          ? html`<p class="empty">
+              Нет статей на языке «${this.lang}». Создайте статьи в разделе «Материалы».
+            </p>`
+          : html`
+              <p class="count">Отмечено ${this.selected.size} из ${this.articles.length}.</p>
+              <ul>
+                ${this.articles.map((a) => this.renderArticle(a))}
+              </ul>
+            `}
+      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
+      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
+      <div class="actions">
+        <cp-button
+          size="sm"
+          ?disabled=${this.busy || !this.changed}
+          @cp-click=${() => void this.save()}
+        >
+          ${this.busy ? 'Сохраняем…' : 'Сохранить связи'}
+        </cp-button>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'issue-articles': IssueArticles;
+  }
+}

--- a/src/redesign/components/issue-files.logic.test.ts
+++ b/src/redesign/components/issue-files.logic.test.ts
@@ -1,5 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { iconFor, fileLang, classifyUpload, plannedAssetPaths } from './issue-files.ts';
+import {
+  iconFor,
+  fileLang,
+  classifyUpload,
+  plannedAssetPaths,
+  classifyIssueAssets,
+} from './issue-files.ts';
+
+const file = (name: string, size = 100): { name: string; path: string; size: number; sha: string } => ({
+  name,
+  path: `magazine/nomer-2/assets/${name}`,
+  size,
+  sha: name,
+});
 
 describe('issue-files type icons', () => {
   it('maps extensions to pictograms', () => {
@@ -59,5 +72,46 @@ describe('issue-files planned asset paths', () => {
 
   it('a rejected upload plans no writes', () => {
     expect(plannedAssetPaths(dir, 'nomer-2', 'ru', 'reject')).toEqual([]);
+  });
+});
+
+describe('issue-files typed asset slots (structured, not a flat dump)', () => {
+  const slug = 'nomer-2';
+  const full = [
+    file('nomer-2.ru.pdf'),
+    file('nomer-2.ru.fb2'),
+    file('cover.ru.png'),
+    file('cover.png'),
+    file('nomer-2.en.pdf'),
+    file('cover.en.png'),
+    file('Magazine1 (3).pdf'), // stray leftover
+  ];
+
+  it('sorts the flat directory into the open language\'s typed slots', () => {
+    const a = classifyIssueAssets(full, slug, 'ru');
+    expect(a.pdf?.name).toBe('nomer-2.ru.pdf');
+    expect(a.fb2?.name).toBe('nomer-2.ru.fb2');
+    expect(a.cover?.name).toBe('cover.ru.png');
+    expect(a.coverShared).toBe(false);
+  });
+
+  it('falls back to the shared cover.png when a language has none', () => {
+    const a = classifyIssueAssets([file('cover.png'), file('nomer-2.es.fb2')], slug, 'es');
+    expect(a.cover?.name).toBe('cover.png');
+    expect(a.coverShared).toBe(true);
+    expect(a.pdf).toBeUndefined();
+    expect(a.fb2?.name).toBe('nomer-2.es.fb2');
+  });
+
+  it('reports empty slots when the language has no assets yet', () => {
+    const a = classifyIssueAssets([file('cover.en.png')], slug, 'ru');
+    expect(a.pdf).toBeUndefined();
+    expect(a.fb2).toBeUndefined();
+    expect(a.cover).toBeUndefined();
+  });
+
+  it('lists only genuinely stray files for cleanup (typed assets of any lang are not stray)', () => {
+    const names = classifyIssueAssets(full, slug, 'ru').other.map((f) => f.name);
+    expect(names).toEqual(['Magazine1 (3).pdf']);
   });
 });

--- a/src/redesign/components/issue-files.logic.test.ts
+++ b/src/redesign/components/issue-files.logic.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { iconFor, fileLang } from './issue-files.ts';
+import { iconFor, fileLang, classifyUpload, plannedAssetPaths } from './issue-files.ts';
 
 describe('issue-files type icons', () => {
   it('maps extensions to pictograms', () => {
@@ -24,5 +24,40 @@ describe('issue-files language detection', () => {
     expect(fileLang('cover.png', langs)).toBeUndefined(); // no lang segment
     expect(fileLang('Magazine1 (3).pdf', langs)).toBeUndefined();
     expect(fileLang('cover.xx.png', langs)).toBeUndefined(); // xx not a known lang
+  });
+});
+
+describe('issue-files upload classification (the ONLY accepted inputs)', () => {
+  it('accepts only pdf and docx, case-insensitively', () => {
+    expect(classifyUpload('nomer-2.PDF')).toBe('pdf');
+    expect(classifyUpload('Газета.docx')).toBe('docx');
+  });
+
+  it('rejects every other type — including the old free-for-all uploads', () => {
+    expect(classifyUpload('cover.png')).toBe('reject');
+    expect(classifyUpload('nomer.fb2')).toBe('reject');
+    expect(classifyUpload('notes.txt')).toBe('reject');
+    expect(classifyUpload('noext')).toBe('reject');
+  });
+});
+
+describe('issue-files planned asset paths', () => {
+  const dir = 'magazine/nomer-2/assets';
+
+  it('docx writes exactly one derived fb2 (the docx itself is never stored)', () => {
+    expect(plannedAssetPaths(dir, 'nomer-2', 'ru', 'docx')).toEqual([
+      'magazine/nomer-2/assets/nomer-2.ru.fb2',
+    ]);
+  });
+
+  it('pdf writes the pdf then the derived cover, in that order', () => {
+    expect(plannedAssetPaths(dir, 'nomer-2', 'it', 'pdf')).toEqual([
+      'magazine/nomer-2/assets/nomer-2.it.pdf',
+      'magazine/nomer-2/assets/cover.it.png',
+    ]);
+  });
+
+  it('a rejected upload plans no writes', () => {
+    expect(plannedAssetPaths(dir, 'nomer-2', 'ru', 'reject')).toEqual([]);
   });
 });

--- a/src/redesign/components/issue-files.ts
+++ b/src/redesign/components/issue-files.ts
@@ -48,11 +48,41 @@ export const fileLang = (name: string, langs: ReadonlySet<string>): string | und
   return langs.has(candidate) ? candidate : undefined;
 };
 
+/** The only two accepted uploads, plus the rejection of everything else. */
+export type UploadKind = 'docx' | 'pdf' | 'reject';
+
+/** Classifies a picked file by extension into the issue upload it drives. */
+export const classifyUpload = (name: string): UploadKind => {
+  const ext = name.split('.').pop()?.toLowerCase() ?? '';
+  return ext === 'docx' ? 'docx' : ext === 'pdf' ? 'pdf' : 'reject';
+};
+
 /**
- * Files of one content directory (a magazine issue's `assets/`), managed
- * entirely through the GitHub Contents API — no clone. Lists what is uploaded,
- * uploads ANY file type (pdf, fb2, doc, images…) and deletes files. This is the
- * "where are the files / upload mine / delete" panel the journal workflow needs.
+ * The asset path(s) an upload writes, in commit order:
+ * - docx → one derived FB2;
+ * - pdf → the pdf itself, then the cover rendered from its first page;
+ * - reject → nothing.
+ */
+export const plannedAssetPaths = (
+  dir: string,
+  slug: string,
+  lang: string,
+  kind: UploadKind,
+): readonly string[] =>
+  kind === 'docx'
+    ? [`${dir}/${slug}.${lang}.fb2`]
+    : kind === 'pdf'
+      ? [`${dir}/${slug}.${lang}.pdf`, `${dir}/cover.${lang}.png`]
+      : [];
+
+/**
+ * The purpose-built file panel for one magazine issue's `assets/`, managed
+ * entirely through the GitHub Contents API — no clone. It lists the issue's
+ * files and accepts exactly ONE kind of upload: the newspaper itself, as PDF
+ * or DOCX. A DOCX is converted client-side to FB2 (the docx is never
+ * persisted); a PDF is stored and its first page is rendered into the cover.
+ * Everything else (re-upload, manual delete of any derived asset) is the
+ * customisation layer on top of that single use case.
  */
 @customElement('issue-files')
 export class IssueFiles extends LitElement {
@@ -159,6 +189,11 @@ export class IssueFiles extends LitElement {
   /** All languages the item exists in — used to detect a file's language suffix. */
   @property({ attribute: false }) langs: readonly string[] = [];
 
+  /** Issue slug + title + description — baked into the derived fb2 / asset names. */
+  @property() slug = '';
+  @property() title = '';
+  @property() desc = '';
+
   /** When true, show files of every language, not just the open one. */
   @state() private showAll = false;
 
@@ -187,22 +222,58 @@ export class IssueFiles extends LitElement {
     this.loading = false;
   }
 
+  /** Commits one derived File to the assets dir, throwing on API failure. */
+  private async commit(path: string, file: File, message: string): Promise<void> {
+    const base64 = await fileToBase64(file);
+    const r = await uploadBinaryViaApi(path, base64, message);
+    if (!r.ok) throw new Error(r.error ?? 'upload failed');
+  }
+
+  /**
+   * The purpose-built issue upload: ONLY the newspaper PDF or DOCX.
+   * - DOCX → converted client-side to FB2 (the docx itself is never persisted)
+   *   and uploaded as `<slug>.<lang>.fb2`.
+   * - PDF → uploaded as `<slug>.<lang>.pdf`, and its first page is rendered and
+   *   uploaded as `cover.<lang>.png`.
+   * The heavy converters (mammoth / mupdf-wasm) load lazily, only on use.
+   */
   private readonly onPick = async (event: Event): Promise<void> => {
     const input = event.target;
     const file = input instanceof HTMLInputElement ? input.files?.[0] : undefined;
     if (input instanceof HTMLInputElement) input.value = '';
     if (file === undefined) return;
+    const kind = classifyUpload(file.name);
+    if (kind === 'reject') {
+      this.error = 'Для номера загружается только файл газеты — PDF или DOCX.';
+      return;
+    }
+    const [primary, cover] = plannedAssetPaths(this.dir, this.slug, this.lang, kind);
     this.busy = true;
     this.message = '';
     this.error = '';
-    const base64 = await fileToBase64(file);
-    const result = await uploadBinaryViaApi(`${this.dir}/${file.name}`, base64, `assets: add ${file.name}`);
-    this.busy = false;
-    if (result.ok) {
-      this.message = `Загружен файл «${file.name}».`;
+    try {
+      if (kind === 'docx') {
+        const { docxFileToFb2 } = await import('@/components/MarkdownEditor/docx-to-fb2');
+        const fb2 = await docxFileToFb2(file, {
+          slug: this.slug,
+          issueTitle: this.title || this.slug,
+          issueLang: this.lang,
+          issueDescription: this.desc === '' ? undefined : this.desc,
+        });
+        await this.commit(primary, fb2, `assets: docx→fb2 ${this.slug}.${this.lang}`);
+        this.message = `DOCX сконвертирован в FB2 и загружен: ${this.slug}.${this.lang}.fb2`;
+      } else {
+        await this.commit(primary, file, `assets: pdf ${this.slug}.${this.lang}`);
+        const { extractPdfCover } = await import('@/features/magazine/extract-pdf-cover');
+        const coverFile = await extractPdfCover(file);
+        await this.commit(cover, coverFile, `assets: cover ${this.slug}.${this.lang}`);
+        this.message = `PDF загружен, обложка извлечена: cover.${this.lang}.png`;
+      }
       await this.load();
-    } else {
-      this.error = result.error ?? 'Загрузка не удалась.';
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.busy = false;
     }
   };
 
@@ -291,10 +362,19 @@ export class IssueFiles extends LitElement {
       ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
       <div class="upload">
         <label>
-          ${this.busy ? 'Обрабатываем…' : 'Загрузить файл (pdf, fb2, любой):'}
-          <input type="file" ?disabled=${this.busy} @change=${this.onPick} />
+          ${this.busy ? 'Обрабатываем файл газеты…' : 'Загрузить файл газеты (PDF или DOCX):'}
+          <input
+            type="file"
+            accept="application/pdf,.pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ?disabled=${this.busy}
+            @change=${this.onPick}
+          />
         </label>
       </div>
+      <p class="msg">
+        DOCX → автоматически конвертируется в FB2. PDF → загружается и из первой страницы
+        извлекается обложка. Другие файлы не загружаются.
+      </p>
     `;
   }
 }

--- a/src/redesign/components/issue-files.ts
+++ b/src/redesign/components/issue-files.ts
@@ -5,6 +5,7 @@ import {
   listDirViaApi,
   uploadBinaryViaApi,
   deleteFileViaApi,
+  rawContentUrl,
   type RepoFile,
 } from '../engine/content.js';
 
@@ -75,14 +76,57 @@ export const plannedAssetPaths = (
       ? [`${dir}/${slug}.${lang}.pdf`, `${dir}/cover.${lang}.png`]
       : [];
 
+/** The three typed slots of a magazine issue in one language, plus stray files. */
+export interface IssueAssets {
+  /** The per-language cover, or the shared `cover.png` fallback. */
+  readonly cover?: RepoFile;
+  /** True when only the shared `cover.png` exists (no per-language cover yet). */
+  readonly coverShared: boolean;
+  /** The newspaper PDF for this language. */
+  readonly pdf?: RepoFile;
+  /** The derived FB2 ebook for this language. */
+  readonly fb2?: RepoFile;
+  /** Anything that fits none of the typed slots of any language — for cleanup. */
+  readonly other: readonly RepoFile[];
+}
+
+/** Whether a filename is a recognised typed asset of some language (cover / pdf /
+ *  fb2), so the cleanup list can show only genuinely stray files. */
+const isTyped = (name: string, slug: string): boolean =>
+  name === 'cover.png' ||
+  /^cover\.[a-z]{2}\.png$/.test(name) ||
+  (name.startsWith(`${slug}.`) && (name.endsWith('.pdf') || name.endsWith('.fb2')));
+
+/** Sorts the flat assets directory into the issue's typed slots for one language. */
+export const classifyIssueAssets = (
+  files: readonly RepoFile[],
+  slug: string,
+  lang: string,
+): IssueAssets => {
+  const byName = (n: string): RepoFile | undefined => files.find((f) => f.name === n);
+  const pdf = byName(`${slug}.${lang}.pdf`);
+  const fb2 = byName(`${slug}.${lang}.fb2`);
+  const coverLang = byName(`cover.${lang}.png`);
+  const coverShared = byName('cover.png');
+  const other = files.filter((f) => !isTyped(f.name, slug));
+  return {
+    cover: coverLang ?? coverShared,
+    coverShared: coverLang === undefined && coverShared !== undefined,
+    pdf,
+    fb2,
+    other,
+  };
+};
+
 /**
- * The purpose-built file panel for one magazine issue's `assets/`, managed
- * entirely through the GitHub Contents API — no clone. It lists the issue's
- * files and accepts exactly ONE kind of upload: the newspaper itself, as PDF
- * or DOCX. A DOCX is converted client-side to FB2 (the docx is never
- * persisted); a PDF is stored and its first page is rendered into the cover.
- * Everything else (re-upload, manual delete of any derived asset) is the
- * customisation layer on top of that single use case.
+ * The purpose-built assets panel for one magazine issue's `assets/`, managed
+ * entirely through the GitHub Contents API — no clone. Instead of a flat file
+ * dump it presents the issue's three typed slots for the open language —
+ * **Обложка**, and the **Файл номера** (PDF + derived FB2) — with a single
+ * upload that accepts ONLY the newspaper as PDF or DOCX:
+ * - DOCX → converted client-side to FB2 (the docx is never persisted);
+ * - PDF → stored, and its first page is rendered into the cover.
+ * A collapsed cleanup list handles any stray leftovers.
  */
 @customElement('issue-files')
 export class IssueFiles extends LitElement {
@@ -90,112 +134,159 @@ export class IssueFiles extends LitElement {
     :host {
       display: block;
     }
-    .fhead {
-      display: flex;
-      align-items: baseline;
-      flex-wrap: wrap;
-      gap: 0.5rem var(--spacing-md);
-      margin: 0 0 var(--spacing-sm);
-    }
     h2 {
       font-size: 1.1rem;
+      margin: 0 0 var(--spacing-md);
+    }
+    .slots {
+      display: grid;
+      gap: var(--spacing-md);
+    }
+    section.slot {
+      border: 1px solid var(--color-hairline);
+      border-radius: var(--radius-md, 10px);
+      padding: var(--spacing-md);
+      display: grid;
+      gap: var(--spacing-sm);
+    }
+    .slot-head {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+    }
+    .slot-head h3 {
+      font-size: 0.95rem;
       margin: 0;
     }
-    .link {
-      border: none;
-      background: transparent;
-      color: var(--color-accent);
-      font: inherit;
-      font-size: 0.82rem;
-      cursor: pointer;
-      padding: 0;
+    .slot-head .spacer {
+      flex: 1;
     }
-    .ficon {
-      flex: none;
+    .cover-preview {
+      display: block;
+      max-width: 160px;
+      width: 100%;
+      height: auto;
+      border-radius: var(--radius-sm, 6px);
+      border: 1px solid var(--color-hairline);
+      background: var(--color-surface-sunken, rgba(0, 0, 0, 0.04));
+    }
+    .cover-none {
+      display: grid;
+      place-items: center;
+      width: 160px;
+      height: 110px;
+      border: 1px dashed var(--color-hairline);
+      border-radius: var(--radius-sm, 6px);
       color: var(--color-text-secondary);
+      font-size: 0.82rem;
     }
-    ul {
+    ul.rows {
       list-style: none;
-      margin: 0 0 var(--spacing-md);
+      margin: 0;
       padding: 0;
       display: grid;
       gap: var(--spacing-xs);
     }
-    li {
+    ul.rows li {
       display: flex;
       align-items: center;
       flex-wrap: wrap;
       gap: 0.5rem var(--spacing-sm);
-      padding: var(--spacing-sm) 0;
-      border-top: 1px solid var(--color-hairline);
     }
-    li:first-child {
-      border-top: none;
+    .kind {
+      font-family: var(--font-mono);
+      font-size: 0.82rem;
+      color: var(--color-text-secondary);
+      min-width: 2.6rem;
     }
     .name {
       font-family: var(--font-mono);
-      font-size: 0.9rem;
+      font-size: 0.86rem;
       overflow-wrap: anywhere;
       min-width: 0;
     }
     .size {
-      font-size: 0.78rem;
+      font-size: 0.76rem;
       color: var(--color-text-secondary);
       font-variant-numeric: tabular-nums;
     }
     .spacer {
       flex: 1;
     }
-    a.dl {
+    a.open {
       color: var(--color-accent);
       text-decoration: none;
-      font-size: 0.82rem;
+      font-size: 0.8rem;
+      white-space: nowrap;
     }
-    .empty,
+    .missing {
+      color: var(--color-text-secondary);
+      font-size: 0.84rem;
+    }
+    .upload {
+      display: grid;
+      gap: 0.35rem;
+      margin-top: var(--spacing-xs);
+    }
+    .upload > span {
+      font-size: 0.85rem;
+      color: var(--color-text-secondary);
+    }
+    input[type='file'] {
+      color: var(--color-text-secondary);
+      font: inherit;
+      font-size: 0.82rem;
+      max-width: 100%;
+    }
+    .hint {
+      font-size: 0.8rem;
+      color: var(--color-text-secondary);
+      margin: 0;
+    }
     .msg {
       color: var(--color-text-secondary);
-      font-size: 0.88rem;
+      font-size: 0.86rem;
       margin: 0.2rem 0;
     }
     .msg.error {
       color: var(--color-danger, #c0392b);
     }
-    .upload {
-      display: inline-flex;
-      align-items: center;
-      gap: var(--spacing-sm);
-      margin-top: var(--spacing-sm);
+    details.cleanup {
+      border-top: 1px solid var(--color-hairline);
+      padding-top: var(--spacing-sm);
     }
-    input[type='file'] {
-      color: var(--color-text-secondary);
-      font: inherit;
+    details.cleanup summary {
+      cursor: pointer;
       font-size: 0.85rem;
-      max-width: 100%;
+      color: var(--color-text-secondary);
+    }
+    details.cleanup li {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem var(--spacing-sm);
+      flex-wrap: wrap;
+      padding: var(--spacing-xs) 0;
     }
     .confirm {
       display: inline-flex;
       gap: 0.35rem;
       align-items: center;
-      font-size: 0.8rem;
     }
   `;
 
   /** The repo directory whose files are managed, e.g. `magazine/<slug>/assets`. */
   @property() dir = '';
 
-  /** The language currently open in the editor — filters the list to it. */
+  /** The language currently open in the editor — the slots are per-language. */
   @property() lang = '';
 
-  /** All languages the item exists in — used to detect a file's language suffix. */
+  /** All languages the item exists in (reserved for cross-language hints). */
   @property({ attribute: false }) langs: readonly string[] = [];
 
   /** Issue slug + title + description — baked into the derived fb2 / asset names. */
   @property() slug = '';
   @property() title = '';
   @property() desc = '';
-
-  /** When true, show files of every language, not just the open one. */
-  @state() private showAll = false;
 
   @state() private files: readonly RepoFile[] = [];
   @state() private loading = false;
@@ -230,12 +321,12 @@ export class IssueFiles extends LitElement {
   }
 
   /**
-   * The purpose-built issue upload: ONLY the newspaper PDF or DOCX.
-   * - DOCX → converted client-side to FB2 (the docx itself is never persisted)
-   *   and uploaded as `<slug>.<lang>.fb2`.
-   * - PDF → uploaded as `<slug>.<lang>.pdf`, and its first page is rendered and
-   *   uploaded as `cover.<lang>.png`.
-   * The heavy converters (mammoth / mupdf-wasm) load lazily, only on use.
+   * The primary upload: ONLY the newspaper PDF or DOCX.
+   * - DOCX → converted client-side to FB2 (`docxFileToFb2`); the docx is never
+   *   persisted, only `<slug>.<lang>.fb2` is committed.
+   * - PDF → committed as `<slug>.<lang>.pdf`, and its first page is rendered
+   *   (`extractPdfCover`) and committed as `cover.<lang>.png`.
+   * Both converters load lazily so mammoth/mupdf stay out of the initial bundle.
    */
   private readonly onPick = async (event: Event): Promise<void> => {
     const input = event.target;
@@ -277,6 +368,35 @@ export class IssueFiles extends LitElement {
     }
   };
 
+  /** Replaces just the cover for the open language with a picked image. */
+  private readonly onPickCover = async (event: Event): Promise<void> => {
+    const input = event.target;
+    const file = input instanceof HTMLInputElement ? input.files?.[0] : undefined;
+    if (input instanceof HTMLInputElement) input.value = '';
+    if (file === undefined) return;
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+    if (!IMAGE_EXT.has(ext)) {
+      this.error = 'Обложка — это изображение (png, jpg, webp…).';
+      return;
+    }
+    this.busy = true;
+    this.message = '';
+    this.error = '';
+    try {
+      await this.commit(
+        `${this.dir}/cover.${this.lang}.png`,
+        file,
+        `assets: cover ${this.slug}.${this.lang}`,
+      );
+      this.message = `Обложка обновлена: cover.${this.lang}.png`;
+      await this.load();
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+    } finally {
+      this.busy = false;
+    }
+  };
+
   private readonly removeFile = async (file: RepoFile): Promise<void> => {
     this.confirmingPath = '';
     this.busy = true;
@@ -292,77 +412,72 @@ export class IssueFiles extends LitElement {
     }
   };
 
-  /** Files shown for the open language plus the shared (no-suffix) ones. */
-  private get visibleFiles(): readonly RepoFile[] {
-    if (this.showAll || this.lang === '') return this.files;
-    const set = new Set(this.langs);
-    return this.files.filter((f) => {
-      const fl = fileLang(f.name, set);
-      return fl === undefined || fl === this.lang;
-    });
-  }
-
-  private renderFile(file: RepoFile): TemplateResult {
-    const confirming = this.confirmingPath === file.path;
+  private renderFileRow(kind: string, file: RepoFile | undefined): TemplateResult {
     return html`
       <li>
-        <cp-icon class="ficon" name=${iconFor(file.name)} size="18"></cp-icon>
-        <span class="name">${file.name}</span>
-        <span class="size">${humanSize(file.size)}</span>
-        <span class="spacer"></span>
-        <a class="dl" href="https://github.com/communist-prometheus/public-website-content/raw/HEAD/${file.path}" target="_blank" rel="noopener">открыть ↗</a>
-        ${confirming
-          ? html`<span class="confirm">
-              <cp-button size="sm" variant="secondary" @cp-click=${() => (this.confirmingPath = '')}
-                >Отмена</cp-button
+        <span class="kind">${kind}</span>
+        ${file === undefined
+          ? html`<span class="missing">— не загружен</span>`
+          : html`
+              <cp-icon name=${iconFor(file.name)} size="16"></cp-icon>
+              <span class="name">${file.name}</span>
+              <span class="size">${humanSize(file.size)}</span>
+              <span class="spacer"></span>
+              <a class="open" href=${rawContentUrl(file.path)} target="_blank" rel="noopener"
+                >открыть ↗</a
               >
-              <cp-button size="sm" ?disabled=${this.busy} @cp-click=${() => void this.removeFile(file)}
-                >Удалить</cp-button
-              >
-            </span>`
-          : html`<cp-button
-              size="sm"
-              variant="ghost"
-              ?disabled=${this.busy}
-              @cp-click=${() => (this.confirmingPath = file.path)}
-              >Удалить</cp-button
-            >`}
+            `}
       </li>
     `;
   }
 
-  override render(): TemplateResult {
-    const visible = this.visibleFiles;
-    const hidden = this.files.length - visible.length;
+  private renderCover(assets: IssueAssets): TemplateResult {
     return html`
-      <div class="fhead">
-        <h2>Файлы номера</h2>
-        ${!this.showAll && hidden > 0
-          ? html`<button class="link" @click=${() => (this.showAll = true)}>
-              показать все языки (+${hidden})
-            </button>`
-          : this.showAll && this.lang !== ''
-            ? html`<button class="link" @click=${() => (this.showAll = false)}>
-                только «${this.lang}»
-              </button>`
-            : nothing}
-      </div>
-      ${this.loading
-        ? html`<p class="msg">Загружаем список файлов…</p>`
-        : visible.length === 0
-          ? html`<p class="empty">
-              ${this.files.length === 0
-                ? 'Файлов пока нет.'
-                : `Для языка «${this.lang}» файлов нет (есть у других языков).`}
-            </p>`
-          : html`<ul>
-              ${visible.map((f) => this.renderFile(f))}
-            </ul>`}
-      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
-      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
-      <div class="upload">
-        <label>
-          ${this.busy ? 'Обрабатываем файл газеты…' : 'Загрузить файл газеты (PDF или DOCX):'}
+      <section class="slot">
+        <div class="slot-head">
+          <h3>Обложка</h3>
+          <span class="spacer"></span>
+          ${assets.cover === undefined
+            ? html`<cp-tag tone="warning">нет</cp-tag>`
+            : assets.coverShared
+              ? html`<cp-tag>общая</cp-tag>`
+              : html`<cp-tag tone="success">есть</cp-tag>`}
+        </div>
+        ${assets.cover === undefined
+          ? html`<div class="cover-none">нет обложки</div>`
+          : html`<img
+              class="cover-preview"
+              src=${rawContentUrl(assets.cover.path)}
+              alt="Обложка номера (${this.lang})"
+              loading="lazy"
+            />`}
+        <label class="upload">
+          <span>${this.busy ? 'Обрабатываем…' : 'Заменить обложку (изображение):'}</span>
+          <input type="file" accept="image/*" ?disabled=${this.busy} @change=${this.onPickCover} />
+        </label>
+      </section>
+    `;
+  }
+
+  private renderNewspaper(assets: IssueAssets): TemplateResult {
+    return html`
+      <section class="slot">
+        <div class="slot-head">
+          <h3>Файл номера</h3>
+          <span class="spacer"></span>
+          ${assets.pdf !== undefined || assets.fb2 !== undefined
+            ? html`<cp-tag tone="success">готов</cp-tag>`
+            : html`<cp-tag tone="warning">пусто</cp-tag>`}
+        </div>
+        <ul class="rows">
+          ${this.renderFileRow('PDF', assets.pdf)}${this.renderFileRow('FB2', assets.fb2)}
+        </ul>
+        <label class="upload">
+          <span
+            >${this.busy
+              ? 'Обрабатываем файл газеты…'
+              : 'Загрузить файл газеты (PDF или DOCX):'}</span
+          >
           <input
             type="file"
             accept="application/pdf,.pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -370,11 +485,63 @@ export class IssueFiles extends LitElement {
             @change=${this.onPick}
           />
         </label>
+        <p class="hint">
+          DOCX → автоматически конвертируется в FB2. PDF → загружается, обложка берётся из
+          первой страницы. Другие файлы не принимаются.
+        </p>
+      </section>
+    `;
+  }
+
+  private renderCleanup(other: readonly RepoFile[]): TemplateResult {
+    return html`
+      <details class="cleanup">
+        <summary>Прочие файлы (${other.length}) — очистка</summary>
+        <ul class="rows">
+          ${other.map((file) => {
+            const confirming = this.confirmingPath === file.path;
+            return html`<li>
+              <cp-icon name=${iconFor(file.name)} size="16"></cp-icon>
+              <span class="name">${file.name}</span>
+              <span class="size">${humanSize(file.size)}</span>
+              <span class="spacer"></span>
+              <a class="open" href=${rawContentUrl(file.path)} target="_blank" rel="noopener"
+                >открыть ↗</a
+              >
+              ${confirming
+                ? html`<span class="confirm">
+                    <cp-button size="sm" variant="secondary" @cp-click=${() => (this.confirmingPath = '')}
+                      >Отмена</cp-button
+                    >
+                    <cp-button size="sm" ?disabled=${this.busy} @cp-click=${() => void this.removeFile(file)}
+                      >Удалить</cp-button
+                    >
+                  </span>`
+                : html`<cp-button
+                    size="sm"
+                    variant="ghost"
+                    ?disabled=${this.busy}
+                    @cp-click=${() => (this.confirmingPath = file.path)}
+                    >Удалить</cp-button
+                  >`}
+            </li>`;
+          })}
+        </ul>
+      </details>
+    `;
+  }
+
+  override render(): TemplateResult {
+    if (this.loading) return html`<h2>Материалы номера</h2><p class="msg">Загружаем…</p>`;
+    const assets = classifyIssueAssets(this.files, this.slug, this.lang);
+    return html`
+      <h2>Материалы номера</h2>
+      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
+      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
+      <div class="slots">
+        ${this.renderCover(assets)}${this.renderNewspaper(assets)}
+        ${assets.other.length > 0 ? this.renderCleanup(assets.other) : nothing}
       </div>
-      <p class="msg">
-        DOCX → автоматически конвертируется в FB2. PDF → загружается и из первой страницы
-        извлекается обложка. Другие файлы не загружаются.
-      </p>
     `;
   }
 }

--- a/src/redesign/engine/content-api.test.ts
+++ b/src/redesign/engine/content-api.test.ts
@@ -8,6 +8,7 @@ import {
   listDirViaApi,
   uploadBinaryViaApi,
   deleteFileViaApi,
+  linkIssueArticlesViaApi,
 } from './content.ts';
 
 vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
@@ -20,12 +21,14 @@ const TREE = {
     { path: 'blog/newer/index.ru.md' },
     { path: 'README.md' },
     { path: 'blog/older/cover.jpg' },
+    { path: 'pages/home/index.ru.md' },
   ],
 };
 
 const FILES: Record<string, string> = {
   'blog/older/index.ru.md': '---\ntitle: Старее\npubDate: 2026-01-01\n---\n\nBody\n',
   'blog/newer/index.ru.md': '---\ntitle: Новее\npublishDate: 2026-05-01\n---\n\nBody\n',
+  'pages/home/index.ru.md': '---\ntitle: Главная\n---\n\nBody\n',
 };
 
 /** Stubs global fetch: tree endpoint returns TREE, contents return raw md. */
@@ -34,12 +37,25 @@ const stub = (opts: { treeStatus?: number; failFile?: string } = {}): void => {
     if (url.includes('/git/trees/')) {
       return new Response(JSON.stringify(TREE), { status: opts.treeStatus ?? 200 });
     }
-    const m = url.match(/contents\/(blog\/[^?]+)/);
+    const m = url.match(/contents\/([^?]+)/);
     const path = m ? decodeURIComponent(m[1]) : '';
     if (opts.failFile !== undefined && path === opts.failFile) throw new Error('throttled');
     return new Response(FILES[path] ?? '', { status: FILES[path] ? 200 : 404 });
   });
 };
+
+/** The `accept` header of a fetch init, without casting an opaque HeadersInit. */
+const acceptOf = (init?: RequestInit): string => {
+  const h = init?.headers;
+  return typeof h === 'object' && 'accept' in h ? String(Reflect.get(h, 'accept')) : '';
+};
+
+/** Parses a stored issue index's `articles:` block for assertions. */
+const readSeq = (md: string): string[] =>
+  md
+    .split('\n')
+    .map((l) => l.match(/^\s+-\s+(.+?)\s*$/)?.[1])
+    .filter((v): v is string => v !== undefined);
 
 beforeEach(() => {
   vi.stubEnv('VITE_DEV_TOKEN', '');
@@ -60,6 +76,14 @@ describe('listArticlesViaApi (API-first article list)', () => {
     expect(articles[0].title).toBe('Новее');
     expect(articles[0].date).toBe('2026-05-01'); // publishDate read too
     expect(articles[1].languages).toEqual(['en', 'ru']);
+  });
+
+  it('lists a non-blog collection (pages) when asked, ignoring blog entries', async () => {
+    stub();
+    const { articles, error } = await listArticlesViaApi(undefined, 'pages');
+    expect(error).toBeUndefined();
+    expect(articles.map((a) => a.slug)).toEqual(['home']);
+    expect(articles[0].title).toBe('Главная');
   });
 
   it('reports the tree fetch error instead of a silent empty (throttling/failure)', async () => {
@@ -191,6 +215,60 @@ describe('editor single-file API (read / langs / publish, no clone)', () => {
     const r = await deleteFileViaApi('magazine/x/assets/old.pdf', 'remove');
     expect(r.ok).toBe(true);
     expect(calls.find((c) => c.method === 'DELETE')?.body).toMatchObject({ sha: 'todelete' });
+  });
+
+  it('linkIssueArticlesViaApi back-links new articles and rewrites the TOC', async () => {
+    const repo: Record<string, string> = {
+      'magazine/n3/index.ru.md': '---\ntitle: N3\nlang: ru\narticles:\n  - a\n---\n\nB\n',
+      'blog/a/index.ru.md': '---\ntitle: A\nlang: ru\nmagazine: n3\n---\n\nB\n',
+      'blog/b/index.ru.md': '---\ntitle: B\nlang: ru\n---\n\nB\n',
+    };
+    const puts: Array<{ path: string; content: string }> = [];
+    const decode = (b64: string): string =>
+      new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+      if (init?.method === 'PUT') {
+        const body = JSON.parse(String(init.body));
+        repo[path] = decode(body.content);
+        puts.push({ path, content: repo[path] });
+        return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+      }
+      if (acceptOf(init).includes('raw')) return new Response(repo[path] ?? '', { status: repo[path] ? 200 : 404 });
+      return new Response(JSON.stringify({ sha: 'blob' }), { status: 200 });
+    });
+
+    const r = await linkIssueArticlesViaApi('n3', 'ru', ['a', 'b']);
+    expect(r).toMatchObject({ ok: true, linked: 1, unlinked: 0 });
+    // b gained the back-link; a kept its; TOC now lists both.
+    expect(repo['blog/b/index.ru.md']).toContain('magazine: n3');
+    expect(readSeq(repo['magazine/n3/index.ru.md'])).toEqual(['a', 'b']);
+    // a was already linked and already in the TOC → not re-committed pointlessly.
+    expect(puts.some((p) => p.path === 'blog/a/index.ru.md')).toBe(false);
+  });
+
+  it('linkIssueArticlesViaApi drops the back-link from de-selected articles', async () => {
+    const repo: Record<string, string> = {
+      'magazine/n3/index.ru.md': '---\ntitle: N3\nlang: ru\narticles:\n  - a\n  - b\n---\n\nB\n',
+      'blog/a/index.ru.md': '---\ntitle: A\nlang: ru\nmagazine: n3\n---\n\nB\n',
+      'blog/b/index.ru.md': '---\ntitle: B\nlang: ru\nmagazine: n3\n---\n\nB\n',
+    };
+    const decode = (b64: string): string =>
+      new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+      if (init?.method === 'PUT') {
+        repo[path] = decode(JSON.parse(String(init.body)).content);
+        return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+      }
+      if (acceptOf(init).includes('raw')) return new Response(repo[path] ?? '', { status: repo[path] ? 200 : 404 });
+      return new Response(JSON.stringify({ sha: 'blob' }), { status: 200 });
+    });
+
+    const r = await linkIssueArticlesViaApi('n3', 'ru', ['a']);
+    expect(r).toMatchObject({ ok: true, linked: 0, unlinked: 1 });
+    expect(repo['blog/b/index.ru.md']).not.toContain('magazine:');
+    expect(readSeq(repo['magazine/n3/index.ru.md'])).toEqual(['a']);
   });
 
   it('publishFileViaApi surfaces the GitHub error message on failure', async () => {

--- a/src/redesign/engine/content.engine.test.ts
+++ b/src/redesign/engine/content.engine.test.ts
@@ -50,6 +50,9 @@ import {
   stageFile,
   clearContentCache,
   createMagazineIssue,
+  removeFrontmatterField,
+  readSequenceField,
+  upsertSequenceField,
 } from './content.ts';
 
 beforeEach(() => {
@@ -125,6 +128,49 @@ describe('listArticles fan-out', () => {
     files['blog/b-publishdate/index.ru.md'] = '---\ntitle: B\npublishDate: 2026-02-01\n---\n';
     const order = (await listArticles()).map((a) => a.slug);
     expect(order).toEqual(['a-pubdate', 'b-publishdate']);
+  });
+});
+
+describe('frontmatter sequence helpers (issue TOC ↔ article back-links)', () => {
+  const ISSUE = '---\ntitle: "N3"\nlang: ru\npublished: true\narticles:\n  - a\n  - b\n---\n\nBody\n';
+
+  it('reads a block sequence as an array', () => {
+    expect(readSequenceField(ISSUE, 'articles')).toEqual(['a', 'b']);
+  });
+
+  it('reads [] when the sequence key is absent', () => {
+    expect(readSequenceField('---\ntitle: X\n---\n', 'articles')).toEqual([]);
+  });
+
+  it('stops at the next key, not swallowing later fields', () => {
+    const md = '---\narticles:\n  - a\nimage: ./c.png\n---\n';
+    expect(readSequenceField(md, 'articles')).toEqual(['a']);
+  });
+
+  it('rewrites the sequence to a new set without orphaning old items', () => {
+    const next = upsertSequenceField(ISSUE, 'articles', ['b', 'c', 'd']);
+    expect(readSequenceField(next, 'articles')).toEqual(['b', 'c', 'd']);
+    expect(next).toContain('title: "N3"'); // other fields untouched
+    expect(next).toContain('Body'); // body untouched
+  });
+
+  it('inserts a new sequence after lang: when absent', () => {
+    const md = '---\ntitle: X\nlang: ru\n---\n\nB\n';
+    const next = upsertSequenceField(md, 'articles', ['a']);
+    expect(next).toBe('---\ntitle: X\nlang: ru\narticles:\n  - a\n---\n\nB\n');
+  });
+
+  it('removes a scalar back-link line, leaving the body intact', () => {
+    const md = '---\ntitle: X\nlang: ru\nmagazine: n3\n---\n\nBody\n';
+    const next = removeFrontmatterField(md, 'magazine');
+    expect(next).not.toContain('magazine:');
+    expect(next).toContain('title: X');
+    expect(next).toContain('Body');
+  });
+
+  it('is a no-op when the field to remove is absent', () => {
+    const md = '---\ntitle: X\n---\n';
+    expect(removeFrontmatterField(md, 'magazine')).toBe(md);
   });
 });
 

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -227,6 +227,67 @@ export const upsertFrontmatterBlock = (markdown: string, key: string, value: str
   return `---\n${lines.join('\n')}${markdown.slice(end)}`;
 };
 
+/**
+ * Removes a scalar frontmatter field (its whole line) if present, leaving the
+ * body untouched. Used to UNLINK an article from an issue — dropping its
+ * `magazine:` back-link. Pure — safe to unit test.
+ */
+export const removeFrontmatterField = (markdown: string, key: string): string => {
+  if (!markdown.startsWith('---')) return markdown;
+  const end = markdown.indexOf('\n---', 3);
+  if (end < 0) return markdown;
+  const lines = markdown.slice(4, end).split('\n').filter((l) => !l.startsWith(`${key}:`));
+  return `---\n${lines.join('\n')}${markdown.slice(end)}`;
+};
+
+/**
+ * Reads a YAML block sequence (`key:` followed by `  - item` lines) as a plain
+ * array — the issue index's `articles:` table of contents. Returns [] when the
+ * key is absent. Pure — safe to unit test.
+ */
+export const readSequenceField = (markdown: string, key: string): readonly string[] => {
+  if (!markdown.startsWith('---')) return [];
+  const end = markdown.indexOf('\n---', 3);
+  const block = end < 0 ? markdown.slice(4) : markdown.slice(4, end);
+  const lines = block.split('\n');
+  const at = lines.findIndex((l) => l.startsWith(`${key}:`));
+  if (at < 0) return [];
+  const items: string[] = [];
+  for (let i = at + 1; i < lines.length; i += 1) {
+    const m = lines[i].match(/^\s+-\s+(.+?)\s*$/);
+    if (m) items.push(m[1].replace(/^["']|["']$/g, ''));
+    else if (lines[i].trim() !== '') break; // next key ends the sequence
+  }
+  return items;
+};
+
+/**
+ * Inserts or replaces a YAML block sequence field (`key:` + `  - item` lines),
+ * dropping the previous items so a rewrite never orphans stale entries. Placed
+ * after `lang:` (or at the block end) when new. Pure — safe to unit test.
+ */
+export const upsertSequenceField = (
+  markdown: string,
+  key: string,
+  items: readonly string[],
+): string => {
+  const field = [`${key}:`, ...items.map((it) => `  - ${it}`)];
+  if (!markdown.startsWith('---')) return `---\n${field.join('\n')}\n---\n\n${markdown}`;
+  const end = markdown.indexOf('\n---', 3);
+  if (end < 0) return markdown;
+  const lines = markdown.slice(4, end).split('\n');
+  const at = lines.findIndex((l) => l.startsWith(`${key}:`));
+  if (at >= 0) {
+    let removeCount = 1;
+    for (let i = at + 1; i < lines.length && /^\s+-\s+/.test(lines[i]); i += 1) removeCount += 1;
+    lines.splice(at, removeCount, ...field);
+  } else {
+    const langAt = lines.findIndex((l) => l.startsWith('lang:'));
+    lines.splice(langAt >= 0 ? langAt + 1 : lines.length, 0, ...field);
+  }
+  return `---\n${lines.join('\n')}${markdown.slice(end)}`;
+};
+
 /** Fields needed to render a magazine issue's `index.<lang>.md`. */
 export interface IssueIndexInput {
   readonly title: string;
@@ -431,10 +492,11 @@ export const listArticles = async (): Promise<readonly ArticleSummary[]> => {
 };
 
 /** Groups `blog/<slug>/index.<lang>.md` paths into slug → sorted langs. */
-const groupArticlePaths = (paths: readonly string[]): Map<string, string[]> => {
+const groupArticlePaths = (paths: readonly string[], collection = 'blog'): Map<string, string[]> => {
   const bySlug = new Map<string, string[]>();
+  const pattern = new RegExp(`^${collection}/([^/]+)/index\\.([a-z]{2,3})\\.md$`);
   for (const p of paths) {
-    const m = p.match(/^blog\/([^/]+)\/index\.([a-z]{2,3})\.md$/);
+    const m = p.match(pattern);
     if (m) {
       const slug = m[1] as string;
       const langs = bySlug.get(slug) ?? [];
@@ -462,6 +524,7 @@ export interface ArticleListResult {
  */
 export const listArticlesViaApi = async (
   onProgress?: (loaded: number, total: number) => void,
+  collection = 'blog',
 ): Promise<ArticleListResult> => {
   const branch = import.meta.env.VITE_GITHUB_BRANCH ?? 'develop';
   const base = `https://api.github.com/repos/communist-prometheus/public-website-content`;
@@ -480,14 +543,14 @@ export const listArticlesViaApi = async (
     const paths = Array.isArray(tree)
       ? tree.map((e) => (typeof e === 'object' && e && 'path' in e ? String(Reflect.get(e, 'path')) : '')).filter(Boolean)
       : [];
-    const slugs = [...groupArticlePaths(paths).entries()];
+    const slugs = [...groupArticlePaths(paths, collection).entries()];
     onProgress?.(0, slugs.length);
     let done = 0;
     const summaries = await mapPool(slugs, 6, async ([slug, langs]) => {
       const lang = preferredLang(langs);
       let md = '';
       try {
-        const fileRes = await fetch(`${base}/contents/blog/${slug}/index.${lang}.md?ref=${branch}`, {
+        const fileRes = await fetch(`${base}/contents/${collection}/${slug}/index.${lang}.md?ref=${branch}`, {
           headers: { ...auth, accept: 'application/vnd.github.raw' },
         });
         if (fileRes.ok) md = await fileRes.text();
@@ -607,6 +670,75 @@ export const publishFileViaApi = async (
   } catch (e) {
     return { ok: false, error: e instanceof Error ? e.message : String(e) };
   }
+};
+
+/** The outcome of re-linking an issue's articles: what changed, or an error. */
+export interface LinkResult {
+  readonly ok: boolean;
+  readonly linked: number;
+  readonly unlinked: number;
+  readonly error?: string;
+}
+
+/**
+ * Reconciles a magazine issue's linked articles for one language, entirely via
+ * the Contents API (no clone). Given the desired set of article slugs it:
+ *  - reads the issue's current `articles:` table of contents,
+ *  - adds a `magazine: <slug>` back-link to every newly-selected article,
+ *  - removes that back-link from every de-selected article,
+ *  - rewrites the issue index's `articles:` list to the new set.
+ * Each write is its own single-file commit — the same "push only what changed"
+ * model the editor uses. Articles missing the issue language are skipped (they
+ * cannot carry a language-specific back-link) and excluded from the TOC.
+ */
+export const linkIssueArticlesViaApi = async (
+  issueSlug: string,
+  lang: string,
+  selected: readonly string[],
+): Promise<LinkResult> => {
+  const indexPath = `magazine/${issueSlug}/index.${lang}.md`;
+  const indexMd = await readFileViaApi(indexPath);
+  if (indexMd === undefined) {
+    return { ok: false, linked: 0, unlinked: 0, error: `Не найден index номера (${lang}).` };
+  }
+  const current = new Set(readSequenceField(indexMd, 'articles'));
+  const want = new Set(selected);
+  const toLink = selected.filter((s) => !current.has(s));
+  const toUnlink = [...current].filter((s) => !want.has(s));
+
+  // Add the back-link to newly-selected articles; skip any without this language.
+  const linked: string[] = [];
+  for (const slug of selected) {
+    const path = `blog/${slug}/index.${lang}.md`;
+    const md = await readFileViaApi(path);
+    if (md === undefined || md === '') continue;
+    linked.push(slug);
+    if (toLink.includes(slug)) {
+      const next = upsertFrontmatterField(md, 'magazine', issueSlug);
+      const r = await publishFileViaApi(path, next, `magazine: ссылка ${slug} → ${issueSlug}`);
+      if (!r.ok) return { ok: false, linked: 0, unlinked: 0, error: r.error };
+    }
+  }
+
+  // Drop the back-link from de-selected articles.
+  let unlinked = 0;
+  for (const slug of toUnlink) {
+    const path = `blog/${slug}/index.${lang}.md`;
+    const md = await readFileViaApi(path);
+    if (md === undefined || md === '') continue;
+    const next = removeFrontmatterField(md, 'magazine');
+    const r = await publishFileViaApi(path, next, `magazine: отвязка ${slug} от ${issueSlug}`);
+    if (!r.ok) return { ok: false, linked: 0, unlinked: 0, error: r.error };
+    unlinked += 1;
+  }
+
+  // Rewrite the issue TOC to exactly the linked set.
+  const nextIndex = upsertSequenceField(indexMd, 'articles', linked);
+  if (nextIndex !== indexMd) {
+    const r = await publishFileViaApi(indexPath, nextIndex, `magazine: оглавление ${issueSlug} (${linked.length})`);
+    if (!r.ok) return { ok: false, linked: 0, unlinked: 0, error: r.error };
+  }
+  return { ok: true, linked: toLink.length, unlinked };
 };
 
 /** One file in a repo directory (a magazine issue's asset, etc.). */

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -571,6 +571,16 @@ export const listArticlesViaApi = async (
 const REPO_BASE = 'https://api.github.com/repos/communist-prometheus/public-website-content';
 const contentBranch = (): string => import.meta.env.VITE_GITHUB_BRANCH ?? 'develop';
 
+/**
+ * A browser-loadable raw URL for a content file on the current branch. The repo
+ * is public, so `<img src>` / download links work without an auth header. The
+ * path segments are encoded so spaces and Cyrillic filenames resolve.
+ */
+export const rawContentUrl = (path: string): string => {
+  const encoded = path.split('/').map(encodeURIComponent).join('/');
+  return `https://raw.githubusercontent.com/communist-prometheus/public-website-content/${contentBranch()}/${encoded}`;
+};
+
 /** UTF-8 → base64 (btoa is latin1-only; article bodies are Cyrillic). */
 const toBase64 = (text: string): string => {
   const bytes = new TextEncoder().encode(text);

--- a/src/redesign/nav.test.ts
+++ b/src/redesign/nav.test.ts
@@ -25,7 +25,15 @@ describe('canSee (QA #2 route/nav gating)', () => {
   });
 
   it('lets editors see the content surfaces', () => {
-    for (const id of ['articles', 'magazine', 'topics', 'tickets', 'deploys']) {
+    for (const id of [
+      'articles',
+      'magazine',
+      'pages',
+      'archive',
+      'topics',
+      'tickets',
+      'deploys',
+    ]) {
       expect(canSee(item(id), auth('editor', false))).toBe(true);
     }
   });

--- a/src/redesign/nav.ts
+++ b/src/redesign/nav.ts
@@ -39,6 +39,8 @@ export const groups: ReadonlyArray<readonly [NavItem['group'], string]> = [
 export const navItems: readonly NavItem[] = [
   { id: 'articles', label: 'Статьи', icon: 'file-text', group: 'content', role: 'editor' },
   { id: 'magazine', label: 'Журнал', icon: 'book', group: 'content', role: 'editor' },
+  { id: 'pages', label: 'Страницы', icon: 'file-text', group: 'content', role: 'editor' },
+  { id: 'archive', label: 'Архив', icon: 'book', group: 'content', role: 'editor' },
   { id: 'topics', label: 'Темы', icon: 'hash', group: 'content', role: 'editor' },
   { id: 'members', label: 'Участники', icon: 'users', group: 'community', role: 'admin' },
   { id: 'tickets', label: 'Тикеты', icon: 'ticket', group: 'community', role: 'editor' },

--- a/src/redesign/screens/index.ts
+++ b/src/redesign/screens/index.ts
@@ -8,6 +8,7 @@ import './screen-magazine.js';
 import './screen-newsletter.js';
 import './screen-topics.js';
 import './screen-tickets.js';
+import './screen-collection.js';
 
 /**
  * Screen registry for the shell router (app-shell R4). Each screen is a
@@ -30,6 +31,14 @@ export const screens: Readonly<Record<string, Screen>> = {
   settings: element('Настройки', () => html`<screen-settings></screen-settings>`),
   editor: element('Редактор', () => html`<screen-editor></screen-editor>`),
   magazine: element('Журнал', () => html`<screen-magazine></screen-magazine>`),
+  pages: element(
+    'Страницы',
+    () => html`<screen-collection collection="pages" heading="Страницы"></screen-collection>`,
+  ),
+  archive: element(
+    'Архив',
+    () => html`<screen-collection collection="archive" heading="Архив"></screen-collection>`,
+  ),
   topics: element('Темы', () => html`<screen-topics></screen-topics>`),
   tickets: element('Тикеты', () => html`<screen-tickets></screen-tickets>`),
   newsletter: element('Рассылка', () => html`<screen-newsletter></screen-newsletter>`),

--- a/src/redesign/screens/screen-collection.ts
+++ b/src/redesign/screens/screen-collection.ts
@@ -1,0 +1,167 @@
+import { LitElement, html, css, nothing, type TemplateResult } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import '@communist-prometheus/cp-components';
+import { listArticlesViaApi, type ArticleSummary } from '../engine/content.js';
+
+/**
+ * A generic content-section list, driven entirely by its `collection` attribute
+ * (`pages`, `positions`, `archive`, …). It lists the real
+ * `<collection>/<slug>/index.<lang>.md` groups via the GitHub API and opens each
+ * in the shared editor at `#/editor/<collection>/<slug>`. This is what surfaces
+ * the content-repo sections beyond Articles (blog) and Magazine, so an editor
+ * can actually reach and edit them. Like the articles screen, there is no
+ * sample fallback — signed out shows a sign-in prompt, never fabricated data.
+ */
+@customElement('screen-collection')
+export class ScreenCollection extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+    }
+    .head {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: var(--spacing-sm);
+      margin-bottom: var(--spacing-lg);
+    }
+    h1 {
+      font-size: clamp(1.9rem, 7vw, 2.6rem);
+      line-height: 1.15;
+      font-weight: 700;
+      margin: 0;
+      background: linear-gradient(135deg, var(--color-accent), var(--color-text-primary));
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
+    .eyebrow {
+      flex-basis: 100%;
+      margin: 0;
+      font-size: 0.8rem;
+      color: var(--color-text-secondary);
+    }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+      gap: var(--spacing-md);
+    }
+    .meta {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: var(--spacing-sm);
+      font-size: 0.85rem;
+      color: var(--color-text-secondary);
+    }
+    .empty {
+      display: grid;
+      justify-items: start;
+      gap: var(--spacing-sm);
+      padding: var(--spacing-2xl) 0;
+      color: var(--color-text-secondary);
+    }
+    .empty p {
+      margin: 0;
+      max-width: 34ch;
+      line-height: 1.5;
+    }
+  `;
+
+  /** The repo content folder this screen lists, e.g. `pages` or `positions`. */
+  @property() collection = 'pages';
+
+  /** The human heading shown as the page title (e.g. the "Pages" label). */
+  @property() heading = '';
+
+  @state() private items: readonly ArticleSummary[] = [];
+  @state() private loaded = false;
+  @state() private loading = false;
+  @state() private progress: { readonly done: number; readonly total: number } = {
+    done: 0,
+    total: 0,
+  };
+  @state() private error = '';
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.load();
+  }
+
+  override updated(changed: Map<string, unknown>): void {
+    if (changed.has('collection')) void this.load();
+  }
+
+  private async load(): Promise<void> {
+    this.loading = true;
+    this.error = '';
+    this.progress = { done: 0, total: 0 };
+    const result = await listArticlesViaApi((done, total) => {
+      this.progress = { done, total };
+    }, this.collection);
+    this.items = result.articles;
+    this.error = result.error ?? '';
+    this.loading = false;
+    this.loaded = true;
+  }
+
+  private open(slug: string): void {
+    location.hash = `/editor/${this.collection}/${slug}`;
+  }
+
+  private renderCard(item: ArticleSummary): TemplateResult {
+    return html`
+      <cp-card hoverable @cp-card-click=${() => this.open(item.slug)}>
+        ${item.topic ? html`<cp-pill slot="pill">${item.topic}</cp-pill>` : nothing}
+        <span slot="title">${item.title === '' ? item.slug : item.title}</span>
+        <span slot="summary">${item.languages.join(' · ')}</span>
+        <div slot="meta" class="meta">
+          ${item.date ? html`<span>${item.date}</span>` : nothing}
+          <cp-status
+            state=${item.published ? 'success' : 'warning'}
+            label=${item.published ? 'опубликовано' : 'черновик'}
+          ></cp-status>
+        </div>
+      </cp-card>
+    `;
+  }
+
+  private renderEmpty(): TemplateResult {
+    if (this.loading) {
+      const { done, total } = this.progress;
+      const label = total > 0 ? `Загружаем заголовки: ${done} из ${total}` : 'Получаем список…';
+      return html`<div class="empty">
+        <cp-progress ?indeterminate=${total === 0} value=${total > 0 ? done / total : 0}></cp-progress>
+        <p>${label}</p>
+      </div>`;
+    }
+    if (this.error === 'signed-out') {
+      return html`<div class="empty">
+        <p>Здесь появятся материалы репозитория. Войдите через GitHub, чтобы загрузить их.</p>
+      </div>`;
+    }
+    return html`<div class="empty">
+      <p>${this.error !== '' ? `Не удалось загрузить: ${this.error}` : 'Материалов пока нет.'}</p>
+      <cp-button variant="secondary" @cp-click=${() => void this.load()}>Обновить</cp-button>
+    </div>`;
+  }
+
+  override render(): TemplateResult {
+    const live = this.items.length > 0;
+    return html`
+      <div class="head">
+        <p class="eyebrow">Контент${live ? html` · ${this.items.length} материалов` : nothing}</p>
+        <h1 tabindex="-1">${this.heading}</h1>
+      </div>
+      ${live
+        ? html`<div class="grid">${this.items.map((item) => this.renderCard(item))}</div>`
+        : this.renderEmpty()}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'screen-collection': ScreenCollection;
+  }
+}

--- a/src/redesign/screens/screen-editor.props.test.ts
+++ b/src/redesign/screens/screen-editor.props.test.ts
@@ -32,7 +32,7 @@ interface EditorInternals {
   pubDate: string;
   published: boolean;
   dirty: boolean;
-  onDescriptionChange: (event: Event) => void;
+  onLeadInput: (event: Event) => void;
   readonly editedMarkdown: string;
   readonly incomplete: boolean;
   applyMarkdown: (markdown: string, path: string, live: boolean) => void;
@@ -89,9 +89,14 @@ describe('screen-editor properties write-back (QA #4)', () => {
     expect(el.dirty).toBe(false);
   });
 
-  it('becomes dirty once a property is edited', () => {
+  it('becomes dirty once the lead (description) is edited', () => {
     const el = seededEditor();
-    el.onDescriptionChange(new CustomEvent('cp-change', { detail: { value: 'edited' } }));
+    const textarea = document.createElement('textarea');
+    textarea.value = 'edited';
+    const event = new Event('input');
+    Object.defineProperty(event, 'target', { value: textarea });
+    el.onLeadInput(event);
+    expect(el.description).toBe('edited');
     expect(el.dirty).toBe(true);
   });
 

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -435,10 +435,8 @@ export class ScreenEditor extends LitElement {
       min-width: 0;
       overflow-wrap: anywhere;
     }
-    .issue-files {
-      margin-top: var(--spacing-xl);
-      padding-top: var(--spacing-lg);
-      border-top: 1px solid var(--color-hairline);
+    .issue-panel {
+      margin-top: var(--spacing-lg);
       display: grid;
       gap: var(--spacing-xl);
     }
@@ -1012,6 +1010,28 @@ export class ScreenEditor extends LitElement {
     `;
   }
 
+  /**
+   * The primary body of a magazine issue: the structured, typed assets panel
+   * (cover + newspaper file + derived fb2) and the article-linking panel. A
+   * journal issue's `index.<lang>.md` carries no prose body, so it shows no
+   * markdown editor — the issue is assembled from its file, cover and articles.
+   */
+  private renderMagazineBody(): TemplateResult {
+    return html`
+      <div class="issue-panel">
+        <issue-files
+          .dir=${`magazine/${this.slug}/assets`}
+          .slug=${this.slug}
+          .title=${this.articleTitle}
+          .desc=${this.description}
+          .lang=${this.activeLang}
+          .langs=${this.availableLangs}
+        ></issue-files>
+        <issue-articles .issueSlug=${this.slug} .lang=${this.activeLang}></issue-articles>
+      </div>
+    `;
+  }
+
   private renderProps(): TemplateResult {
     // Topic/rubric are blog-article taxonomy; a journal issue has neither, so
     // those fields (and the required-topic gate) are hidden when editing one.
@@ -1153,18 +1173,22 @@ export class ScreenEditor extends LitElement {
             : nothing}
         </div>
         ${this.renderAddLangDialog()}
-        ${this.renderToolbar()}
-        <cp-markdown-editor
-          class="live"
-          .value=${this.body}
-          placeholder="Текст статьи в Markdown…"
-          @cp-change=${this.onBodyChange}
-        ></cp-markdown-editor>
-        <p class="hint">
-          Живой предпросмотр: форматирование отрендерено сразу, а разметку
-          <span class="kbd">#</span> <span class="kbd">**</span>
-          <span class="kbd">&gt;</span> видно только на строке с курсором.
-        </p>
+        ${this.collection === 'magazine'
+          ? this.renderMagazineBody()
+          : html`
+              ${this.renderToolbar()}
+              <cp-markdown-editor
+                class="live"
+                .value=${this.body}
+                placeholder="Текст статьи в Markdown…"
+                @cp-change=${this.onBodyChange}
+              ></cp-markdown-editor>
+              <p class="hint">
+                Живой предпросмотр: форматирование отрендерено сразу, а разметку
+                <span class="kbd">#</span> <span class="kbd">**</span>
+                <span class="kbd">&gt;</span> видно только на строке с курсором.
+              </p>
+            `}
         <p class="save-note">
           ${this.dirty
             ? html`<cp-icon name="warning" size="16"></cp-icon>
@@ -1175,22 +1199,6 @@ export class ScreenEditor extends LitElement {
           <span aria-hidden="true">·</span>
           <span class="path">${this.articlePath}</span>
         </p>
-        ${this.collection === 'magazine' && this.slug !== ''
-          ? html`<div class="issue-files">
-              <issue-files
-                .dir=${`magazine/${this.slug}/assets`}
-                .slug=${this.slug}
-                .title=${this.articleTitle}
-                .desc=${this.description}
-                .lang=${this.activeLang}
-                .langs=${this.availableLangs}
-              ></issue-files>
-              <issue-articles
-                .issueSlug=${this.slug}
-                .lang=${this.activeLang}
-              ></issue-articles>
-            </div>`
-          : nothing}
       </article>
       ${this.renderProps()}${this.renderPublishDialog()}
     `;

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -13,6 +13,7 @@ import {
   upsertFrontmatterBlock,
 } from '../engine/content.js';
 import '../components/issue-files.js';
+import '../components/issue-articles.js';
 
 /** One editable article block: a stable id plus its raw markdown source line(s).
  *  The rendered typography is derived from the raw text on every render, so the
@@ -60,6 +61,10 @@ const LANG_LABELS: Readonly<Record<string, string>> = {
 /** Builds the language tabs from the codes an article actually has. */
 const langTabs = (codes: readonly string[]): readonly CpTab[] =>
   codes.map((code) => ({ id: code, label: LANG_LABELS[code] ?? code.toUpperCase() }));
+
+/** Non-blog collections the route may name as `#/editor/<collection>/<slug>`;
+ * anything else falls back to a blog article at `#/editor/<slug>`. */
+const EDITOR_COLLECTIONS: ReadonlySet<string> = new Set(['magazine', 'pages', 'archive']);
 
 /** Presentational toolbar affordances (block/inline formatting placeholders). */
 const FORMAT_TOOLS: readonly FormatTool[] = [
@@ -216,6 +221,35 @@ export class ScreenEditor extends LitElement {
       -webkit-background-clip: text;
       background-clip: text;
       color: transparent;
+    }
+
+    /* The description now lives here as the lead under the title (design mock),
+       not buried in the properties sheet. It reads as prose but edits in place. */
+    .lead {
+      width: 100%;
+      box-sizing: border-box;
+      margin: 0 0 var(--spacing-md);
+      padding: var(--spacing-sm) 0;
+      border: none;
+      border-bottom: 1px dashed transparent;
+      background: transparent;
+      resize: vertical;
+      font-family: inherit;
+      font-size: 1.15rem;
+      line-height: 1.5;
+      color: var(--color-text-secondary);
+    }
+    .lead::placeholder {
+      color: var(--color-text-tertiary, var(--color-text-secondary));
+      opacity: 0.7;
+    }
+    .lead:hover {
+      border-bottom-color: var(--color-hairline);
+    }
+    .lead:focus {
+      outline: none;
+      border-bottom-color: var(--color-accent);
+      color: var(--color-text-primary);
     }
 
     /* The language tabs can be wider than a phone (5 native names); let them
@@ -405,6 +439,8 @@ export class ScreenEditor extends LitElement {
       margin-top: var(--spacing-xl);
       padding-top: var(--spacing-lg);
       border-top: 1px solid var(--color-hairline);
+      display: grid;
+      gap: var(--spacing-xl);
     }
 
     .sheet-form {
@@ -474,6 +510,12 @@ export class ScreenEditor extends LitElement {
 
   /** Active language variant driving the `cp-tabs`. */
   @state() private activeLang = 'ru';
+
+  /** Add-translation dialog visibility + the chosen new language + progress. */
+  @state() private addLangOpen = false;
+  @state() private addLangChoice = '';
+  @state() private addLangBusy = false;
+  @state() private addLangError = '';
 
   /** Frontmatter slide-over visibility. */
   @state() private propsOpen = false;
@@ -561,12 +603,15 @@ export class ScreenEditor extends LitElement {
 
   /**
    * The item the route names: `#/editor/<slug>` (a blog article, the default) or
-   * `#/editor/magazine/<slug>` (a journal issue). The collection selects the repo
-   * folder so the same editor edits both.
+   * `#/editor/<collection>/<slug>` for a non-blog section (magazine, pages,
+   * positions, archive). The collection selects the repo folder so the same
+   * editor edits every content type.
    */
   private routeTarget(): { collection: string; slug: string } {
     const parts = window.location.hash.split('/');
-    if (parts[2] === 'magazine') return { collection: 'magazine', slug: parts[3] ?? '' };
+    if (parts[2] !== undefined && EDITOR_COLLECTIONS.has(parts[2])) {
+      return { collection: parts[2], slug: parts[3] ?? '' };
+    }
     return { collection: 'blog', slug: parts[2] ?? '' };
   }
 
@@ -710,10 +755,94 @@ export class ScreenEditor extends LitElement {
   private async switchLang(lang: string): Promise<void> {
     const buffered = this.langBuffers.get(lang);
     if (buffered !== undefined) {
-      this.applyMarkdown(buffered, `blog/${this.slug}/index.${lang}.md`, true);
+      this.applyMarkdown(buffered, `${this.collection}/${this.slug}/index.${lang}.md`, true);
       return;
     }
     await this.loadLang(lang);
+  }
+
+  /** Known languages the item does NOT yet have — the add-translation choices. */
+  private get addableLangs(): readonly string[] {
+    return Object.keys(LANG_LABELS).filter((c) => !this.availableLangs.includes(c));
+  }
+
+  private readonly openAddLang = (): void => {
+    this.addLangChoice = this.addableLangs[0] ?? '';
+    this.addLangError = '';
+    this.addLangOpen = true;
+  };
+
+  private readonly closeAddLang = (): void => {
+    if (!this.addLangBusy) this.addLangOpen = false;
+  };
+
+  /**
+   * Creates a new language variant (`index.<lang>.md`) for the open blog article
+   * or magazine issue, seeded from the current language's frontmatter + body so
+   * the translator edits the original in place. The seed forces the new `lang:`
+   * and marks it an unpublished draft until reviewed. One Contents-API commit.
+   */
+  private readonly confirmAddLang = async (): Promise<void> => {
+    const lang = this.addLangChoice;
+    if (lang === '' || this.slug === '') return;
+    // Stash the current language's edits so switching away never loses them.
+    this.langBuffers.set(this.activeLang, this.editedMarkdown);
+    const source = this.editedMarkdown;
+    const withLang = upsertFrontmatterField(source, 'lang', lang);
+    const seed = upsertFrontmatterField(withLang, 'published', 'false');
+    const path = `${this.collection}/${this.slug}/index.${lang}.md`;
+    this.addLangBusy = true;
+    this.addLangError = '';
+    const result = await publishFileViaApi(path, seed, `${this.collection}: перевод ${this.slug} → ${lang}`);
+    this.addLangBusy = false;
+    if (!result.ok) {
+      this.addLangError = result.error ?? 'Не удалось создать перевод.';
+      return;
+    }
+    this.availableLangs = [...this.availableLangs, lang].sort();
+    this.langBuffers.set(lang, seed);
+    this.activeLang = lang;
+    this.applyMarkdown(seed, path, true);
+    this.addLangOpen = false;
+  };
+
+  private renderAddLangDialog(): TemplateResult {
+    const options: readonly CpSelectOption[] = this.addableLangs.map((c) => ({
+      value: c,
+      label: LANG_LABELS[c] ?? c.toUpperCase(),
+    }));
+    return html`
+      <cp-dialog
+        ?open=${this.addLangOpen}
+        ?busy=${this.addLangBusy}
+        heading="Новый перевод"
+        @cp-cancel=${this.closeAddLang}
+      >
+        <p class="hint">
+          Создаётся вариант на выбранном языке из текущего текста — переведите его
+          на месте. Пока не опубликован.
+        </p>
+        <cp-select
+          .options=${options}
+          .value=${this.addLangChoice}
+          @cp-change=${(e: Event) => {
+            if (e instanceof CustomEvent && typeof e.detail?.value === 'string')
+              this.addLangChoice = e.detail.value;
+          }}
+        ></cp-select>
+        ${this.addLangError !== ''
+          ? html`<p class="hint" style="color:var(--color-danger,#c0392b)">${this.addLangError}</p>`
+          : nothing}
+        <div slot="footer" class="dialog-foot">
+          ${this.addLangBusy
+            ? html`<cp-button variant="secondary" disabled>Создаём…</cp-button>`
+            : html`<cp-button variant="secondary" @cp-click=${this.closeAddLang}>Отмена</cp-button>
+                <cp-button arrow ?disabled=${this.addLangChoice === ''} @cp-click=${() => void this.confirmAddLang()}
+                  >Создать</cp-button
+                >`}
+        </div>
+      </cp-dialog>
+    `;
   }
 
   // The editor's cp-change only fires for real user edits (the component
@@ -753,13 +882,13 @@ export class ScreenEditor extends LitElement {
     }
   };
 
-  private onDescriptionChange = (event: Event): void => {
-    if (event instanceof CustomEvent) {
-      const value: unknown = event.detail?.value;
-      if (typeof value === 'string') {
-        this.description = value;
-        this.dirty = true;
-      }
+  /** The lead field under the title is a native textarea (a plain input event),
+   *  writing the article's `description` frontmatter. */
+  private onLeadInput = (event: Event): void => {
+    const target = event.target;
+    if (target instanceof HTMLTextAreaElement) {
+      this.description = target.value;
+      this.dirty = true;
     }
   };
 
@@ -906,12 +1035,6 @@ export class ScreenEditor extends LitElement {
                 @cp-change=${this.onTopicChange}
               ></cp-select>`
             : nothing}
-          <cp-textarea
-            label="Описание"
-            rows="3"
-            .value=${this.description}
-            @cp-change=${this.onDescriptionChange}
-          ></cp-textarea>
           ${isArticle
             ? html`<cp-select
                 label="Рубрика"
@@ -1006,13 +1129,30 @@ export class ScreenEditor extends LitElement {
           </h1>
           <cp-tag tone="success">данные из репозитория</cp-tag>
         </div>
+        <textarea
+          class="lead"
+          rows="2"
+          placeholder="Лид — короткое описание под заголовком"
+          .value=${this.description}
+          @input=${this.onLeadInput}
+        ></textarea>
         <div class="tabs-scroll">
           <cp-tabs
             .tabs=${langTabs(this.availableLangs)}
             active=${this.activeLang}
             @cp-tab-change=${this.onLangChange}
           ></cp-tabs>
+          ${this.slug !== '' && this.addableLangs.length > 0
+            ? html`<cp-button
+                size="sm"
+                variant="ghost"
+                title="Добавить перевод"
+                @cp-click=${this.openAddLang}
+                >+ язык</cp-button
+              >`
+            : nothing}
         </div>
+        ${this.renderAddLangDialog()}
         ${this.renderToolbar()}
         <cp-markdown-editor
           class="live"
@@ -1039,9 +1179,16 @@ export class ScreenEditor extends LitElement {
           ? html`<div class="issue-files">
               <issue-files
                 .dir=${`magazine/${this.slug}/assets`}
+                .slug=${this.slug}
+                .title=${this.articleTitle}
+                .desc=${this.description}
                 .lang=${this.activeLang}
                 .langs=${this.availableLangs}
               ></issue-files>
+              <issue-articles
+                .issueSlug=${this.slug}
+                .lang=${this.activeLang}
+              ></issue-articles>
             </div>`
           : nothing}
       </article>


### PR DESCRIPTION
Promote the redesign admin improvements from `develop` to production
(`admin.comprom.org`). Bundles #422 + #423, both green on dev-admin.

- **Structured, typed magazine issue page** (#423) — cover preview + PDF/FB2
  slots + collapsed cleanup + article checklist; no markdown editor for issues.
  Replaces the old flat file dump.
- **PDF/DOCX-only upload** (#422) — docx→fb2 (docx never persisted), pdf→pdf+cover.
- **New translation** flow (`+ язык`) for blog articles and magazine issues.
- **Content sections** — nav exposes Статьи / Журнал / Страницы / Архив.
- **Lead field** — description moved out of Свойства to under the title.
- No ⚠ for journal issues; newest→oldest sort everywhere.

`validate` (incl. sonar), 149 redesign specs, realmode, and the dev-admin
deploy are all green; structured bundle verified live on dev-admin.