### PR TITLE
prod: editor fixes — no more corrupted translations, properties on the page, target site named

### DIFF
--- a/src/redesign/app-shell.env.test.ts
+++ b/src/redesign/app-shell.env.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import './app-shell.ts';
+import type { AppShell } from './app-shell.ts';
+
+/**
+ * The dev admin and the production admin are the same UI pointed at different
+ * content branches, and used to be indistinguishable. An editor published a
+ * translation on the dev one, never found it on comprom.org, and hand-edited
+ * the file on GitHub — which broke the production build. The shell must say
+ * which site it writes to whenever that site is not the public one.
+ */
+const mount = async (): Promise<AppShell> => {
+  const el = document.createElement('app-shell') as AppShell;
+  document.body.append(el);
+  await el.updateComplete;
+  return el;
+};
+
+const text = (el: AppShell): string => (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('app-shell environment badge', () => {
+  it('marks a non-production admin with the site it publishes to', async () => {
+    vi.stubEnv('VITE_GITHUB_BRANCH', 'develop');
+    const el = await mount();
+    expect(text(el)).toContain('dev.comprom.org');
+  });
+
+  it('carries a short label too, for a phone header that cannot fit the host', async () => {
+    vi.stubEnv('VITE_GITHUB_BRANCH', 'develop');
+    const el = await mount();
+    const badge = el.shadowRoot?.querySelector('.env');
+    expect(badge?.querySelector('.env-full')?.textContent).toBe('dev.comprom.org');
+    expect(badge?.querySelector('.env-short')?.textContent).toBe('dev');
+    // The tooltip names the site in full, whichever label is on screen.
+    expect(badge?.getAttribute('title')).toContain('dev.comprom.org');
+  });
+
+  it('stays clean on the production admin', async () => {
+    vi.stubEnv('VITE_GITHUB_BRANCH', 'master');
+    const el = await mount();
+    expect(text(el)).not.toContain('dev.comprom.org');
+  });
+});

--- a/src/redesign/app-shell.ts
+++ b/src/redesign/app-shell.ts
@@ -6,6 +6,7 @@ import { screens } from './screens/index.js';
 import { createGitStateStore, type GitStateStore, type SyncStatus } from './engine/git-state.js';
 import { login, loginWithToken, logout, currentUser } from './engine/auth.js';
 import { bootEngine } from './engine/engine-boot.js';
+import { publishTarget } from './engine/publish-target.js';
 import { getViewerRole, type ViewerRole } from './engine/github-api.js';
 
 /** One of the four viewport corners the draggable FAB can snap to. */
@@ -74,6 +75,51 @@ export class AppShell extends LitElement {
     }
     :host([data-theme='dark']) .logo-dark {
       display: inline;
+    }
+    /* A non-production admin says so: it looks identical to the real one
+       otherwise, and publishing to the wrong site is invisible until the
+       article fails to appear on comprom.org. */
+    .env {
+      flex: 0 0 auto;
+      margin-right: var(--spacing-sm);
+      padding: 0.15rem 0.5rem;
+      border: 1px solid var(--color-accent);
+      border-radius: 999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--color-accent);
+      white-space: nowrap;
+    }
+    /* The full host does not fit a phone header next to the account controls,
+       and pushing them off-screen would be worse than a short label. */
+    .env-short {
+      display: none;
+    }
+    /* A phone header is tight even without the badge: at 390px the brand, the
+       account name, the sign-out button and the theme toggle already overflow,
+       pushing the last of them off-screen. Tighten the spacing and cap the
+       account name so everything stays reachable. */
+    @media (max-width: 767px) {
+      header {
+        gap: var(--spacing-xs, 0.5rem);
+        padding: 0 var(--spacing-xs, 0.5rem);
+      }
+      .brand img {
+        height: 24px;
+      }
+      .env-full {
+        display: none;
+      }
+      .env-short {
+        display: inline;
+        text-transform: uppercase;
+      }
+      .header-right .account {
+        max-width: 5rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
     .header-right {
       display: flex;
@@ -865,6 +911,14 @@ export class AppShell extends LitElement {
           <img class="logo-light" src="/logo-light.svg" alt="" />
           <img class="logo-dark" src="/logo-dark.svg" alt="" />
         </a>
+        ${publishTarget().production
+          ? nothing
+          : html`<span
+              class="env"
+              title=${`Публикации из этой админки идут на ${publishTarget().site}, не на comprom.org`}
+              ><span class="env-full">${publishTarget().site}</span
+              ><span class="env-short">${publishTarget().site.split('.')[0]}</span></span
+            >`}
         <div class="header-right">
           <cp-status state=${this.sync.tone} label=${this.sync.label}></cp-status>
           ${!this.authChecked

--- a/src/redesign/components/issue-articles.test.ts
+++ b/src/redesign/components/issue-articles.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+import './issue-articles.ts';
+import type { IssueArticles } from './issue-articles.ts';
+
+vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
+
+/**
+ * The develop incident, end to end through the panel: a journal issue was
+ * translated to `en` and inherited the ru table of contents; the editor then
+ * removed the one article that had an `en` file. Every remaining slug was
+ * ru-only, so the rewritten TOC came out as a bare `articles:` (an empty YAML value) and
+ * the public build failed on the collection schema.
+ */
+const article = (title: string, lang: string): string =>
+  `---\ntitle: ${title}\nlang: ${lang}\ncategory: t\nmagazine: n2\n---\n\nB\n`;
+
+const seedRepo = (): Record<string, string> => ({
+  'magazine/n2/index.ru.md': '---\ntitle: N2\nlang: ru\narticles:\n  - a\n  - b\n---\n\nB\n',
+  'magazine/n2/index.en.md':
+    '---\ntitle: N2\nlang: en\npublished: false\narticles:\n  - a\n  - b\nimage: ./assets/cover.ru.png\n---\n\nB\n',
+  'blog/a/index.ru.md': article('A ru', 'ru'),
+  'blog/a/index.en.md': article('A en', 'en'),
+  'blog/b/index.ru.md': article('B ru', 'ru'),
+});
+
+const decode = (b64: string): string =>
+  new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+
+const acceptOf = (init?: RequestInit): string => {
+  const h = init?.headers;
+  return typeof h === 'object' && 'accept' in h ? String(Reflect.get(h, 'accept')) : '';
+};
+
+/** A GitHub Contents/Trees API double over an in-memory repo; records PUTs. */
+const stubGitHub = (repo: Record<string, string>, puts: string[]): void => {
+  vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    if (url.includes('/git/trees/')) {
+      return new Response(JSON.stringify({ tree: Object.keys(repo).map((path) => ({ path })) }), { status: 200 });
+    }
+    const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+    if (init?.method === 'PUT') {
+      repo[path] = decode(JSON.parse(String(init.body)).content);
+      puts.push(path);
+      return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+    }
+    if (acceptOf(init).includes('raw')) return new Response(repo[path] ?? '', { status: repo[path] ? 200 : 404 });
+    return new Response(JSON.stringify({ sha: 'blob' }), { status: 200 });
+  });
+};
+
+interface PanelInternals {
+  selected: ReadonlySet<string>;
+  loading: boolean;
+  busy: boolean;
+  toggle: (slug: string) => void;
+  save: () => Promise<void>;
+}
+
+const mount = async (lang: string): Promise<{ el: IssueArticles; priv: PanelInternals }> => {
+  const el = document.createElement('issue-articles');
+  el.issueSlug = 'n2';
+  el.lang = lang;
+  document.body.append(el);
+  const priv = el as unknown as PanelInternals;
+  // load() is fire-and-forget from connectedCallback; wait for it to settle.
+  for (let i = 0; i < 50 && (priv.loading || priv.selected.size === 0); i += 1) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  await el.updateComplete;
+  return { el, priv };
+};
+
+const shadowText = (el: HTMLElement): string => (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  vi.stubEnv('VITE_DEV_TOKEN', '');
+  vi.stubEnv('VITE_GITHUB_BRANCH', 'develop');
+  vi.mocked(ensureFreshToken).mockResolvedValue('tok');
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('issue-articles: removing the last translated article from an issue', () => {
+  it('stores an explicit empty TOC the site schema accepts, never a bare `articles:`', async () => {
+    const repo = seedRepo();
+    const puts: string[] = [];
+    stubGitHub(repo, puts);
+
+    const { el, priv } = await mount('en');
+    expect([...priv.selected].sort()).toEqual(['a', 'b']);
+    // Only `a` has an English file, so it is the only article the panel lists
+    // (titles come from the preferred ru file).
+    expect(shadowText(el)).toContain('A ru');
+    expect(shadowText(el)).not.toContain('B ru');
+
+    priv.toggle('a');
+    await priv.save();
+    await el.updateComplete;
+
+    expect(puts).toContain('magazine/n2/index.en.md');
+    const fm: unknown = parseYaml(repo['magazine/n2/index.en.md'].split('\n---')[0].slice(4));
+    expect(fm).toMatchObject({ lang: 'en', articles: [] });
+    // The de-selected article lost its back-link.
+    expect(repo['blog/a/index.en.md']).not.toContain('magazine:');
+    expect(shadowText(el)).toContain('Связи обновлены');
+  });
+
+  it('aborts instead of silently dropping links when an article read fails (expired token)', async () => {
+    const repo = seedRepo();
+    const puts: string[] = [];
+    stubGitHub(repo, puts);
+    const { el, priv } = await mount('en');
+
+    // The session token expires mid-edit: every raw read now answers 401.
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') puts.push(url);
+      return new Response(JSON.stringify({ message: 'Bad credentials' }), { status: 401 });
+    });
+    priv.toggle('a');
+    await priv.save();
+    await el.updateComplete;
+
+    expect(puts).toEqual([]);
+    expect(shadowText(el)).toContain('Bad credentials');
+  });
+});

--- a/src/redesign/components/issue-articles.ts
+++ b/src/redesign/components/issue-articles.ts
@@ -16,6 +16,11 @@ import {
  * in or out — the manual "reassign articles" the journal workflow needs. Saving
  * reconciles both sides of the link (the issue TOC and each article's
  * `magazine:` back-link) via the Contents API, no clone.
+ *
+ * Built to stay usable at a hundred-plus articles: a search box filters by
+ * title, the articles already in the issue are pinned to the top, and a toggle
+ * narrows the list to just those — so the editor is never scrolling a flat wall
+ * of checkboxes to find what is in the issue or to add one more.
  */
 @customElement('issue-articles')
 export class IssueArticles extends LitElement {
@@ -27,22 +32,61 @@ export class IssueArticles extends LitElement {
       font-size: 1.1rem;
       margin: 0 0 var(--spacing-sm);
     }
+    .toolbar {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+      flex-wrap: wrap;
+      margin-bottom: var(--spacing-xs);
+    }
+    .toolbar cp-input {
+      flex: 1 1 12rem;
+    }
+    .only {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      color: var(--color-text-secondary);
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .only input {
+      accent-color: var(--color-accent);
+    }
+    .count {
+      font-size: 0.82rem;
+      color: var(--color-text-secondary);
+      margin: 0 0 var(--spacing-xs);
+    }
+    .count b {
+      color: var(--color-text-primary);
+    }
+    .scroll {
+      max-height: 24rem;
+      overflow-y: auto;
+      border: 1px solid var(--color-hairline);
+      border-radius: var(--radius-md, 10px);
+    }
     ul {
       list-style: none;
-      margin: 0 0 var(--spacing-md);
+      margin: 0;
       padding: 0;
       display: grid;
-      gap: var(--spacing-xs);
     }
     li {
       display: flex;
       align-items: baseline;
       gap: var(--spacing-sm);
-      padding: var(--spacing-xs) 0;
+      padding: var(--spacing-xs) var(--spacing-sm);
       border-top: 1px solid var(--color-hairline);
     }
     li:first-child {
       border-top: none;
+    }
+    /* An article already in the issue reads as selected at a glance. */
+    li.on {
+      background: color-mix(in srgb, var(--color-accent) 10%, transparent);
     }
     label {
       display: flex;
@@ -50,9 +94,16 @@ export class IssueArticles extends LitElement {
       gap: var(--spacing-sm);
       cursor: pointer;
       min-width: 0;
+      flex: 1;
     }
     .title {
       overflow-wrap: anywhere;
+    }
+    .in {
+      font-size: 0.7rem;
+      font-weight: 600;
+      color: var(--color-accent);
+      white-space: nowrap;
     }
     .date {
       font-size: 0.78rem;
@@ -66,19 +117,21 @@ export class IssueArticles extends LitElement {
       align-items: center;
       gap: var(--spacing-md);
       flex-wrap: wrap;
+      margin-top: var(--spacing-sm);
     }
     .empty,
     .msg {
       color: var(--color-text-secondary);
       font-size: 0.88rem;
       margin: 0.2rem 0;
+      padding: 0 var(--spacing-sm);
     }
     .msg.error {
       color: var(--color-danger, #c0392b);
     }
-    .count {
+    .dirty {
       font-size: 0.82rem;
-      color: var(--color-text-secondary);
+      color: var(--color-accent);
     }
   `;
 
@@ -95,6 +148,12 @@ export class IssueArticles extends LitElement {
   @state() private busy = false;
   @state() private message = '';
   @state() private error = '';
+
+  /** Free-text filter over article titles / slugs. */
+  @state() private query = '';
+
+  /** When true, only the articles already in the issue are listed. */
+  @state() private onlySelected = false;
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -134,6 +193,32 @@ export class IssueArticles extends LitElement {
     this.selected = next;
   };
 
+  private readonly onQuery = (event: Event): void => {
+    if (!(event instanceof CustomEvent)) return;
+    const value: unknown = event.detail?.value;
+    if (typeof value === 'string') this.query = value;
+  };
+
+  /** The visible article list: filtered by the search and the "only selected"
+   *  toggle, with the ones already in the issue pinned to the top, then newest
+   *  first — so both "what is in the issue" and "add another" stay one glance
+   *  away however long the full catalogue grows. */
+  private get view(): readonly ArticleSummary[] {
+    const q = this.query.trim().toLowerCase();
+    const matches = (a: ArticleSummary): boolean => {
+      const inSearch = q === '' || a.title.toLowerCase().includes(q) || a.slug.toLowerCase().includes(q);
+      return inSearch && (!this.onlySelected || this.selected.has(a.slug));
+    };
+    const rank = (a: ArticleSummary): number => (this.selected.has(a.slug) ? 0 : 1);
+    return [...this.articles.filter(matches)].sort((a, b) => {
+      if (rank(a) !== rank(b)) return rank(a) - rank(b);
+      const da = a.date ?? '';
+      const db = b.date ?? '';
+      if (da !== db) return da < db ? 1 : -1; // newest first
+      return (a.title || a.slug).localeCompare(b.title || b.slug);
+    });
+  }
+
   /** True once the selection differs from what was loaded — enables Save. */
   private get changed(): boolean {
     if (this.selected.size !== this.linkedAtLoad.size) return true;
@@ -156,19 +241,43 @@ export class IssueArticles extends LitElement {
   };
 
   private renderArticle(a: ArticleSummary): TemplateResult {
+    const on = this.selected.has(a.slug);
     return html`
-      <li>
+      <li class=${on ? 'on' : ''}>
         <label>
           <input
             type="checkbox"
-            .checked=${this.selected.has(a.slug)}
+            .checked=${on}
             ?disabled=${this.busy}
             @change=${() => this.toggle(a.slug)}
           />
           <span class="title">${a.title === '' ? a.slug : a.title}</span>
+          ${on ? html`<span class="in">в номере</span>` : nothing}
         </label>
         ${a.date !== undefined ? html`<span class="date">${a.date}</span>` : nothing}
       </li>
+    `;
+  }
+
+  private renderList(): TemplateResult {
+    const view = this.view;
+    if (this.articles.length === 0) {
+      return html`<p class="empty">
+        Нет статей на языке «${this.lang}». Создайте статьи в разделе «Материалы».
+      </p>`;
+    }
+    return html`
+      <p class="count">
+        В номере <b>${this.selected.size}</b> · показано ${view.length} из ${this.articles.length}
+        ${this.changed ? html`· <span class="dirty">есть несохранённые изменения</span>` : nothing}
+      </p>
+      ${view.length === 0
+        ? html`<p class="empty">Ничего не найдено по запросу «${this.query}».</p>`
+        : html`<div class="scroll">
+            <ul>
+              ${view.map((a) => this.renderArticle(a))}
+            </ul>
+          </div>`}
     `;
   }
 
@@ -177,16 +286,25 @@ export class IssueArticles extends LitElement {
       <h2>Статьи номера</h2>
       ${this.loading
         ? html`<p class="msg">Загружаем статьи…</p>`
-        : this.articles.length === 0
-          ? html`<p class="empty">
-              Нет статей на языке «${this.lang}». Создайте статьи в разделе «Материалы».
-            </p>`
-          : html`
-              <p class="count">Отмечено ${this.selected.size} из ${this.articles.length}.</p>
-              <ul>
-                ${this.articles.map((a) => this.renderArticle(a))}
-              </ul>
-            `}
+        : html`
+            <div class="toolbar">
+              <cp-input
+                placeholder="Поиск статьи по названию…"
+                .value=${this.query}
+                @cp-input=${this.onQuery}
+                @cp-change=${this.onQuery}
+              ></cp-input>
+              <label class="only">
+                <input
+                  type="checkbox"
+                  .checked=${this.onlySelected}
+                  @change=${() => (this.onlySelected = !this.onlySelected)}
+                />
+                только в номере
+              </label>
+            </div>
+            ${this.renderList()}
+          `}
       ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
       ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
       <div class="actions">

--- a/src/redesign/components/issue-files.ts
+++ b/src/redesign/components/issue-files.ts
@@ -243,6 +243,19 @@ export class IssueFiles extends LitElement {
       color: var(--color-text-secondary);
       margin: 0;
     }
+    /* A picked-but-unpublished file: the note explains nothing committed yet,
+       the actions carry the explicit publish + cancel. */
+    .stage-note {
+      font-size: 0.82rem;
+      color: var(--color-accent);
+      margin: 0;
+    }
+    .stage-actions {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-sm);
+      flex-wrap: wrap;
+    }
     .msg {
       color: var(--color-text-secondary);
       font-size: 0.86rem;
@@ -296,13 +309,33 @@ export class IssueFiles extends LitElement {
   /** Path awaiting a delete confirmation (two-step, so a tap can't wipe a file). */
   @state() private confirmingPath = '';
 
+  /** A cover image chosen but NOT yet published — previewed for confirmation so
+   *  picking a file never silently commits. Published only on the button. */
+  @state() private stagedCover?: File;
+  @state() private stagedCoverUrl = '';
+
+  /** A newspaper file (PDF/DOCX) chosen but not yet uploaded. */
+  @state() private stagedPaper?: File;
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
   }
 
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.clearStagedCover();
+  }
+
   override updated(changed: Map<string, unknown>): void {
     if (changed.has('dir')) void this.load();
+  }
+
+  /** Drops the staged cover and frees its object URL. */
+  private clearStagedCover(): void {
+    if (this.stagedCoverUrl !== '') URL.revokeObjectURL(this.stagedCoverUrl);
+    this.stagedCoverUrl = '';
+    this.stagedCover = undefined;
   }
 
   private async load(): Promise<void> {
@@ -328,16 +361,34 @@ export class IssueFiles extends LitElement {
    *   (`extractPdfCover`) and committed as `cover.<lang>.png`.
    * Both converters load lazily so mammoth/mupdf stay out of the initial bundle.
    */
-  private readonly onPick = async (event: Event): Promise<void> => {
+  /** Stages a picked newspaper file for confirmation — no commit yet. */
+  private readonly onPick = (event: Event): void => {
     const input = event.target;
     const file = input instanceof HTMLInputElement ? input.files?.[0] : undefined;
     if (input instanceof HTMLInputElement) input.value = '';
     if (file === undefined) return;
-    const kind = classifyUpload(file.name);
-    if (kind === 'reject') {
+    if (classifyUpload(file.name) === 'reject') {
       this.error = 'Для номера загружается только файл газеты — PDF или DOCX.';
       return;
     }
+    this.stagedPaper = file;
+    this.error = '';
+    this.message = '';
+  };
+
+  /**
+   * Publishes the staged newspaper file — the explicit action behind the
+   * upload button, so nothing reaches the repo until the editor confirms:
+   * - DOCX → converted client-side to FB2 (`docxFileToFb2`); the docx is never
+   *   persisted, only `<slug>.<lang>.fb2` is committed.
+   * - PDF → committed as `<slug>.<lang>.pdf`, and its first page is rendered
+   *   (`extractPdfCover`) and committed as `cover.<lang>.png`.
+   * Both converters load lazily so mammoth/mupdf stay out of the initial bundle.
+   */
+  private readonly commitPaper = async (): Promise<void> => {
+    const file = this.stagedPaper;
+    if (file === undefined) return;
+    const kind = classifyUpload(file.name);
     const [primary, cover] = plannedAssetPaths(this.dir, this.slug, this.lang, kind);
     this.busy = true;
     this.message = '';
@@ -360,6 +411,7 @@ export class IssueFiles extends LitElement {
         await this.commit(cover, coverFile, `assets: cover ${this.slug}.${this.lang}`);
         this.message = `PDF загружен, обложка извлечена: cover.${this.lang}.png`;
       }
+      this.stagedPaper = undefined;
       await this.load();
     } catch (e) {
       this.error = e instanceof Error ? e.message : String(e);
@@ -368,8 +420,8 @@ export class IssueFiles extends LitElement {
     }
   };
 
-  /** Replaces just the cover for the open language with a picked image. */
-  private readonly onPickCover = async (event: Event): Promise<void> => {
+  /** Stages a picked cover image for confirmation — previews it, no commit. */
+  private readonly onPickCover = (event: Event): void => {
     const input = event.target;
     const file = input instanceof HTMLInputElement ? input.files?.[0] : undefined;
     if (input instanceof HTMLInputElement) input.value = '';
@@ -379,6 +431,17 @@ export class IssueFiles extends LitElement {
       this.error = 'Обложка — это изображение (png, jpg, webp…).';
       return;
     }
+    this.clearStagedCover();
+    this.stagedCover = file;
+    this.stagedCoverUrl = URL.createObjectURL(file);
+    this.error = '';
+    this.message = '';
+  };
+
+  /** Publishes the staged cover for the open language — the explicit button. */
+  private readonly commitCover = async (): Promise<void> => {
+    const file = this.stagedCover;
+    if (file === undefined) return;
     this.busy = true;
     this.message = '';
     this.error = '';
@@ -388,6 +451,7 @@ export class IssueFiles extends LitElement {
         file,
         `assets: cover ${this.slug}.${this.lang}`,
       );
+      this.clearStagedCover();
       this.message = `Обложка обновлена: cover.${this.lang}.png`;
       await this.load();
     } catch (e) {
@@ -432,29 +496,53 @@ export class IssueFiles extends LitElement {
   }
 
   private renderCover(assets: IssueAssets): TemplateResult {
+    const staged = this.stagedCover !== undefined;
     return html`
       <section class="slot">
         <div class="slot-head">
           <h3>Обложка</h3>
           <span class="spacer"></span>
-          ${assets.cover === undefined
-            ? html`<cp-tag tone="warning">нет</cp-tag>`
-            : assets.coverShared
-              ? html`<cp-tag>общая</cp-tag>`
-              : html`<cp-tag tone="success">есть</cp-tag>`}
+          ${staged
+            ? html`<cp-tag tone="warning">новая, не опубликована</cp-tag>`
+            : assets.cover === undefined
+              ? html`<cp-tag tone="warning">нет</cp-tag>`
+              : assets.coverShared
+                ? html`<cp-tag>общая</cp-tag>`
+                : html`<cp-tag tone="success">есть</cp-tag>`}
         </div>
-        ${assets.cover === undefined
-          ? html`<div class="cover-none">нет обложки</div>`
-          : html`<img
-              class="cover-preview"
-              src=${rawContentUrl(assets.cover.path)}
-              alt="Обложка номера (${this.lang})"
-              loading="lazy"
-            />`}
-        <label class="upload">
-          <span>${this.busy ? 'Обрабатываем…' : 'Заменить обложку (изображение):'}</span>
-          <input type="file" accept="image/*" ?disabled=${this.busy} @change=${this.onPickCover} />
-        </label>
+        ${staged
+          ? html`<img class="cover-preview" src=${this.stagedCoverUrl} alt="Новая обложка (предпросмотр)" />`
+          : assets.cover === undefined
+            ? html`<div class="cover-none">нет обложки</div>`
+            : html`<img
+                class="cover-preview"
+                src=${rawContentUrl(assets.cover.path)}
+                alt="Обложка номера (${this.lang})"
+                loading="lazy"
+              />`}
+        ${staged
+          ? html`
+              <p class="stage-note">
+                Выбран файл «${this.stagedCover?.name}». Пока ничего не загружено — нажмите
+                «Опубликовать обложку».
+              </p>
+              <div class="stage-actions">
+                <cp-button size="sm" ?disabled=${this.busy} @cp-click=${() => void this.commitCover()}>
+                  ${this.busy ? 'Публикуем…' : 'Опубликовать обложку'}
+                </cp-button>
+                <cp-button
+                  size="sm"
+                  variant="secondary"
+                  ?disabled=${this.busy}
+                  @cp-click=${() => this.clearStagedCover()}
+                  >Отмена</cp-button
+                >
+              </div>
+            `
+          : html`<label class="upload">
+              <span>Заменить обложку (изображение):</span>
+              <input type="file" accept="image/*" ?disabled=${this.busy} @change=${this.onPickCover} />
+            </label>`}
       </section>
     `;
   }
@@ -472,19 +560,34 @@ export class IssueFiles extends LitElement {
         <ul class="rows">
           ${this.renderFileRow('PDF', assets.pdf)}${this.renderFileRow('FB2', assets.fb2)}
         </ul>
-        <label class="upload">
-          <span
-            >${this.busy
-              ? 'Обрабатываем файл газеты…'
-              : 'Загрузить файл газеты (PDF или DOCX):'}</span
-          >
-          <input
-            type="file"
-            accept="application/pdf,.pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            ?disabled=${this.busy}
-            @change=${this.onPick}
-          />
-        </label>
+        ${this.stagedPaper !== undefined
+          ? html`
+              <p class="stage-note">
+                Выбран файл «${this.stagedPaper.name}». Пока ничего не загружено — нажмите
+                «Загрузить».
+              </p>
+              <div class="stage-actions">
+                <cp-button size="sm" ?disabled=${this.busy} @cp-click=${() => void this.commitPaper()}>
+                  ${this.busy ? 'Загружаем…' : 'Загрузить файл номера'}
+                </cp-button>
+                <cp-button
+                  size="sm"
+                  variant="secondary"
+                  ?disabled=${this.busy}
+                  @cp-click=${() => (this.stagedPaper = undefined)}
+                  >Отмена</cp-button
+                >
+              </div>
+            `
+          : html`<label class="upload">
+              <span>Выбрать файл газеты (PDF или DOCX):</span>
+              <input
+                type="file"
+                accept="application/pdf,.pdf,.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                ?disabled=${this.busy}
+                @change=${this.onPick}
+              />
+            </label>`}
         <p class="hint">
           DOCX → автоматически конвертируется в FB2. PDF → загружается, обложка берётся из
           первой страницы. Другие файлы не принимаются.

--- a/src/redesign/engine/content-api.test.ts
+++ b/src/redesign/engine/content-api.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
 import {
   listArticlesViaApi,
@@ -160,12 +161,13 @@ describe('editor single-file API (read / langs / publish, no clone)', () => {
       }
       return new Response(JSON.stringify({ sha: 'blob1' }), { status: 200 });
     });
-    const r = await publishFileViaApi('blog/x/index.ru.md', 'Привет, мир', 'msg');
+    const md = '---\ntitle: Привет\nlang: ru\ncategory: t\n---\n\nПривет, мир\n';
+    const r = await publishFileViaApi('blog/x/index.ru.md', md, 'msg');
     expect(r).toEqual({ ok: true, sha: 'commit1' });
     const put = calls.find((c) => c.method === 'PUT');
     expect(put?.body?.sha).toBe('blob1'); // updates against the current blob
     expect(put?.body?.message).toBe('msg');
-    expect(decode(String(put?.body?.content))).toBe('Привет, мир'); // Cyrillic survives
+    expect(decode(String(put?.body?.content))).toBe(md); // Cyrillic survives
   });
 
   it('listDirViaApi returns only files (not sub-dirs), with size and sha', async () => {
@@ -220,8 +222,8 @@ describe('editor single-file API (read / langs / publish, no clone)', () => {
   it('linkIssueArticlesViaApi back-links new articles and rewrites the TOC', async () => {
     const repo: Record<string, string> = {
       'magazine/n3/index.ru.md': '---\ntitle: N3\nlang: ru\narticles:\n  - a\n---\n\nB\n',
-      'blog/a/index.ru.md': '---\ntitle: A\nlang: ru\nmagazine: n3\n---\n\nB\n',
-      'blog/b/index.ru.md': '---\ntitle: B\nlang: ru\n---\n\nB\n',
+      'blog/a/index.ru.md': '---\ntitle: A\nlang: ru\ncategory: t\nmagazine: n3\n---\n\nB\n',
+      'blog/b/index.ru.md': '---\ntitle: B\nlang: ru\ncategory: t\n---\n\nB\n',
     };
     const puts: Array<{ path: string; content: string }> = [];
     const decode = (b64: string): string =>
@@ -250,8 +252,8 @@ describe('editor single-file API (read / langs / publish, no clone)', () => {
   it('linkIssueArticlesViaApi drops the back-link from de-selected articles', async () => {
     const repo: Record<string, string> = {
       'magazine/n3/index.ru.md': '---\ntitle: N3\nlang: ru\narticles:\n  - a\n  - b\n---\n\nB\n',
-      'blog/a/index.ru.md': '---\ntitle: A\nlang: ru\nmagazine: n3\n---\n\nB\n',
-      'blog/b/index.ru.md': '---\ntitle: B\nlang: ru\nmagazine: n3\n---\n\nB\n',
+      'blog/a/index.ru.md': '---\ntitle: A\nlang: ru\ncategory: t\nmagazine: n3\n---\n\nB\n',
+      'blog/b/index.ru.md': '---\ntitle: B\nlang: ru\ncategory: t\nmagazine: n3\n---\n\nB\n',
     };
     const decode = (b64: string): string =>
       new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
@@ -269,6 +271,111 @@ describe('editor single-file API (read / langs / publish, no clone)', () => {
     expect(r).toMatchObject({ ok: true, linked: 0, unlinked: 1 });
     expect(repo['blog/b/index.ru.md']).not.toContain('magazine:');
     expect(readSeq(repo['magazine/n3/index.ru.md'])).toEqual(['a']);
+  });
+
+  it('linkIssueArticlesViaApi writes a YAML array (never a bare key) when no article exists in the language', async () => {
+    // The real incident: an issue translated to `en` inherited the ru TOC, none
+    // of those articles had an `en` file, so the rewritten TOC came out as a bare
+    // `articles:` (an empty YAML value) and the public build failed on the schema.
+    const repo: Record<string, string> = {
+      'magazine/n2/index.en.md':
+        '---\ntitle: N2\nlang: en\npublished: false\narticles:\n  - a\n  - b\nimage: ./assets/cover.ru.png\n---\n\nB\n',
+      'blog/a/index.ru.md': '---\ntitle: A\nlang: ru\ncategory: t\nmagazine: n2\n---\n\nB\n',
+      'blog/b/index.ru.md': '---\ntitle: B\nlang: ru\ncategory: t\nmagazine: n2\n---\n\nB\n',
+    };
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+      if (init?.method === 'PUT') {
+        repo[path] = decode(JSON.parse(String(init.body)).content);
+        return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+      }
+      if (acceptOf(init).includes('raw')) return new Response(repo[path] ?? '', { status: repo[path] ? 200 : 404 });
+      return new Response(JSON.stringify({ sha: 'blob' }), { status: 200 });
+    });
+
+    const r = await linkIssueArticlesViaApi('n2', 'en', ['a']);
+    expect(r.ok).toBe(true);
+    const fm: unknown = parseYaml(repo['magazine/n2/index.en.md'].split('\n---')[0].slice(4));
+    expect(fm).toMatchObject({ articles: [] });
+  });
+
+  it('linkIssueArticlesViaApi aborts (no writes) when an article read fails for a reason other than 404', async () => {
+    const puts: string[] = [];
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') puts.push(url);
+      const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+      if (path === 'magazine/n2/index.en.md') {
+        return new Response('---\ntitle: N2\nlang: en\narticles:\n  - a\n---\n\nB\n', { status: 200 });
+      }
+      return new Response(JSON.stringify({ message: 'Bad credentials' }), { status: 401 });
+    });
+    const r = await linkIssueArticlesViaApi('n2', 'en', ['a', 'b']);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('Bad credentials');
+    expect(puts).toEqual([]);
+  });
+
+  it('publishFileViaApi refuses a content file whose frontmatter is not valid YAML (no commit)', async () => {
+    // The real master incident: a multi-line `description` pasted unquoted with a
+    // `: ` inside — js-yaml: "bad indentation of a mapping entry".
+    const broken = [
+      '---',
+      'title: Excess Capital And Excess Population',
+      'lang: en',
+      'description: While bourgeois thought writes off crises, Marx exposes the paradox of the system: the surplus.',
+      '"Without revolutionary theory", reads the axiom.',
+      'category: programme',
+      'published: true',
+      '---',
+      '',
+      'Body',
+      '',
+    ].join('\n');
+    const puts: string[] = [];
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') puts.push(url);
+      return new Response(JSON.stringify({ sha: 'b', commit: { sha: 'c' } }), { status: 200 });
+    });
+    const r = await publishFileViaApi('blog/surplus/index.en.md', broken, 'm');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/YAML/);
+    expect(puts).toEqual([]);
+  });
+
+  it('publishFileViaApi refuses a content file the site schema would reject (no commit)', async () => {
+    const bareToc = '---\ntitle: N2\nlang: en\npublished: false\narticles:\nimage: ./assets/cover.ru.png\n---\n\nB\n';
+    const puts: string[] = [];
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') puts.push(url);
+      return new Response(JSON.stringify({ sha: 'b', commit: { sha: 'c' } }), { status: 200 });
+    });
+    const r = await publishFileViaApi('magazine/n2/index.en.md', bareToc, 'm');
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/articles/);
+    expect(puts).toEqual([]);
+  });
+
+  it('publishFileViaApi refuses a frontmatter lang that contradicts the filename (no commit)', async () => {
+    const puts: string[] = [];
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') puts.push(url);
+      return new Response(JSON.stringify({ sha: 'b', commit: { sha: 'c' } }), { status: 200 });
+    });
+    const md = '---\ntitle: A\nlang: ru\ncategory: t\n---\n\nB\n';
+    const r = await publishFileViaApi('blog/a/index.en.md', md, 'm');
+    expect(r.ok).toBe(false);
+    expect(puts).toEqual([]);
+  });
+
+  it('publishFileViaApi leaves non-content paths (assets, settings) ungated', async () => {
+    const puts: string[] = [];
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') puts.push(url);
+      return new Response(JSON.stringify({ sha: 'b', commit: { sha: 'c' } }), { status: 200 });
+    });
+    const r = await publishFileViaApi('settings/topics.json', '{}', 'm');
+    expect(r.ok).toBe(true);
+    expect(puts).toHaveLength(1);
   });
 
   it('publishFileViaApi surfaces the GitHub error message on failure', async () => {

--- a/src/redesign/engine/content.engine.test.ts
+++ b/src/redesign/engine/content.engine.test.ts
@@ -154,6 +154,15 @@ describe('frontmatter sequence helpers (issue TOC ↔ article back-links)', () =
     expect(next).toContain('Body'); // body untouched
   });
 
+  it('writes an explicit empty list when nothing is linked (never a bare `key:`)', () => {
+    // A bare `articles:` parses as an empty YAML value; the site schema wants an
+    // array and the build died on exactly this (magazine-2-avgust-2026/index.en.md).
+    const next = upsertSequenceField(ISSUE, 'articles', []);
+    expect(next).toContain('articles: []');
+    expect(next).not.toMatch(/articles:\s*\n/);
+    expect(readSequenceField(next, 'articles')).toEqual([]);
+  });
+
   it('inserts a new sequence after lang: when absent', () => {
     const md = '---\ntitle: X\nlang: ru\n---\n\nB\n';
     const next = upsertSequenceField(md, 'articles', ['a']);

--- a/src/redesign/engine/content.frontmatter.test.ts
+++ b/src/redesign/engine/content.frontmatter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import {
+  readFrontmatterField,
+  upsertFrontmatterBlock,
+  upsertFrontmatterField,
+} from './content.ts';
+
+/*
+ * The 2026-09-06 incident on `illuziya-socializma-i-realnost-kapitala-v-sssr`:
+ * the editor added an English translation of an article whose `description`
+ * was a multi-line DOUBLE-QUOTED scalar with blank lines inside it (the shape
+ * every magazine-era article carries). Two helpers mishandled it:
+ *
+ *   - the read took only the first physical line, so the editor showed a
+ *     truncated lead (719 of 1797 characters);
+ *   - the write removed only the indented lines that immediately followed the
+ *     key and stopped at the first BLANK line, so the tail of the Russian
+ *     description stayed behind under the new English one.
+ *
+ * The published `index.en.md` therefore carried an English lead followed by a
+ * stray Russian paragraph and a literal `\n"`.
+ */
+const QUOTED_MULTILINE = [
+  '---',
+  'title: Illusion of socialism',
+  'lang: ru',
+  'magazine: magazine-2-avgust-2026',
+  'category: programme',
+  'published: true',
+  'publishDate: 2026-06-28',
+  'description: "First paragraph of the Russian lead.',
+  '',
+  '',
+  '  Second paragraph, after a blank line.',
+  '',
+  '  \\n"',
+  '---',
+  '',
+  'Body text.',
+  '',
+].join('\n');
+
+const fence = (markdown: string): string =>
+  markdown.match(/^---\r?\n([\s\S]*?)\r?\n---/)?.[1] ?? '';
+
+const field = (markdown: string, key: string): unknown => {
+  const parsed: unknown = parseYaml(fence(markdown));
+  return typeof parsed === 'object' && parsed !== null ? Reflect.get(parsed, key) : undefined;
+};
+
+describe('frontmatter helpers vs a multi-line quoted description', () => {
+  it('reads the whole quoted scalar, not just its first line', () => {
+    const lead = readFrontmatterField(QUOTED_MULTILINE, 'description') ?? '';
+    expect(lead).toContain('First paragraph');
+    expect(lead).toContain('Second paragraph');
+    expect(lead).not.toContain('"');
+  });
+
+  it('replaces the whole previous value, leaving no orphaned tail', () => {
+    const next = upsertFrontmatterBlock(QUOTED_MULTILINE, 'description', 'A new English lead.');
+    expect(field(next, 'description')).toBe('A new English lead.');
+    expect(next).not.toContain('Second paragraph');
+    expect(next).not.toContain('\\n"');
+    // Neighbouring keys and the body survive untouched.
+    expect(field(next, 'category')).toBe('programme');
+    expect(field(next, 'publishDate')).toBeDefined();
+    expect(next).toContain('Body text.');
+  });
+
+  it('produces a valid, single-language file for the add-translation flow', () => {
+    // The add-translation dialog seeds the new language from the open one …
+    const seed = upsertFrontmatterField(
+      upsertFrontmatterField(QUOTED_MULTILINE, 'lang', 'en'),
+      'published',
+      'false',
+    );
+    // … then the translator retypes the lead and publishes.
+    const published = upsertFrontmatterBlock(seed, 'description', 'The English lead.');
+    expect(() => parseYaml(fence(published))).not.toThrow();
+    expect(field(published, 'lang')).toBe('en');
+    expect(field(published, 'description')).toBe('The English lead.');
+    expect(published).not.toMatch(/Second paragraph|\\n"/);
+  });
+
+  it('still handles the simple shapes it always did', () => {
+    const inline = '---\ntitle: T\ndescription: One line.\nlang: ru\n---\n\nB\n';
+    expect(readFrontmatterField(inline, 'description')).toBe('One line.');
+    const folded = '---\ntitle: T\ndescription: >-\n  A.\n  B.\nlang: ru\n---\n\nB\n';
+    expect(readFrontmatterField(folded, 'description')).toBe('A. B.');
+    const literal = '---\ntitle: T\ndescription: |-\n  A.\n  B.\nlang: ru\n---\n\nB\n';
+    expect(readFrontmatterField(literal, 'description')).toBe('A.\nB.');
+    expect(readFrontmatterField(inline, 'missing')).toBeUndefined();
+  });
+});

--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -7,6 +7,7 @@
  * SW reports "not ready" — otherwise content silently reads empty after an SW
  * eviction or a post-deploy SW version bump.
  */
+import { fieldSpan, readFieldText } from './frontmatter-value.js';
 import { swFetch } from './sw-fetch.js';
 import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
 
@@ -168,10 +169,11 @@ export const upsertFrontmatterField = (markdown: string, key: string, value: str
   if (!markdown.startsWith('---')) return `---\n${line}\n---\n\n${markdown}`;
   const end = markdown.indexOf('\n---', 3);
   if (end < 0) return markdown;
-  const prefix = `${key}:`;
   const lines = markdown.slice(4, end).split('\n');
-  const at = lines.findIndex((l) => l.startsWith(prefix));
-  if (at >= 0) lines[at] = line;
+  // Replace the key's WHOLE previous value: overwriting only its first line
+  // would orphan the continuations of a multi-line one.
+  const span = fieldSpan(lines, key);
+  if (span !== undefined) lines.splice(span.start, span.end - span.start, line);
   else {
     const langAt = lines.findIndex((l) => l.startsWith('lang:'));
     lines.splice(langAt >= 0 ? langAt + 1 : lines.length, 0, line);
@@ -191,16 +193,7 @@ export const readFrontmatterField = (markdown: string, key: string): string | un
   if (!markdown.startsWith('---')) return undefined;
   const end = markdown.indexOf('\n---', 3);
   const lines = (end < 0 ? markdown.slice(4) : markdown.slice(4, end)).split('\n');
-  const at = lines.findIndex((l) => l.startsWith(`${key}:`));
-  if (at < 0) return undefined;
-  const inline = lines[at].slice(key.length + 1).trim();
-  const block = inline.match(/^([|>])[+-]?$/);
-  if (!block) return inline.replace(/^["']|["']$/g, '');
-  const cont: string[] = [];
-  for (let i = at + 1; i < lines.length && /^\s/.test(lines[i]); i += 1) {
-    cont.push(lines[i].replace(/^\s+/, ''));
-  }
-  return block[1] === '>' ? cont.join(' ') : cont.join('\n');
+  return readFieldText(lines, key);
 };
 
 /**
@@ -215,12 +208,12 @@ export const upsertFrontmatterBlock = (markdown: string, key: string, value: str
   const end = markdown.indexOf('\n---', 3);
   if (end < 0) return markdown;
   const lines = markdown.slice(4, end).split('\n');
-  const at = lines.findIndex((l) => l.startsWith(`${key}:`));
-  if (at >= 0) {
-    let removeCount = 1;
-    for (let i = at + 1; i < lines.length && /^\s/.test(lines[i]); i += 1) removeCount += 1;
-    lines.splice(at, removeCount, ...field);
-  } else {
+  // The span covers the WHOLE previous value — a multi-line quoted scalar with
+  // blank lines inside it included. Removing less is what left the tail of a
+  // Russian description sitting under a new English one.
+  const span = fieldSpan(lines, key);
+  if (span !== undefined) lines.splice(span.start, span.end - span.start, ...field);
+  else {
     const langAt = lines.findIndex((l) => l.startsWith('lang:'));
     lines.splice(langAt >= 0 ? langAt + 1 : lines.length, 0, ...field);
   }
@@ -236,7 +229,12 @@ export const removeFrontmatterField = (markdown: string, key: string): string =>
   if (!markdown.startsWith('---')) return markdown;
   const end = markdown.indexOf('\n---', 3);
   if (end < 0) return markdown;
-  const lines = markdown.slice(4, end).split('\n').filter((l) => !l.startsWith(`${key}:`));
+  const lines = markdown.slice(4, end).split('\n');
+  const span = fieldSpan(lines, key);
+  if (span === undefined) return markdown;
+  // Drop the whole value, not just its first line, so a multi-line field
+  // cannot leave orphaned continuation lines behind.
+  lines.splice(span.start, span.end - span.start);
   return `---\n${lines.join('\n')}${markdown.slice(end)}`;
 };
 
@@ -271,7 +269,9 @@ export const upsertSequenceField = (
   key: string,
   items: readonly string[],
 ): string => {
-  const field = [`${key}:`, ...items.map((it) => `  - ${it}`)];
+  // An empty set is written as an explicit `key: []` — a bare `key:` is YAML's
+  // empty value, which the site's collection schema rejects (it wants a list).
+  const field = items.length === 0 ? [`${key}: []`] : [`${key}:`, ...items.map((it) => `  - ${it}`)];
   if (!markdown.startsWith('---')) return `---\n${field.join('\n')}\n---\n\n${markdown}`;
   const end = markdown.indexOf('\n---', 3);
   if (end < 0) return markdown;
@@ -452,6 +452,33 @@ const isTopic = (x: unknown): x is Topic =>
 export const readTopics = async (): Promise<readonly Topic[]> =>
   parseJsonArray(await readFile('settings/topics.json'), isTopic);
 
+/** One `<option>` for a topic picker: the topic key plus its Russian name. */
+export interface TopicOption {
+  readonly value: string;
+  readonly label: string;
+}
+
+/**
+ * The editorial topics as select options, read straight from the repository
+ * through the API (no clone), so the editor offers the topics that actually
+ * exist instead of a list hardcoded in the UI. Empty on any failure — the topic
+ * is optional, so an unreadable settings file must not block editing.
+ */
+export const topicOptionsViaApi = async (): Promise<readonly TopicOption[]> => {
+  const raw = await readFileViaApi('settings/topics.json');
+  if (raw === undefined) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isTopic).map((topic) => ({
+      value: topic.key,
+      label: topic.name['ru'] ?? topic.name['en'] ?? topic.key,
+    }));
+  } catch {
+    return [];
+  }
+};
+
 /** A summary of one blog article (grouped from `blog/<slug>/index.<lang>.md`). */
 export interface ArticleSummary {
   readonly slug: string;
@@ -610,6 +637,30 @@ export const readFileViaApi = async (path: string): Promise<string | undefined> 
   }
 };
 
+/** A content read that tells "absent" apart from "failed": a 404 means the
+ *  item has no such language, anything else (401 expired token, 403 throttle,
+ *  5xx) is a failure the caller must not mistake for absence. */
+type ContentRead =
+  | { readonly kind: 'ok'; readonly text: string }
+  | { readonly kind: 'missing' }
+  | { readonly kind: 'error'; readonly error: string };
+
+const readContentFile = async (path: string): Promise<ContentRead> => {
+  const t = await freshGhToken();
+  if (t === undefined) return { kind: 'error', error: 'signed-out' };
+  try {
+    const res = await fetch(`${REPO_BASE}/contents/${path}?ref=${contentBranch()}`, {
+      cache: 'no-store',
+      headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github.raw' },
+    });
+    if (res.ok) return { kind: 'ok', text: await res.text() };
+    if (res.status === 404) return { kind: 'missing' };
+    return { kind: 'error', error: await apiError(res, `Чтение не удалось (${res.status}).`) };
+  } catch (e) {
+    return { kind: 'error', error: e instanceof Error ? e.message : String(e) };
+  }
+};
+
 /** The languages one item exists in (its `index.<lang>.md` files), via API. The
  *  collection is `blog` for articles, `magazine` for journal issues. */
 export const articleLangsViaApi = async (
@@ -638,6 +689,19 @@ export const articleLangsViaApi = async (
 };
 
 /**
+ * The content gate for the direct-API write path — the same YAML / lang /
+ * schema rules the Service Worker applies at stage time, so a single-file
+ * commit can no more push an unbuildable article than a clone+push can. The
+ * gate (and the schema library behind it) loads lazily: publishing is rare,
+ * the shell's first paint is not. Non-content paths pass straight through.
+ */
+const guardContentWrite = async (path: string, content: string): Promise<string | undefined> => {
+  const { validateContentFile } = await import('@/validation/content-gate');
+  const reason = validateContentFile(path, content);
+  return reason === undefined ? undefined : `Файл не прошёл проверку и не сохранён: ${reason}`;
+};
+
+/**
  * Commits ONE edited file via the GitHub Contents API — a single-file commit,
  * no clone and no whole-repo push. Fetches the file's current blob sha (an
  * update needs it), then PUTs the new content. Returns the commit sha or the
@@ -648,6 +712,8 @@ export const publishFileViaApi = async (
   content: string,
   message: string,
 ): Promise<{ ok: boolean; sha?: string; error?: string }> => {
+  const rejected = await guardContentWrite(path, content);
+  if (rejected !== undefined) return { ok: false, error: rejected };
   const t = await freshGhToken();
   if (t === undefined) return { ok: false, error: 'signed-out' };
   const auth = { authorization: `Bearer ${t}` };
@@ -707,24 +773,29 @@ export const linkIssueArticlesViaApi = async (
   selected: readonly string[],
 ): Promise<LinkResult> => {
   const indexPath = `magazine/${issueSlug}/index.${lang}.md`;
-  const indexMd = await readFileViaApi(indexPath);
-  if (indexMd === undefined) {
+  const index = await readContentFile(indexPath);
+  if (index.kind === 'missing') {
     return { ok: false, linked: 0, unlinked: 0, error: `Не найден index номера (${lang}).` };
   }
+  if (index.kind === 'error') return { ok: false, linked: 0, unlinked: 0, error: index.error };
+  const indexMd = index.text;
   const current = new Set(readSequenceField(indexMd, 'articles'));
   const want = new Set(selected);
   const toLink = selected.filter((s) => !current.has(s));
   const toUnlink = [...current].filter((s) => !want.has(s));
 
-  // Add the back-link to newly-selected articles; skip any without this language.
+  // Add the back-link to newly-selected articles; skip any without this
+  // language. A failed read (not a 404) aborts the whole save — treating it as
+  // "absent" would silently drop the article from the issue.
   const linked: string[] = [];
   for (const slug of selected) {
     const path = `blog/${slug}/index.${lang}.md`;
-    const md = await readFileViaApi(path);
-    if (md === undefined || md === '') continue;
+    const read = await readContentFile(path);
+    if (read.kind === 'error') return { ok: false, linked: 0, unlinked: 0, error: read.error };
+    if (read.kind === 'missing' || read.text === '') continue;
     linked.push(slug);
     if (toLink.includes(slug)) {
-      const next = upsertFrontmatterField(md, 'magazine', issueSlug);
+      const next = upsertFrontmatterField(read.text, 'magazine', issueSlug);
       const r = await publishFileViaApi(path, next, `magazine: ссылка ${slug} → ${issueSlug}`);
       if (!r.ok) return { ok: false, linked: 0, unlinked: 0, error: r.error };
     }
@@ -734,9 +805,10 @@ export const linkIssueArticlesViaApi = async (
   let unlinked = 0;
   for (const slug of toUnlink) {
     const path = `blog/${slug}/index.${lang}.md`;
-    const md = await readFileViaApi(path);
-    if (md === undefined || md === '') continue;
-    const next = removeFrontmatterField(md, 'magazine');
+    const read = await readContentFile(path);
+    if (read.kind === 'error') return { ok: false, linked: 0, unlinked: 0, error: read.error };
+    if (read.kind === 'missing' || read.text === '') continue;
+    const next = removeFrontmatterField(read.text, 'magazine');
     const r = await publishFileViaApi(path, next, `magazine: отвязка ${slug} от ${issueSlug}`);
     if (!r.ok) return { ok: false, linked: 0, unlinked: 0, error: r.error };
     unlinked += 1;

--- a/src/redesign/engine/frontmatter-value.ts
+++ b/src/redesign/engine/frontmatter-value.ts
@@ -1,0 +1,134 @@
+/**
+ * Where a frontmatter field's value starts and ends, and how to read it back.
+ *
+ * A frontmatter value is not always one line. It can be a block scalar
+ * (`key: |-` / `key: >-` plus indented lines), a quoted scalar that runs over
+ * several lines with blank lines inside it, or a plain scalar with indented
+ * continuations. Editing a field means replacing exactly that span — the bug
+ * this module exists to prevent stopped at the first BLANK line and left the
+ * tail of the previous value orphaned under the new one, mixing two languages
+ * into one description.
+ *
+ * Everything here is pure line arithmetic over the frontmatter block, so it
+ * stays cheap enough for the editor's hot path and is fully unit-testable.
+ */
+
+/** A top-level `key:` line — what ends the previous field's value. */
+const KEY_LINE = /^[A-Za-z_][\w.-]*:(\s|$)/;
+
+const isBlockIndicator = (inline: string): '|' | '>' | undefined => {
+  const match = inline.match(/^([|>])[+-]?\d*$/);
+  return match?.[1] === '|' ? '|' : match?.[1] === '>' ? '>' : undefined;
+};
+
+/** The quote a scalar opens with, when it opens with one. */
+const openingQuote = (inline: string): '"' | "'" | undefined =>
+  inline.startsWith('"') ? '"' : inline.startsWith("'") ? "'" : undefined;
+
+/**
+ * Whether a quoted scalar that starts on this text is already closed by it.
+ * A double-quoted scalar may contain escaped quotes (`\"`), which do not close.
+ */
+const closesQuote = (text: string, quote: '"' | "'"): boolean => {
+  const body = text.slice(1);
+  const unescaped = quote === '"' ? body.replace(/\\./g, '') : body.replace(/''/g, '');
+  return unescaped.includes(quote);
+};
+
+/** The line index (exclusive) where the value that starts at `at` ends. */
+const endOfQuoted = (lines: readonly string[], at: number, quote: '"' | "'", inline: string): number => {
+  if (closesQuote(inline, quote)) return at + 1;
+  for (let i = at + 1; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    // A new top-level key means the quote was never closed (a malformed file):
+    // stop rather than swallow the rest of the frontmatter.
+    if (KEY_LINE.test(line)) return i;
+    const unescaped = quote === '"' ? line.replace(/\\./g, '') : line.replace(/''/g, '');
+    if (unescaped.includes(quote)) return i + 1;
+  }
+  return lines.length;
+};
+
+/** The line index (exclusive) where an indented block or plain continuation ends. */
+const endOfIndented = (lines: readonly string[], at: number): number => {
+  let end = at + 1;
+  let lastNonBlank = at + 1;
+  for (let i = at + 1; i < lines.length; i += 1) {
+    const line = lines[i] ?? '';
+    if (KEY_LINE.test(line)) break;
+    // Blank lines belong to the value only when indented content follows them.
+    if (line.trim() !== '') lastNonBlank = i + 1;
+    end = i + 1;
+  }
+  return Math.max(lastNonBlank, at + 1) === at + 1 ? at + 1 : lastNonBlank;
+};
+
+/** One field's span inside the frontmatter lines: `[start, end)`. */
+export interface FieldSpan {
+  readonly start: number;
+  readonly end: number;
+}
+
+/**
+ * The span of `key`'s whole value inside the frontmatter lines, or undefined
+ * when the key is absent.
+ * @param lines - frontmatter block split into lines (no `---` fences)
+ * @param key - frontmatter key to locate
+ * @returns the `[start, end)` line span of the key and its value
+ */
+export const fieldSpan = (lines: readonly string[], key: string): FieldSpan | undefined => {
+  const start = lines.findIndex((l) => l.startsWith(`${key}:`));
+  if (start < 0) return undefined;
+  const inline = (lines[start] ?? '').slice(key.length + 1).trim();
+  const quote = openingQuote(inline);
+  if (quote !== undefined) return { start, end: endOfQuoted(lines, start, quote, inline) };
+  if (isBlockIndicator(inline) !== undefined) return { start, end: endOfIndented(lines, start) };
+  if (inline !== '') return { start, end: endOfIndented(lines, start) };
+  // A bare `key:` owns nothing but its own line (an empty value).
+  return { start, end: start + 1 };
+};
+
+/** Strips YAML escapes from a double-quoted scalar's text. */
+const unescapeDouble = (text: string): string =>
+  text.replace(/\\n/g, '\n').replace(/\\t/g, '\t').replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+
+/**
+ * Joins a scalar's physical lines the way YAML folds them: a blank line is a
+ * paragraph break, everything else joins with a single space.
+ */
+const fold = (parts: readonly string[]): string =>
+  parts
+    .reduce<string[]>((acc, part) => {
+      const trimmed = part.trim();
+      if (trimmed === '') return acc.at(-1) === '' ? acc : [...acc, ''];
+      const last = acc.at(-1);
+      return last === undefined || last === ''
+        ? [...acc, trimmed]
+        : [...acc.slice(0, -1), `${last} ${trimmed}`];
+    }, [])
+    .filter((part) => part !== '')
+    .join('\n');
+
+/**
+ * Reads the value of `key` from frontmatter lines, whatever YAML shape it uses:
+ * inline, single- or multi-line quoted, folded (`>`) or literal (`|`) block.
+ * @param lines - frontmatter block split into lines (no `---` fences)
+ * @param key - frontmatter key to read
+ * @returns the value's text, or undefined when the key is absent
+ */
+export const readFieldText = (lines: readonly string[], key: string): string | undefined => {
+  const span = fieldSpan(lines, key);
+  if (span === undefined) return undefined;
+  const inline = (lines[span.start] ?? '').slice(key.length + 1).trim();
+  const quote = openingQuote(inline);
+  if (quote !== undefined) {
+    const parts = [inline.slice(1), ...lines.slice(span.start + 1, span.end)];
+    const joined = fold(parts).replace(new RegExp(`${quote}\\s*$`), '');
+    return quote === '"' ? unescapeDouble(joined).trim() : joined.replace(/''/g, "'").trim();
+  }
+  const block = isBlockIndicator(inline);
+  const continuation = lines.slice(span.start + 1, span.end).map((l) => l.replace(/^\s+/, ''));
+  if (block === '|') return continuation.join('\n').replace(/\n+$/, '');
+  if (block === '>') return fold(continuation);
+  return fold([inline, ...continuation]);
+};

--- a/src/redesign/engine/publish-target.test.ts
+++ b/src/redesign/engine/publish-target.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { publishTarget } from './publish-target.ts';
+
+/*
+ * The 2026-09-06 report: an editor added a translation, published it, saw a
+ * success, and the article never appeared on comprom.org. It had gone to the
+ * `develop` content branch, because the admin they were using was the dev one —
+ * and nothing in the UI distinguishes the two. The editor then hand-created the
+ * file on master through github.com and broke the production build.
+ *
+ * A publish must therefore be able to say, in the editor's own words, which
+ * site it reaches.
+ */
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('publishTarget', () => {
+  it('names the production site for the master content branch', () => {
+    vi.stubEnv('VITE_GITHUB_BRANCH', 'master');
+    expect(publishTarget()).toEqual({
+      branch: 'master',
+      site: 'comprom.org',
+      siteUrl: 'https://comprom.org',
+      production: true,
+    });
+  });
+
+  it('names the dev site for the develop content branch', () => {
+    vi.stubEnv('VITE_GITHUB_BRANCH', 'develop');
+    expect(publishTarget()).toEqual({
+      branch: 'develop',
+      site: 'dev.comprom.org',
+      siteUrl: 'https://dev.comprom.org',
+      production: false,
+    });
+  });
+
+  it('treats any other branch as a non-production target and names it', () => {
+    vi.stubEnv('VITE_GITHUB_BRANCH', 'experiment');
+    const target = publishTarget();
+    expect(target.branch).toBe('experiment');
+    expect(target.production).toBe(false);
+    expect(target.site).toContain('experiment');
+  });
+
+  it('falls back to the develop target when the branch is unset', () => {
+    vi.stubEnv('VITE_GITHUB_BRANCH', '');
+    expect(publishTarget().production).toBe(false);
+  });
+});

--- a/src/redesign/engine/publish-target.ts
+++ b/src/redesign/engine/publish-target.ts
@@ -1,0 +1,37 @@
+/**
+ * Which site a publish from THIS admin actually reaches.
+ *
+ * The admin is deployed twice against the same content repository: the
+ * production build writes the `master` branch (comprom.org), the dev build
+ * writes `develop` (dev.comprom.org). Nothing used to say which one you had
+ * open, so an editor published a translation on the dev admin, saw it succeed,
+ * never found it on the public site, and went on to hand-edit the file on
+ * GitHub — which broke the production build.
+ */
+
+/** The site a publish on the current build lands on. */
+export interface PublishTarget {
+  /** Content branch this build reads and writes. */
+  readonly branch: string;
+  /** Host of the site that branch is published to. */
+  readonly site: string;
+  readonly siteUrl: string;
+  /** True only for the branch that feeds the public site. */
+  readonly production: boolean;
+}
+
+const PRODUCTION_BRANCH = 'master';
+
+const hostFor = (branch: string): string =>
+  branch === PRODUCTION_BRANCH ? 'comprom.org' : branch === 'develop' ? 'dev.comprom.org' : `${branch}.comprom.org`;
+
+/**
+ * The publish target of the running build.
+ * @returns branch, site host and whether that site is the public one
+ */
+export const publishTarget = (): PublishTarget => {
+  const configured = import.meta.env.VITE_GITHUB_BRANCH;
+  const branch = typeof configured === 'string' && configured !== '' ? configured : 'develop';
+  const site = hostFor(branch);
+  return { branch, site, siteUrl: `https://${site}`, production: branch === PRODUCTION_BRANCH };
+};

--- a/src/redesign/engine/site-build-state.test.ts
+++ b/src/redesign/engine/site-build-state.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { siteBuildState } from './site-build-state.ts';
+import type { DeployRun } from './github-api.ts';
+
+/*
+ * The admin reads the content repository; the public site is what the deploy
+ * BUILDS from it. When that build fails, the two diverge: the editor opens the
+ * admin, sees the article sitting there, and cannot find it on the site — with
+ * nothing anywhere in the editor to explain why. That is what happened on
+ * 2026-09-06: production deploys failed from 13:49 until 22:08 UTC on one
+ * unbuildable file, so nothing published at all in between.
+ */
+const run = (
+  status: DeployRun['status'],
+  conclusion: string,
+  id = 1,
+): DeployRun => ({ id, status, conclusion, url: `https://run/${id}`, createdAt: '2026-09-06T13:49:32Z' });
+
+describe('siteBuildState', () => {
+  it('reports a failing site build with the run to look at', () => {
+    const state = siteBuildState([run('completed', 'failure', 7)]);
+    expect(state.phase).toBe('failed');
+    expect(state.runUrl).toBe('https://run/7');
+  });
+
+  it('is healthy when the newest finished run succeeded', () => {
+    const state = siteBuildState([run('completed', 'success', 9)]);
+    expect(state.phase).toBe('ok');
+  });
+
+  it('reports a build in flight', () => {
+    const state = siteBuildState([run('in_progress', '', 3)]);
+    expect(state.phase).toBe('building');
+  });
+
+  /*
+   * A run still building tells nothing about the last published state, so the
+   * newest FINISHED run decides whether the site is currently broken.
+   */
+  it('looks past an in-flight run to the last finished one', () => {
+    const state = siteBuildState([run('in_progress', '', 4), run('completed', 'failure', 3)]);
+    expect(state.phase).toBe('building');
+    expect(state.lastFailedUrl).toBe('https://run/3');
+  });
+
+  it('says nothing when there is no run history to judge by', () => {
+    expect(siteBuildState([]).phase).toBe('unknown');
+  });
+
+  it('ignores runs that were cancelled by a newer deploy', () => {
+    const state = siteBuildState([run('completed', 'cancelled', 5), run('completed', 'success', 4)]);
+    expect(state.phase).toBe('ok');
+  });
+});

--- a/src/redesign/engine/site-build-state.ts
+++ b/src/redesign/engine/site-build-state.ts
@@ -1,0 +1,44 @@
+import type { DeployRun } from './github-api.js';
+
+/**
+ * Whether the public site is currently building what the repository holds.
+ *
+ * The admin shows the content repository; the site shows what the deploy built
+ * from it. A failing deploy silently separates the two — the article is in the
+ * admin, correct and published, and simply never appears on the site. Surfacing
+ * the build state next to the publish is what closes that gap.
+ */
+export type SiteBuildPhase = 'ok' | 'building' | 'failed' | 'unknown';
+
+/** The site's build state, plus where to look when it is not healthy. */
+export interface SiteBuildState {
+  readonly phase: SiteBuildPhase;
+  /** The run this state came from, when there is one. */
+  readonly runUrl?: string;
+  /** The newest failed run, even while a later one is still building. */
+  readonly lastFailedUrl?: string;
+}
+
+/** A run that reached a verdict of its own (not cancelled by a newer deploy). */
+const isDecided = (run: DeployRun): boolean =>
+  run.status === 'completed' && run.conclusion !== 'cancelled' && run.conclusion !== 'skipped';
+
+const isFailure = (run: DeployRun): boolean =>
+  run.conclusion === 'failure' || run.conclusion === 'timed_out';
+
+/**
+ * Derives the site's build state from recent deploy runs, newest first.
+ * @param runs - deploy runs for the branch this admin publishes to
+ * @returns the current phase and the runs worth linking to
+ */
+export const siteBuildState = (runs: readonly DeployRun[]): SiteBuildState => {
+  const inFlight = runs.find((run) => run.status !== 'completed');
+  const decided = runs.find(isDecided);
+  const lastFailed = decided !== undefined && isFailure(decided) ? decided : undefined;
+  const failedUrl = lastFailed === undefined ? {} : { lastFailedUrl: lastFailed.url };
+  if (inFlight !== undefined) return { phase: 'building', runUrl: inFlight.url, ...failedUrl };
+  if (decided === undefined) return { phase: 'unknown' };
+  return isFailure(decided)
+    ? { phase: 'failed', runUrl: decided.url, lastFailedUrl: decided.url }
+    : { phase: 'ok', runUrl: decided.url };
+};

--- a/src/redesign/screens/screen-editor.add-lang.test.ts
+++ b/src/redesign/screens/screen-editor.add-lang.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+import './screen-editor.ts';
+import type { ScreenEditor } from './screen-editor.ts';
+
+vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
+
+/**
+ * The add-translation dialog seeds `index.<lang>.md` from the open language's
+ * text with ONE Contents-API commit. That commit must pass the same content gate
+ * every other write does: a source whose frontmatter is already unbuildable (say, edited by hand
+ * on github.com) must not be cloned into a second broken language, and the
+ * editor must see why instead of a silent success.
+ */
+const BROKEN_RU = [
+  '---',
+  'title: Excess Capital',
+  'lang: ru',
+  'description: Marx exposes the paradox of the system: surplus capital.',
+  '"Without revolutionary theory", reads the axiom.',
+  'category: programme',
+  'published: true',
+  '---',
+  '',
+  'Body',
+  '',
+].join('\n');
+
+const GOOD_RU = '---\ntitle: "RU"\nlang: ru\ncategory: t\npublished: true\n---\n\nRU body\n';
+
+interface EditorInternals {
+  slug: string;
+  collection: string;
+  live: boolean;
+  activeLang: string;
+  availableLangs: readonly string[];
+  addLangChoice: string;
+  addLangError: string;
+  applyMarkdown: (markdown: string, path: string, live: boolean) => void;
+  confirmAddLang: () => Promise<void>;
+}
+
+const seededEditor = (markdown: string): EditorInternals => {
+  const el = document.createElement('screen-editor') as ScreenEditor;
+  const priv = el as unknown as EditorInternals;
+  priv.slug = 'x';
+  priv.collection = 'blog';
+  priv.live = true;
+  priv.activeLang = 'ru';
+  priv.availableLangs = ['ru'];
+  priv.applyMarkdown(markdown, 'blog/x/index.ru.md', true);
+  priv.addLangChoice = 'en';
+  return priv;
+};
+
+/** Records every Contents-API PUT; answers the blob-sha probe with 404 (new file). */
+const stubGitHub = (puts: Array<{ path: string; content: string }>): void => {
+  const decode = (b64: string): string =>
+    new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+  vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+    if (init?.method === 'PUT') {
+      puts.push({ path, content: decode(JSON.parse(String(init.body)).content) });
+      return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+    }
+    return new Response('', { status: 404 });
+  });
+};
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  vi.stubEnv('VITE_DEV_TOKEN', '');
+  vi.stubEnv('VITE_GITHUB_BRANCH', 'develop');
+  vi.mocked(ensureFreshToken).mockResolvedValue('tok');
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('screen-editor add-translation goes through the content gate', () => {
+  it('seeds a valid source into a new language with lang + draft flag rewritten', async () => {
+    const puts: Array<{ path: string; content: string }> = [];
+    stubGitHub(puts);
+    const el = seededEditor(GOOD_RU);
+    await el.confirmAddLang();
+    expect(el.addLangError).toBe('');
+    expect(puts).toHaveLength(1);
+    expect(puts[0].path).toBe('blog/x/index.en.md');
+    expect(puts[0].content).toContain('lang: en');
+    expect(puts[0].content).toContain('published: false');
+    expect(el.availableLangs).toEqual(['en', 'ru']);
+  });
+
+  it('refuses to clone unbuildable frontmatter and tells the editor why (no commit)', async () => {
+    const puts: Array<{ path: string; content: string }> = [];
+    stubGitHub(puts);
+    const el = seededEditor(BROKEN_RU);
+    await el.confirmAddLang();
+    expect(puts).toEqual([]);
+    expect(el.addLangError).toMatch(/YAML/);
+    expect(el.availableLangs).toEqual(['ru']);
+  });
+});

--- a/src/redesign/screens/screen-editor.panel.test.ts
+++ b/src/redesign/screens/screen-editor.panel.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import './screen-editor.ts';
+import type { ScreenEditor } from './screen-editor.ts';
+
+/**
+ * The properties of a material (rubric, topic, date, published) must be part of
+ * the page, not hidden behind a modal, and the page must say whether what you
+ * are looking at is published or a draft.
+ *
+ * The 2026-09-06 report: an editor published a translation, the breadcrumb still
+ * read "draft" (it was hardcoded), the required-marked topic select showed empty
+ * for an article that has a category, and the properties were only reachable
+ * through a sheet. Driving the private state via a cast mirrors the sibling
+ * screen-editor tests; it is the only way to seed the element headlessly.
+ */
+const PUBLISHED = '---\ntitle: "T"\nlang: ru\ncategory: programme\npublished: true\n---\n\nBody\n';
+const DRAFT = '---\ntitle: "T"\nlang: ru\ncategory: programme\npublished: false\n---\n\nBody\n';
+
+interface EditorInternals {
+  slug: string;
+  collection: string;
+  live: boolean;
+  activeLang: string;
+  availableLangs: readonly string[];
+  applyMarkdown: (markdown: string, path: string, live: boolean) => void;
+}
+
+const mounted = async (markdown: string): Promise<ScreenEditor> => {
+  const el = document.createElement('screen-editor') as ScreenEditor;
+  const priv = el as unknown as EditorInternals;
+  priv.slug = 'x';
+  priv.collection = 'blog';
+  priv.live = true;
+  priv.activeLang = 'ru';
+  priv.availableLangs = ['ru'];
+  priv.applyMarkdown(markdown, 'blog/x/index.ru.md', true);
+  document.body.append(el);
+  await el.updateComplete;
+  return el;
+};
+
+const text = (el: ScreenEditor): string =>
+  (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+/** Every rendered form control, including those inside the properties area. */
+const controls = (el: ScreenEditor): readonly Element[] => [
+  ...(el.shadowRoot?.querySelectorAll('cp-select, cp-date-input, cp-switch') ?? []),
+];
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('screen-editor: publication status in the header', () => {
+  it('says the material is published when it is', async () => {
+    const el = await mounted(PUBLISHED);
+    expect(text(el)).toContain('опубликовано');
+    expect(text(el)).not.toContain('черновик');
+  });
+
+  it('says draft only for an unpublished material', async () => {
+    const el = await mounted(DRAFT);
+    expect(text(el)).toContain('черновик');
+  });
+});
+
+describe('screen-editor: properties live on the page', () => {
+  it('renders the property controls without opening anything', async () => {
+    const el = await mounted(PUBLISHED);
+    // rubric + topic + date + published switch, all inline.
+    expect(controls(el).length).toBeGreaterThanOrEqual(4);
+    const labels = controls(el).map((control) => control.getAttribute('label'));
+    expect(labels).toContain('Рубрика');
+    expect(labels).toContain('Тема');
+    expect(labels).toContain('Опубликовано');
+  });
+
+  it('keeps the properties editable, seeded from the file', async () => {
+    const el = await mounted(PUBLISHED);
+    const rubric = el.shadowRoot?.querySelector('cp-select[label="Рубрика"]');
+    expect(rubric).not.toBeNull();
+    expect(Reflect.get(rubric ?? {}, 'value')).toBe('programme');
+    expect(el.shadowRoot?.querySelector('cp-switch[label="Опубликовано"]')).not.toBeNull();
+  });
+
+  it('has no modal properties sheet left', async () => {
+    const el = await mounted(PUBLISHED);
+    expect(el.shadowRoot?.querySelector('cp-sheet')).toBeNull();
+  });
+});
+
+describe('screen-editor: topic is optional', () => {
+  it('never demands a topic', async () => {
+    const el = await mounted('---\ntitle: "T"\nlang: ru\npublished: true\n---\n\nBody\n');
+    expect(text(el)).not.toContain('обязательное');
+    expect(el.shadowRoot?.querySelector('cp-select[required]')).toBeNull();
+  });
+});
+
+describe('screen-editor: the state of the site build', () => {
+  it('warns when the site build is failing, so a published article that never appears is explained', async () => {
+    const el = await mounted(PUBLISHED);
+    const priv = el as unknown as { siteBuild: { phase: string; runUrl?: string } };
+    priv.siteBuild = { phase: 'failed', runUrl: 'https://run/7' };
+    el.requestUpdate();
+    await el.updateComplete;
+    const banner = el.shadowRoot?.querySelector('cp-banner[tone="danger"]');
+    expect(banner?.getAttribute('title')).toBe('Сборка сайта падает');
+    expect(text(el)).toContain('не доезжают до сайта');
+    expect(el.shadowRoot?.querySelector('a[href="https://run/7"]')).not.toBeNull();
+  });
+
+  it('stays quiet while the site builds fine', async () => {
+    const el = await mounted(PUBLISHED);
+    const priv = el as unknown as { siteBuild: { phase: string } };
+    priv.siteBuild = { phase: 'ok' };
+    el.requestUpdate();
+    await el.updateComplete;
+    expect(el.shadowRoot?.querySelector('cp-banner[tone="danger"]')).toBeNull();
+  });
+});

--- a/src/redesign/screens/screen-editor.props.test.ts
+++ b/src/redesign/screens/screen-editor.props.test.ts
@@ -28,13 +28,13 @@ interface EditorInternals {
   live: boolean;
   activeLang: string;
   topic: string;
+  rubric: string;
   description: string;
   pubDate: string;
   published: boolean;
   dirty: boolean;
   onLeadInput: (event: Event) => void;
   readonly editedMarkdown: string;
-  readonly incomplete: boolean;
   applyMarkdown: (markdown: string, path: string, live: boolean) => void;
 }
 
@@ -55,17 +55,58 @@ describe('screen-editor properties write-back (QA #4)', () => {
     document.body.replaceChildren();
   });
 
-  it('seeds topic from the article category on load (no false incomplete)', () => {
+  it('seeds the rubric from the article category on load', () => {
     const el = seededEditor();
-    expect(el.topic).toBe('programme');
-    expect(el.incomplete).toBe(false);
+    expect(el.rubric).toBe('programme');
   });
 
-  it('writes an edited category back into the published frontmatter', () => {
+  it('writes an edited rubric back as the article category', () => {
     const el = seededEditor();
-    el.topic = 'history';
+    el.rubric = 'history';
     expect(el.editedMarkdown).toContain('category: history');
     expect(el.editedMarkdown).not.toContain('category: programme');
+  });
+
+  /*
+   * The topic field is the OPTIONAL editorial marker (`topic`, keyed by
+   * settings/topics.json), not the required `category`. Writing the topic
+   * list's values into `category` is what emptied the select for every real
+   * article (whose category is programme/history/international/…) and made the
+   * editor believe a required field was missing.
+   */
+  it('keeps topic and category apart: a chosen topic never overwrites the category', () => {
+    const el = seededEditor();
+    el.topic = 'translation';
+    const out = el.editedMarkdown;
+    expect(out).toContain('topic: translation');
+    expect(out).toContain('category: programme');
+  });
+
+  it('leaves a missing topic empty and publishes without one', () => {
+    const el = editorFrom('---\ntitle: "T"\ncategory: programme\nlang: en\n---\n\nBody\n');
+    expect(el.topic).toBe('');
+    expect(el.editedMarkdown).not.toContain('topic:');
+  });
+
+  it('seeds an existing topic instead of inventing one from the category', () => {
+    const el = editorFrom(
+      '---\ntitle: "T"\ncategory: programme\ntopic: editorial\nlang: en\n---\n\nBody\n',
+    );
+    expect(el.topic).toBe('editorial');
+    expect(el.rubric).toBe('programme');
+  });
+
+  /*
+   * The strongest guard against the admin corrupting content: opening an
+   * article and publishing it with no edits must be a no-op. The incident file
+   * gained a `pubDate` of the publishing day next to its existing
+   * `publishDate`, and lost part of its description, from exactly this path.
+   */
+  it('re-emits an untouched article byte-identically', () => {
+    const original =
+      '---\ntitle: "T"\nlang: ru\nmagazine: magazine-2\ncategory: programme\npublished: true\npublishDate: 2026-06-28\ndescription: >-\n  A lead.\n  Second line.\n---\n\nBody text.\n';
+    const el = editorFrom(original, 'ru');
+    expect(el.editedMarkdown).toBe(original);
   });
 
   it('writes an edited pubDate back into the published frontmatter', () => {

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -11,7 +11,12 @@ import {
   upsertFrontmatterField,
   readFrontmatterField,
   upsertFrontmatterBlock,
+  removeFrontmatterField,
+  topicOptionsViaApi,
 } from '../engine/content.js';
+import { publishTarget } from '../engine/publish-target.js';
+import { listDeployRuns } from '../engine/github-api.js';
+import { siteBuildState, type SiteBuildState } from '../engine/site-build-state.js';
 import '../components/issue-files.js';
 import '../components/issue-articles.js';
 
@@ -75,20 +80,28 @@ const FORMAT_TOOLS: readonly FormatTool[] = [
   { label: 'Список', glyph: '•', prefix: '- ' },
 ];
 
-/** Frontmatter «Тема» options; the empty value keeps the field incomplete. */
-const TOPIC_OPTIONS: readonly CpSelectOption[] = [
-  { value: '', label: '— выберите тему —' },
-  { value: 'translation', label: 'Наш перевод' },
+/**
+ * «Рубрика» is the article's `category` — the field the site's collection
+ * schema requires. These are the values the content repository actually uses;
+ * an article whose category is outside the list keeps it (see `rubricOptions`).
+ */
+const RUBRIC_OPTIONS: readonly CpSelectOption[] = [
+  { value: '', label: '— без рубрики —' },
+  { value: 'programme', label: 'Программа' },
+  { value: 'theory', label: 'Теория' },
+  { value: 'history', label: 'История' },
+  { value: 'international', label: 'Международное' },
   { value: 'editorial', label: 'От редакции' },
-  { value: 'primer', label: 'Ликбез' },
+  { value: 'critique', label: 'Критика' },
+  { value: 'appeal', label: 'Обращение' },
+  { value: 'translation', label: 'Перевод' },
 ];
 
-/** Frontmatter «Рубрика» options. */
-const RUBRIC_OPTIONS: readonly CpSelectOption[] = [
-  { value: 'economics', label: 'Экономика' },
-  { value: 'theory', label: 'Теория' },
-  { value: 'critique', label: 'Критика' },
-];
+/** The «Тема» placeholder; real topics are read from settings/topics.json. */
+const NO_TOPIC: CpSelectOption = { value: '', label: '— без темы —' };
+
+/** Frontmatter keys that have carried the publication date over time. */
+const DATE_KEYS: readonly string[] = ['pubDate', 'publishDate', 'date'];
 
 /** Publish is now a single GitHub API commit of the one edited file. */
 const REAL_STAGES: readonly string[] = ['Публикация'];
@@ -167,7 +180,8 @@ const renderInline = (text: string): readonly (TemplateResult | string)[] => {
  * single FOCUSED block reveals its raw markdown markers by becoming a
  * `--font-mono`/`--color-accent` textarea whose input updates the in-memory
  * markdown. A sticky toolbar hosts presentational formatting affordances, a
- * «Свойства» `cp-sheet` of frontmatter, the ru/en/it language `cp-tabs`, and the
+ * inline properties panel (rubric, topic, date, published), the ru/en/it
+ * language `cp-tabs`, and the
  * primary «Опубликовать» action.
  *
  * «Опубликовать» opens a `cp-dialog` staging the pipeline via `cp-steps`
@@ -446,6 +460,26 @@ export class ScreenEditor extends LitElement {
       flex-direction: column;
       gap: var(--spacing-md);
     }
+    /* The material's properties sit on the page, above its text: what a
+       publish will write must be visible without opening anything. */
+    .props {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+      align-items: end;
+      gap: var(--spacing-md);
+      margin: var(--spacing-sm) 0 var(--spacing-md);
+      padding: var(--spacing-md);
+      border: 1px solid var(--color-hairline);
+      border-radius: var(--radius-md, 10px);
+    }
+    .eyebrow .live {
+      color: var(--color-accent);
+      font-weight: 600;
+    }
+    .eyebrow .draft {
+      color: var(--draft, var(--color-text-secondary));
+      font-weight: 600;
+    }
 
     .dialog-note {
       margin: var(--spacing-md) 0 0;
@@ -515,10 +549,10 @@ export class ScreenEditor extends LitElement {
   @state() private addLangBusy = false;
   @state() private addLangError = '';
 
-  /** Frontmatter slide-over visibility. */
-  @state() private propsOpen = false;
-
-  /** Selected «Тема»; empty keeps the material incomplete. */
+  /**
+   * The OPTIONAL editorial marker (`topic`, keyed by settings/topics.json).
+   * It is not the article's category and never stands in for one.
+   */
   @state() private topic = '';
 
   /** Article description frontmatter, seeded from the file + written back. */
@@ -527,14 +561,40 @@ export class ScreenEditor extends LitElement {
   /** The description as loaded, so writeback only fires when the user changed it. */
   private descriptionSeed = '';
 
-  /** Selected «Рубрика». */
-  @state() private rubric = 'theory';
+  /** The article's `category` — required by the site's collection schema. */
+  @state() private rubric = '';
 
   /** Publication date (ISO), seeded from frontmatter when present. */
-  @state() private pubDate = '2026-07-24';
+  @state() private pubDate = '';
 
-  /** «Опубликовано» frontmatter switch. */
+  /** The `published` frontmatter switch. */
   @state() private published = false;
+
+  /**
+   * Every property as it was loaded. A publish rewrites ONLY what the user
+   * actually changed, so opening an article and publishing it is a no-op — the
+   * incident file grew a second date key (`pubDate` next to `publishDate`)
+   * precisely because every field was re-emitted unconditionally.
+   */
+  private seeds: Readonly<Record<'topic' | 'rubric' | 'pubDate' | 'published', string>> = {
+    topic: '',
+    rubric: '',
+    pubDate: '',
+    published: '',
+  };
+
+  /** Which key holds the date in THIS file: `pubDate`, `publishDate` or `date`. */
+  private dateKey = 'pubDate';
+
+  /** Topics offered in the properties panel, read from settings/topics.json. */
+  @state() private topicOptions: readonly CpSelectOption[] = [];
+
+  /**
+   * Whether the public site is currently building what the repository holds.
+   * A red build is why a correctly published article can sit in the admin and
+   * never appear on the site — the editor has to be told, here.
+   */
+  @state() private siteBuild: SiteBuildState = { phase: 'unknown' };
 
   /** Publish confirmation dialog visibility. */
   @state() private publishOpen = false;
@@ -579,6 +639,14 @@ export class ScreenEditor extends LitElement {
     void import('../editor/cp-markdown-editor.js');
     this.loadedSlug = this.routeSlug();
     void this.load();
+    // The topic list comes from the repository, so the picker offers the topics
+    // that exist rather than a list frozen into the UI.
+    void topicOptionsViaApi().then((options) => {
+      this.topicOptions = options;
+    });
+    void listDeployRuns().then((runs) => {
+      this.siteBuild = siteBuildState(runs);
+    });
     globalThis.addEventListener('hashchange', this.onHashChange);
     // The article is read directly from the GitHub API, so there is no engine
     // clone to wait on — no ready-gate re-read needed.
@@ -681,10 +749,13 @@ export class ScreenEditor extends LitElement {
     this.body = parsed.body;
     this.articlePath = path;
     this.live = live;
-    // Seed the Свойства fields from the real frontmatter — "Тема" maps to the
-    // article's `category`. Without this seed the required-field check below
-    // always fired a false "заполните Тема" warning.
-    this.topic = frontmatterValue(fm, 'category') ?? frontmatterValue(fm, 'topic') ?? '';
+    // The two taxonomies are separate frontmatter keys and are seeded as such:
+    // `category` (required by the site schema, values like programme/history)
+    // and the optional `topic` marker from settings/topics.json. Seeding the
+    // topic select from `category` is what showed it empty for every real
+    // article and let a topic choice overwrite the category.
+    this.rubric = frontmatterValue(fm, 'category') ?? '';
+    this.topic = frontmatterValue(fm, 'topic') ?? '';
     // Block-scalar aware: descriptions are stored as folded (`>-`) blocks, so a
     // naive single-line read would seed just ">-" and a publish would overwrite
     // the real text. Seed the full text and remember it to only write on change.
@@ -693,14 +764,19 @@ export class ScreenEditor extends LitElement {
     // Content is inconsistent: some articles use `pubDate`, some `publishDate`
     // (magazine-era), some `date`. Read all three so every article carries a real
     // date (else half the list has no date and clumps at the end when sorted).
-    const date =
-      frontmatterValue(fm, 'pubDate') ??
-      frontmatterValue(fm, 'publishDate') ??
-      frontmatterValue(fm, 'date');
-    if (date !== undefined) this.pubDate = date;
+    // Whichever key this file uses is the one a publish writes back to, so an
+    // article dated with `publishDate` never grows a second `pubDate` key.
+    this.dateKey = DATE_KEYS.find((key) => frontmatterValue(fm, key) !== undefined) ?? 'pubDate';
+    this.pubDate = frontmatterValue(fm, this.dateKey) ?? '';
     const published = frontmatterValue(fm, 'published');
     this.published =
       published !== undefined ? published === 'true' : frontmatterValue(fm, 'draft') !== 'true';
+    this.seeds = {
+      topic: this.topic,
+      rubric: this.rubric,
+      pubDate: this.pubDate,
+      published: published ?? '',
+    };
     // Freshly loaded content is not "unsaved" — clear the dirty flag the save
     // note reads (it used to be hardcoded on, flagging every article).
     this.dirty = false;
@@ -714,24 +790,27 @@ export class ScreenEditor extends LitElement {
   private get editedMarkdown(): string {
     let fm = this.frontmatter;
     if (fm !== '') {
-      if (this.topic !== '') fm = upsertFrontmatterField(fm, 'category', this.topic);
+      // Each property is written back ONLY when it differs from what was
+      // loaded, so opening an article and publishing it changes nothing.
+      if (this.rubric !== this.seeds.rubric && this.rubric !== '')
+        fm = upsertFrontmatterField(fm, 'category', this.rubric);
+      if (this.topic !== this.seeds.topic)
+        fm =
+          this.topic === ''
+            ? removeFrontmatterField(fm, 'topic')
+            : upsertFrontmatterField(fm, 'topic', this.topic);
       // Only rewrite the description when the user actually edited it, so an
       // untouched folded-block description is left byte-identical (no orphaned
       // continuation lines); a real edit is re-emitted as a clean literal block.
       if (this.description !== this.descriptionSeed)
         fm = upsertFrontmatterBlock(fm, 'description', this.description);
-      if (this.pubDate !== '') fm = upsertFrontmatterField(fm, 'pubDate', this.pubDate);
-      fm = upsertFrontmatterField(fm, 'published', String(this.published));
+      if (this.pubDate !== this.seeds.pubDate && this.pubDate !== '')
+        fm = upsertFrontmatterField(fm, this.dateKey, this.pubDate);
+      if (String(this.published) !== this.seeds.published)
+        fm = upsertFrontmatterField(fm, 'published', String(this.published));
     }
     const body = this.body.trimEnd();
     return fm === '' ? `${body}\n` : `${fm}\n\n${body}\n`;
-  }
-
-  /** A required frontmatter field is empty. */
-  private get incomplete(): boolean {
-    // A journal issue has no topic, so it is never "incomplete" for that reason
-    // (this was still flagging the warning icon on the props button for issues).
-    return this.collection !== 'magazine' && this.topic === '';
   }
 
   private onLangChange = (event: Event): void => {
@@ -900,14 +979,6 @@ export class ScreenEditor extends LitElement {
     }
   };
 
-  private openProps = (): void => {
-    this.propsOpen = true;
-  };
-
-  private closeProps = (): void => {
-    this.propsOpen = false;
-  };
-
   private startPublish = (): void => {
     this.publishOpen = true;
     this.publishSha = '';
@@ -1001,11 +1072,9 @@ export class ScreenEditor extends LitElement {
           <cp-icon name="upload" size="18"></cp-icon>
         </button>
         <span class="spacer"></span>
-        <cp-button variant="ghost" size="sm" @cp-click=${this.openProps}>
-          ${this.incomplete ? html`<cp-icon name="warning" size="16"></cp-icon>` : nothing}
-          Свойства
-        </cp-button>
-        <cp-button size="sm" arrow @cp-click=${this.startPublish}>Опубликовать</cp-button>
+        <cp-button size="sm" arrow @cp-click=${this.startPublish}
+          >Опубликовать на ${publishTarget().site}</cp-button
+        >
       </div>
     `;
   }
@@ -1032,50 +1101,80 @@ export class ScreenEditor extends LitElement {
     `;
   }
 
+  /**
+   * The rubric choices: the repository's real categories, plus this article's
+   * own value when it is not among them, so opening an article can never
+   * silently drop the category it already carries.
+   */
+  private get rubricOptions(): readonly CpSelectOption[] {
+    const known = RUBRIC_OPTIONS.some((option) => option.value === this.rubric);
+    return known ? RUBRIC_OPTIONS : [...RUBRIC_OPTIONS, { value: this.rubric, label: this.rubric }];
+  }
+
+  /** Same for the topic marker, which comes from settings/topics.json. */
+  private get topicChoices(): readonly CpSelectOption[] {
+    const options = [NO_TOPIC, ...this.topicOptions];
+    return options.some((option) => option.value === this.topic)
+      ? options
+      : [...options, { value: this.topic, label: this.topic }];
+  }
+
+  /**
+   * The properties of the material, rendered as part of the page. They used to
+   * live behind a `cp-sheet`, so what a publish would write was invisible
+   * unless you went looking for it — and a wrong value (a missing category, a
+   * draft flag) is exactly what keeps an article off the public site.
+   */
+  /**
+   * The banner that tells an editor the site is not building. Without it a
+   * failed deploy is invisible from here: the article is in the repository and
+   * the admin shows it, while the site keeps serving the last good build.
+   */
+  private renderSiteBuildWarning(): TemplateResult | typeof nothing {
+    if (this.siteBuild.phase !== 'failed') return nothing;
+    const url = this.siteBuild.runUrl;
+    return html`
+      <cp-banner tone="danger" title="Сборка сайта падает">
+        Последняя сборка ${publishTarget().site} завершилась ошибкой, поэтому изменения
+        не доезжают до сайта — даже опубликованные.
+        ${url === undefined
+          ? nothing
+          : html`<a href=${url} target="_blank" rel="noopener">Открыть журнал сборки ↗</a>`}
+      </cp-banner>
+    `;
+  }
+
   private renderProps(): TemplateResult {
-    // Topic/rubric are blog-article taxonomy; a journal issue has neither, so
-    // those fields (and the required-topic gate) are hidden when editing one.
+    // Rubric/topic are blog-article taxonomy; a journal issue has neither.
     const isArticle = this.collection !== 'magazine';
     return html`
-      <cp-sheet
-        ?open=${this.propsOpen}
-        heading="Свойства материала"
-        @cp-close=${this.closeProps}
-      >
-        <div class="sheet-form">
-          ${isArticle && this.incomplete
-            ? html`<cp-tag tone="warning">заполните обязательное поле «Тема»</cp-tag>`
-            : nothing}
-          ${isArticle
-            ? html`<cp-select
-                label="Тема"
-                required
-                .value=${this.topic}
-                .options=${TOPIC_OPTIONS}
-                @cp-change=${this.onTopicChange}
-              ></cp-select>`
-            : nothing}
-          ${isArticle
-            ? html`<cp-select
+      <section class="props" aria-label="Свойства материала">
+        ${isArticle
+          ? html`<cp-select
                 label="Рубрика"
                 .value=${this.rubric}
-                .options=${RUBRIC_OPTIONS}
+                .options=${this.rubricOptions}
                 @cp-change=${this.onRubricChange}
+              ></cp-select>
+              <cp-select
+                label="Тема"
+                .value=${this.topic}
+                .options=${this.topicChoices}
+                @cp-change=${this.onTopicChange}
               ></cp-select>`
-            : nothing}
-          <cp-date-input
-            label="Дата публикации"
-            type="date"
-            .value=${this.pubDate}
-            @cp-change=${this.onDateChange}
-          ></cp-date-input>
-          <cp-switch
-            label="Опубликовано"
-            ?checked=${this.published}
-            @cp-change=${this.onPublishedChange}
-          ></cp-switch>
-        </div>
-      </cp-sheet>
+          : nothing}
+        <cp-date-input
+          label="Дата публикации"
+          type="date"
+          .value=${this.pubDate}
+          @cp-change=${this.onDateChange}
+        ></cp-date-input>
+        <cp-switch
+          label="Опубликовано"
+          ?checked=${this.published}
+          @cp-change=${this.onPublishedChange}
+        ></cp-switch>
+      </section>
     `;
   }
 
@@ -1143,12 +1242,19 @@ export class ScreenEditor extends LitElement {
     return html`
       <article class="ed">
         <div class="head">
-          <p class="eyebrow">Контент · ${this.slug} · черновик</p>
+          <p class="eyebrow">
+            Контент · ${this.slug} ·
+            <span class=${this.published ? 'live' : 'draft'}
+              >${this.published ? 'опубликовано' : 'черновик'}</span
+            >
+            · ${publishTarget().site}
+          </p>
           <h1 class="title" tabindex="-1">
             ${this.articleTitle === '' ? 'Без названия' : this.articleTitle}
           </h1>
           <cp-tag tone="success">данные из репозитория</cp-tag>
         </div>
+        ${this.renderSiteBuildWarning()}
         <textarea
           class="lead"
           rows="2"
@@ -1172,7 +1278,7 @@ export class ScreenEditor extends LitElement {
               >`
             : nothing}
         </div>
-        ${this.renderAddLangDialog()}
+        ${this.renderAddLangDialog()} ${this.renderProps()}
         ${this.collection === 'magazine'
           ? this.renderMagazineBody()
           : html`
@@ -1200,7 +1306,7 @@ export class ScreenEditor extends LitElement {
           <span class="path">${this.articlePath}</span>
         </p>
       </article>
-      ${this.renderProps()}${this.renderPublishDialog()}
+      ${this.renderPublishDialog()}
     `;
   }
 }

--- a/src/sw/handlers/file/validate-stage-rules.ts
+++ b/src/sw/handlers/file/validate-stage-rules.ts
@@ -1,47 +1,13 @@
-import { Either } from 'effect'
-import { validateFrontmatter } from '@/validation/schemas/frontmatter'
+import { validateParsedContent } from '@/validation/content-gate'
 import { workerState } from '../../state/state'
-import { parseFrontmatterStrict } from '../shared/frontmatter'
 import type { ContentPathParts } from './path-parts'
 
-type ParseResult =
-  | { readonly ok: true; readonly data: Record<string, unknown> }
-  | { readonly ok: false; readonly reason: string }
-
-const tryParseFrontmatter = (content: string): ParseResult => {
-  try {
-    return { ok: true, data: parseFrontmatterStrict(content) }
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e)
-    return { ok: false, reason: `frontmatter is not valid YAML — ${msg}` }
-  }
-}
-
-const langReason = (
-  parts: ContentPathParts,
-  fm: Record<string, unknown>
-): string | undefined => {
-  const allowed = workerState.supportedLangs
-  return allowed.has(parts.lang)
-    ? fm['lang'] === parts.lang
-      ? undefined
-      : `frontmatter lang (${String(fm['lang'])}) must match filename lang (${parts.lang})`
-    : `lang "${parts.lang}" not in supported set (${[...allowed].join(',')}) — ` +
-        `update settings/languages.json or rename the file`
-}
-
-const schemaReason = (
-  type: ContentPathParts['type'],
-  data: Record<string, unknown>
-): string | undefined => {
-  const r = validateFrontmatter(type, data)
-  return Either.isLeft(r) ? r.left : undefined
-}
-
 /**
- * Run the four-step content gate against an already-parsed path.
- * Returns the first failing reason or undefined when the payload
- * is safe to stage.
+ * Run the content gate against an already-parsed path with the
+ * worker's live language whitelist (refreshed from
+ * `settings/languages.json` after every sync). The rules themselves
+ * live in `@/validation/content-gate` so the Contents-API publish
+ * path on the main thread applies the very same ones.
  * @param parts - parsed `<type>` + `<lang>` from the path
  * @param content - full file body, including YAML frontmatter
  * @returns error message or undefined
@@ -49,10 +15,5 @@ const schemaReason = (
 export const validateContent = (
   parts: ContentPathParts,
   content: string
-): string | undefined => {
-  const parsed = tryParseFrontmatter(content)
-  return parsed.ok === false
-    ? parsed.reason
-    : (langReason(parts, parsed.data) ??
-        schemaReason(parts.type, parsed.data))
-}
+): string | undefined =>
+  validateParsedContent(parts, content, workerState.supportedLangs)

--- a/src/validation/README.md
+++ b/src/validation/README.md
@@ -10,3 +10,18 @@ Schema-based validation infrastructure using Effect.Schema. All data crossing tr
 - `extractString` -- safely extract a string from Vue route query values
 - `normalizeHeaders` -- normalize HeadersInit to a flat record
 - `serializeBody` -- serialize BodyInit to string for SW transport
+
+## Content gate
+
+`content-gate.ts` (rules in `content-gate-rules.ts`) is the one set of checks every write of a `<type>/<slug>/index.<lang>.md` must pass before it reaches git, whatever transport carries it:
+
+1. the frontmatter is valid YAML with a mapping root,
+2. the filename `<lang>` is in the supported set (when the caller has one — the Service Worker passes `workerState.supportedLangs`),
+3. `frontmatter.lang` equals the filename `<lang>`,
+4. the per-type schema (`schemas/frontmatter-*.ts`) accepts the record.
+
+It is pure, so both the Service Worker's stage handler (`sw/handlers/file/validate-stage-rules.ts`) and the redesign's Contents-API publish (`redesign/engine/content.ts` → `publishFileViaApi`, loaded lazily) run the same rules. It exists because the public site's Astro build fails on exactly these — an unquoted `:` in a description, a bare `articles:` (an empty YAML value where the magazine schema wants a list) — and one such commit blocks every deploy until someone fixes it by hand.
+
+## Related: the editor's frontmatter helpers
+
+`redesign/engine/frontmatter-value.ts` decides where a frontmatter field's value starts and ends, so an edit replaces exactly that span. It exists because a value is not always one line: a quoted scalar can run over several lines with blank lines inside it, and removing "the key plus the indented lines that follow" left the tail of the previous value orphaned under the new one — how an English translation ended up carrying half a Russian description.

--- a/src/validation/content-gate-rules.ts
+++ b/src/validation/content-gate-rules.ts
@@ -1,0 +1,61 @@
+import { Either } from 'effect'
+import type { ContentPathParts } from '@/sw/handlers/file/path-parts'
+import { parseFrontmatterStrict } from '@/sw/handlers/shared/frontmatter'
+import { validateFrontmatter } from '@/validation/schemas/frontmatter'
+
+/**
+ * The individual rules of the content gate (see `content-gate.ts`).
+ * Each returns the reason a payload fails, or undefined when it passes.
+ */
+
+type ParseResult =
+  | { readonly ok: true; readonly data: Record<string, unknown> }
+  | { readonly ok: false; readonly reason: string }
+
+/**
+ * Rule 1: the frontmatter fence is valid YAML with a mapping root.
+ * @param content - full file body, including YAML frontmatter
+ * @returns the parsed record, or the parser's reason
+ */
+export const tryParseFrontmatter = (content: string): ParseResult => {
+  try {
+    return { ok: true, data: parseFrontmatterStrict(content) }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e)
+    return { ok: false, reason: `frontmatter is not valid YAML — ${msg}` }
+  }
+}
+
+/**
+ * Rules 2 + 3: the filename lang is allowed (when a set is given) and
+ * the frontmatter `lang` agrees with it.
+ * @param parts - parsed `<type>` + `<lang>` from the path
+ * @param fm - parsed frontmatter record
+ * @param allowed - allowed filename langs; undefined skips rule 2
+ * @returns the failing reason or undefined
+ */
+export const langReason = (
+  parts: ContentPathParts,
+  fm: Record<string, unknown>,
+  allowed: ReadonlySet<string> | undefined
+): string | undefined =>
+  allowed !== undefined && !allowed.has(parts.lang)
+    ? `lang "${parts.lang}" not in supported set (${[...allowed].join(',')}) — ` +
+      `update settings/languages.json or rename the file`
+    : fm['lang'] === parts.lang
+      ? undefined
+      : `frontmatter lang (${String(fm['lang'])}) must match filename lang (${parts.lang})`
+
+/**
+ * Rule 4: the per-type schema accepts the record.
+ * @param type - content type from the path
+ * @param data - parsed frontmatter record
+ * @returns the schema's reason or undefined
+ */
+export const schemaReason = (
+  type: ContentPathParts['type'],
+  data: Record<string, unknown>
+): string | undefined => {
+  const r = validateFrontmatter(type, data)
+  return Either.isLeft(r) ? r.left : undefined
+}

--- a/src/validation/content-gate.ts
+++ b/src/validation/content-gate.ts
@@ -1,0 +1,65 @@
+import {
+  type ContentPathParts,
+  parseContentPath,
+} from '@/sw/handlers/file/path-parts'
+import {
+  langReason,
+  schemaReason,
+  tryParseFrontmatter,
+} from './content-gate-rules'
+
+/**
+ * The content gate: the one set of rules every write of a
+ * `<type>/<slug>/index.<lang>.md` must pass before it reaches git,
+ * whichever transport carries it (the SW clone+push path or the
+ * direct Contents-API single-file commit). Pure — no worker state,
+ * no network — so both the Service Worker and the main thread can
+ * run it.
+ *
+ *   1. the frontmatter is valid YAML,
+ *   2. filename `<lang>` is in `supportedLangs` (when a set is given),
+ *   3. `frontmatter.lang` equals filename `<lang>`,
+ *   4. the per-type schema accepts the record.
+ *
+ * A rejected payload is exactly what breaks the public build: an
+ * unquoted `: ` in a description (YAML), or a bare `articles:` the
+ * collection schema reads as an empty value instead of a list.
+ */
+
+/**
+ * Run the gate against an already-parsed path.
+ * @param parts - parsed `<type>` + `<lang>` from the path
+ * @param content - full file body, including YAML frontmatter
+ * @param supportedLangs - allowed filename langs; omit to skip rule 2
+ * @returns the first failing reason, or undefined when safe to write
+ */
+export const validateParsedContent = (
+  parts: ContentPathParts,
+  content: string,
+  supportedLangs?: ReadonlySet<string>
+): string | undefined => {
+  const parsed = tryParseFrontmatter(content)
+  return parsed.ok === false
+    ? parsed.reason
+    : (langReason(parts, parsed.data, supportedLangs) ??
+        schemaReason(parts.type, parsed.data))
+}
+
+/**
+ * Run the gate against a repo path. Non-content paths (assets,
+ * settings/, README …) pass straight through.
+ * @param path - repo-relative path being written
+ * @param content - full file body, including YAML frontmatter
+ * @param supportedLangs - allowed filename langs; omit to skip rule 2
+ * @returns the first failing reason, or undefined when safe to write
+ */
+export const validateContentFile = (
+  path: string,
+  content: string,
+  supportedLangs?: ReadonlySet<string>
+): string | undefined => {
+  const parts = parseContentPath(path)
+  return parts === undefined
+    ? undefined
+    : validateParsedContent(parts, content, supportedLangs)
+}

--- a/src/validation/schemas/frontmatter-magazine.ts
+++ b/src/validation/schemas/frontmatter-magazine.ts
@@ -14,4 +14,10 @@ export const MagazineFrontmatterSchema = Schema.Struct({
     Schema.Union(Schema.String, Schema.DateFromSelf)
   ),
   image: Schema.optional(Schema.String),
+  /*
+   * The issue's table of contents: blog slugs, in print order. Optional,
+   * but when present it must be a list — a bare `articles:` (YAML's empty
+   * value) is what the public build rejects, so it is rejected here first.
+   */
+  articles: Schema.optional(Schema.Array(Schema.String)),
 })

--- a/src/validation/schemas/frontmatter.ts
+++ b/src/validation/schemas/frontmatter.ts
@@ -1,4 +1,4 @@
-import { Either, Schema } from 'effect'
+import { Either, ParseResult, Schema } from 'effect'
 import type { ContentType } from '@/types/content'
 import { ArchiveFrontmatterSchema } from './frontmatter-archive'
 import { BlogFrontmatterSchema } from './frontmatter-blog'
@@ -8,10 +8,26 @@ import { PositionsFrontmatterSchema } from './frontmatter-positions'
 
 type Result = Either.Either<void, string>
 
+/*
+ * One line per failing field (`articles: Expected ReadonlyArray<string>,
+ * actual null`) instead of Effect's default dump of the whole struct type,
+ * which is what an editor would otherwise see in the publish dialog.
+ */
+const describe = (error: ParseResult.ParseError): string => {
+  const byField = new Map<string, string>()
+  for (const issue of ParseResult.ArrayFormatter.formatErrorSync(error)) {
+    const field = issue.path.join('.') || 'frontmatter'
+    // A union (`T | undefined`) reports one issue per branch; the first is
+    // the one that names the type the field should have.
+    byField.set(field, byField.get(field) ?? `${field}: ${issue.message}`)
+  }
+  return [...byField.values()].join('; ')
+}
+
 const run = <A>(schema: Schema.Schema<A>, value: unknown): Result => {
   const parsed = Schema.decodeUnknownEither(schema)(value)
   return Either.mapBoth(parsed, {
-    onLeft: e => e.message,
+    onLeft: describe,
     onRight: () => undefined,
   })
 }


### PR DESCRIPTION
Promotes to production (admin.comprom.org) the work from #427.

- **Content gate on the Contents-API publish path** — the same YAML / lang / schema rules the Service Worker applies at stage time now run on the single-file commit path too, so the admin cannot push a file the site cannot build.
- **Translations are no longer corrupted on write** — a multi-line quoted `description` is read whole and replaced whole; the incident file carried an English lead followed by the tail of the Russian one.
- **Publishing rewrites only what changed** — opening an article and publishing it is a no-op; it used to add a second date key.
- **Properties are on the page** — «Рубрика» is the article's `category`, «Тема» the optional `topic` from settings/topics.json, nothing is required. The header states published vs draft instead of always saying draft.
- **The target site is named** — badge in the shell on any non-production admin, the site in the editor header and on the publish button, and a banner when the site build is failing (an article can be correct in the admin and still never appear while deploys are red).
- **Phone header fixed** — it overflowed at 390px even before the badge, pushing sign-out and the theme toggle off-screen.

CI on #427: realmode green. `bun run validate` green, 1280 unit + 189 redesign tests green. Verified in the browser against live content on desktop and at 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJdyKYYiV415PzW72712mg
