### PR TITLE
prod: taxonomy screens + editable article title and address

### DIFF
--- a/src/redesign/engine/content.ts
+++ b/src/redesign/engine/content.ts
@@ -876,6 +876,67 @@ const apiError = async (res: Response, fallback: string): Promise<string> => {
   return typeof e === 'object' && e && 'message' in e ? String(Reflect.get(e, 'message')) : fallback;
 };
 
+/** Every path in the repository tree, optionally narrowed to one folder. */
+const repoTree = async (): Promise<readonly string[]> => {
+  const t = await freshGhToken();
+  if (t === undefined) return [];
+  const res = await fetch(`${REPO_BASE}/git/trees/${contentBranch()}?recursive=1`, {
+    headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) return [];
+  const data: unknown = await res.json();
+  const tree = typeof data === 'object' && data && 'tree' in data ? Reflect.get(data, 'tree') : undefined;
+  return Array.isArray(tree)
+    ? tree
+        .map((e) => (typeof e === 'object' && e && 'path' in e ? String(Reflect.get(e, 'path')) : ''))
+        .filter((path) => path !== '')
+    : [];
+};
+
+/**
+ * With no `slug`: every slug the collection contains — what a new or renamed
+ * article must not collide with. With a `slug`: every file path inside that
+ * article's folder, which is what a rename has to move.
+ * @param collection - `blog`, `pages`, `magazine`, …
+ * @param slug - when given, list that article's files instead of the slugs
+ * @returns slugs, or file paths
+ */
+export const listSlugsViaApi = async (
+  collection: string,
+  slug?: string,
+): Promise<readonly string[]> => {
+  const paths = await repoTree();
+  if (slug !== undefined) {
+    const prefix = `${collection}/${slug}/`;
+    return paths.filter((path) => path.startsWith(prefix));
+  }
+  const prefix = `${collection}/`;
+  const slugs = new Set(
+    paths
+      .filter((path) => path.startsWith(prefix))
+      .map((path) => path.slice(prefix.length).split('/')[0] ?? '')
+      .filter((name) => name !== ''),
+  );
+  return [...slugs].sort();
+};
+
+/** A file's raw bytes, base64-encoded — binary-safe, for moving assets. */
+export const readBinaryViaApi = async (
+  path: string,
+): Promise<{ readonly content: string } | undefined> => {
+  const t = await freshGhToken();
+  if (t === undefined) return undefined;
+  const res = await fetch(`${REPO_BASE}/contents/${path}?ref=${contentBranch()}`, {
+    cache: 'no-store',
+    headers: { authorization: `Bearer ${t}`, accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) return undefined;
+  const data: unknown = await res.json();
+  const content = typeof data === 'object' && data && 'content' in data ? String(Reflect.get(data, 'content')) : undefined;
+  // The API returns base64 wrapped at 60 columns; the write path wants it flat.
+  return content === undefined ? undefined : { content: content.replace(/\s+/g, '') };
+};
+
 /** Uploads a file (already base64-encoded) via the Contents API — ANY type,
  *  including fb2/doc/pdf. Overwrites in place when the path already exists. */
 export const uploadBinaryViaApi = async (

--- a/src/redesign/engine/rename-article.test.ts
+++ b/src/redesign/engine/rename-article.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+import { renameArticleViaApi } from './rename-article.ts';
+
+vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
+
+/*
+ * Changing an article's address moves every file of its folder — all languages
+ * and its assets — because the folder IS the address. The dangerous outcomes
+ * are a half-moved article (some languages at the old address, some at the new)
+ * and an address that silently lands on top of another article's folder.
+ */
+const repo = (): Record<string, string> => ({
+  'blog/old-name/index.ru.md': '---\ntitle: T\nlang: ru\ncategory: t\n---\n\nRU\n',
+  'blog/old-name/index.en.md': '---\ntitle: T\nlang: en\ncategory: t\n---\n\nEN\n',
+  'blog/old-name/assets/cover.png': 'PNG-BYTES',
+  'blog/other/index.ru.md': '---\ntitle: O\nlang: ru\ncategory: t\n---\n\nO\n',
+});
+
+const decode = (b64: string): string =>
+  new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+const encode = (text: string): string => {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+};
+
+const acceptOf = (init?: RequestInit): string => {
+  const h = init?.headers;
+  return typeof h === 'object' && 'accept' in h ? String(Reflect.get(h, 'accept')) : '';
+};
+
+/** A Contents API double: tree listing, raw/base64 reads, PUT and DELETE. */
+const stubGitHub = (files: Record<string, string>, calls: string[]): void => {
+  vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    if (url.includes('/git/trees/')) {
+      return new Response(JSON.stringify({ tree: Object.keys(files).map((path) => ({ path })) }), {
+        status: 200,
+      });
+    }
+    const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+    if (init?.method === 'PUT') {
+      files[path] = decode(JSON.parse(String(init.body)).content);
+      calls.push(`PUT ${path}`);
+      return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+    }
+    if (init?.method === 'DELETE') {
+      delete files[path];
+      calls.push(`DELETE ${path}`);
+      return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 200 });
+    }
+    if (files[path] === undefined) return new Response('', { status: 404 });
+    if (acceptOf(init).includes('raw')) return new Response(files[path], { status: 200 });
+    return new Response(JSON.stringify({ sha: 'blob', content: encode(files[path]) }), { status: 200 });
+  });
+};
+
+beforeEach(() => {
+  vi.stubEnv('VITE_DEV_TOKEN', '');
+  vi.stubEnv('VITE_GITHUB_BRANCH', 'develop');
+  vi.mocked(ensureFreshToken).mockResolvedValue('tok');
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('renameArticleViaApi', () => {
+  it('moves every language and asset to the new address', async () => {
+    const files = repo();
+    const calls: string[] = [];
+    stubGitHub(files, calls);
+
+    const result = await renameArticleViaApi('blog', 'old-name', 'new-name');
+    expect(result.ok).toBe(true);
+
+    expect(Object.keys(files).sort()).toEqual([
+      'blog/new-name/assets/cover.png',
+      'blog/new-name/index.en.md',
+      'blog/new-name/index.ru.md',
+      'blog/other/index.ru.md',
+    ]);
+    expect(files['blog/new-name/index.ru.md']).toContain('RU');
+    expect(files['blog/new-name/assets/cover.png']).toBe('PNG-BYTES');
+  });
+
+  it('writes every file before deleting any, so a failure cannot lose content', async () => {
+    const files = repo();
+    const calls: string[] = [];
+    stubGitHub(files, calls);
+    await renameArticleViaApi('blog', 'old-name', 'new-name');
+    const firstDelete = calls.findIndex((c) => c.startsWith('DELETE'));
+    const lastPut = calls.map((c) => c.startsWith('PUT')).lastIndexOf(true);
+    expect(lastPut).toBeLessThan(firstDelete);
+  });
+
+  it('refuses an address another article already occupies, touching nothing', async () => {
+    const files = repo();
+    const calls: string[] = [];
+    stubGitHub(files, calls);
+    const result = await renameArticleViaApi('blog', 'old-name', 'other');
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/занят/i);
+    expect(calls).toEqual([]);
+  });
+
+  it('refuses a malformed address', async () => {
+    const files = repo();
+    const calls: string[] = [];
+    stubGitHub(files, calls);
+    const result = await renameArticleViaApi('blog', 'old-name', 'Новое Имя');
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/латин/i);
+    expect(calls).toEqual([]);
+  });
+
+  it('is a no-op when the address does not change', async () => {
+    const files = repo();
+    const calls: string[] = [];
+    stubGitHub(files, calls);
+    const result = await renameArticleViaApi('blog', 'old-name', 'old-name');
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  it('stops before deleting anything when a copy fails', async () => {
+    const files = repo();
+    const calls: string[] = [];
+    stubGitHub(files, calls);
+    const original = globalThis.fetch;
+    vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT' && url.includes('index.en.md')) {
+        return new Response(JSON.stringify({ message: 'Bad credentials' }), { status: 401 });
+      }
+      return original(url, init);
+    });
+
+    const result = await renameArticleViaApi('blog', 'old-name', 'new-name');
+    expect(result.ok).toBe(false);
+    expect(calls.some((c) => c.startsWith('DELETE'))).toBe(false);
+    // The original article is still whole.
+    expect(files['blog/old-name/index.ru.md']).toBeDefined();
+    expect(files['blog/old-name/index.en.md']).toBeDefined();
+  });
+});

--- a/src/redesign/engine/rename-article.ts
+++ b/src/redesign/engine/rename-article.ts
@@ -1,0 +1,68 @@
+import {
+  deleteFileViaApi,
+  listSlugsViaApi,
+  readBinaryViaApi,
+  uploadBinaryViaApi,
+} from './content.js';
+import { slugProblem } from './slug.js';
+
+/**
+ * Changing an article's address. The folder IS the address
+ * (`blog/<slug>/index.<lang>.md` → comprom.org/<lang>/blog/<slug>/), so a
+ * rename moves every file of that folder: all languages and every asset.
+ *
+ * Order matters. Every file is copied to the new address FIRST and only then
+ * are the originals deleted, so a failure half-way leaves the article whole at
+ * its old address instead of scattering it across two.
+ */
+
+/** The outcome of a rename. */
+export interface RenameResult {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
+/**
+ * Moves an article to a new slug.
+ * @param collection - `blog`, `pages`, `magazine`, …
+ * @param from - the article's current slug
+ * @param to - the requested slug
+ * @returns ok, or the reason nothing was changed
+ */
+export const renameArticleViaApi = async (
+  collection: string,
+  from: string,
+  to: string,
+): Promise<RenameResult> => {
+  if (from === to) return { ok: true };
+
+  const taken = await listSlugsViaApi(collection);
+  const problem = slugProblem(to, taken, from);
+  if (problem !== undefined) return { ok: false, error: problem };
+
+  const files = await listSlugsViaApi(collection, from);
+  if (files.length === 0) return { ok: false, error: `Не найдены файлы материала «${from}».` };
+
+  // Copy everything first — binary-safe, so covers and PDFs survive the move.
+  const copied: string[] = [];
+  for (const path of files) {
+    const base64 = await readBinaryViaApi(path);
+    if (base64 === undefined) return { ok: false, error: `Не удалось прочитать ${path}.` };
+    const target = path.replace(`${collection}/${from}/`, `${collection}/${to}/`);
+    const upload = await uploadBinaryViaApi(target, base64.content, `адрес: ${from} → ${to}`);
+    if (!upload.ok) return { ok: false, error: upload.error };
+    copied.push(target);
+  }
+
+  // Only now remove the originals.
+  for (const path of files) {
+    const removed = await deleteFileViaApi(path, `адрес: ${from} → ${to} (удаление старого)`);
+    if (!removed.ok) {
+      return {
+        ok: false,
+        error: `${removed.error ?? 'Не удалось удалить старые файлы.'} Материал уже скопирован в «${to}» — удалите «${from}» вручную.`,
+      };
+    }
+  }
+  return { ok: true };
+};

--- a/src/redesign/engine/settings-io.test.ts
+++ b/src/redesign/engine/settings-io.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+import {
+  readLabelsViaApi,
+  readTopicsViaApi,
+  saveLabelsViaApi,
+  saveTopicsViaApi,
+} from './settings-io.ts';
+
+vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
+
+/*
+ * The topics screen read `settings/topics.json` through the Service Worker git
+ * engine, which needs a full repository clone. Every other screen had long since
+ * moved to the GitHub API, so on a session where the clone never completed the
+ * screen sat on its loading placeholder forever — the editor could neither see nor
+ * edit topics. Categories (`settings/labels.json`) had no screen at all.
+ */
+const TOPICS = [
+  {
+    key: 'editorial',
+    color: '#b03a2e',
+    name: { ru: 'От редакции', en: 'Editorial' },
+    subtitle: { ru: 'Позиция редакции' },
+    description: {},
+  },
+];
+
+const LABELS = [
+  { key: 'programme', translations: { ru: 'Программа', en: 'Programme' } },
+  { key: 'history', translations: { ru: 'История', en: 'History' } },
+];
+
+const decode = (b64: string): string =>
+  new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+
+const acceptOf = (init?: RequestInit): string => {
+  const h = init?.headers;
+  return typeof h === 'object' && 'accept' in h ? String(Reflect.get(h, 'accept')) : '';
+};
+
+/** A Contents API double over an in-memory settings tree; records PUTs. */
+const stubGitHub = (files: Record<string, string>, puts: Array<{ path: string; body: string; message: string }>): void => {
+  vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+    if (init?.method === 'PUT') {
+      const parsed = JSON.parse(String(init.body));
+      files[path] = decode(parsed.content);
+      puts.push({ path, body: files[path], message: String(parsed.message) });
+      return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+    }
+    if (acceptOf(init).includes('raw')) {
+      return new Response(files[path] ?? '', { status: files[path] ? 200 : 404 });
+    }
+    return new Response(JSON.stringify({ sha: 'blob' }), { status: 200 });
+  });
+};
+
+beforeEach(() => {
+  vi.stubEnv('VITE_DEV_TOKEN', '');
+  vi.stubEnv('VITE_GITHUB_BRANCH', 'master');
+  vi.mocked(ensureFreshToken).mockResolvedValue('tok');
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('settings read over the API (no clone needed)', () => {
+  it('reads the repository topics', async () => {
+    stubGitHub({ 'settings/topics.json': JSON.stringify(TOPICS) }, []);
+    const topics = await readTopicsViaApi();
+    expect(topics).toHaveLength(1);
+    expect(topics[0]).toMatchObject({ key: 'editorial', color: '#b03a2e' });
+    expect(topics[0]?.name['ru']).toBe('От редакции');
+  });
+
+  it('reads the repository categories', async () => {
+    stubGitHub({ 'settings/labels.json': JSON.stringify(LABELS) }, []);
+    const labels = await readLabelsViaApi();
+    expect(labels.map((l) => l.key)).toEqual(['programme', 'history']);
+    expect(labels[0]?.translations['ru']).toBe('Программа');
+  });
+
+  it('reports a read failure instead of pretending the repository is empty', async () => {
+    vi.stubGlobal('fetch', async () => new Response('boom', { status: 500 }));
+    await expect(readTopicsViaApi()).rejects.toThrow();
+  });
+
+  it('reads an empty list from an empty settings file without throwing', async () => {
+    stubGitHub({ 'settings/topics.json': '[]' }, []);
+    expect(await readTopicsViaApi()).toEqual([]);
+  });
+});
+
+describe('settings write over the API', () => {
+  it('saves topics as formatted JSON under a descriptive message', async () => {
+    const files: Record<string, string> = { 'settings/topics.json': JSON.stringify(TOPICS) };
+    const puts: Array<{ path: string; body: string; message: string }> = [];
+    stubGitHub(files, puts);
+
+    const next = [...TOPICS, { key: 'primer', color: '#2563eb', name: { ru: 'Ликбез' }, subtitle: {}, description: {} }];
+    const result = await saveTopicsViaApi(next);
+    expect(result.ok).toBe(true);
+    expect(puts).toHaveLength(1);
+    expect(puts[0].path).toBe('settings/topics.json');
+    expect(puts[0].message).toMatch(/тем/i);
+    // Stored as readable JSON, and it round-trips.
+    expect(puts[0].body.endsWith('\n')).toBe(true);
+    expect(JSON.parse(puts[0].body)).toHaveLength(2);
+    expect(puts[0].body).toContain('\n  ');
+  });
+
+  it('saves categories the same way', async () => {
+    const files: Record<string, string> = { 'settings/labels.json': JSON.stringify(LABELS) };
+    const puts: Array<{ path: string; body: string; message: string }> = [];
+    stubGitHub(files, puts);
+
+    const result = await saveLabelsViaApi([...LABELS, { key: 'appeal', translations: { ru: 'Обращение' } }]);
+    expect(result.ok).toBe(true);
+    expect(puts[0].path).toBe('settings/labels.json');
+    expect(JSON.parse(puts[0].body).map((l: { key: string }) => l.key)).toEqual([
+      'programme',
+      'history',
+      'appeal',
+    ]);
+  });
+
+  it('refuses to save an entry without a key, rather than corrupting the file', async () => {
+    const puts: Array<{ path: string; body: string; message: string }> = [];
+    stubGitHub({ 'settings/labels.json': JSON.stringify(LABELS) }, puts);
+    const result = await saveLabelsViaApi([...LABELS, { key: '  ', translations: {} }]);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/ключ/i);
+    expect(puts).toEqual([]);
+  });
+
+  it('refuses duplicate keys', async () => {
+    const puts: Array<{ path: string; body: string; message: string }> = [];
+    stubGitHub({ 'settings/topics.json': JSON.stringify(TOPICS) }, puts);
+    const result = await saveTopicsViaApi([...TOPICS, { ...TOPICS[0] }]);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/editorial/);
+    expect(puts).toEqual([]);
+  });
+
+  it('surfaces the GitHub error when the write is rejected', async () => {
+    vi.stubGlobal('fetch', async (_url: string, init?: RequestInit) =>
+      init?.method === 'PUT'
+        ? new Response(JSON.stringify({ message: 'Resource not accessible by integration' }), { status: 403 })
+        : new Response(JSON.stringify({ sha: 'blob' }), { status: 200 }),
+    );
+    const result = await saveLabelsViaApi(LABELS);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Resource not accessible');
+  });
+});

--- a/src/redesign/engine/settings-io.ts
+++ b/src/redesign/engine/settings-io.ts
@@ -1,0 +1,131 @@
+import { publishFileViaApi, readFileViaApi, type Localized } from './content.js';
+
+/**
+ * Reading and writing the content repository's settings files over the GitHub
+ * API — the taxonomies an editor has to be able to manage: topics
+ * (`settings/topics.json`, the coloured plaque on an article) and categories
+ * (`settings/labels.json`, the rubric shown on cards and in the blog filter).
+ *
+ * The API, not the Service-Worker git engine: the topics screen used to read
+ * through the SW, which needs a full repository clone, and sat on its loading
+ * placeholder forever whenever that clone had not completed.
+ */
+
+/** One editorial topic: a stable key, a colour and per-language text. */
+export interface Topic {
+  readonly key: string;
+  readonly color: string;
+  readonly name: Localized;
+  readonly subtitle?: Localized;
+  readonly description?: Localized;
+}
+
+/** One category (rubric): a stable key with per-language display text. */
+export interface Label {
+  readonly key: string;
+  readonly translations: Localized;
+}
+
+/** The outcome of a settings write. */
+export interface SaveResult {
+  readonly ok: boolean;
+  readonly error?: string;
+}
+
+const TOPICS_PATH = 'settings/topics.json';
+const LABELS_PATH = 'settings/labels.json';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const localized = (value: unknown): Localized => {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+  );
+};
+
+const toTopic = (value: unknown): Topic | undefined => {
+  if (!isRecord(value) || typeof value['key'] !== 'string') return undefined;
+  return {
+    key: value['key'],
+    color: typeof value['color'] === 'string' ? value['color'] : '#888888',
+    name: localized(value['name']),
+    subtitle: localized(value['subtitle']),
+    description: localized(value['description']),
+  };
+};
+
+const toLabel = (value: unknown): Label | undefined => {
+  if (!isRecord(value) || typeof value['key'] !== 'string') return undefined;
+  return { key: value['key'], translations: localized(value['translations']) };
+};
+
+/**
+ * Reads one settings array. Throws when the file cannot be read, so a screen
+ * can say "could not load" instead of rendering an empty list that looks like
+ * a repository with no topics in it.
+ */
+const readSettingsArray = async <T>(
+  path: string,
+  parse: (value: unknown) => T | undefined,
+): Promise<readonly T[]> => {
+  const raw = await readFileViaApi(path);
+  if (raw === undefined) throw new Error(`Не удалось прочитать ${path}.`);
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error(`${path}: ожидался список.`);
+  return parsed.map(parse).filter((entry): entry is T => entry !== undefined);
+};
+
+/** The repository's editorial topics. Throws when the file cannot be read. */
+export const readTopicsViaApi = async (): Promise<readonly Topic[]> =>
+  readSettingsArray(TOPICS_PATH, toTopic);
+
+/** The repository's categories. Throws when the file cannot be read. */
+export const readLabelsViaApi = async (): Promise<readonly Label[]> =>
+  readSettingsArray(LABELS_PATH, toLabel);
+
+/**
+ * Refuses a list that would break the site: an entry without a key is
+ * unreferenceable, and a duplicate key silently shadows the earlier one.
+ */
+const keyProblem = (entries: readonly { readonly key: string }[]): string | undefined => {
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    const key = entry.key.trim();
+    if (key === '') return 'У каждой записи должен быть ключ.';
+    if (seen.has(key)) return `Ключ «${key}» повторяется — ключи должны быть уникальными.`;
+    seen.add(key);
+  }
+  return undefined;
+};
+
+/** Settings are committed as readable JSON so a diff stays reviewable. */
+const toJson = (value: unknown): string => `${JSON.stringify(value, undefined, 2)}\n`;
+
+const saveSettings = async (
+  path: string,
+  entries: readonly { readonly key: string }[],
+  message: string,
+): Promise<SaveResult> => {
+  const problem = keyProblem(entries);
+  if (problem !== undefined) return { ok: false, error: problem };
+  const result = await publishFileViaApi(path, toJson(entries), message);
+  return result.ok ? { ok: true } : { ok: false, error: result.error };
+};
+
+/**
+ * Commits the topic list.
+ * @param topics - the full list, in the order it should be stored
+ * @returns ok, or the reason the write was refused
+ */
+export const saveTopicsViaApi = async (topics: readonly Topic[]): Promise<SaveResult> =>
+  saveSettings(TOPICS_PATH, topics, `settings: темы (${topics.length})`);
+
+/**
+ * Commits the category list.
+ * @param labels - the full list, in the order it should be stored
+ * @returns ok, or the reason the write was refused
+ */
+export const saveLabelsViaApi = async (labels: readonly Label[]): Promise<SaveResult> =>
+  saveSettings(LABELS_PATH, labels, `settings: рубрики (${labels.length})`);

--- a/src/redesign/engine/slug.test.ts
+++ b/src/redesign/engine/slug.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { slugify, slugProblem } from './slug.ts';
+
+/*
+ * A slug is the article's address: `blog/<slug>/index.<lang>.md` becomes
+ * comprom.org/<lang>/blog/<slug>/. It has to be typeable into a URL — Latin
+ * letters, digits and hyphens — and it has to be unique, because two articles
+ * sharing one slug means one silently overwrites the other's folder.
+ */
+describe('slugify', () => {
+  it('lowercases and joins words with hyphens', () => {
+    expect(slugify('The Illusion Of Socialism')).toBe('the-illusion-of-socialism');
+  });
+
+  it('transliterates Cyrillic instead of dropping it', () => {
+    expect(slugify('Иллюзия социализма')).toBe('illyuziya-socializma');
+    expect(slugify('Ёлка и щука')).toBe('yolka-i-schuka');
+  });
+
+  it('collapses separators and trims them from the ends', () => {
+    expect(slugify('  a   b -- c  ')).toBe('a-b-c');
+    expect(slugify('---edge---')).toBe('edge');
+  });
+
+  it('drops punctuation a URL should not carry', () => {
+    expect(slugify('Маркс: «Капитал», т. III')).toBe('marks-kapital-t-iii');
+    expect(slugify('a/b?c=d#e')).toBe('a-b-c-d-e');
+  });
+
+  it('keeps digits and an already-valid slug untouched', () => {
+    expect(slugify('magazine-2-avgust-2026')).toBe('magazine-2-avgust-2026');
+  });
+
+  it('returns an empty string when there is nothing left to keep', () => {
+    expect(slugify('   ')).toBe('');
+    expect(slugify('!!!')).toBe('');
+  });
+});
+
+describe('slugProblem', () => {
+  const taken = ['programme-outline', 'cyber-tool'];
+
+  it('accepts a fresh, well-formed slug', () => {
+    expect(slugProblem('new-article', taken)).toBeUndefined();
+  });
+
+  it('rejects an empty slug', () => {
+    expect(slugProblem('', taken)).toMatch(/адрес/i);
+  });
+
+  it('rejects characters that cannot go in a URL', () => {
+    expect(slugProblem('Иллюзия', taken)).toMatch(/латин/i);
+    expect(slugProblem('two words', taken)).toMatch(/латин/i);
+    expect(slugProblem('UPPER', taken)).toMatch(/латин/i);
+  });
+
+  it('rejects a slug that another article already uses', () => {
+    expect(slugProblem('cyber-tool', taken)).toMatch(/занят|существует/i);
+  });
+
+  it('lets an article keep its own slug', () => {
+    expect(slugProblem('cyber-tool', taken, 'cyber-tool')).toBeUndefined();
+  });
+});

--- a/src/redesign/engine/slug.ts
+++ b/src/redesign/engine/slug.ts
@@ -1,0 +1,55 @@
+/**
+ * The article's address. `blog/<slug>/index.<lang>.md` is served as
+ * comprom.org/<lang>/blog/<slug>/, so a slug must be typeable into a URL —
+ * lowercase Latin letters, digits and single hyphens — and unique across the
+ * collection: two articles sharing a slug share a folder, and one overwrites
+ * the other.
+ */
+
+/** Cyrillic → Latin, the way the existing content repository transliterates. */
+const CYRILLIC: Readonly<Record<string, string>> = {
+  а: 'a', б: 'b', в: 'v', г: 'g', д: 'd', е: 'e', ё: 'yo', ж: 'zh', з: 'z', и: 'i',
+  й: 'y', к: 'k', л: 'l', м: 'm', н: 'n', о: 'o', п: 'p', р: 'r', с: 's', т: 't',
+  у: 'u', ф: 'f', х: 'h', ц: 'c', ч: 'ch', ш: 'sh', щ: 'sch', ъ: '', ы: 'y', ь: '',
+  э: 'e', ю: 'yu', я: 'ya',
+  і: 'i', ї: 'yi', є: 'ye', ґ: 'g', ў: 'u',
+};
+
+/** The shape a stored slug must have. */
+const VALID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const transliterate = (text: string): string =>
+  [...text.toLowerCase()].map((char) => CYRILLIC[char] ?? char).join('');
+
+/**
+ * Turns anything the editor types into a usable slug: transliterated,
+ * lowercased, punctuation dropped, spaces and separators collapsed into single
+ * hyphens, no hyphen at either end.
+ * @param input - raw text (a title, or a half-typed address)
+ * @returns the normalised slug, empty when nothing usable remains
+ */
+export const slugify = (input: string): string =>
+  transliterate(input)
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+/**
+ * Why a slug cannot be used, or undefined when it can.
+ * @param slug - the candidate address
+ * @param taken - slugs already present in the collection
+ * @param current - the article's own slug, which it may keep
+ * @returns the reason, in the editor's language
+ */
+export const slugProblem = (
+  slug: string,
+  taken: readonly string[],
+  current?: string,
+): string | undefined => {
+  if (slug.trim() === '') return 'Укажите адрес материала.';
+  if (!VALID.test(slug)) {
+    return 'Адрес — только латиница в нижнем регистре, цифры и дефисы (например: illyuziya-socializma).';
+  }
+  if (slug !== current && taken.includes(slug)) return `Адрес «${slug}» уже занят другим материалом.`;
+  return undefined;
+};

--- a/src/redesign/nav.ts
+++ b/src/redesign/nav.ts
@@ -42,6 +42,7 @@ export const navItems: readonly NavItem[] = [
   { id: 'pages', label: 'Страницы', icon: 'file-text', group: 'content', role: 'editor' },
   { id: 'archive', label: 'Архив', icon: 'book', group: 'content', role: 'editor' },
   { id: 'topics', label: 'Темы', icon: 'hash', group: 'content', role: 'editor' },
+  { id: 'categories', label: 'Рубрики', icon: 'hash', group: 'content', role: 'editor' },
   { id: 'members', label: 'Участники', icon: 'users', group: 'community', role: 'admin' },
   { id: 'tickets', label: 'Тикеты', icon: 'ticket', group: 'community', role: 'editor' },
   { id: 'newsletter', label: 'Рассылка', icon: 'mail', group: 'distribution', ownerOnly: true },

--- a/src/redesign/screens/index.ts
+++ b/src/redesign/screens/index.ts
@@ -7,6 +7,7 @@ import './screen-deploys.js';
 import './screen-magazine.js';
 import './screen-newsletter.js';
 import './screen-topics.js';
+import './screen-categories.js';
 import './screen-tickets.js';
 import './screen-collection.js';
 
@@ -40,6 +41,7 @@ export const screens: Readonly<Record<string, Screen>> = {
     () => html`<screen-collection collection="archive" heading="Архив"></screen-collection>`,
   ),
   topics: element('Темы', () => html`<screen-topics></screen-topics>`),
+  categories: element('Рубрики', () => html`<screen-categories></screen-categories>`),
   tickets: element('Тикеты', () => html`<screen-tickets></screen-tickets>`),
   newsletter: element('Рассылка', () => html`<screen-newsletter></screen-newsletter>`),
   deploys: element('Деплои', () => html`<screen-deploys></screen-deploys>`),

--- a/src/redesign/screens/screen-categories.ts
+++ b/src/redesign/screens/screen-categories.ts
@@ -1,0 +1,144 @@
+import { LitElement, html, css, nothing } from 'lit';
+import type { TemplateResult } from 'lit';
+import { customElement, state } from 'lit/decorators.js';
+import '@communist-prometheus/cp-components';
+import { readLabelsViaApi, saveLabelsViaApi, type Label } from '../engine/settings-io.js';
+import { publishTarget } from '../engine/publish-target.js';
+import { TAXONOMY_LANGS, taxonomyStyles } from './taxonomy-shared.js';
+import { emptyLabel, withKey, withText, withoutAt } from './taxonomy-draft.js';
+
+/**
+ * The categories (rubrics) screen — the taxonomy that had no editor at all, so
+ * a rubric could only be created by hand-editing `settings/labels.json` on
+ * GitHub. A category is the key an article's `category` frontmatter carries;
+ * the site turns it into display text through this file, per language.
+ *
+ * Reads and writes over the GitHub API, like every other screen in this UI.
+ */
+@customElement('screen-categories')
+export class ScreenCategories extends LitElement {
+  static override styles = taxonomyStyles;
+
+  @state() private draft: readonly Label[] = [];
+  @state() private loading = true;
+  @state() private busy = false;
+  @state() private error = '';
+  @state() private message = '';
+  @state() private activeLang = 'ru';
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    void this.load();
+  }
+
+  private async load(): Promise<void> {
+    this.loading = true;
+    this.error = '';
+    try {
+      this.draft = await readLabelsViaApi();
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+    }
+    this.loading = false;
+  }
+
+  private readonly add = (): void => {
+    this.draft = [...this.draft, emptyLabel()];
+    this.message = '';
+  };
+
+  private readonly removeAt = (index: number): void => {
+    this.draft = withoutAt(this.draft, index);
+    this.message = '';
+  };
+
+  private readonly updateKey = (index: number, value: string): void => {
+    this.draft = withKey(this.draft, index, value);
+    this.message = '';
+  };
+
+  private readonly updateText = (index: number, lang: string, value: string): void => {
+    this.draft = withText(this.draft, index, 'translations', lang, value);
+    this.message = '';
+  };
+
+  private readonly save = async (): Promise<void> => {
+    this.busy = true;
+    this.error = '';
+    this.message = '';
+    const result = await saveLabelsViaApi(this.draft);
+    this.busy = false;
+    if (result.ok) this.message = `Сохранено в ${publishTarget().site}.`;
+    else this.error = result.error ?? 'Не удалось сохранить.';
+  };
+
+  private renderRow(label: Label, index: number): TemplateResult {
+    return html`
+      <li class="row">
+        <cp-input
+          label="Ключ"
+          .value=${label.key}
+          placeholder="programme"
+          @cp-input=${(e: Event) => this.onInput(e, (v) => this.updateKey(index, v))}
+          @cp-change=${(e: Event) => this.onInput(e, (v) => this.updateKey(index, v))}
+        ></cp-input>
+        <cp-input
+          label=${`Название (${this.activeLang})`}
+          .value=${label.translations[this.activeLang] ?? ''}
+          @cp-input=${(e: Event) => this.onInput(e, (v) => this.updateText(index, this.activeLang, v))}
+          @cp-change=${(e: Event) => this.onInput(e, (v) => this.updateText(index, this.activeLang, v))}
+        ></cp-input>
+        <cp-button variant="ghost" size="sm" @cp-click=${() => this.removeAt(index)}>Удалить</cp-button>
+      </li>
+    `;
+  }
+
+  /** Reads a value out of a component's input/change event. */
+  private onInput(event: Event, apply: (value: string) => void): void {
+    if (!(event instanceof CustomEvent)) return;
+    const value: unknown = event.detail?.value;
+    if (typeof value === 'string') apply(value);
+  }
+
+  override render(): TemplateResult {
+    return html`
+      <p class="eyebrow">Настройки · рубрики статей</p>
+      <h1>Рубрики</h1>
+      <p class="lede">
+        Рубрика — то, что стоит в поле «Рубрика» у материала (<code>category</code>) и что читатель
+        видит на карточке и в фильтре блога. Здесь задаются ключ и название на каждом языке.
+      </p>
+      ${this.loading
+        ? html`<p class="msg">Загружаем рубрики…</p>`
+        : html`
+            <cp-tabs
+              .tabs=${TAXONOMY_LANGS}
+              active=${this.activeLang}
+              @cp-tab-change=${(e: Event) => {
+                if (e instanceof CustomEvent && typeof e.detail?.id === 'string')
+                  this.activeLang = e.detail.id;
+              }}
+            ></cp-tabs>
+            ${this.draft.length === 0
+              ? html`<p class="msg">Рубрик пока нет — добавьте первую.</p>`
+              : html`<ul class="rows">
+                  ${this.draft.map((label, index) => this.renderRow(label, index))}
+                </ul>`}
+            <div class="actions">
+              <cp-button variant="secondary" size="sm" @cp-click=${this.add}>+ рубрика</cp-button>
+              <cp-button size="sm" arrow ?disabled=${this.busy} @cp-click=${() => void this.save()}>
+                ${this.busy ? 'Сохраняем…' : `Сохранить в ${publishTarget().site}`}
+              </cp-button>
+            </div>
+          `}
+      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
+      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'screen-categories': ScreenCategories;
+  }
+}

--- a/src/redesign/screens/screen-editor.identity.test.ts
+++ b/src/redesign/screens/screen-editor.identity.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import './screen-editor.ts';
+import type { ScreenEditor } from './screen-editor.ts';
+
+/**
+ * Reported 2026-09-07: an article's title and its address could not be changed
+ * in the admin at all. Both are identity: the title is what every listing shows,
+ * the address is the page's URL — and an address has to be URL-safe and unique,
+ * because two articles sharing one folder means one overwrites the other.
+ */
+const ARTICLE = '---\ntitle: "Старое название"\nlang: ru\ncategory: programme\npublished: true\n---\n\nBody\n';
+
+interface EditorInternals {
+  slug: string;
+  collection: string;
+  live: boolean;
+  activeLang: string;
+  availableLangs: readonly string[];
+  articleTitle: string;
+  slugDraft: string;
+  takenSlugs: readonly string[];
+  readonly editedMarkdown: string;
+  readonly slugError: string;
+  onTitleInput: (event: Event) => void;
+  onSlugInput: (event: Event) => void;
+  applyMarkdown: (markdown: string, path: string, live: boolean) => void;
+}
+
+const editor = (): { el: ScreenEditor; priv: EditorInternals } => {
+  const el = document.createElement('screen-editor') as ScreenEditor;
+  const priv = el as unknown as EditorInternals;
+  priv.slug = 'staroe-nazvanie';
+  priv.collection = 'blog';
+  priv.live = true;
+  priv.activeLang = 'ru';
+  priv.availableLangs = ['ru'];
+  priv.applyMarkdown(ARTICLE, 'blog/staroe-nazvanie/index.ru.md', true);
+  priv.takenSlugs = ['staroe-nazvanie', 'cyber-tool'];
+  return { el, priv };
+};
+
+/** An input event carrying `value`, as the title/address fields emit. */
+const typed = (value: string): Event => {
+  const input = document.createElement('input');
+  input.value = value;
+  const event = new CustomEvent('cp-input', { detail: { value } });
+  Object.defineProperty(event, 'target', { value: input });
+  return event;
+};
+
+beforeEach(() => {
+  document.body.replaceChildren();
+});
+
+describe('editing the article title', () => {
+  it('writes the new title into the frontmatter', () => {
+    const { priv } = editor();
+    priv.onTitleInput(typed('Новое название'));
+    expect(priv.articleTitle).toBe('Новое название');
+    expect(priv.editedMarkdown).toContain('title: "Новое название"');
+    expect(priv.editedMarkdown).not.toContain('Старое название');
+  });
+
+  it('quotes a title containing a colon so the file stays valid YAML', () => {
+    const { priv } = editor();
+    priv.onTitleInput(typed('Маркс: Капитал'));
+    expect(priv.editedMarkdown).toContain('title: "Маркс: Капитал"');
+  });
+
+  it('escapes quotes inside the title', () => {
+    const { priv } = editor();
+    priv.onTitleInput(typed('Статья «о "кавычках"»'));
+    expect(priv.editedMarkdown).toContain('title: "Статья «о \\"кавычках\\"»"');
+  });
+});
+
+describe('editing the article address', () => {
+  it('normalises what is typed: lowercase, Latin, hyphens for spaces', () => {
+    const { priv } = editor();
+    priv.onSlugInput(typed('Новый Адрес Статьи'));
+    expect(priv.slugDraft).toBe('novyy-adres-stati');
+    expect(priv.slugError).toBe('');
+  });
+
+  it('reports an address another article already uses', () => {
+    const { priv } = editor();
+    priv.onSlugInput(typed('cyber-tool'));
+    expect(priv.slugError).toMatch(/занят/i);
+  });
+
+  it('accepts the article keeping its own address', () => {
+    const { priv } = editor();
+    priv.onSlugInput(typed('staroe-nazvanie'));
+    expect(priv.slugError).toBe('');
+  });
+
+  it('reports an empty address', () => {
+    const { priv } = editor();
+    priv.onSlugInput(typed('!!!'));
+    expect(priv.slugDraft).toBe('');
+    expect(priv.slugError).toMatch(/адрес/i);
+  });
+});
+
+describe('the identity fields are on the page', () => {
+  it('renders an editable title and address', async () => {
+    const { el, priv } = editor();
+    document.body.append(el);
+    await el.updateComplete;
+    const labels = [...(el.shadowRoot?.querySelectorAll('cp-input') ?? [])].map((input) =>
+      input.getAttribute('label'),
+    );
+    expect(labels).toContain('Заголовок');
+    expect(labels).toContain('Адрес');
+    expect(priv.slugDraft).toBe('staroe-nazvanie');
+  });
+});

--- a/src/redesign/screens/screen-editor.ts
+++ b/src/redesign/screens/screen-editor.ts
@@ -15,6 +15,9 @@ import {
   topicOptionsViaApi,
 } from '../engine/content.js';
 import { publishTarget } from '../engine/publish-target.js';
+import { listSlugsViaApi } from '../engine/content.js';
+import { slugify, slugProblem } from '../engine/slug.js';
+import { renameArticleViaApi } from '../engine/rename-article.js';
 import { listDeployRuns } from '../engine/github-api.js';
 import { siteBuildState, type SiteBuildState } from '../engine/site-build-state.js';
 import '../components/issue-files.js';
@@ -110,6 +113,12 @@ const REAL_STAGES: readonly string[] = ['Публикация'];
 const frontmatterValue = (text: string, key: string): string | undefined => {
   const match = text.match(new RegExp(`^${key}:\\s*(.+)$`, 'm'));
   return match ? (match.at(1) ?? '').trim().replace(/^["']|["']$/g, '') : undefined;
+};
+
+/** Quotes a value for YAML: prose may hold a colon, a quote or a leading dash. */
+const quoteYaml = (value: string): string => {
+  const escaped = value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+  return `"${escaped}"`;
 };
 
 /** Splits a raw markdown document into its frontmatter block, `title` and body. */
@@ -576,7 +585,8 @@ export class ScreenEditor extends LitElement {
    * incident file grew a second date key (`pubDate` next to `publishDate`)
    * precisely because every field was re-emitted unconditionally.
    */
-  private seeds: Readonly<Record<'topic' | 'rubric' | 'pubDate' | 'published', string>> = {
+  private seeds: Readonly<Record<'title' | 'topic' | 'rubric' | 'pubDate' | 'published', string>> = {
+    title: '',
     topic: '',
     rubric: '',
     pubDate: '',
@@ -585,6 +595,15 @@ export class ScreenEditor extends LitElement {
 
   /** Which key holds the date in THIS file: `pubDate`, `publishDate` or `date`. */
   private dateKey = 'pubDate';
+
+  /** True while the article's files are being moved to a new address. */
+  @state() private renaming = false;
+
+  /** The address being edited, normalised as the editor types. */
+  @state() private slugDraft = '';
+
+  /** Slugs already used in this collection — an address must not collide. */
+  @state() private takenSlugs: readonly string[] = [];
 
   /** Topics offered in the properties panel, read from settings/topics.json. */
   @state() private topicOptions: readonly CpSelectOption[] = [];
@@ -646,6 +665,11 @@ export class ScreenEditor extends LitElement {
     });
     void listDeployRuns().then((runs) => {
       this.siteBuild = siteBuildState(runs);
+    });
+    // The addresses already in use, so a collision is caught while typing
+    // rather than by overwriting another article's folder.
+    void listSlugsViaApi(this.collection).then((slugs) => {
+      this.takenSlugs = slugs;
     });
     globalThis.addEventListener('hashchange', this.onHashChange);
     // The article is read directly from the GitHub API, so there is no engine
@@ -771,7 +795,9 @@ export class ScreenEditor extends LitElement {
     const published = frontmatterValue(fm, 'published');
     this.published =
       published !== undefined ? published === 'true' : frontmatterValue(fm, 'draft') !== 'true';
+    this.slugDraft = this.slug;
     this.seeds = {
+      title: this.articleTitle,
       topic: this.topic,
       rubric: this.rubric,
       pubDate: this.pubDate,
@@ -792,6 +818,10 @@ export class ScreenEditor extends LitElement {
     if (fm !== '') {
       // Each property is written back ONLY when it differs from what was
       // loaded, so opening an article and publishing it changes nothing.
+      // A title is free-form prose: it is always quoted, so a colon or a quote
+      // inside it cannot turn the frontmatter into invalid YAML.
+      if (this.articleTitle !== this.seeds.title)
+        fm = upsertFrontmatterField(fm, 'title', quoteYaml(this.articleTitle));
       if (this.rubric !== this.seeds.rubric && this.rubric !== '')
         fm = upsertFrontmatterField(fm, 'category', this.rubric);
       if (this.topic !== this.seeds.topic)
@@ -958,6 +988,64 @@ export class ScreenEditor extends LitElement {
       }
     }
   };
+
+  /**
+   * Moves the article to the typed address. Every language and asset moves
+   * together, and the editor is sent to the new address afterwards so it is not
+   * left looking at a folder that no longer exists.
+   */
+  private async applyRename(): Promise<void> {
+    if (this.slugError !== '' || this.slugDraft === this.slug) return;
+    this.renaming = true;
+    const from = this.slug;
+    const result = await renameArticleViaApi(this.collection, from, this.slugDraft);
+    this.renaming = false;
+    if (!result.ok) {
+      this.publishError = result.error ?? 'Не удалось перенести материал.';
+      this.publishOpen = true;
+      return;
+    }
+    this.slug = this.slugDraft;
+    this.takenSlugs = [...this.takenSlugs.filter((s) => s !== from), this.slugDraft];
+    this.articlePath = `${this.collection}/${this.slug}/index.${this.activeLang}.md`;
+    globalThis.location.hash =
+      this.collection === 'blog' ? `#/editor/${this.slug}` : `#/editor/${this.collection}/${this.slug}`;
+  }
+
+  /** Reads the `value` of a component input/change event. */
+  private eventValue(event: Event): string | undefined {
+    if (event instanceof CustomEvent && typeof event.detail?.value === 'string') {
+      return event.detail.value;
+    }
+    const target = event.target;
+    return target instanceof HTMLInputElement ? target.value : undefined;
+  }
+
+  /** The article title — what every listing and the page heading show. */
+  private readonly onTitleInput = (event: Event): void => {
+    const value = this.eventValue(event);
+    if (value === undefined) return;
+    this.articleTitle = value;
+    this.dirty = true;
+  };
+
+  /**
+   * The address, normalised as it is typed: transliterated, lowercased, spaces
+   * turned into hyphens. Typing is never blocked — what cannot be normalised
+   * shows as an error under the field instead.
+   */
+  private readonly onSlugInput = (event: Event): void => {
+    const value = this.eventValue(event);
+    if (value === undefined) return;
+    this.slugDraft = slugify(value);
+    this.dirty = true;
+  };
+
+  /** Why the typed address cannot be used, or '' when it can. */
+  private get slugError(): string {
+    if (this.slugDraft === this.slug) return '';
+    return slugProblem(this.slugDraft, this.takenSlugs, this.slug) ?? '';
+  }
 
   /** The lead field under the title is a native textarea (a plain input event),
    *  writing the article's `description` frontmatter. */
@@ -1249,9 +1337,37 @@ export class ScreenEditor extends LitElement {
             >
             · ${publishTarget().site}
           </p>
-          <h1 class="title" tabindex="-1">
-            ${this.articleTitle === '' ? 'Без названия' : this.articleTitle}
-          </h1>
+          <cp-input
+            class="title-field"
+            label="Заголовок"
+            .value=${this.articleTitle}
+            placeholder="Без названия"
+            @cp-input=${this.onTitleInput}
+            @cp-change=${this.onTitleInput}
+          ></cp-input>
+          <div class="address">
+            <cp-input
+              label="Адрес"
+              .value=${this.slugDraft}
+              placeholder="illyuziya-socializma"
+              @cp-input=${this.onSlugInput}
+              @cp-change=${this.onSlugInput}
+            ></cp-input>
+            <p class="address-note">
+              ${this.slugError !== ''
+                ? html`<span class="bad">${this.slugError}</span>`
+                : html`${publishTarget().siteUrl}/${this.activeLang}/${this.collection}/${this.slugDraft}/`}
+            </p>
+            ${this.slugDraft !== this.slug && this.slugError === ''
+              ? html`<cp-button
+                  size="sm"
+                  variant="secondary"
+                  ?disabled=${this.renaming}
+                  @cp-click=${() => void this.applyRename()}
+                  >${this.renaming ? 'Переносим…' : 'Перенести материал'}</cp-button
+                >`
+              : nothing}
+          </div>
           <cp-tag tone="success">данные из репозитория</cp-tag>
         </div>
         ${this.renderSiteBuildWarning()}

--- a/src/redesign/screens/screen-taxonomy.test.ts
+++ b/src/redesign/screens/screen-taxonomy.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ensureFreshToken } from '@/composables/useAuth/ensure-fresh-token';
+import './screen-topics.ts';
+import './screen-categories.ts';
+import type { ScreenTopics } from './screen-topics.ts';
+import type { ScreenCategories } from './screen-categories.ts';
+
+vi.mock('@/composables/useAuth/ensure-fresh-token', () => ({ ensureFreshToken: vi.fn() }));
+
+/*
+ * Reported 2026-09-07: the topics screen never got past its loading placeholder
+ * (it read through the Service Worker git engine, which needs a clone), and
+ * categories had no screen at all. Between them an editor could neither create
+ * nor edit either taxonomy — the tags every article carries.
+ */
+const TOPICS = [
+  { key: 'editorial', color: '#b03a2e', name: { ru: 'От редакции' }, subtitle: {}, description: {} },
+];
+const LABELS = [{ key: 'programme', translations: { ru: 'Программа', en: 'Programme' } }];
+
+const decode = (b64: string): string =>
+  new TextDecoder().decode(Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)));
+
+const acceptOf = (init?: RequestInit): string => {
+  const h = init?.headers;
+  return typeof h === 'object' && 'accept' in h ? String(Reflect.get(h, 'accept')) : '';
+};
+
+const stubGitHub = (files: Record<string, string>, puts: string[]): void => {
+  vi.stubGlobal('fetch', async (url: string, init?: RequestInit) => {
+    const path = decodeURIComponent(url.match(/contents\/([^?]+)/)?.[1] ?? '');
+    if (init?.method === 'PUT') {
+      files[path] = decode(JSON.parse(String(init.body)).content);
+      puts.push(path);
+      return new Response(JSON.stringify({ commit: { sha: 'c' } }), { status: 201 });
+    }
+    if (acceptOf(init).includes('raw')) {
+      return new Response(files[path] ?? '', { status: files[path] ? 200 : 404 });
+    }
+    return new Response(JSON.stringify({ sha: 'blob' }), { status: 200 });
+  });
+};
+
+interface TaxonomyInternals {
+  loading: boolean;
+  error: string;
+  save: () => Promise<void>;
+  add: () => void;
+}
+
+const settle = async (el: HTMLElement & { updateComplete: Promise<unknown> }): Promise<void> => {
+  const priv = el as unknown as TaxonomyInternals;
+  for (let i = 0; i < 60 && priv.loading; i += 1) await new Promise((r) => setTimeout(r, 10));
+  await el.updateComplete;
+};
+
+const mountTopics = async (): Promise<ScreenTopics> => {
+  const el = document.createElement('screen-topics') as ScreenTopics;
+  document.body.append(el);
+  await settle(el);
+  return el;
+};
+
+const mountCategories = async (): Promise<ScreenCategories> => {
+  const el = document.createElement('screen-categories') as ScreenCategories;
+  document.body.append(el);
+  await settle(el);
+  return el;
+};
+
+const text = (el: HTMLElement): string => (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  vi.stubEnv('VITE_DEV_TOKEN', '');
+  vi.stubEnv('VITE_GITHUB_BRANCH', 'develop');
+  vi.mocked(ensureFreshToken).mockResolvedValue('tok');
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe('screen-topics reads over the API', () => {
+  it('shows the repository topics instead of a stuck loading placeholder', async () => {
+    stubGitHub({ 'settings/topics.json': JSON.stringify(TOPICS) }, []);
+    const el = await mountTopics();
+    expect(text(el)).toContain('От редакции');
+    expect(text(el)).not.toContain('Загружаем');
+  });
+
+  it('says so when the settings file cannot be read', async () => {
+    vi.stubGlobal('fetch', async () => new Response('nope', { status: 500 }));
+    const el = await mountTopics();
+    expect(text(el)).toMatch(/не удалось|ошибка/i);
+    expect(text(el)).not.toContain('Загружаем');
+  });
+
+  it('adds a topic and commits the whole list', async () => {
+    const files: Record<string, string> = { 'settings/topics.json': JSON.stringify(TOPICS) };
+    const puts: string[] = [];
+    stubGitHub(files, puts);
+    const el = await mountTopics();
+    const priv = el as unknown as TaxonomyInternals;
+
+    priv.add();
+    el.requestUpdate();
+    await el.updateComplete;
+    const rows = el.shadowRoot?.querySelectorAll('.row');
+    expect(rows?.length).toBe(2);
+
+    // A new row has no key yet, so saving must be refused rather than corrupt the file.
+    await priv.save();
+    expect(puts).toEqual([]);
+    expect(text(el)).toContain('ключ');
+  });
+
+  it('saves an edited topic', async () => {
+    const files: Record<string, string> = { 'settings/topics.json': JSON.stringify(TOPICS) };
+    const puts: string[] = [];
+    stubGitHub(files, puts);
+    const el = await mountTopics();
+    const priv = el as unknown as TaxonomyInternals & {
+      updateColor: (index: number, value: string) => void;
+    };
+    priv.updateColor(0, '#123456');
+    await priv.save();
+    expect(puts).toEqual(['settings/topics.json']);
+    expect(JSON.parse(files['settings/topics.json'])[0].color).toBe('#123456');
+  });
+});
+
+describe('screen-categories: the rubric editor that did not exist', () => {
+  it('lists the repository categories', async () => {
+    stubGitHub({ 'settings/labels.json': JSON.stringify(LABELS) }, []);
+    const el = await mountCategories();
+    // The values live in the inputs the editor types into, not in page text.
+    const values = [...(el.shadowRoot?.querySelectorAll('.row cp-input') ?? [])].map((input) =>
+      Reflect.get(input, 'value'),
+    );
+    expect(values).toContain('programme');
+    expect(values).toContain('Программа');
+    expect(text(el)).not.toContain('Загружаем');
+  });
+
+  it('creates a category and commits it', async () => {
+    const files: Record<string, string> = { 'settings/labels.json': JSON.stringify(LABELS) };
+    const puts: string[] = [];
+    stubGitHub(files, puts);
+    const el = await mountCategories();
+    const priv = el as unknown as TaxonomyInternals & {
+      updateKey: (index: number, value: string) => void;
+      updateText: (index: number, lang: string, value: string) => void;
+    };
+
+    priv.add();
+    priv.updateKey(1, 'appeal');
+    priv.updateText(1, 'ru', 'Обращение');
+    await priv.save();
+
+    expect(puts).toEqual(['settings/labels.json']);
+    const stored = JSON.parse(files['settings/labels.json']);
+    expect(stored).toHaveLength(2);
+    expect(stored[1]).toMatchObject({ key: 'appeal', translations: { ru: 'Обращение' } });
+  });
+
+  it('removes a category', async () => {
+    const files: Record<string, string> = { 'settings/labels.json': JSON.stringify(LABELS) };
+    const puts: string[] = [];
+    stubGitHub(files, puts);
+    const el = await mountCategories();
+    const priv = el as unknown as TaxonomyInternals & { removeAt: (index: number) => void };
+    priv.removeAt(0);
+    await priv.save();
+    expect(JSON.parse(files['settings/labels.json'])).toEqual([]);
+  });
+});

--- a/src/redesign/screens/screen-topics.ts
+++ b/src/redesign/screens/screen-topics.ts
@@ -1,304 +1,182 @@
 import { LitElement, html, css, nothing } from 'lit';
+import type { TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import type { CpTab } from '@communist-prometheus/cp-components';
 import '@communist-prometheus/cp-components';
-import { readTopics, type Topic } from '../engine/content.js';
-import { onEngineReady } from '../engine/engine-ready.js';
-import { classifyEmpty } from '../engine/load-state.js';
+import { readTopicsViaApi, saveTopicsViaApi, type Topic } from '../engine/settings-io.js';
+import { publishTarget } from '../engine/publish-target.js';
+import { TAXONOMY_LANGS, taxonomyStyles } from './taxonomy-shared.js';
+import { emptyTopic, withColor, withKey, withText, withoutAt } from './taxonomy-draft.js';
 
 /**
- * The seven publication languages, expressed as the keys used inside a topic's
- * `name` map (`settings/topics.json`). Bulgarian is stored as `bl` and Ukrainian
- * as `uk` — the tab labels below humanise them to BG/UK.
- */
-type LangCode = 'ru' | 'en' | 'it' | 'es' | 'bl' | 'pl' | 'uk';
-
-/** Language segments for the per-topic `cp-tabs` strip (label ≠ name-map key). */
-const LANGUAGES: readonly CpTab[] = [
-  { id: 'ru', label: 'RU' },
-  { id: 'en', label: 'EN' },
-  { id: 'it', label: 'IT' },
-  { id: 'es', label: 'ES' },
-  { id: 'bl', label: 'BG' },
-  { id: 'pl', label: 'PL' },
-  { id: 'uk', label: 'UK' },
-];
-
-/** The set of valid language keys, for narrowing an arbitrary tab id. */
-const LANG_CODES: ReadonlySet<string> = new Set(LANGUAGES.map((tab) => tab.id));
-
-/** Narrows an arbitrary tab id to a known {@link LangCode}. */
-const isLangCode = (value: string): value is LangCode => LANG_CODES.has(value);
-
-/**
- * Topics screen (settings spec: the "Темы" subpanel). When the real content
- * engine is running (local `dev:token`), it reads the repo's
- * `settings/topics.json` and lists the ACTUAL topics — colour, per-language name
- * and stable key — proving live data end-to-end; a `cp-tag` badge reports
- * whether the data is live or a demo fallback. Each topic renders a colour-left
- * `article` with a swatch, the name for the currently selected language, editable
- * name/note/description fields seeded from that language, and a live `cp-pill`
- * previewing the on-site plaque in the topic's colour. A `cp-tabs` strip switches
- * the active language (tracked in local `@state`). Theme tokens inherit from
- * `:root` through the shadow boundary; no ad-hoc chrome, tokens only.
+ * The topics screen: the coloured editorial plaque an article can carry
+ * (`topic` in its frontmatter, defined in `settings/topics.json`).
+ *
+ * It used to read through the Service Worker git engine, which needs a full
+ * repository clone, and so could sit on its loading placeholder indefinitely while
+ * every other screen in this UI read happily over the GitHub API. It now reads
+ * — and writes — over that same API, so topics can actually be created and
+ * edited here instead of by hand on GitHub.
  */
 @customElement('screen-topics')
 export class ScreenTopics extends LitElement {
-  static override styles = css`
-    :host {
-      display: block;
-      font-family: var(--font-sans);
-      color: var(--color-text-primary);
-      line-height: 1.6;
-    }
+  static override styles = [
+    taxonomyStyles,
+    css`
+      .preview {
+        flex: 0 0 auto;
+        padding: 0.15rem 0.6rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: #fff;
+      }
+    `,
+  ];
 
-    .head {
-      display: flex;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: var(--spacing-sm);
-      margin-bottom: var(--spacing-md);
-    }
-
-    h1 {
-      font-size: clamp(1.9rem, 7vw, 2.6rem);
-      line-height: 1.15;
-      font-weight: 700;
-      margin: 0;
-      margin-right: auto;
-      background: linear-gradient(135deg, var(--color-accent), var(--color-text-primary));
-      -webkit-background-clip: text;
-      background-clip: text;
-      color: transparent;
-    }
-
-    h1:focus-visible {
-      outline: 2px solid var(--color-accent);
-      outline-offset: 4px;
-    }
-
-    .eyebrow {
-      flex-basis: 100%;
-      margin: 0;
-      font-size: 0.8rem;
-      color: var(--color-text-secondary);
-    }
-
-    .intro {
-      max-width: 64ch;
-      margin: 0 0 var(--spacing-lg);
-      color: var(--color-text-secondary);
-    }
-
-    .tabs-scroll {
-      overflow-x: auto;
-      max-width: 100%;
-      margin-bottom: var(--spacing-lg);
-    }
-
-    .list {
-      display: grid;
-      gap: var(--spacing-lg);
-    }
-
-    .topic {
-      display: flex;
-      flex-direction: column;
-      gap: var(--spacing-md);
-      padding: var(--spacing-lg);
-      background: var(--color-surface);
-      border: 1px solid var(--color-hairline);
-      border-inline-start: 4px solid var(--tc, var(--color-accent));
-      border-radius: var(--radius-md);
-    }
-
-    .thead {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-sm);
-    }
-
-    .swatch {
-      inline-size: 1.5rem;
-      block-size: 1.5rem;
-      flex: none;
-      background: var(--tc, var(--color-accent));
-      border: 1px solid var(--color-hairline);
-      border-radius: var(--radius-sm);
-    }
-
-    .name {
-      margin: 0;
-      margin-right: auto;
-      font-size: 1.1rem;
-      font-weight: 700;
-    }
-
-    .key {
-      font-family: var(--font-mono);
-      font-size: 0.8rem;
-      color: var(--color-text-secondary);
-    }
-
-    .fields {
-      margin: 0;
-      display: grid;
-      gap: var(--spacing-sm);
-    }
-
-    .field {
-      display: grid;
-      gap: 0.15rem;
-    }
-
-    .field dt {
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: var(--color-text-secondary);
-    }
-
-    .field dd {
-      margin: 0;
-      font-size: 1rem;
-    }
-
-    .missing {
-      color: var(--color-text-secondary);
-      font-style: italic;
-    }
-
-    cp-banner {
-      display: block;
-      margin-bottom: var(--spacing-lg);
-    }
-
-    .preview {
-      display: flex;
-      align-items: center;
-      gap: var(--spacing-sm);
-      flex-wrap: wrap;
-      padding-top: var(--spacing-xs);
-      border-top: 1px dashed var(--color-hairline);
-    }
-
-    .preview-label {
-      font-size: 0.8rem;
-      font-weight: 600;
-      color: var(--color-text-secondary);
-    }
-
-    .note {
-      margin: var(--spacing-md) 0 0;
-      font-size: 0.85rem;
-      color: var(--color-text-secondary);
-    }
-  `;
-
-  /** Topics read from the repo; empty until loaded (or if the engine is off). */
-  @state() private topics: readonly Topic[] = [];
-
-  /** Whether the real read has completed. */
-  @state() private loaded = false;
-
-  /** Currently edited language; drives which localised name the fields show. */
-  @state() private activeLang: LangCode = 'ru';
-
-  /** Unsubscribes the engine-ready listener on disconnect. */
-  private disposeReady: () => void = () => {};
+  @state() private draft: readonly Topic[] = [];
+  @state() private loading = true;
+  @state() private busy = false;
+  @state() private error = '';
+  @state() private message = '';
+  @state() private activeLang = 'ru';
 
   override connectedCallback(): void {
     super.connectedCallback();
     void this.load();
-    // Re-read when the engine finishes booting (first-load race, QA #12).
-    this.disposeReady = onEngineReady(() => void this.load());
-  }
-
-  override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this.disposeReady();
   }
 
   private async load(): Promise<void> {
-    const topics = await readTopics();
-    this.topics = topics;
-    this.loaded = true;
+    this.loading = true;
+    this.error = '';
+    try {
+      this.draft = await readTopicsViaApi();
+    } catch (e) {
+      this.error = e instanceof Error ? e.message : String(e);
+    }
+    this.loading = false;
   }
 
-  private readonly onLangChange = (event: CustomEvent<{ readonly id: string }>): void => {
-    if (isLangCode(event.detail.id)) {
-      this.activeLang = event.detail.id;
-    }
+  private readonly add = (): void => {
+    this.draft = [...this.draft, emptyTopic()];
+    this.message = '';
   };
 
-  private renderTopic(topic: Topic) {
-    const lang = this.activeLang;
-    const name = topic.name[lang] ?? '';
-    const hasName = name !== '';
+  private readonly removeAt = (index: number): void => {
+    this.draft = withoutAt(this.draft, index);
+    this.message = '';
+  };
+
+  private readonly updateKey = (index: number, value: string): void => {
+    this.draft = withKey(this.draft, index, value);
+    this.message = '';
+  };
+
+  private readonly updateColor = (index: number, value: string): void => {
+    this.draft = withColor(this.draft, index, value);
+    this.message = '';
+  };
+
+  private readonly updateText = (
+    index: number,
+    field: 'name' | 'subtitle',
+    lang: string,
+    value: string,
+  ): void => {
+    this.draft = withText(this.draft, index, field, lang, value);
+    this.message = '';
+  };
+
+  private readonly save = async (): Promise<void> => {
+    this.busy = true;
+    this.error = '';
+    this.message = '';
+    const result = await saveTopicsViaApi(this.draft);
+    this.busy = false;
+    if (result.ok) this.message = `Сохранено в ${publishTarget().site}.`;
+    else this.error = result.error ?? 'Не удалось сохранить.';
+  };
+
+  /** Reads a value out of a component's input/change event. */
+  private onInput(event: Event, apply: (value: string) => void): void {
+    if (!(event instanceof CustomEvent)) return;
+    const value: unknown = event.detail?.value;
+    if (typeof value === 'string') apply(value);
+  }
+
+  private renderRow(topic: Topic, index: number): TemplateResult {
+    const name = topic.name[this.activeLang] ?? '';
     return html`
-      <article class="topic" style="--tc:${topic.color}">
-        <div class="thead">
-          <span class="swatch" aria-hidden="true"></span>
-          <h2 class="name">${hasName ? name : topic.key}</h2>
-          <span class="key">${topic.key}</span>
-          <span class="key" aria-hidden="true">${topic.color}</span>
-        </div>
-
-        <dl class="fields">
-          <div class="field">
-            <dt>Название · ${lang}</dt>
-            <dd>${hasName ? name : html`<span class="missing">нет перевода</span>`}</dd>
-          </div>
-        </dl>
-
-        <div class="preview">
-          <span class="preview-label">Плашка на сайте:</span>
-          <cp-pill style="--tc:${topic.color}">${hasName ? name : topic.key}</cp-pill>
-        </div>
-      </article>
+      <li class="row">
+        <input
+          class="swatch"
+          type="color"
+          aria-label="Цвет темы"
+          .value=${topic.color}
+          @input=${(e: Event) => {
+            const target = e.target;
+            if (target instanceof HTMLInputElement) this.updateColor(index, target.value);
+          }}
+        />
+        <cp-input
+          label="Ключ"
+          .value=${topic.key}
+          placeholder="editorial"
+          @cp-input=${(e: Event) => this.onInput(e, (v) => this.updateKey(index, v))}
+          @cp-change=${(e: Event) => this.onInput(e, (v) => this.updateKey(index, v))}
+        ></cp-input>
+        <cp-input
+          label=${`Название (${this.activeLang})`}
+          .value=${name}
+          @cp-input=${(e: Event) => this.onInput(e, (v) => this.updateText(index, 'name', this.activeLang, v))}
+          @cp-change=${(e: Event) => this.onInput(e, (v) => this.updateText(index, 'name', this.activeLang, v))}
+        ></cp-input>
+        <cp-input
+          label=${`Приписка (${this.activeLang})`}
+          .value=${topic.subtitle?.[this.activeLang] ?? ''}
+          @cp-input=${(e: Event) =>
+            this.onInput(e, (v) => this.updateText(index, 'subtitle', this.activeLang, v))}
+          @cp-change=${(e: Event) =>
+            this.onInput(e, (v) => this.updateText(index, 'subtitle', this.activeLang, v))}
+        ></cp-input>
+        <span class="preview" style=${`background:${topic.color}`}>${name || topic.key || '—'}</span>
+        <cp-button variant="ghost" size="sm" @cp-click=${() => this.removeAt(index)}>Удалить</cp-button>
+      </li>
     `;
   }
 
-  override render() {
-    const live = this.topics.length > 0;
+  override render(): TemplateResult {
     return html`
-      <header class="head">
-        <p class="eyebrow">Настройки · оформление статей</p>
-        <h1 tabindex="-1">Темы</h1>
-      </header>
-      <p class="intro">
-        Темы группируют статьи цветной плашкой. Название задаётся для каждого из 7 языков в
-        settings/topics.json.
+      <p class="eyebrow">Настройки · оформление статей</p>
+      <h1>Темы</h1>
+      <p class="lede">
+        Тема группирует статьи цветной плашкой на странице материала и на карточке. Ключ хранится в
+        поле <code>topic</code> материала, а цвет и названия по языкам — здесь.
       </p>
-
-      ${live
-        ? html`
-            <cp-banner tone="info" title="Просмотр без редактирования">
-              Темы пока правятся в settings/topics.json. Здесь — что сейчас в репозитории:
-              ключ, цвет и название на выбранном языке.
-            </cp-banner>
-
-            <div class="tabs-scroll">
-              <cp-tabs
-                .tabs=${LANGUAGES}
-                active=${this.activeLang}
-                @cp-tab-change=${this.onLangChange}
-              ></cp-tabs>
+      ${this.loading
+        ? html`<p class="msg">Загружаем темы…</p>`
+        : html`
+            <cp-tabs
+              .tabs=${TAXONOMY_LANGS}
+              active=${this.activeLang}
+              @cp-tab-change=${(e: Event) => {
+                if (e instanceof CustomEvent && typeof e.detail?.id === 'string')
+                  this.activeLang = e.detail.id;
+              }}
+            ></cp-tabs>
+            ${this.draft.length === 0
+              ? html`<p class="msg">Тем пока нет — добавьте первую.</p>`
+              : html`<ul class="rows">
+                  ${this.draft.map((topic, index) => this.renderRow(topic, index))}
+                </ul>`}
+            <div class="actions">
+              <cp-button variant="secondary" size="sm" @cp-click=${this.add}>+ тема</cp-button>
+              <cp-button size="sm" arrow ?disabled=${this.busy} @cp-click=${() => void this.save()}>
+                ${this.busy ? 'Сохраняем…' : `Сохранить в ${publishTarget().site}`}
+              </cp-button>
             </div>
-
-            <div class="list">${this.topics.map((topic) => this.renderTopic(topic))}</div>
-
-            <p class="note">
-              Прочитано из settings/topics.json — ${this.topics.length}
-              ${this.topics.length === 1 ? 'тема' : 'тем'} реального репозитория.
-            </p>
-          `
-        : html`<p class="note">
-            ${classifyEmpty(this.loaded) === 'loading'
-              ? 'Загружаем темы…'
-              : classifyEmpty(this.loaded) === 'signed-out'
-                ? 'Войдите через GitHub, чтобы увидеть темы из settings/topics.json.'
-                : 'Тем пока нет или не удалось их загрузить.'}
-          </p>`}
+          `}
+      ${this.error !== '' ? html`<p class="msg error">${this.error}</p>` : nothing}
+      ${this.message !== '' ? html`<p class="msg">${this.message}</p>` : nothing}
     `;
   }
 }

--- a/src/redesign/screens/taxonomy-draft.ts
+++ b/src/redesign/screens/taxonomy-draft.ts
@@ -1,0 +1,82 @@
+import type { Label, Topic } from '../engine/settings-io.js';
+
+/**
+ * Pure edits on a taxonomy draft — the list a screen holds while the editor
+ * works on it, before it is committed. Kept out of the components so the rules
+ * (never mutate, always replace) are testable on their own.
+ */
+
+/** A blank topic row, ready for the editor to name. */
+export const emptyTopic = (): Topic => ({
+  key: '',
+  color: '#888888',
+  name: {},
+  subtitle: {},
+  description: {},
+});
+
+/** A blank category row. */
+export const emptyLabel = (): Label => ({ key: '', translations: {} });
+
+/** Replaces the entry at `index` with the result of `change`. */
+const replaceAt = <T>(draft: readonly T[], index: number, change: (entry: T) => T): readonly T[] =>
+  draft.map((entry, i) => (i === index ? change(entry) : entry));
+
+/**
+ * Sets one entry's key.
+ * @param draft - current draft list
+ * @param index - row being edited
+ * @param key - new key
+ * @returns a new list
+ */
+export const withKey = <T extends { readonly key: string }>(
+  draft: readonly T[],
+  index: number,
+  key: string,
+): readonly T[] => replaceAt(draft, index, (entry) => ({ ...entry, key }));
+
+/**
+ * Sets one topic's colour.
+ * @param draft - current draft list
+ * @param index - row being edited
+ * @param color - new colour
+ * @returns a new list
+ */
+export const withColor = (draft: readonly Topic[], index: number, color: string): readonly Topic[] =>
+  replaceAt(draft, index, (topic) => ({ ...topic, color }));
+
+/**
+ * Sets one entry's text for a language. An emptied field is dropped rather than
+ * stored as an empty string, so the site falls back to another language instead
+ * of rendering a blank plaque.
+ * @param draft - current draft list
+ * @param index - row being edited
+ * @param field - which localized map to touch
+ * @param lang - language code
+ * @param value - new text
+ * @returns a new list
+ */
+export const withText = <T>(
+  draft: readonly T[],
+  index: number,
+  field: keyof T & string,
+  lang: string,
+  value: string,
+): readonly T[] =>
+  replaceAt(draft, index, (entry) => {
+    const current: unknown = Reflect.get(entry as object, field);
+    const pairs = typeof current === 'object' && current !== undefined ? Object.entries({ ...current }) : [];
+    const kept = pairs.filter((pair): pair is [string, string] => typeof pair[1] === 'string');
+    const map = Object.fromEntries(kept.filter(([code]) => code !== lang));
+    const next = value.trim() === '' ? map : { ...map, [lang]: value };
+    return { ...entry, [field]: next };
+  });
+
+/**
+ * Drops the entry at `index`.
+ * @param draft - current draft list
+ * @param index - row to remove
+ * @returns a new list
+ */
+export const withoutAt = <T>(draft: readonly T[], index: number): readonly T[] =>
+  draft.filter((_, i) => i !== index);

--- a/src/redesign/screens/taxonomy-shared.ts
+++ b/src/redesign/screens/taxonomy-shared.ts
@@ -1,0 +1,92 @@
+import { css } from 'lit';
+import type { CpTab } from '@communist-prometheus/cp-components';
+
+/**
+ * What the two taxonomy screens (topics and categories) share: the language
+ * strip and the row layout. Both edit a list of `{ key, per-language text }`
+ * entries stored in the content repository's settings, so they look and behave
+ * the same on purpose.
+ */
+
+/** The publication languages, as the keys used inside the settings files. */
+export const TAXONOMY_LANGS: readonly CpTab[] = [
+  { id: 'ru', label: 'RU' },
+  { id: 'en', label: 'EN' },
+  { id: 'it', label: 'IT' },
+  { id: 'es', label: 'ES' },
+  { id: 'bl', label: 'BG' },
+  { id: 'pl', label: 'PL' },
+  { id: 'uk', label: 'UK' },
+];
+
+export const taxonomyStyles = css`
+  :host {
+    display: block;
+    font-family: var(--font-sans);
+    color: var(--color-text-primary);
+    line-height: 1.6;
+  }
+  .eyebrow {
+    margin: 0;
+    font-size: 0.8rem;
+    color: var(--color-text-secondary);
+  }
+  h1 {
+    margin: 0.2rem 0 var(--spacing-sm);
+    font-size: clamp(1.6rem, 4vw, 2.2rem);
+    color: var(--color-accent);
+  }
+  .lede {
+    margin: 0 0 var(--spacing-md);
+    max-width: 46rem;
+    color: var(--color-text-secondary);
+  }
+  .rows {
+    list-style: none;
+    margin: var(--spacing-md) 0 0;
+    padding: 0;
+    display: grid;
+    gap: var(--spacing-sm);
+  }
+  /* One row per entry: it wraps to a column on a phone rather than scrolling. */
+  .row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: end;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    border: 1px solid var(--color-hairline);
+    border-radius: var(--radius-md, 10px);
+  }
+  .row cp-input {
+    flex: 1 1 10rem;
+    min-width: 0;
+  }
+  .row .swatch {
+    flex: 0 0 auto;
+    inline-size: 2.25rem;
+    block-size: 2.25rem;
+    padding: 0;
+    border: 1px solid var(--color-hairline);
+    border-radius: var(--radius-sm, 6px);
+    background: none;
+  }
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-md);
+  }
+  .msg {
+    color: var(--color-text-secondary);
+    font-size: 0.9rem;
+  }
+  .msg.error {
+    color: var(--color-danger, #c0392b);
+  }
+  code {
+    font-family: var(--font-mono, monospace);
+    font-size: 0.9em;
+  }
+`;


### PR DESCRIPTION
Promotes #430 to production (admin.comprom.org).

- **Topics load again** — the screen read through the Service Worker git engine (needs a full clone) and could hang on its loading placeholder; it now reads and writes over the GitHub API, and topics can be created, recoloured, renamed and deleted.
- **Categories have a screen** — «Рубрики», the rubric list behind `settings/labels.json`, which previously could only be edited by hand on GitHub.
- **Article title and address are editable** — the title is written back as quoted YAML; the address is transliterated, lowercased and hyphenated as it is typed, checked for collisions against the collection's real slugs, shows the resulting public URL, and moves every language and asset when applied (all copies before any delete).

CI on #430: realmode green. Redesign suite 230, full admin suite 1280, `bun run validate` green. Dev deploy verified on the live bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJdyKYYiV415PzW72712mg
